### PR TITLE
fix display of I/O Queue delay

### DIFF
--- a/grafana/scylla-dash-io-per-server.json
+++ b/grafana/scylla-dash-io-per-server.json
@@ -915,7 +915,7 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(seastar_io_queue{type=\"delay\", metric=~\"compaction.*\"}[30s])*1000000) by (instance)",
+                  "expr": "1000000*max(seastar_io_queue{type=\"delay\", metric=~\"compaction.*\"}) by (instance)",
                   "intervalFactor": 2,
                   "metric": "seastar_io_queue_delay",
                   "refId": "A",
@@ -1143,7 +1143,7 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(seastar_io_queue{type=\"delay\", metric=~\"query.*\"}[30s])*1000000) by (instance)",
+                  "expr": "1000000*max(seastar_io_queue{type=\"delay\", metric=~\"query.*\"}) by (instance)",
                   "intervalFactor": 2,
                   "metric": "seastar_io_queue_delay",
                   "refId": "A",
@@ -1372,7 +1372,7 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(seastar_io_queue{type=\"delay\", metric=~\"commitlog.*\"}[30s])*1000000) by (instance)",
+                  "expr": "1000000*max(seastar_io_queue{type=\"delay\", metric=~\"commitlog.*\"}) by (instance)",
                   "intervalFactor": 2,
                   "metric": "seastar_io_queue_delay",
                   "refId": "A",
@@ -1600,7 +1600,7 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(seastar_io_queue{type=\"delay\", metric=~\"memtable.*\"}[30s])*1000000) by (instance)",
+                  "expr": "1000000*max(seastar_io_queue{type=\"delay\", metric=~\"memtable.*\"}) by (instance)",
                   "intervalFactor": 2,
                   "metric": "seastar_io_queue_delay",
                   "refId": "A",
@@ -1828,7 +1828,7 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(seastar_io_queue{type=\"delay\", metric=~\"streaming_read.*\"}[30s])*1000000) by (instance)",
+                  "expr": "1000000*max(seastar_io_queue{type=\"delay\", metric=~\"streaming_read.*\"}) by (instance)",
                   "intervalFactor": 2,
                   "metric": "seastar_io_queue_delay",
                   "refId": "A",
@@ -2056,7 +2056,7 @@
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(seastar_io_queue{type=\"delay\", metric=~\"streaming_write.*\"}[30s])*1000000) by (instance)",
+                  "expr": "1000000*max(seastar_io_queue{type=\"delay\", metric=~\"streaming_write.*\"}) by (instance)",
                   "intervalFactor": 2,
                   "metric": "seastar_io_queue_delay",
                   "refId": "A",


### PR DESCRIPTION
First, sum doesn't mean much: we should be displaying maximums when it
comes to delay. Also, this is not a derivative, so lose irate.

Signed-off-by: Glauber Costa <glommer@scylladb.com>