### PR TITLE
Fix configure typo and update doc of loading history data

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,25 @@ Update `prometheus/prometheus.yml` with the targets (server you wish to monitor)
 ./start-all.sh
 ```
 
+### Load original data to prometheus server
+
+```
+Additional parameters:
+  -v <data>:/prometheus
+
+Full commandline:
+  sudo docker run -d -v <data>:/prometheus -v $PWD/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:Z -p 9090:9090 --name aprom prom/prometheus:v1.0.0
+
+Comment:
+  <data> is the local path to original data directory
+
+Data source:
+1. Download from docker prometheus server, reference:
+https://github.com/scylladb/scylla/wiki/How-to-report-a-Scylla-problem#prometheus
+2. Get from Scylla-Cluster-Test log.
+3. etc
+```
+
 ### Kill
 
 ```

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -10,4 +10,4 @@ scrape_configs:
 - job_name: scylla
   honor_labels: true
   static_configs:
-  - targets: ['127.0.0.1.18:9103']
+  - targets: ['127.0.0.1:9103']


### PR DESCRIPTION
The 1st patch fixed a typo of ip address in prometheus.yml

The 2nd patch updated README about loading history data to prometheus server. User may report a issue with a prometheus data, we also download prometheus data in SCT performance testing, it's a easy way to review the history data.
