### PR TITLE
grafana: per-server: Use step 1

### DIFF
--- a/grafana/scylla-dash-per-server.json
+++ b/grafana/scylla-dash-per-server.json
@@ -82,10 +82,10 @@
                         "targets": [
                             {
                                 "expr": "count(up{job=\"scylla\"})",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
-                                "step": 40
+                                "step": 1
                             }
                         ],
                         "thresholds": "",
@@ -165,7 +165,7 @@
                                 "expr": "count(up{job=\"scylla\"})-count(seastar_memory{metric=\"free\",shard=\"0\",type=\"total_operations\"})",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 20
+                                "step": 1
                             }
                         ],
                         "thresholds": "1,2",
@@ -265,9 +265,9 @@
                         "targets": [
                             {
                                 "expr": "sum(irate(seastar_transport{type=\"total_requests\", metric=\"requests_served\"}[30s])) + sum(irate(seastar_thrift{type=\"total_requests\", metric=\"served\"}[30s]))",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 4
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -458,10 +458,10 @@
                         "targets": [
                             {
                                 "expr": "sum(irate(seastar_transport{type=\"total_requests\", metric=\"requests_served\"}[30s])) by (instance) + sum(irate(seastar_thrift{type=\"total_requests\", metric=\"served\"}[30s])) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "step": 4
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -524,16 +524,16 @@
                         "targets": [
                             {
                                 "expr": "sum(node_filesystem_files_free{mountpoint=\"/var/lib/scylla\"})/1000000000",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "step": 1200
+                                "step": 1
                             },
                             {
                                 "expr": "(sum(node_filesystem_size{mountpoint=\"/var/lib/scylla\"})-sum(node_filesystem_files_free{mountpoint=\"/var/lib/scylla\"}))/1000000000",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "B",
-                                "step": 1200
+                                "step": 1
                             }
                         ],
                         "title": "Total Storage",
@@ -643,9 +643,9 @@
                         "targets": [
                             {
                                 "expr": "sum(seastar_storage_proxy{type=\"queue_length\", metric=\"foreground writes\"}) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 10
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -723,10 +723,10 @@
                         "targets": [
                             {
                                 "expr": "sum(seastar_storage_proxy{type=\"queue_length\", metric=\"reads\"}) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "step": 10
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -804,9 +804,9 @@
                         "targets": [
                             {
                                 "expr": "sum(irate(seastar_storage_proxy{type=\"total_operations\", metric=\"write timeouts\"}[30s])) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 10
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -884,9 +884,9 @@
                         "targets": [
                             {
                                 "expr": "sum(irate(seastar_storage_proxy{type=\"total_operations\", metric=\"write unavailable\"}[30s])) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 10
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -972,9 +972,9 @@
                         "targets": [
                             {
                                 "expr": "sum(seastar_storage_proxy{type=\"queue_length\", metric=\"background writes\"}) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 10
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -1052,9 +1052,9 @@
                         "targets": [
                             {
                                 "expr": "sum(seastar_storage_proxy{type=\"queue_length\", metric=\"background reads\"}) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 10
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -1132,9 +1132,9 @@
                         "targets": [
                             {
                                 "expr": "sum(irate(seastar_storage_proxy{type=\"total_operations\", metric=\"read timeouts\"}[30s])) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 10
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -1212,9 +1212,9 @@
                         "targets": [
                             {
                                 "expr": "sum(irate(seastar_storage_proxy{type=\"total_operations\", metric=\"read unavailable\"}[30s])) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 10
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -1344,11 +1344,11 @@
                         "targets": [
                             {
                                 "expr": "irate(node_disk_writes_completed{device=\"md0\"}[30s])",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
-                                "step": 10
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -1426,9 +1426,9 @@
                         "targets": [
                             {
                                 "expr": "irate(node_disk_reads_completed{device=\"md0\"}[30s])",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 10
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -1506,9 +1506,9 @@
                         "targets": [
                             {
                                 "expr": "sum(irate(seastar_cache{type=\"total_operations\", metric=\"hits\"}[30s])) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 10
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -1586,9 +1586,9 @@
                         "targets": [
                             {
                                 "expr": "sum(irate(seastar_cache{type=\"total_operations\", metric=\"misses\"}[30s])) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 10
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -1674,10 +1674,10 @@
                         "targets": [
                             {
                                 "expr": "irate(node_disk_bytes_written{device=\"md0\"}[30s])",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "step": 10
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -1755,9 +1755,9 @@
                         "targets": [
                             {
                                 "expr": "irate(node_disk_bytes_read{device=\"md0\"}[30s])",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 10
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -1829,9 +1829,9 @@
                         "targets": [
                             {
                                 "expr": "sum(irate(seastar_cache{type=\"total_operations\", metric=\"insertions\"}[30s])) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 40
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -1903,9 +1903,9 @@
                         "targets": [
                             {
                                 "expr": "sum(irate(seastar_cache{type=\"total_operations\", metric=\"evictions\"}[30s])) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 40
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -1990,9 +1990,9 @@
                         "targets": [
                             {
                                 "expr": "sum(irate(seastar_cache{type=\"total_operations\", metric=\"merges\"}[30s])) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 60
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -2064,9 +2064,9 @@
                         "targets": [
                             {
                                 "expr": "sum(irate(seastar_cache{type=\"total_operations\", metric=\"removals\"}[30s])) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 60
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -2151,9 +2151,9 @@
                         "targets": [
                             {
                                 "expr": "sum(seastar_cache{type=\"objects\", metric=\"partitions\"}) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 40
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -2225,9 +2225,9 @@
                         "targets": [
                             {
                                 "expr": "sum(seastar_cache{type=\"bytes\", metric=\"total\"}) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 40
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -2330,9 +2330,9 @@
                         "targets": [
                             {
                                 "expr": "sum(seastar_lsa{type=\"bytes\", metric=\"total_space\"}) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 20
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -2404,9 +2404,9 @@
                         "targets": [
                             {
                                 "expr": "sum(seastar_lsa{type=\"bytes\", metric=\"non_lsa_used_space\"}) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 20
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -2517,10 +2517,10 @@
                         "targets": [
                             {
                                 "expr": "irate(node_network_receive_packets{device=\"eth0\"}[30s])",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "step": 4
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -2598,10 +2598,10 @@
                         "targets": [
                             {
                                 "expr": "irate(node_network_transmit_packets{device=\"eth0\"}[30s])",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "step": 4
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -2687,10 +2687,10 @@
                         "targets": [
                             {
                                 "expr": "irate(node_network_receive_bytes{device=\"eth0\"}[30s])",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "step": 4
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -2768,10 +2768,10 @@
                         "targets": [
                             {
                                 "expr": "irate(node_network_transmit_bytes{device=\"eth0\"}[30s])",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "step": 4
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -2884,10 +2884,10 @@
                         "targets": [
                             {
                                 "expr": "sum(seastar_compaction_manager{type=\"objects\"}) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "step": 2
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,


### PR DESCRIPTION
When I set scraping interval to 1s I see graphs "jiggle" in a way that
historical data points change values. After looking closer at this it
turns out that graphs alternate on refreshes between showing samples
from only odd and only even timestamp values.

Setting "resolution" parameter for queries from 1/2 to 1/1 fixes the
problem.

Fixes #45