### PR TITLE
Switching to Scylla prometheus

### DIFF
--- a/grafana/scylla-dash-io-per-server.json
+++ b/grafana/scylla-dash-io-per-server.json
@@ -93,7 +93,7 @@
               },
               "targets": [
                 {
-                  "expr": "count(up)",
+                  "expr": "count(up{job=\"scylla\"})",
                   "intervalFactor": 2,
                   "legendFormat": "",
                   "refId": "A",
@@ -172,7 +172,7 @@
               },
               "targets": [
                 {
-                  "expr": "count(up)-count(collectd_processes_ps_code{processes=\"scylla\"}>0)",
+                  "expr": "count(up{job=\"scylla\"})-count(seastar_memory{metric=\"free\",shard=\"0\",type=\"total_operations\"})",
                   "intervalFactor": 1,
                   "refId": "A",
                   "step": 120
@@ -248,7 +248,7 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_transport_total_requests{type=\"requests_served\"}[30s])) + sum(irate(collectd_thrift_total_requests{type=\"served\"}[30s]))",
+                  "expr": "sum(irate(seastar_transport{type=\"total_requests\", metric=\"requests_served\"}[30s])) + sum(irate(seastar_thrift{type=\"total_requests\", metric=\"served\"}[30s]))",
                   "intervalFactor": 2,
                   "refId": "A",
                   "step": 30
@@ -350,7 +350,7 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "avg(collectd_reactor_gauge{type=\"load\"} ) by (instance)",
+                  "expr": "avg(seastar_reactor{type=\"gauge\", metric=\"load\"} ) by (instance)",
                   "intervalFactor": 2,
                   "refId": "A",
                   "step": 30
@@ -425,7 +425,7 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_transport_total_requests{type=\"requests_served\"}[30s])) by (instance) + sum(irate(collectd_thrift_total_requests{type=\"served\"}[30s])) by (instance)",
+                  "expr": "sum(irate(seastar_transport{type=\"total_requests\", metric=\"requests_served\"}[30s])) by (instance) + sum(irate(seastar_thrift{type=\"total_requests\", metric=\"served\"}[30s])) by (instance)",
                   "intervalFactor": 2,
                   "metric": "",
                   "refId": "A",
@@ -492,14 +492,14 @@
               "strokeWidth": 1,
               "targets": [
                 {
-                  "expr": "sum(collectd_df_complex{df=\"var-lib-scylla\", type=\"free\"})/1000000000",
+                  "expr": "sum(node_filesystem_files_free{mountpoint=\"/var/lib/scylla\"})/1000000000",
                   "intervalFactor": 2,
                   "metric": "",
                   "refId": "A",
                   "step": 7200
                 },
                 {
-                  "expr": "sum(collectd_df_complex{df=\"var-lib-scylla\", type=\"used\"})/1000000000",
+                  "expr": "(sum(node_filesystem_size{mountpoint=\"/var/lib/scylla\"})-sum(node_filesystem_files_free{mountpoint=\"/var/lib/scylla\"}))/1000000000",
                   "intervalFactor": 2,
                   "refId": "B",
                   "step": 7200
@@ -577,7 +577,7 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "irate(collectd_disk_ops_1{disk=\"md0\"}[30s])",
+                  "expr": "irate(node_disk_writes_completed{device=\"md0\"}[30s])",
                   "intervalFactor": 2,
                   "legendFormat": "",
                   "metric": "",
@@ -653,7 +653,7 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "irate(collectd_disk_ops_0{disk=\"md0\"}[30s])",
+                  "expr": "irate(node_disk_reads_completed{device=\"md0\"}[30s])",
                   "intervalFactor": 2,
                   "refId": "A",
                   "step": 20
@@ -735,7 +735,7 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "irate(collectd_disk_octets_1{disk=\"md0\"}[30s])",
+                  "expr": "irate(node_disk_bytes_written{device=\"md0\"}[30s])",
                   "intervalFactor": 2,
                   "metric": "",
                   "refId": "A",
@@ -810,7 +810,7 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "irate(collectd_disk_octets_0{disk=\"md0\"}[30s])",
+                  "expr": "irate(node_disk_bytes_read{device=\"md0\"}[30s])",
                   "intervalFactor": 2,
                   "refId": "A",
                   "step": 20
@@ -915,9 +915,9 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_io_queue_delay{type=~\"compaction.*\"}[30s])*1000000) by (instance)",
+                  "expr": "sum(irate(seastar_io_queue{type=\"delay\", metric=~\"compaction.*\"}[30s])*1000000) by (instance)",
                   "intervalFactor": 2,
-                  "metric": "collectd_io_queue_delay",
+                  "metric": "seastar_io_queue_delay",
                   "refId": "A",
                   "step": 30
                 }
@@ -991,9 +991,9 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_io_queue_derive{type=~\"compaction.*\"}[30s])) by (instance)",
+                  "expr": "sum(irate(seastar_io_queue{type=\"derive\", metric=~\"compaction.*\"}[30s])) by (instance)",
                   "intervalFactor": 2,
-                  "metric": "collectd_io_queue_delay",
+                  "metric": "seastar_io_queue_delay",
                   "refId": "A",
                   "step": 30
                 }
@@ -1067,9 +1067,9 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_io_queue_total_operations{type=~\"compaction.*\"}[30s])) by (instance)",
+                  "expr": "sum(irate(seastar_io_queue{type=\"total_operations\", metric=~\"compaction.*\"}[30s])) by (instance)",
                   "intervalFactor": 2,
-                  "metric": "collectd_io_queue_delay",
+                  "metric": "seastar_io_queue_delay",
                   "refId": "A",
                   "step": 30
                 }
@@ -1143,9 +1143,9 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_io_queue_delay{type=~\"query.*\"}[30s])*1000000) by (instance)",
+                  "expr": "sum(irate(seastar_io_queue{type=\"delay\", metric=~\"query.*\"}[30s])*1000000) by (instance)",
                   "intervalFactor": 2,
-                  "metric": "collectd_io_queue_delay",
+                  "metric": "seastar_io_queue_delay",
                   "refId": "A",
                   "step": 30
                 }
@@ -1219,9 +1219,9 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_io_queue_derive{type=~\"query.*\"}[30s])) by (instance)",
+                  "expr": "sum(irate(seastar_io_queue{type=\"derive\", metric=~\"query.*\"}[30s])) by (instance)",
                   "intervalFactor": 2,
-                  "metric": "collectd_io_queue_delay",
+                  "metric": "seastar_io_queue_delay",
                   "refId": "A",
                   "step": 30
                 }
@@ -1295,9 +1295,9 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_io_queue_total_operations{type=~\"query.*\"}[30s])) by (instance)",
+                  "expr": "sum(irate(seastar_io_queue{type=\"total_operations\", metric=~\"query.*\"}[30s])) by (instance)",
                   "intervalFactor": 2,
-                  "metric": "collectd_io_queue_delay",
+                  "metric": "seastar_io_queue_delay",
                   "refId": "A",
                   "step": 30
                 }
@@ -1372,9 +1372,9 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_io_queue_delay{type=~\"commitlog.*\"}[30s])*1000000) by (instance)",
+                  "expr": "sum(irate(seastar_io_queue{type=\"delay\", metric=~\"commitlog.*\"}[30s])*1000000) by (instance)",
                   "intervalFactor": 2,
-                  "metric": "collectd_io_queue_delay",
+                  "metric": "seastar_io_queue_delay",
                   "refId": "A",
                   "step": 30
                 }
@@ -1448,9 +1448,9 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_io_queue_derive{type=~\"commitlog.*\"}[30s])) by (instance)",
+                  "expr": "sum(irate(seastar_io_queue{type=\"derive\", metric=~\"commitlog.*\"}[30s])) by (instance)",
                   "intervalFactor": 2,
-                  "metric": "collectd_io_queue_delay",
+                  "metric": "seastar_io_queue_delay",
                   "refId": "A",
                   "step": 30
                 }
@@ -1524,9 +1524,9 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_io_queue_total_operations{type=~\"commitlog.*\"}[30s])) by (instance)",
+                  "expr": "sum(irate(seastar_io_queue{type=\"total_operations\", metric=~\"commitlog.*\"}[30s])) by (instance)",
                   "intervalFactor": 2,
-                  "metric": "collectd_io_queue_delay",
+                  "metric": "seastar_io_queue_delay",
                   "refId": "A",
                   "step": 30
                 }
@@ -1600,9 +1600,9 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_io_queue_delay{type=~\"memtable.*\"}[30s])*1000000) by (instance)",
+                  "expr": "sum(irate(seastar_io_queue{type=\"delay\", metric=~\"memtable.*\"}[30s])*1000000) by (instance)",
                   "intervalFactor": 2,
-                  "metric": "collectd_io_queue_delay",
+                  "metric": "seastar_io_queue_delay",
                   "refId": "A",
                   "step": 30
                 }
@@ -1676,9 +1676,9 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_io_queue_derive{type=~\"memtable.*\"}[30s])) by (instance)",
+                  "expr": "sum(irate(seastar_io_queue{type=\"derive\", metric=~\"memtable.*\"}[30s])) by (instance)",
                   "intervalFactor": 2,
-                  "metric": "collectd_io_queue_delay",
+                  "metric": "seastar_io_queue_delay",
                   "refId": "A",
                   "step": 30
                 }
@@ -1752,9 +1752,9 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_io_queue_total_operations{type=~\"memtable.*\"}[30s])) by (instance)",
+                  "expr": "sum(irate(seastar_io_queue{type=\"total_operations\", metric=~\"memtable.*\"}[30s])) by (instance)",
                   "intervalFactor": 2,
-                  "metric": "collectd_io_queue_delay",
+                  "metric": "seastar_io_queue_delay",
                   "refId": "A",
                   "step": 30
                 }
@@ -1828,9 +1828,9 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_io_queue_delay{type=~\"streaming_read.*\"}[30s])*1000000) by (instance)",
+                  "expr": "sum(irate(seastar_io_queue{type=\"delay\", metric=~\"streaming_read.*\"}[30s])*1000000) by (instance)",
                   "intervalFactor": 2,
-                  "metric": "collectd_io_queue_delay",
+                  "metric": "seastar_io_queue_delay",
                   "refId": "A",
                   "step": 30
                 }
@@ -1904,9 +1904,9 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_io_queue_derive{type=~\"streaming_read.*\"}[30s])) by (instance)",
+                  "expr": "sum(irate(seastar_io_queue{type=\"derive\", metric=~\"streaming_read.*\"}[30s])) by (instance)",
                   "intervalFactor": 2,
-                  "metric": "collectd_io_queue_delay",
+                  "metric": "seastar_io_queue_delay",
                   "refId": "A",
                   "step": 30
                 }
@@ -1980,9 +1980,9 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_io_queue_total_operations{type=~\"streaming_reads.*\"}[30s])) by (instance)",
+                  "expr": "sum(irate(seastar_io_queue{type=\"total_operations\", metric=~\"streaming_reads.*\"}[30s])) by (instance)",
                   "intervalFactor": 2,
-                  "metric": "collectd_io_queue_delay",
+                  "metric": "seastar_io_queue_delay",
                   "refId": "A",
                   "step": 30
                 }
@@ -2056,9 +2056,9 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_io_queue_delay{type=~\"streaming_write.*\"}[30s])*1000000) by (instance)",
+                  "expr": "sum(irate(seastar_io_queue{type=\"delay\", metric=~\"streaming_write.*\"}[30s])*1000000) by (instance)",
                   "intervalFactor": 2,
-                  "metric": "collectd_io_queue_delay",
+                  "metric": "seastar_io_queue_delay",
                   "refId": "A",
                   "step": 30
                 }
@@ -2132,9 +2132,9 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_io_queue_derive{type=~\"streaming_write.*\"}[30s])) by (instance)",
+                  "expr": "sum(irate(seastar_io_queue{type=\"derive\", metric=~\"streaming_write.*\"}[30s])) by (instance)",
                   "intervalFactor": 2,
-                  "metric": "collectd_io_queue_delay",
+                  "metric": "seastar_io_queue_delay",
                   "refId": "A",
                   "step": 30
                 }
@@ -2208,9 +2208,9 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_io_queue_total_operations{type=~\"streaming_write.*\"}[30s])) by (instance)",
+                  "expr": "sum(irate(seastar_io_queue{type=\"total_operations\", metric=~\"streaming_write.*\"}[30s])) by (instance)",
                   "intervalFactor": 2,
-                  "metric": "collectd_io_queue_delay",
+                  "metric": "seastar_io_queue_delay",
                   "refId": "A",
                   "step": 30
                 }

--- a/grafana/scylla-dash-io-per-server.json
+++ b/grafana/scylla-dash-io-per-server.json
@@ -1980,7 +1980,7 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(seastar_io_queue{type=\"total_operations\", metric=~\"streaming_reads.*\"}[30s])) by (instance)",
+                  "expr": "sum(irate(seastar_io_queue{type=\"total_operations\", metric=~\"streaming_read.*\"}[30s])) by (instance)",
                   "intervalFactor": 2,
                   "metric": "seastar_io_queue_delay",
                   "refId": "A",

--- a/grafana/scylla-dash-per-server.json
+++ b/grafana/scylla-dash-per-server.json
@@ -81,7 +81,7 @@
                         },
                         "targets": [
                             {
-                                "expr": "count(up)",
+                                "expr": "count(up{job=\"scylla\"})",
                                 "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -162,7 +162,7 @@
                         },
                         "targets": [
                             {
-                                "expr": "count(up)-count(collectd_processes_ps_code{processes=\"scylla\"}>0)",
+                                "expr": "count(up{job=\"scylla\"})-count(seastar_memory{metric=\"free\",shard=\"0\",type=\"total_operations\"})",
                                 "intervalFactor": 1,
                                 "refId": "A",
                                 "step": 20
@@ -264,7 +264,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(collectd_transport_total_requests{type=\"requests_served\"}[30s])) + sum(irate(collectd_thrift_total_requests{type=\"served\"}[30s]))",
+                                "expr": "sum(irate(seastar_transport{type=\"total_requests\", metric=\"requests_served\"}[30s])) + sum(irate(seastar_thrift{type=\"total_requests\", metric=\"served\"}[30s]))",
                                 "intervalFactor": 2,
                                 "refId": "A",
                                 "step": 4
@@ -376,7 +376,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "avg(collectd_reactor_gauge{type=\"load\"} ) by (instance)",
+                                "expr": "avg(seastar_reactor{type=\"gauge\", metric=\"load\"} ) by (instance)",
                                 "intervalFactor": 2,
                                 "refId": "A",
                                 "step": 4
@@ -457,7 +457,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(collectd_transport_total_requests{type=\"requests_served\"}[30s])) by (instance) + sum(irate(collectd_thrift_total_requests{type=\"served\"}[30s])) by (instance)",
+                                "expr": "sum(irate(seastar_transport{type=\"total_requests\", metric=\"requests_served\"}[30s])) by (instance) + sum(irate(seastar_thrift{type=\"total_requests\", metric=\"served\"}[30s])) by (instance)",
                                 "intervalFactor": 2,
                                 "metric": "",
                                 "refId": "A",
@@ -523,14 +523,14 @@
                         "span": 2,
                         "targets": [
                             {
-                                "expr": "sum(collectd_df_complex{df=\"var-lib-scylla\", type=\"free\"})/1000000000",
+                                "expr": "sum(node_filesystem_files_free{mountpoint=\"/var/lib/scylla\"})/1000000000",
                                 "intervalFactor": 2,
                                 "metric": "",
                                 "refId": "A",
                                 "step": 1200
                             },
                             {
-                                "expr": "sum(collectd_df_complex{df=\"var-lib-scylla\", type=\"used\"})/1000000000",
+                                "expr": "(sum(node_filesystem_size{mountpoint=\"/var/lib/scylla\"})-sum(node_filesystem_files_free{mountpoint=\"/var/lib/scylla\"}))/1000000000",
                                 "intervalFactor": 2,
                                 "refId": "B",
                                 "step": 1200
@@ -642,7 +642,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(collectd_storage_proxy_queue_length{type=\"foreground writes\"}) by (instance)",
+                                "expr": "sum(seastar_storage_proxy{type=\"queue_length\", metric=\"foreground writes\"}) by (instance)",
                                 "intervalFactor": 2,
                                 "refId": "A",
                                 "step": 10
@@ -722,7 +722,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(collectd_storage_proxy_queue_length{type=\"reads\"}) by (instance)",
+                                "expr": "sum(seastar_storage_proxy{type=\"queue_length\", metric=\"reads\"}) by (instance)",
                                 "intervalFactor": 2,
                                 "metric": "",
                                 "refId": "A",
@@ -803,7 +803,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(collectd_storage_proxy_total_operations{type=\"write timeouts\"}[30s])) by (instance)",
+                                "expr": "sum(irate(seastar_storage_proxy{type=\"total_operations\", metric=\"write timeouts\"}[30s])) by (instance)",
                                 "intervalFactor": 2,
                                 "refId": "A",
                                 "step": 10
@@ -883,7 +883,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(collectd_storage_proxy_total_operations{type=\"write unavailable\"}[30s])) by (instance)",
+                                "expr": "sum(irate(seastar_storage_proxy{type=\"total_operations\", metric=\"write unavailable\"}[30s])) by (instance)",
                                 "intervalFactor": 2,
                                 "refId": "A",
                                 "step": 10
@@ -971,7 +971,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(collectd_storage_proxy_queue_length{type=\"background writes\"}) by (instance)",
+                                "expr": "sum(seastar_storage_proxy{type=\"queue_length\", metric=\"background writes\"}) by (instance)",
                                 "intervalFactor": 2,
                                 "refId": "A",
                                 "step": 10
@@ -1051,7 +1051,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(collectd_storage_proxy_queue_length{type=\"background reads\"}) by (instance)",
+                                "expr": "sum(seastar_storage_proxy{type=\"queue_length\", metric=\"background reads\"}) by (instance)",
                                 "intervalFactor": 2,
                                 "refId": "A",
                                 "step": 10
@@ -1131,7 +1131,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(collectd_storage_proxy_total_operations{type=\"read timeouts\"}[30s])) by (instance)",
+                                "expr": "sum(irate(seastar_storage_proxy{type=\"total_operations\", metric=\"read timeouts\"}[30s])) by (instance)",
                                 "intervalFactor": 2,
                                 "refId": "A",
                                 "step": 10
@@ -1211,7 +1211,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(collectd_storage_proxy_total_operations{type=\"read unavailable\"}[30s])) by (instance)",
+                                "expr": "sum(irate(seastar_storage_proxy{type=\"total_operations\", metric=\"read unavailable\"}[30s])) by (instance)",
                                 "intervalFactor": 2,
                                 "refId": "A",
                                 "step": 10
@@ -1343,7 +1343,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "irate(collectd_disk_ops_1{disk=\"md0\"}[30s])",
+                                "expr": "irate(node_disk_writes_completed{device=\"md0\"}[30s])",
                                 "intervalFactor": 2,
                                 "legendFormat": "",
                                 "metric": "",
@@ -1425,7 +1425,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "irate(collectd_disk_ops_0{disk=\"md0\"}[30s])",
+                                "expr": "irate(node_disk_reads_completed{device=\"md0\"}[30s])",
                                 "intervalFactor": 2,
                                 "refId": "A",
                                 "step": 10
@@ -1505,7 +1505,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(collectd_cache_total_operations{type=\"hits\"}[30s])) by (instance)",
+                                "expr": "sum(irate(seastar_cache{type=\"total_operations\", metric=\"hits\"}[30s])) by (instance)",
                                 "intervalFactor": 2,
                                 "refId": "A",
                                 "step": 10
@@ -1585,7 +1585,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(collectd_cache_total_operations{type=\"misses\"}[30s])) by (instance)",
+                                "expr": "sum(irate(seastar_cache{type=\"total_operations\", metric=\"misses\"}[30s])) by (instance)",
                                 "intervalFactor": 2,
                                 "refId": "A",
                                 "step": 10
@@ -1673,7 +1673,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "irate(collectd_disk_octets_1{disk=\"md0\"}[30s])",
+                                "expr": "irate(node_disk_bytes_written{device=\"md0\"}[30s])",
                                 "intervalFactor": 2,
                                 "metric": "",
                                 "refId": "A",
@@ -1754,7 +1754,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "irate(collectd_disk_octets_0{disk=\"md0\"}[30s])",
+                                "expr": "irate(node_disk_bytes_read{device=\"md0\"}[30s])",
                                 "intervalFactor": 2,
                                 "refId": "A",
                                 "step": 10
@@ -1828,7 +1828,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(collectd_cache_total_operations{type=\"insertions\"}[30s])) by (instance)",
+                                "expr": "sum(irate(seastar_cache{type=\"total_operations\", metric=\"insertions\"}[30s])) by (instance)",
                                 "intervalFactor": 2,
                                 "refId": "A",
                                 "step": 40
@@ -1902,7 +1902,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(collectd_cache_total_operations{type=\"evictions\"}[30s])) by (instance)",
+                                "expr": "sum(irate(seastar_cache{type=\"total_operations\", metric=\"evictions\"}[30s])) by (instance)",
                                 "intervalFactor": 2,
                                 "refId": "A",
                                 "step": 40
@@ -1989,7 +1989,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(collectd_cache_total_operations{type=\"merges\"}[30s])) by (instance)",
+                                "expr": "sum(irate(seastar_cache{type=\"total_operations\", metric=\"merges\"}[30s])) by (instance)",
                                 "intervalFactor": 2,
                                 "refId": "A",
                                 "step": 60
@@ -2063,7 +2063,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(collectd_cache_total_operations{type=\"removals\"}[30s])) by (instance)",
+                                "expr": "sum(irate(seastar_cache{type=\"total_operations\", metric=\"removals\"}[30s])) by (instance)",
                                 "intervalFactor": 2,
                                 "refId": "A",
                                 "step": 60
@@ -2150,7 +2150,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(collectd_cache_objects{type=\"partitions\"}) by (instance)",
+                                "expr": "sum(seastar_cache{type=\"objects\", metric=\"partitions\"}) by (instance)",
                                 "intervalFactor": 2,
                                 "refId": "A",
                                 "step": 40
@@ -2224,7 +2224,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(collectd_cache_bytes{type=\"total\"}) by (instance)",
+                                "expr": "sum(seastar_cache{type=\"bytes\", metric=\"total\"}) by (instance)",
                                 "intervalFactor": 2,
                                 "refId": "A",
                                 "step": 40
@@ -2329,7 +2329,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(collectd_lsa_bytes{type=\"total_space\"}) by (instance)",
+                                "expr": "sum(seastar_lsa{type=\"bytes\", metric=\"total_space\"}) by (instance)",
                                 "intervalFactor": 2,
                                 "refId": "A",
                                 "step": 20
@@ -2403,7 +2403,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(collectd_lsa_bytes{type=\"non_lsa_used_space\"}) by (instance)",
+                                "expr": "sum(seastar_lsa{type=\"bytes\", metric=\"non_lsa_used_space\"}) by (instance)",
                                 "intervalFactor": 2,
                                 "refId": "A",
                                 "step": 20
@@ -2516,7 +2516,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "irate(collectd_interface_if_packets_0{interface=\"eth0\"}[30s])",
+                                "expr": "irate(node_network_receive_packets{device=\"eth0\"}[30s])",
                                 "intervalFactor": 2,
                                 "metric": "",
                                 "refId": "A",
@@ -2597,7 +2597,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "irate(collectd_interface_if_packets_1{interface=\"eth0\"}[30s])",
+                                "expr": "irate(node_network_transmit_packets{device=\"eth0\"}[30s])",
                                 "intervalFactor": 2,
                                 "metric": "",
                                 "refId": "A",
@@ -2686,7 +2686,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "irate(collectd_interface_if_octets_0{interface=\"eth0\"}[30s])",
+                                "expr": "irate(node_network_receive_bytes{device=\"eth0\"}[30s])",
                                 "intervalFactor": 2,
                                 "metric": "",
                                 "refId": "A",
@@ -2767,7 +2767,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "irate(collectd_interface_if_octets_1{interface=\"eth0\"}[30s])",
+                                "expr": "irate(node_network_transmit_bytes{device=\"eth0\"}[30s])",
                                 "intervalFactor": 2,
                                 "metric": "",
                                 "refId": "A",
@@ -2883,7 +2883,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(collectd_compaction_manager_objects) by (instance)",
+                                "expr": "sum(seastar_compaction_manager_objects) by (instance)",
                                 "intervalFactor": 2,
                                 "metric": "",
                                 "refId": "A",

--- a/grafana/scylla-dash-per-server.json
+++ b/grafana/scylla-dash-per-server.json
@@ -2883,7 +2883,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(seastar_compaction_manager_objects) by (instance)",
+                                "expr": "sum(seastar_compaction_manager{type=\"objects\"}) by (instance)",
                                 "intervalFactor": 2,
                                 "metric": "",
                                 "refId": "A",

--- a/grafana/scylla-dash.json
+++ b/grafana/scylla-dash.json
@@ -82,7 +82,7 @@
                         },
                         "targets": [
                             {
-                                "expr": "count(up)",
+                                "expr": "count(up{job=\"scylla\"})",
                                 "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -145,7 +145,7 @@
                         },
                         "targets": [
                             {
-                                "expr": "count(up)-count(collectd_processes_ps_code{processes=\"scylla\"}>0)",
+                                "expr": "count(up{job=\"scylla\"})-count(seastar_memory{metric=\"free\",shard=\"0\",type=\"total_operations\"})",
                                 "intervalFactor": 1,
                                 "refId": "A",
                                 "step": 20
@@ -258,7 +258,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "avg(collectd_reactor_gauge{type=\"load\"} ) ",
+                                "expr": "avg(seastar_reactor{type=\"gauge\", metric=\"load\"} ) ",
                                 "intervalFactor": 2,
                                 "refId": "A",
                                 "step": 4
@@ -338,7 +338,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(collectd_transport_total_requests{type=\"requests_served\"}[30s])) + sum(irate(collectd_thrift_total_requests{type=\"served\"}[30s]))",
+                                "expr": "sum(irate(seastar_transport{type=\"total_requests\", metric=\"requests_served\"}[30s])) + sum(irate(seastar_thrift{type=\"total_requests\", metric=\"served\"}[30s]))",
                                 "intervalFactor": 2,
                                 "metric": "",
                                 "refId": "A",
@@ -403,14 +403,14 @@
                         "span": 2,
                         "targets": [
                             {
-                                "expr": "sum(collectd_df_complex{df=\"var-lib-scylla\", type=\"free\"})/1000000000",
+                                "expr": "sum(node_filesystem_files_free{mountpoint=\"/var/lib/scylla\"})/1000000000",
                                 "intervalFactor": 2,
                                 "metric": "",
                                 "refId": "A",
                                 "step": 1200
                             },
                             {
-                                "expr": "sum(collectd_df_complex{df=\"var-lib-scylla\", type=\"used\"})/1000000000",
+                                "expr": "(sum(node_filesystem_size{mountpoint=\"/var/lib/scylla\"})-sum(node_filesystem_files_free{mountpoint=\"/var/lib/scylla\"}))/1000000000",
                                 "intervalFactor": 2,
                                 "refId": "B",
                                 "step": 1200
@@ -516,7 +516,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(collectd_storage_proxy_queue_length{type=\"foreground writes\"}) ",
+                                "expr": "sum(seastar_storage_proxy{type=\"queue_length\", metric=\"foreground writes\"}) ",
                                 "intervalFactor": 2,
                                 "refId": "A",
                                 "step": 10
@@ -595,7 +595,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(collectd_storage_proxy_queue_length{type=\"reads\"}) ",
+                                "expr": "sum(seastar_storage_proxy{type=\"queue_length\", metric=\"reads\"}) ",
                                 "intervalFactor": 2,
                                 "metric": "",
                                 "refId": "A",
@@ -675,7 +675,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(collectd_storage_proxy_total_operations{type=\"write timeouts\"}[30s])) ",
+                                "expr": "sum(irate(seastar_storage_proxy{type=\"total_operations\", metric=\"write timeouts\"}[30s])) ",
                                 "intervalFactor": 2,
                                 "refId": "A",
                                 "step": 10
@@ -754,7 +754,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(collectd_storage_proxy_total_operations{type=\"write unavailable\"}[30s])) ",
+                                "expr": "sum(irate(seastar_storage_proxy{type=\"total_operations\", metric=\"write unavailable\"}[30s])) ",
                                 "intervalFactor": 2,
                                 "refId": "A",
                                 "step": 10
@@ -841,7 +841,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(collectd_storage_proxy_queue_length{type=\"background writes\"}) ",
+                                "expr": "sum(seastar_storage_proxy{type=\"queue_length\", metric=\"background writes\"}) ",
                                 "intervalFactor": 2,
                                 "refId": "A",
                                 "step": 10
@@ -920,7 +920,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(collectd_storage_proxy_queue_length{type=\"background reads\"}) ",
+                                "expr": "sum(seastar_storage_proxy{type=\"queue_length\", metric=\"background reads\"}) ",
                                 "intervalFactor": 2,
                                 "refId": "A",
                                 "step": 10
@@ -999,7 +999,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(collectd_storage_proxy_total_operations{type=\"read timeouts\"}[30s])) ",
+                                "expr": "sum(irate(seastar_storage_proxy{type=\"total_operations\", metric=\"read timeouts\"}[30s])) ",
                                 "intervalFactor": 2,
                                 "refId": "A",
                                 "step": 10
@@ -1078,7 +1078,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(collectd_storage_proxy_total_operations{type=\"read unavailable\"}[30s])) ",
+                                "expr": "sum(irate(seastar_storage_proxy{type=\"total_operations\", metric=\"read unavailable\"}[30s])) ",
                                 "intervalFactor": 2,
                                 "refId": "A",
                                 "step": 10
@@ -1191,7 +1191,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(collectd_cache_total_operations{type=\"hits\"}[30s])) ",
+                                "expr": "sum(irate(seastar_cache{type=\"total_operations\", metric=\"hits\"}[30s])) ",
                                 "intervalFactor": 2,
                                 "refId": "A",
                                 "step": 10
@@ -1270,7 +1270,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(collectd_cache_total_operations{type=\"misses\"}[30s])) ",
+                                "expr": "sum(irate(seastar_cache{type=\"total_operations\", metric=\"misses\"}[30s])) ",
                                 "intervalFactor": 2,
                                 "refId": "A",
                                 "step": 10

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -10,5 +10,10 @@ scrape_configs:
 - job_name: scylla
   honor_labels: true
   static_configs:
-  - targets: ['127.0.0.1:9103']
+  - targets: ["127.0.0.1:9180"]
+- job_name: node_exporter
+  honor_labels: true
+  static_configs:
+  - targets: ['127.0.0.1:9100']
+
 ## two servers example: - targets: ["172.17.0.3:9103","172.17.0.2:9103"]


### PR DESCRIPTION
This patch set the prometheus to use the Scylla Prometheus API.

The chanages are:
1. Modify the names from the collectd_exporter names to prometheus
names.
2. Use the node_exporter instead of the collectd for node metrics.
3. set the prometheus server to listen both to scylla and to the
node_exporter.

Signed-off-by: Amnon Heiman <amnon@scylladb.com>