### PR TITLE
Fix metrics

### DIFF
--- a/grafana/scylla-dash-io-per-server.json
+++ b/grafana/scylla-dash-io-per-server.json
@@ -915,7 +915,7 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_io_queue_delay{type=~\"compaction.*\"}[30s])) by (instance)",
+                  "expr": "sum(irate(collectd_io_queue_delay{type=~\"compaction.*\"}[30s])*1000000) by (instance)",
                   "intervalFactor": 2,
                   "metric": "collectd_io_queue_delay",
                   "refId": "A",
@@ -937,7 +937,7 @@
               },
               "yaxes": [
                 {
-                  "format": "s",
+                  "format": "µs",
                   "logBase": 1,
                   "max": null,
                   "min": 0,
@@ -1143,7 +1143,7 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_io_queue_delay{type=~\"query.*\"}[30s])) by (instance)",
+                  "expr": "sum(irate(collectd_io_queue_delay{type=~\"query.*\"}[30s])*1000000) by (instance)",
                   "intervalFactor": 2,
                   "metric": "collectd_io_queue_delay",
                   "refId": "A",
@@ -1165,7 +1165,7 @@
               },
               "yaxes": [
                 {
-                  "format": "s",
+                  "format": "µs",
                   "logBase": 1,
                   "max": null,
                   "min": 0,
@@ -1372,7 +1372,7 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_io_queue_delay{type=~\"commitlog.*\"}[30s])) by (instance)",
+                  "expr": "sum(irate(collectd_io_queue_delay{type=~\"commitlog.*\"}[30s])*1000000) by (instance)",
                   "intervalFactor": 2,
                   "metric": "collectd_io_queue_delay",
                   "refId": "A",
@@ -1394,7 +1394,7 @@
               },
               "yaxes": [
                 {
-                  "format": "s",
+                  "format": "µs",
                   "logBase": 1,
                   "max": null,
                   "min": 0,
@@ -1600,7 +1600,7 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_io_queue_delay{type=~\"memtable.*\"}[30s])) by (instance)",
+                  "expr": "sum(irate(collectd_io_queue_delay{type=~\"memtable.*\"}[30s])*1000000) by (instance)",
                   "intervalFactor": 2,
                   "metric": "collectd_io_queue_delay",
                   "refId": "A",
@@ -1622,7 +1622,7 @@
               },
               "yaxes": [
                 {
-                  "format": "s",
+                  "format": "µs",
                   "logBase": 1,
                   "max": null,
                   "min": 0,
@@ -1828,7 +1828,7 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_io_queue_delay{type=~\"streaming_read.*\"}[30s])) by (instance)",
+                  "expr": "sum(irate(collectd_io_queue_delay{type=~\"streaming_read.*\"}[30s])*1000000) by (instance)",
                   "intervalFactor": 2,
                   "metric": "collectd_io_queue_delay",
                   "refId": "A",
@@ -1850,7 +1850,7 @@
               },
               "yaxes": [
                 {
-                  "format": "s",
+                  "format": "µs",
                   "logBase": 1,
                   "max": null,
                   "min": 0,
@@ -2056,7 +2056,7 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_io_queue_delay{type=~\"streaming_write.*\"}[30s])) by (instance)",
+                  "expr": "sum(irate(collectd_io_queue_delay{type=~\"streaming_write.*\"}[30s])*1000000) by (instance)",
                   "intervalFactor": 2,
                   "metric": "collectd_io_queue_delay",
                   "refId": "A",
@@ -2078,7 +2078,7 @@
               },
               "yaxes": [
                 {
-                  "format": "s",
+                  "format": "µs",
                   "logBase": 1,
                   "max": null,
                   "min": 0,

--- a/grafana/scylla-dash-per-server.json
+++ b/grafana/scylla-dash-per-server.json
@@ -1695,7 +1695,7 @@
                         },
                         "yaxes": [
                             {
-                                "format": "short",
+                                "format": "Bps",
                                 "logBase": 1,
                                 "max": null,
                                 "min": 0,
@@ -1775,7 +1775,7 @@
                         },
                         "yaxes": [
                             {
-                                "format": "short",
+                                "format": "Bps",
                                 "logBase": 1,
                                 "max": null,
                                 "min": 0,
@@ -2060,7 +2060,7 @@
                         },
                         "yaxes": [
                             {
-                                "format": "short",
+                                "format": "Bps",
                                 "logBase": 1,
                                 "max": null,
                                 "min": 0,
@@ -2141,7 +2141,7 @@
                         },
                         "yaxes": [
                             {
-                                "format": "short",
+                                "format": "Bps",
                                 "logBase": 1,
                                 "max": null,
                                 "min": 0,


### PR DESCRIPTION
Some metrics are not properly formatted.
- The I/O queue dash shows delay in seconds, which is inconvenient.
- The per server dashboard shows network and disk bandwidth without units.

This PR aims to fix both issues.
