### PR TITLE
prometheus: Set honor_labels to true

### DIFF
--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -8,5 +8,6 @@ global:
 
 scrape_configs:
 - job_name: scylla
+  honor_labels: true
   static_configs:
   - targets: ['127.0.0.1.18:9103']


### PR DESCRIPTION
I have a setup with a single collectd sink instance (ccm cluster) and
therefore single collectd_exporter. In such configuration all samples
will be assigned by prometheus the same instance label - the collectd
exporter's IP. They do however have distinct instance label set by the
exporter. Setting honor_labels to true makes prometheus respect the
label, which fixes the per-server dashboard in such setups.
