### PR TITLE
Add checks and errors for common problems in start script

### DIFF
--- a/start-all.sh
+++ b/start-all.sh
@@ -24,7 +24,7 @@ done
 if [ ! "$(sudo docker ps)" ]
 then
         echo "Error: Docker engine is not running"
-        exit 1;
+        exit 1
 fi
 
 if [ -z $DATA_DIR ]
@@ -33,6 +33,11 @@ then
 else
     echo "Loading prometheus data from $DATA_DIR"
     sudo docker run -d -v $DATA_DIR:/prometheus:Z -v $PWD/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:Z -p 9090:9090 --name aprom prom/prometheus:v1.0.0
+fi
+
+if [ $? -ne 0 ]; then
+    echo "Error: Prometheus container failed to start"
+    exit 1
 fi
 
 # Number of retries waiting for a Docker container to start
@@ -50,7 +55,7 @@ done
 if [ ! "$(sudo docker ps -q -f name=aprom)" ]
 then
         echo "Error: Prometheus container failed to start"
-        exit 1;
+        exit 1
 fi
 
 sudo docker run -d -i -p 3000:3000 \
@@ -59,6 +64,11 @@ sudo docker run -d -i -p 3000:3000 \
      -e "GF_AUTH_ANONYMOUS_ORG_ROLE=Admin" \
      -e "GF_INSTALL_PLUGINS=grafana-piechart-panel" \
      --name agraf grafana/grafana:3.1.0
+
+if [ $? -ne 0 ]; then
+    echo "Error: Grafana container failed to start"
+    exit 1
+fi
 
 # Wait till Grafana API is available
 printf "Wait for Grafana container to start."
@@ -72,7 +82,7 @@ done
 if [ ! "$(sudo docker ps -q -f name=agraf)" ]
 then
         echo "Error: Grafana container failed to start"
-        exit 1;
+        exit 1
 fi
 
 DB_IP="$(sudo docker inspect --format '{{ .NetworkSettings.IPAddress }}' aprom)"


### PR DESCRIPTION
This PR add proper error messages to problems in start-all.sh script:
- docker engine is not running
- Prometheus failed to start
- Grafana failed to start
