### PR TITLE
Add scripts for running local and EC2 containers

### DIFF
--- a/grafana/create-data-source.json
+++ b/grafana/create-data-source.json
@@ -1,7 +1,0 @@
-{
-  "name":"prometheus",
-  "type":"prometheus",
-  "url":"http://localhost:9090",
-  "access":"proxy",
-  "basicAuth":false
-}

--- a/start-all-ec2.sh
+++ b/start-all-ec2.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+source start-all.sh `curl http://169.254.169.254/latest/meta-data/public-ipv4`

--- a/start-all-local.sh
+++ b/start-all-local.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+source start-all.sh 127.0.0.1

--- a/start-all.sh
+++ b/start-all.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 
+DB_IP=$1
+
 sudo docker run -d -v $PWD/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml -p 9090:9090 prom/prometheus
 sudo docker run -d -i -p 3000:3000 -e "GF_AUTH_BASIC_ENABLED=false" -e "GF_AUTH_ANONYMOUS_ENABLED=true" -e "GF_AUTH_ANONYMOUS_ORG_ROLE=Admin" grafana/grafana
 
-curl -XPOST -i http://localhost:3000/api/datasources --data-binary @./grafana/create-data-source.json -H "Content-Type: application/json"
+sleep 3
+curl -XPOST -i http://localhost:3000/api/datasources \
+     --data-binary '{"name":"prometheus", "type":"prometheus", "url":"'"http://$DB_IP:9090"'", "access":"proxy", "basicAuth":false}' \
+     -H "Content-Type: application/json"
 curl -XPOST -i http://localhost:3000/api/dashboards/db --data-binary @./grafana/trivial-dash.json -H "Content-Type: application/json"


### PR DESCRIPTION
When adding Prometheus as data source on EC2, the instance external IP need to be used.
To fetch it, 2 scripts are introduce:
start-all-local.sh - use local IP
start-all-ec2.sh - use EC2 external IP
