### PR TITLE
use docker inspect to get prometheus ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,18 +21,18 @@ ubuntu $ sudo systemctl restart docker
 centos $ sudo service docker start
 ```
 
-Update `prometheus/prometheus.yml` with the targets (server you wish to monitor). 
+Update `prometheus/prometheus.yml` with the targets (server you wish to monitor).
 
-### Run locally
-
-```
-./start-all-local.sh
-```
-
-### Run on EC2
+### Run
 
 ```
-./start-all-ec2.sh
+./start-all.sh
+```
+
+### Kill
+
+```
+./kill-all.sh
 ```
 
 ### Use

--- a/kill-all.sh
+++ b/kill-all.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+sudo docker kill agraf aprom
+sudo docker rm agraf aprom

--- a/start-all-ec2.sh
+++ b/start-all-ec2.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
-source start-all.sh `curl http://169.254.169.254/latest/meta-data/public-ipv4`
+echo "This file is deprecated and kept for backward compatibility. You should use start-all.sh directly"
+
+source start-all.sh

--- a/start-all-local.sh
+++ b/start-all-local.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
-source start-all.sh 127.0.0.1
+echo "This file is deprecated and kept for backward compatibility. You should use start-all.sh directly"
+
+source start-all.sh

--- a/start-all.sh
+++ b/start-all.sh
@@ -1,16 +1,17 @@
 #!/usr/bin/env bash
 
-DB_IP=$1
-
-sudo docker run -d -v $PWD/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml -p 9090:9090 prom/prometheus:v1.0.0
+sudo docker run -d -v $PWD/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml -p 9090:9090 --name aprom prom/prometheus:v1.0.0
 sudo docker run -d -i -p 3000:3000 \
      -e "GF_AUTH_BASIC_ENABLED=false" \
      -e "GF_AUTH_ANONYMOUS_ENABLED=true" \
      -e "GF_AUTH_ANONYMOUS_ORG_ROLE=Admin" \
      -e "GF_INSTALL_PLUGINS=grafana-piechart-panel" \
-     grafana/grafana:3.1.0
+     --name agraf grafana/grafana:3.1.0
 
 sleep 10
+
+DB_IP="$(sudo docker inspect --format '{{ .NetworkSettings.IPAddress }}' aprom)"
+
 curl -XPOST -i http://localhost:3000/api/datasources \
      --data-binary '{"name":"prometheus", "type":"prometheus", "url":"'"http://$DB_IP:9090"'", "access":"proxy", "basicAuth":false}' \
      -H "Content-Type: application/json"


### PR DESCRIPTION
This request bypass hacks used to provide the grafana instance the IP of the prometheus image, by using docker inspect. This makes the special EC2 and local use case redundant, and one can always use start-all.sh

A new script kill-all.sh, kill and remove the two docker instances.
