### PR TITLE
use max instead of sum when dealing with time delays

### DIFF
--- a/grafana/scylla-dash-io-per-server.json
+++ b/grafana/scylla-dash-io-per-server.json
@@ -915,7 +915,7 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_io_queue_delay{type=~\"compaction.*\"}[30s])*1000000) by (instance)",
+                  "expr": "max(irate(collectd_io_queue_delay{type=~\"compaction.*\"}[30s])*1000000) by (instance)",
                   "intervalFactor": 2,
                   "metric": "collectd_io_queue_delay",
                   "refId": "A",
@@ -1143,7 +1143,7 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_io_queue_delay{type=~\"query.*\"}[30s])*1000000) by (instance)",
+                  "expr": "max(irate(collectd_io_queue_delay{type=~\"query.*\"}[30s])*1000000) by (instance)",
                   "intervalFactor": 2,
                   "metric": "collectd_io_queue_delay",
                   "refId": "A",
@@ -1372,7 +1372,7 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_io_queue_delay{type=~\"commitlog.*\"}[30s])*1000000) by (instance)",
+                  "expr": "max(irate(collectd_io_queue_delay{type=~\"commitlog.*\"}[30s])*1000000) by (instance)",
                   "intervalFactor": 2,
                   "metric": "collectd_io_queue_delay",
                   "refId": "A",
@@ -1600,7 +1600,7 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_io_queue_delay{type=~\"memtable.*\"}[30s])*1000000) by (instance)",
+                  "expr": "max(irate(collectd_io_queue_delay{type=~\"memtable.*\"}[30s])*1000000) by (instance)",
                   "intervalFactor": 2,
                   "metric": "collectd_io_queue_delay",
                   "refId": "A",
@@ -1828,7 +1828,7 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_io_queue_delay{type=~\"streaming_read.*\"}[30s])*1000000) by (instance)",
+                  "expr": "max(irate(collectd_io_queue_delay{type=~\"streaming_read.*\"}[30s])*1000000) by (instance)",
                   "intervalFactor": 2,
                   "metric": "collectd_io_queue_delay",
                   "refId": "A",
@@ -2056,7 +2056,7 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(collectd_io_queue_delay{type=~\"streaming_write.*\"}[30s])*1000000) by (instance)",
+                  "expr": "max(irate(collectd_io_queue_delay{type=~\"streaming_write.*\"}[30s])*1000000) by (instance)",
                   "intervalFactor": 2,
                   "metric": "collectd_io_queue_delay",
                   "refId": "A",


### PR DESCRIPTION
We use sum() to aggregate IOPS and bandwidth, but are using it by mistake
to aggregate delays. That makes little sense, and for time we should be using
max() instead.