### PR TITLE
I/O Queue dashboard: fix name of graph

### DIFF
--- a/grafana/scylla-dash-io-per-server.json
+++ b/grafana/scylla-dash-io-per-server.json
@@ -1304,7 +1304,7 @@
               ],
               "timeFrom": null,
               "timeShift": null,
-              "title": "Compactions I/O Queue IOPS",
+              "title": "Query I/O Queue IOPS",
               "tooltip": {
                 "msResolution": false,
                 "shared": true,


### PR DESCRIPTION
One of the Query bandwidth dashboard really said "Compaction".
That was just a cut'n paste typo.

Signed-off-by: Glauber Costa glommer@scylladb.com
