### PR TITLE
show all dashboard in dashboard list widget, not just starred ones

### DIFF
--- a/grafana/scylla-dash-io-per-server.json
+++ b/grafana/scylla-dash-io-per-server.json
@@ -295,9 +295,9 @@
               "links": [],
               "query": "",
               "recent": false,
-              "search": false,
+              "search": true,
               "span": 2,
-              "starred": true,
+              "starred": false,
               "tags": [],
               "title": "Dashboards",
               "type": "dashlist"

--- a/grafana/scylla-dash-per-server.json
+++ b/grafana/scylla-dash-per-server.json
@@ -313,9 +313,9 @@
                         ],
                         "query": "",
                         "recent": false,
-                        "search": false,
+                        "search": true,
                         "span": 2,
-                        "starred": true,
+                        "starred": false,
                         "tags": [
 
                         ],

--- a/grafana/scylla-dash.json
+++ b/grafana/scylla-dash.json
@@ -195,9 +195,9 @@
                         ],
                         "query": "",
                         "recent": false,
-                        "search": false,
+                        "search": true,
                         "span": 2,
-                        "starred": true,
+                        "starred": false,
                         "tags": [
 
                         ],


### PR DESCRIPTION
fix #53 , not by starring all dashboards, rather by presenting all dashboards in the widget
![image](https://cloud.githubusercontent.com/assets/170200/20647516/c1634582-b49e-11e6-929b-78a72ae68c21.png)

