### PR TITLE
grafana: Use intervalFactor 1

### DIFF
--- a/grafana/scylla-dash-io-per-server.json
+++ b/grafana/scylla-dash-io-per-server.json
@@ -1,2308 +1,2492 @@
 {
     "dashboard": {
-      "id": null,
-      "title": "Scylla Per-Server Disk I/O",
-      "tags": [],
-      "style": "dark",
-      "timezone": "browser",
-      "editable": true,
-      "hideControls": true,
-      "sharedCrosshair": true,
-      "rows": [
-        {
-          "collapse": false,
-          "editable": true,
-          "height": "25px",
-          "panels": [
-            {
-              "content": "<img src=\"http://www.scylladb.com/img/logo.svg\" height=\"70\">\n<hr style=\"border-top: 3px solid #5780c1;\">",
-              "editable": true,
-              "error": false,
-              "id": 41,
-              "isNew": true,
-              "links": [],
-              "mode": "html",
-              "span": 12,
-              "title": "",
-              "transparent": true,
-              "type": "text"
-            }
-          ],
-          "title": "New row"
-        },
-        {
-          "collapse": false,
-          "editable": true,
-          "height": "150px",
-          "panels": [
-            {
-              "cacheTimeout": null,
-              "colorBackground": false,
-              "colorValue": false,
-              "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-              ],
-              "datasource": "prometheus",
-              "editable": true,
-              "error": false,
-              "format": "none",
-              "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-              },
-              "id": 38,
-              "interval": null,
-              "isNew": true,
-              "links": [],
-              "mappingType": 1,
-              "mappingTypes": [
-                {
-                  "name": "value to text",
-                  "value": 1
-                },
-                {
-                  "name": "range to text",
-                  "value": 2
-                }
-              ],
-              "maxDataPoints": 100,
-              "nullPointMode": "connected",
-              "nullText": null,
-              "postfix": "",
-              "postfixFontSize": "50%",
-              "prefix": "",
-              "prefixFontSize": "50%",
-              "rangeMaps": [
-                {
-                  "from": "null",
-                  "text": "N/A",
-                  "to": "null"
-                }
-              ],
-              "span": 1,
-              "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-              },
-              "targets": [
-                {
-                  "expr": "count(up{job=\"scylla\"})",
-                  "intervalFactor": 2,
-                  "legendFormat": "",
-                  "refId": "A",
-                  "step": 240
-                }
-              ],
-              "thresholds": "",
-              "title": "Total Nodes",
-              "transparent": true,
-              "type": "singlestat",
-              "valueFontSize": "150%",
-              "valueMaps": [
-                {
-                  "op": "=",
-                  "text": "N/A",
-                  "value": "null"
-                }
-              ],
-              "valueName": "current"
-            },
-            {
-              "cacheTimeout": null,
-              "colorBackground": false,
-              "colorValue": true,
-              "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(250, 113, 0, 0.89)",
-                "rgba(255, 0, 0, 0.9)"
-              ],
-              "datasource": "prometheus",
-              "editable": true,
-              "error": false,
-              "format": "none",
-              "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": false
-              },
-              "id": 33,
-              "interval": null,
-              "isNew": true,
-              "links": [],
-              "mappingType": 1,
-              "mappingTypes": [
-                {
-                  "name": "value to text",
-                  "value": 1
-                },
-                {
-                  "name": "range to text",
-                  "value": 2
-                }
-              ],
-              "maxDataPoints": 100,
-              "nullPointMode": "connected",
-              "nullText": null,
-              "postfix": "",
-              "postfixFontSize": "50%",
-              "prefix": "",
-              "prefixFontSize": "50%",
-              "rangeMaps": [
-                {
-                  "from": "null",
-                  "text": "N/A",
-                  "to": "null"
-                }
-              ],
-              "span": 1,
-              "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-              },
-              "targets": [
-                {
-                  "expr": "count(up{job=\"scylla\"})-count(seastar_memory{metric=\"free\",shard=\"0\",type=\"total_operations\"})",
-                  "intervalFactor": 1,
-                  "refId": "A",
-                  "step": 120
-                }
-              ],
-              "thresholds": "1,2",
-              "title": "Dead Nodes",
-              "transparent": true,
-              "type": "singlestat",
-              "valueFontSize": "150%",
-              "valueMaps": [
-                {
-                  "op": "=",
-                  "text": "N/A",
-                  "value": "null"
-                }
-              ],
-              "valueName": "current"
-            },
-            {
-              "content": "##  ",
-              "editable": true,
-              "error": false,
-              "id": 39,
-              "isNew": true,
-              "links": [],
-              "mode": "markdown",
-              "span": 3,
-              "style": {},
-              "title": "",
-              "transparent": true,
-              "type": "text"
-            },
-            {
-              "aliasColors": {
-                "{}": "#584477"
-              },
-              "bars": true,
-              "datasource": "prometheus",
-              "editable": true,
-              "error": false,
-              "fill": 0,
-              "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-              },
-              "id": 36,
-              "isNew": true,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-              },
-              "lines": false,
-              "linewidth": 2,
-              "links": [],
-              "nullPointMode": "connected",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [
-                {}
-              ],
-              "span": 5,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "sum(irate(seastar_transport{type=\"total_requests\", metric=\"requests_served\"}[30s])) + sum(irate(seastar_thrift{type=\"total_requests\", metric=\"served\"}[30s]))",
-                  "intervalFactor": 2,
-                  "refId": "A",
-                  "step": 30
-                }
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Total Requests",
-              "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-              },
-              "transparent": false,
-              "type": "graph",
-              "xaxis": {
-                "show": true
-              },
-              "yaxes": [
-                {
-                  "format": "short",
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ]
-            },
-            {
-              "editable": true,
-              "error": false,
-              "headings": false,
-              "id": 30,
-              "isNew": true,
-              "limit": 10,
-              "links": [],
-              "query": "",
-              "recent": false,
-              "search": false,
-              "span": 2,
-              "starred": true,
-              "tags": [],
-              "title": "Dashboards",
-              "type": "dashlist"
-            }
-          ],
-          "title": "New row"
-        },
-        {
-          "collapse": false,
-          "editable": true,
-          "height": "250px",
-          "panels": [
-            {
-              "aliasColors": {},
-              "bars": false,
-              "datasource": "prometheus",
-              "editable": true,
-              "error": false,
-              "fill": 0,
-              "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-              },
-              "id": 12,
-              "isNew": true,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 2,
-              "links": [],
-              "nullPointMode": "connected",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [
-                {}
-              ],
-              "span": 5,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "avg(seastar_reactor{type=\"gauge\", metric=\"load\"} ) by (instance)",
-                  "intervalFactor": 2,
-                  "refId": "A",
-                  "step": 30
-                }
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Load per Server",
-              "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-              },
-              "transparent": false,
-              "type": "graph",
-              "xaxis": {
-                "show": true
-              },
-              "yaxes": [
-                {
-                  "format": "short",
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ]
-            },
-            {
-              "aliasColors": {},
-              "bars": false,
-              "datasource": "prometheus",
-              "editable": true,
-              "error": false,
-              "fill": 0,
-              "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-              },
-              "id": 3,
-              "isNew": true,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 2,
-              "links": [],
-              "nullPointMode": "connected",
-              "percentage": false,
-              "pointradius": 1,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "span": 5,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "sum(irate(seastar_transport{type=\"total_requests\", metric=\"requests_served\"}[30s])) by (instance) + sum(irate(seastar_thrift{type=\"total_requests\", metric=\"served\"}[30s])) by (instance)",
-                  "intervalFactor": 2,
-                  "metric": "",
-                  "refId": "A",
-                  "step": 30
-                }
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Requests Served per Server",
-              "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-              },
-              "type": "graph",
-              "xaxis": {
-                "show": true
-              },
-              "yaxes": [
-                {
-                  "format": "short",
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ]
-            },
-            {
-              "aliasColors": {},
-              "cacheTimeout": null,
-              "datasource": "prometheus",
-              "editable": true,
-              "error": false,
-              "fontSize": "80%",
-              "format": "short",
-              "id": 40,
-              "interval": null,
-              "isNew": true,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-              },
-              "legendType": "rightSide",
-              "links": [],
-              "maxDataPoints": 3,
-              "nullPointMode": "connected",
-              "nullText": null,
-              "pieType": "pie",
-              "span": 2,
-              "strokeWidth": 1,
-              "targets": [
-                {
-                  "expr": "sum(node_filesystem_files_free{mountpoint=\"/var/lib/scylla\"})/1000000000",
-                  "intervalFactor": 2,
-                  "metric": "",
-                  "refId": "A",
-                  "step": 7200
-                },
-                {
-                  "expr": "(sum(node_filesystem_size{mountpoint=\"/var/lib/scylla\"})-sum(node_filesystem_files_free{mountpoint=\"/var/lib/scylla\"}))/1000000000",
-                  "intervalFactor": 2,
-                  "refId": "B",
-                  "step": 7200
-                }
-              ],
-              "title": "Total Storage",
-              "type": "grafana-piechart-panel",
-              "valueName": "current"
-            }
-          ],
-          "title": "New row"
-        },
-        {
-          "collapse": false,
-          "editable": true,
-          "height": "25px",
-          "panels": [
-            {
-              "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Disk Activity</h1>",
-              "editable": true,
-              "error": false,
-              "id": 28,
-              "isNew": true,
-              "links": [],
-              "mode": "html",
-              "span": 12,
-              "style": {},
-              "title": "",
-              "transparent": true,
-              "type": "text"
-            }
-          ],
-          "title": "New row"
-        },
-        {
-          "collapse": false,
-          "editable": true,
-          "height": "250px",
-          "panels": [
-            {
-              "aliasColors": {},
-              "bars": false,
-              "datasource": "prometheus",
-              "editable": true,
-              "error": false,
-              "fill": 1,
-              "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-              },
-              "id": 19,
-              "isNew": true,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 2,
-              "links": [],
-              "nullPointMode": "connected",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "span": 6,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "irate(node_disk_writes_completed{device=\"$monitor_disk\"}[30s])",
-                  "intervalFactor": 2,
-                  "legendFormat": "",
-                  "metric": "",
-                  "refId": "A",
-                  "step": 20
-                }
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Disk Writes per Server per Second",
-              "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-              },
-              "type": "graph",
-              "xaxis": {
-                "show": true
-              },
-              "yaxes": [
-                {
-                  "format": "short",
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ]
-            },
-            {
-              "aliasColors": {},
-              "bars": false,
-              "datasource": "prometheus",
-              "editable": true,
-              "error": false,
-              "fill": 1,
-              "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-              },
-              "id": 20,
-              "isNew": true,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 2,
-              "links": [],
-              "nullPointMode": "connected",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "span": 6,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "irate(node_disk_reads_completed{device=\"$monitor_disk\"}[30s])",
-                  "intervalFactor": 2,
-                  "refId": "A",
-                  "step": 20
-                }
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Disk Reads per Server per Second",
-              "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-              },
-              "type": "graph",
-              "xaxis": {
-                "show": true
-              },
-              "yaxes": [
-                {
-                  "format": "short",
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ]
-            }
-          ],
-          "title": "New row"
-        },
-        {
-          "collapse": false,
-          "editable": true,
-          "height": "250px",
-          "panels": [
-            {
-              "aliasColors": {},
-              "bars": false,
-              "datasource": "prometheus",
-              "editable": true,
-              "error": false,
-              "fill": 1,
-              "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-              },
-              "id": 22,
-              "isNew": true,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 2,
-              "links": [],
-              "nullPointMode": "connected",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "span": 6,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "irate(node_disk_bytes_written{device=\"$monitor_disk\"}[30s])",
-                  "intervalFactor": 2,
-                  "metric": "",
-                  "refId": "A",
-                  "step": 20
-                }
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Disk Writes Bps per Server",
-              "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-              },
-              "type": "graph",
-              "xaxis": {
-                "show": true
-              },
-              "yaxes": [
-                {
-                  "format": "Bps",
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ]
-            },
-            {
-              "aliasColors": {},
-              "bars": false,
-              "datasource": "prometheus",
-              "editable": true,
-              "error": false,
-              "fill": 1,
-              "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-              },
-              "id": 23,
-              "isNew": true,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 2,
-              "links": [],
-              "nullPointMode": "connected",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "span": 6,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "irate(node_disk_bytes_read{device=\"$monitor_disk\"}[30s])",
-                  "intervalFactor": 2,
-                  "refId": "A",
-                  "step": 20
-                }
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Disk Read Bps per Server",
-              "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-              },
-              "type": "graph",
-              "xaxis": {
-                "show": true
-              },
-              "yaxes": [
-                {
-                  "format": "Bps",
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ]
-            }
-          ],
-          "title": "New row"
-        },
-        {
-          "collapse": false,
-          "editable": true,
-          "height": "25px",
-          "panels": [
-            {
-              "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue</h1>",
-              "editable": true,
-              "error": false,
-              "id": 42,
-              "isNew": true,
-              "links": [],
-              "mode": "html",
-              "span": 12,
-              "style": {},
-              "title": "",
-              "transparent": true,
-              "type": "text"
-            }
-          ],
-          "title": "New row"
-        },
-        {
-          "collapse": false,
-          "editable": true,
-          "height": "250px",
-          "panels": [
-            {
-              "aliasColors": {},
-              "bars": false,
-              "datasource": "prometheus",
-              "decimals": 0,
-              "editable": true,
-              "error": false,
-              "fill": 0,
-              "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-              },
-              "id": 44,
-              "isNew": true,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 2,
-              "links": [],
-              "nullPointMode": "connected",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "span": 4,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "1000000*max(seastar_io_queue{type=\"delay\", metric=~\"compaction.*\"}) by (instance)",
-                  "intervalFactor": 2,
-                  "metric": "seastar_io_queue_delay",
-                  "refId": "A",
-                  "step": 30
-                }
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Compactions I/O Queue delay",
-              "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-              },
-              "type": "graph",
-              "xaxis": {
-                "show": true
-              },
-              "yaxes": [
-                {
-                  "format": "µs",
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ]
-            },
-            {
-              "aliasColors": {},
-              "bars": false,
-              "datasource": "prometheus",
-              "decimals": 0,
-              "editable": true,
-              "error": false,
-              "fill": 0,
-              "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-              },
-              "id": 45,
-              "isNew": true,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 2,
-              "links": [],
-              "nullPointMode": "connected",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "span": 4,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "sum(irate(seastar_io_queue{type=\"derive\", metric=~\"compaction.*\"}[30s])) by (instance)",
-                  "intervalFactor": 2,
-                  "metric": "seastar_io_queue_delay",
-                  "refId": "A",
-                  "step": 30
-                }
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Compactions I/O Queue bandwidth",
-              "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-              },
-              "type": "graph",
-              "xaxis": {
-                "show": true
-              },
-              "yaxes": [
-                {
-                  "format": "Bps",
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ]
-            },
-            {
-              "aliasColors": {},
-              "bars": false,
-              "datasource": "prometheus",
-              "decimals": 0,
-              "editable": true,
-              "error": false,
-              "fill": 0,
-              "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-              },
-              "id": 46,
-              "isNew": true,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 2,
-              "links": [],
-              "nullPointMode": "connected",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "span": 4,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "sum(irate(seastar_io_queue{type=\"total_operations\", metric=~\"compaction.*\"}[30s])) by (instance)",
-                  "intervalFactor": 2,
-                  "metric": "seastar_io_queue_delay",
-                  "refId": "A",
-                  "step": 30
-                }
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Compactions I/O Queue IOPS",
-              "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-              },
-              "type": "graph",
-              "xaxis": {
-                "show": true
-              },
-              "yaxes": [
-                {
-                  "format": "iops",
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ]
-            },
-            {
-              "aliasColors": {},
-              "bars": false,
-              "datasource": "prometheus",
-              "decimals": 0,
-              "editable": true,
-              "error": false,
-              "fill": 0,
-              "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-              },
-              "id": 47,
-              "isNew": true,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 2,
-              "links": [],
-              "nullPointMode": "connected",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "span": 4,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "1000000*max(seastar_io_queue{type=\"delay\", metric=~\"query.*\"}) by (instance)",
-                  "intervalFactor": 2,
-                  "metric": "seastar_io_queue_delay",
-                  "refId": "A",
-                  "step": 30
-                }
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Query I/O Queue delay",
-              "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-              },
-              "type": "graph",
-              "xaxis": {
-                "show": true
-              },
-              "yaxes": [
-                {
-                  "format": "µs",
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ]
-            },
-            {
-              "aliasColors": {},
-              "bars": false,
-              "datasource": "prometheus",
-              "decimals": 0,
-              "editable": true,
-              "error": false,
-              "fill": 0,
-              "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-              },
-              "id": 48,
-              "isNew": true,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 2,
-              "links": [],
-              "nullPointMode": "connected",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "span": 4,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "sum(irate(seastar_io_queue{type=\"derive\", metric=~\"query.*\"}[30s])) by (instance)",
-                  "intervalFactor": 2,
-                  "metric": "seastar_io_queue_delay",
-                  "refId": "A",
-                  "step": 30
-                }
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Query I/O Queue bandwidth",
-              "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-              },
-              "type": "graph",
-              "xaxis": {
-                "show": true
-              },
-              "yaxes": [
-                {
-                  "format": "Bps",
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ]
-            },
-            {
-              "aliasColors": {},
-              "bars": false,
-              "datasource": "prometheus",
-              "decimals": 0,
-              "editable": true,
-              "error": false,
-              "fill": 0,
-              "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-              },
-              "id": 49,
-              "isNew": true,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 2,
-              "links": [],
-              "nullPointMode": "connected",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "span": 4,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "sum(irate(seastar_io_queue{type=\"total_operations\", metric=~\"query.*\"}[30s])) by (instance)",
-                  "intervalFactor": 2,
-                  "metric": "seastar_io_queue_delay",
-                  "refId": "A",
-                  "step": 30
-                }
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Query I/O Queue IOPS",
-              "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-              },
-              "type": "graph",
-              "xaxis": {
-                "show": true
-              },
-              "yaxes": [
-                {
-                  "format": "iops",
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ]
-            },
-            {
-              "aliasColors": {},
-              "bars": false,
-              "datasource": "prometheus",
-              "decimals": 0,
-              "editable": true,
-              "error": false,
-              "fill": 0,
-              "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)",
-                "thresholdLine": false
-              },
-              "id": 50,
-              "isNew": true,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 2,
-              "links": [],
-              "nullPointMode": "connected",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "span": 4,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "1000000*max(seastar_io_queue{type=\"delay\", metric=~\"commitlog.*\"}) by (instance)",
-                  "intervalFactor": 2,
-                  "metric": "seastar_io_queue_delay",
-                  "refId": "A",
-                  "step": 30
-                }
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Commitlog I/O Queue delay",
-              "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-              },
-              "type": "graph",
-              "xaxis": {
-                "show": true
-              },
-              "yaxes": [
-                {
-                  "format": "µs",
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ]
-            },
-            {
-              "aliasColors": {},
-              "bars": false,
-              "datasource": "prometheus",
-              "decimals": 0,
-              "editable": true,
-              "error": false,
-              "fill": 0,
-              "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-              },
-              "id": 51,
-              "isNew": true,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 2,
-              "links": [],
-              "nullPointMode": "connected",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "span": 4,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "sum(irate(seastar_io_queue{type=\"derive\", metric=~\"commitlog.*\"}[30s])) by (instance)",
-                  "intervalFactor": 2,
-                  "metric": "seastar_io_queue_delay",
-                  "refId": "A",
-                  "step": 30
-                }
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Commitlog I/O Queue bandwidth",
-              "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-              },
-              "type": "graph",
-              "xaxis": {
-                "show": true
-              },
-              "yaxes": [
-                {
-                  "format": "Bps",
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ]
-            },
-            {
-              "aliasColors": {},
-              "bars": false,
-              "datasource": "prometheus",
-              "decimals": 0,
-              "editable": true,
-              "error": false,
-              "fill": 0,
-              "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-              },
-              "id": 52,
-              "isNew": true,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 2,
-              "links": [],
-              "nullPointMode": "connected",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "span": 4,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "sum(irate(seastar_io_queue{type=\"total_operations\", metric=~\"commitlog.*\"}[30s])) by (instance)",
-                  "intervalFactor": 2,
-                  "metric": "seastar_io_queue_delay",
-                  "refId": "A",
-                  "step": 30
-                }
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Commitlog I/O Queue IOPS",
-              "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-              },
-              "type": "graph",
-              "xaxis": {
-                "show": true
-              },
-              "yaxes": [
-                {
-                  "format": "iops",
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ]
-            },
-            {
-              "aliasColors": {},
-              "bars": false,
-              "datasource": "prometheus",
-              "decimals": 0,
-              "editable": true,
-              "error": false,
-              "fill": 0,
-              "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-              },
-              "id": 53,
-              "isNew": true,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 2,
-              "links": [],
-              "nullPointMode": "connected",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "span": 4,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "1000000*max(seastar_io_queue{type=\"delay\", metric=~\"memtable.*\"}) by (instance)",
-                  "intervalFactor": 2,
-                  "metric": "seastar_io_queue_delay",
-                  "refId": "A",
-                  "step": 30
-                }
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Memtable Flush I/O Queue delay",
-              "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-              },
-              "type": "graph",
-              "xaxis": {
-                "show": true
-              },
-              "yaxes": [
-                {
-                  "format": "µs",
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ]
-            },
-            {
-              "aliasColors": {},
-              "bars": false,
-              "datasource": "prometheus",
-              "decimals": 0,
-              "editable": true,
-              "error": false,
-              "fill": 0,
-              "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-              },
-              "id": 54,
-              "isNew": true,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 2,
-              "links": [],
-              "nullPointMode": "connected",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "span": 4,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "sum(irate(seastar_io_queue{type=\"derive\", metric=~\"memtable.*\"}[30s])) by (instance)",
-                  "intervalFactor": 2,
-                  "metric": "seastar_io_queue_delay",
-                  "refId": "A",
-                  "step": 30
-                }
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Memtable Flush I/O Queue bandwidth",
-              "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-              },
-              "type": "graph",
-              "xaxis": {
-                "show": true
-              },
-              "yaxes": [
-                {
-                  "format": "Bps",
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ]
-            },
-            {
-              "aliasColors": {},
-              "bars": false,
-              "datasource": "prometheus",
-              "decimals": 0,
-              "editable": true,
-              "error": false,
-              "fill": 0,
-              "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-              },
-              "id": 55,
-              "isNew": true,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 2,
-              "links": [],
-              "nullPointMode": "connected",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "span": 4,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "sum(irate(seastar_io_queue{type=\"total_operations\", metric=~\"memtable.*\"}[30s])) by (instance)",
-                  "intervalFactor": 2,
-                  "metric": "seastar_io_queue_delay",
-                  "refId": "A",
-                  "step": 30
-                }
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Memtable Flush I/O Queue IOPS",
-              "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-              },
-              "type": "graph",
-              "xaxis": {
-                "show": true
-              },
-              "yaxes": [
-                {
-                  "format": "iops",
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ]
-            },
-            {
-              "aliasColors": {},
-              "bars": false,
-              "datasource": "prometheus",
-              "decimals": 0,
-              "editable": true,
-              "error": false,
-              "fill": 0,
-              "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-              },
-              "id": 56,
-              "isNew": true,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 2,
-              "links": [],
-              "nullPointMode": "connected",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "span": 4,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "1000000*max(seastar_io_queue{type=\"delay\", metric=~\"streaming_read.*\"}) by (instance)",
-                  "intervalFactor": 2,
-                  "metric": "seastar_io_queue_delay",
-                  "refId": "A",
-                  "step": 30
-                }
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Streaming Reads I/O Queue delay",
-              "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-              },
-              "type": "graph",
-              "xaxis": {
-                "show": true
-              },
-              "yaxes": [
-                {
-                  "format": "µs",
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ]
-            },
-            {
-              "aliasColors": {},
-              "bars": false,
-              "datasource": "prometheus",
-              "decimals": 0,
-              "editable": true,
-              "error": false,
-              "fill": 0,
-              "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-              },
-              "id": 57,
-              "isNew": true,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 2,
-              "links": [],
-              "nullPointMode": "connected",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "span": 4,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "sum(irate(seastar_io_queue{type=\"derive\", metric=~\"streaming_read.*\"}[30s])) by (instance)",
-                  "intervalFactor": 2,
-                  "metric": "seastar_io_queue_delay",
-                  "refId": "A",
-                  "step": 30
-                }
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Streaming Reads I/O Queue bandwidth",
-              "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-              },
-              "type": "graph",
-              "xaxis": {
-                "show": true
-              },
-              "yaxes": [
-                {
-                  "format": "Bps",
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ]
-            },
-            {
-              "aliasColors": {},
-              "bars": false,
-              "datasource": "prometheus",
-              "decimals": 0,
-              "editable": true,
-              "error": false,
-              "fill": 0,
-              "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-              },
-              "id": 58,
-              "isNew": true,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 2,
-              "links": [],
-              "nullPointMode": "connected",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "span": 4,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "sum(irate(seastar_io_queue{type=\"total_operations\", metric=~\"streaming_read.*\"}[30s])) by (instance)",
-                  "intervalFactor": 2,
-                  "metric": "seastar_io_queue_delay",
-                  "refId": "A",
-                  "step": 30
-                }
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Streaming Reads I/O Queue IOPS",
-              "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-              },
-              "type": "graph",
-              "xaxis": {
-                "show": true
-              },
-              "yaxes": [
-                {
-                  "format": "iops",
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ]
-            },
-            {
-              "aliasColors": {},
-              "bars": false,
-              "datasource": "prometheus",
-              "decimals": 0,
-              "editable": true,
-              "error": false,
-              "fill": 0,
-              "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-              },
-              "id": 59,
-              "isNew": true,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 2,
-              "links": [],
-              "nullPointMode": "connected",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "span": 4,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "1000000*max(seastar_io_queue{type=\"delay\", metric=~\"streaming_write.*\"}) by (instance)",
-                  "intervalFactor": 2,
-                  "metric": "seastar_io_queue_delay",
-                  "refId": "A",
-                  "step": 30
-                }
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Streaming Writes I/O Queue delay",
-              "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-              },
-              "type": "graph",
-              "xaxis": {
-                "show": true
-              },
-              "yaxes": [
-                {
-                  "format": "µs",
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ]
-            },
-            {
-              "aliasColors": {},
-              "bars": false,
-              "datasource": "prometheus",
-              "decimals": 0,
-              "editable": true,
-              "error": false,
-              "fill": 0,
-              "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-              },
-              "id": 60,
-              "isNew": true,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 2,
-              "links": [],
-              "nullPointMode": "connected",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "span": 4,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "sum(irate(seastar_io_queue{type=\"derive\", metric=~\"streaming_write.*\"}[30s])) by (instance)",
-                  "intervalFactor": 2,
-                  "metric": "seastar_io_queue_delay",
-                  "refId": "A",
-                  "step": 30
-                }
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Streaming Writes I/O Queue bandwidth",
-              "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-              },
-              "type": "graph",
-              "xaxis": {
-                "show": true
-              },
-              "yaxes": [
-                {
-                  "format": "Bps",
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ]
-            },
-            {
-              "aliasColors": {},
-              "bars": false,
-              "datasource": "prometheus",
-              "decimals": 0,
-              "editable": true,
-              "error": false,
-              "fill": 0,
-              "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-              },
-              "id": 61,
-              "isNew": true,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 2,
-              "links": [],
-              "nullPointMode": "connected",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "span": 4,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "sum(irate(seastar_io_queue{type=\"total_operations\", metric=~\"streaming_write.*\"}[30s])) by (instance)",
-                  "intervalFactor": 2,
-                  "metric": "seastar_io_queue_delay",
-                  "refId": "A",
-                  "step": 30
-                }
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Streaming Writes I/O Queue IOPS",
-              "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-              },
-              "type": "graph",
-              "xaxis": {
-                "show": true
-              },
-              "yaxes": [
-                {
-                  "format": "iops",
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ]
-            }
-          ],
-          "title": "New row"
-        }
-      ],
-      "time": {
-        "from": "now-3h",
-        "to": "now"
-      },
-      "timepicker": {
-        "now": true,
-        "refresh_intervals": [
-          "5s",
-          "10s",
-          "30s",
-          "1m",
-          "5m",
-          "15m",
-          "30m",
-          "1h",
-          "2h",
-          "1d"
+        "id": null,
+        "title": "Scylla Per-Server Disk I/O",
+        "tags": [
+
         ],
-        "time_options": [
-          "5m",
-          "15m",
-          "1h",
-          "6h",
-          "12h",
-          "24h",
-          "2d",
-          "7d",
-          "30d"
-        ]
-      },
-      "templating": {
-        "list": [
-	     {
-	        "type": "query",
-	        "datasource": "prometheus",
-	        "refresh": 1,
-	        "name": "monitor_disk",
-	        "hide": 0,
-	        "options": [],
-	        "includeAll": false,
-	        "multi": false,
-	        "regex": "/.*device=\"([^\\\"]*)\".*/",
-	        "current": {},
-	        "query": "node_disk_bytes_read"
-	      }
-        ]
-      },
-      "annotations": {
-        "list": []
-      },
-      "refresh": "5s",
-      "schemaVersion": 12,
-      "version": 0,
-      "links": [],
-      "gnetId": null
+        "style": "dark",
+        "timezone": "browser",
+        "editable": true,
+        "hideControls": true,
+        "sharedCrosshair": true,
+        "rows": [
+            {
+                "collapse": false,
+                "editable": true,
+                "height": "25px",
+                "panels": [
+                    {
+                        "content": "<img src=\"http://www.scylladb.com/img/logo.svg\" height=\"70\">\n<hr style=\"border-top: 3px solid #5780c1;\">",
+                        "editable": true,
+                        "error": false,
+                        "id": 41,
+                        "isNew": true,
+                        "links": [
+
+                        ],
+                        "mode": "html",
+                        "span": 12,
+                        "title": "",
+                        "transparent": true,
+                        "type": "text"
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "collapse": false,
+                "editable": true,
+                "height": "150px",
+                "panels": [
+                    {
+                        "cacheTimeout": null,
+                        "colorBackground": false,
+                        "colorValue": false,
+                        "colors": [
+                            "rgba(245, 54, 54, 0.9)",
+                            "rgba(237, 129, 40, 0.89)",
+                            "rgba(50, 172, 45, 0.97)"
+                        ],
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "format": "none",
+                        "gauge": {
+                            "maxValue": 100,
+                            "minValue": 0,
+                            "show": false,
+                            "thresholdLabels": false,
+                            "thresholdMarkers": true
+                        },
+                        "id": 38,
+                        "interval": null,
+                        "isNew": true,
+                        "links": [
+
+                        ],
+                        "mappingType": 1,
+                        "mappingTypes": [
+                            {
+                                "name": "value to text",
+                                "value": 1
+                            },
+                            {
+                                "name": "range to text",
+                                "value": 2
+                            }
+                        ],
+                        "maxDataPoints": 100,
+                        "nullPointMode": "connected",
+                        "nullText": null,
+                        "postfix": "",
+                        "postfixFontSize": "50%",
+                        "prefix": "",
+                        "prefixFontSize": "50%",
+                        "rangeMaps": [
+                            {
+                                "from": "null",
+                                "text": "N/A",
+                                "to": "null"
+                            }
+                        ],
+                        "span": 1,
+                        "sparkline": {
+                            "fillColor": "rgba(31, 118, 189, 0.18)",
+                            "full": false,
+                            "lineColor": "rgb(31, 120, 193)",
+                            "show": false
+                        },
+                        "targets": [
+                            {
+                                "expr": "count(up{job=\"scylla\"})",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 240
+                            }
+                        ],
+                        "thresholds": "",
+                        "title": "Total Nodes",
+                        "transparent": true,
+                        "type": "singlestat",
+                        "valueFontSize": "150%",
+                        "valueMaps": [
+                            {
+                                "op": "=",
+                                "text": "N/A",
+                                "value": "null"
+                            }
+                        ],
+                        "valueName": "current"
+                    },
+                    {
+                        "cacheTimeout": null,
+                        "colorBackground": false,
+                        "colorValue": true,
+                        "colors": [
+                            "rgba(50, 172, 45, 0.97)",
+                            "rgba(250, 113, 0, 0.89)",
+                            "rgba(255, 0, 0, 0.9)"
+                        ],
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "format": "none",
+                        "gauge": {
+                            "maxValue": 100,
+                            "minValue": 0,
+                            "show": false,
+                            "thresholdLabels": false,
+                            "thresholdMarkers": false
+                        },
+                        "id": 33,
+                        "interval": null,
+                        "isNew": true,
+                        "links": [
+
+                        ],
+                        "mappingType": 1,
+                        "mappingTypes": [
+                            {
+                                "name": "value to text",
+                                "value": 1
+                            },
+                            {
+                                "name": "range to text",
+                                "value": 2
+                            }
+                        ],
+                        "maxDataPoints": 100,
+                        "nullPointMode": "connected",
+                        "nullText": null,
+                        "postfix": "",
+                        "postfixFontSize": "50%",
+                        "prefix": "",
+                        "prefixFontSize": "50%",
+                        "rangeMaps": [
+                            {
+                                "from": "null",
+                                "text": "N/A",
+                                "to": "null"
+                            }
+                        ],
+                        "span": 1,
+                        "sparkline": {
+                            "fillColor": "rgba(31, 118, 189, 0.18)",
+                            "full": false,
+                            "lineColor": "rgb(31, 120, 193)",
+                            "show": false
+                        },
+                        "targets": [
+                            {
+                                "expr": "count(up{job=\"scylla\"})-count(seastar_memory{metric=\"free\",shard=\"0\",type=\"total_operations\"})",
+                                "intervalFactor": 1,
+                                "refId": "A",
+                                "step": 120
+                            }
+                        ],
+                        "thresholds": "1,2",
+                        "title": "Dead Nodes",
+                        "transparent": true,
+                        "type": "singlestat",
+                        "valueFontSize": "150%",
+                        "valueMaps": [
+                            {
+                                "op": "=",
+                                "text": "N/A",
+                                "value": "null"
+                            }
+                        ],
+                        "valueName": "current"
+                    },
+                    {
+                        "content": "##  ",
+                        "editable": true,
+                        "error": false,
+                        "id": 39,
+                        "isNew": true,
+                        "links": [
+
+                        ],
+                        "mode": "markdown",
+                        "span": 3,
+                        "style": {
+
+                        },
+                        "title": "",
+                        "transparent": true,
+                        "type": "text"
+                    },
+                    {
+                        "aliasColors": {
+                            "{}": "#584477"
+                        },
+                        "bars": true,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 0,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 36,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": false,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+                            {
+
+                            }
+                        ],
+                        "span": 5,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(seastar_transport{type=\"total_requests\", metric=\"requests_served\"}[30s])) + sum(irate(seastar_thrift{type=\"total_requests\", metric=\"served\"}[30s]))",
+                                "intervalFactor": 1,
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Total Requests",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "transparent": false,
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "editable": true,
+                        "error": false,
+                        "headings": false,
+                        "id": 30,
+                        "isNew": true,
+                        "limit": 10,
+                        "links": [
+
+                        ],
+                        "query": "",
+                        "recent": false,
+                        "search": false,
+                        "span": 2,
+                        "starred": true,
+                        "tags": [
+
+                        ],
+                        "title": "Dashboards",
+                        "type": "dashlist"
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "collapse": false,
+                "editable": true,
+                "height": "250px",
+                "panels": [
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 0,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 12,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+                            {
+
+                            }
+                        ],
+                        "span": 5,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "avg(seastar_reactor{type=\"gauge\", metric=\"load\"} ) by (instance)",
+                                "intervalFactor": 1,
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Load per Server",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "transparent": false,
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 0,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 3,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 1,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 5,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(seastar_transport{type=\"total_requests\", metric=\"requests_served\"}[30s])) by (instance) + sum(irate(seastar_thrift{type=\"total_requests\", metric=\"served\"}[30s])) by (instance)",
+                                "intervalFactor": 1,
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Requests Served per Server",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "cacheTimeout": null,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fontSize": "80%",
+                        "format": "short",
+                        "id": 40,
+                        "interval": null,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "legendType": "rightSide",
+                        "links": [
+
+                        ],
+                        "maxDataPoints": 3,
+                        "nullPointMode": "connected",
+                        "nullText": null,
+                        "pieType": "pie",
+                        "span": 2,
+                        "strokeWidth": 1,
+                        "targets": [
+                            {
+                                "expr": "sum(node_filesystem_files_free{mountpoint=\"/var/lib/scylla\"})/1000000000",
+                                "intervalFactor": 1,
+                                "metric": "",
+                                "refId": "A",
+                                "step": 7200
+                            },
+                            {
+                                "expr": "(sum(node_filesystem_size{mountpoint=\"/var/lib/scylla\"})-sum(node_filesystem_files_free{mountpoint=\"/var/lib/scylla\"}))/1000000000",
+                                "intervalFactor": 1,
+                                "refId": "B",
+                                "step": 7200
+                            }
+                        ],
+                        "title": "Total Storage",
+                        "type": "grafana-piechart-panel",
+                        "valueName": "current"
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "collapse": false,
+                "editable": true,
+                "height": "25px",
+                "panels": [
+                    {
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Disk Activity</h1>",
+                        "editable": true,
+                        "error": false,
+                        "id": 28,
+                        "isNew": true,
+                        "links": [
+
+                        ],
+                        "mode": "html",
+                        "span": 12,
+                        "style": {
+
+                        },
+                        "title": "",
+                        "transparent": true,
+                        "type": "text"
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "collapse": false,
+                "editable": true,
+                "height": "250px",
+                "panels": [
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 19,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 6,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "irate(node_disk_writes_completed{device=\"$monitor_disk\"}[30s])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 20
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Disk Writes per Server per Second",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 20,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 6,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "irate(node_disk_reads_completed{device=\"$monitor_disk\"}[30s])",
+                                "intervalFactor": 1,
+                                "refId": "A",
+                                "step": 20
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Disk Reads per Server per Second",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "collapse": false,
+                "editable": true,
+                "height": "250px",
+                "panels": [
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 22,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 6,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "irate(node_disk_bytes_written{device=\"$monitor_disk\"}[30s])",
+                                "intervalFactor": 1,
+                                "metric": "",
+                                "refId": "A",
+                                "step": 20
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Disk Writes Bps per Server",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "Bps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 23,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 6,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "irate(node_disk_bytes_read{device=\"$monitor_disk\"}[30s])",
+                                "intervalFactor": 1,
+                                "refId": "A",
+                                "step": 20
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Disk Read Bps per Server",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "Bps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "collapse": false,
+                "editable": true,
+                "height": "25px",
+                "panels": [
+                    {
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue</h1>",
+                        "editable": true,
+                        "error": false,
+                        "id": 42,
+                        "isNew": true,
+                        "links": [
+
+                        ],
+                        "mode": "html",
+                        "span": 12,
+                        "style": {
+
+                        },
+                        "title": "",
+                        "transparent": true,
+                        "type": "text"
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "collapse": false,
+                "editable": true,
+                "height": "250px",
+                "panels": [
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "decimals": 0,
+                        "editable": true,
+                        "error": false,
+                        "fill": 0,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 44,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 4,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "1000000*max(seastar_io_queue{type=\"delay\", metric=~\"compaction.*\"}) by (instance)",
+                                "intervalFactor": 1,
+                                "metric": "seastar_io_queue_delay",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Compactions I/O Queue delay",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "µs",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "decimals": 0,
+                        "editable": true,
+                        "error": false,
+                        "fill": 0,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 45,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 4,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(seastar_io_queue{type=\"derive\", metric=~\"compaction.*\"}[30s])) by (instance)",
+                                "intervalFactor": 1,
+                                "metric": "seastar_io_queue_delay",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Compactions I/O Queue bandwidth",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "Bps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "decimals": 0,
+                        "editable": true,
+                        "error": false,
+                        "fill": 0,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 46,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 4,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(seastar_io_queue{type=\"total_operations\", metric=~\"compaction.*\"}[30s])) by (instance)",
+                                "intervalFactor": 1,
+                                "metric": "seastar_io_queue_delay",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Compactions I/O Queue IOPS",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "iops",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "decimals": 0,
+                        "editable": true,
+                        "error": false,
+                        "fill": 0,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 47,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 4,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "1000000*max(seastar_io_queue{type=\"delay\", metric=~\"query.*\"}) by (instance)",
+                                "intervalFactor": 1,
+                                "metric": "seastar_io_queue_delay",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Query I/O Queue delay",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "µs",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "decimals": 0,
+                        "editable": true,
+                        "error": false,
+                        "fill": 0,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 48,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 4,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(seastar_io_queue{type=\"derive\", metric=~\"query.*\"}[30s])) by (instance)",
+                                "intervalFactor": 1,
+                                "metric": "seastar_io_queue_delay",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Query I/O Queue bandwidth",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "Bps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "decimals": 0,
+                        "editable": true,
+                        "error": false,
+                        "fill": 0,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 49,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 4,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(seastar_io_queue{type=\"total_operations\", metric=~\"query.*\"}[30s])) by (instance)",
+                                "intervalFactor": 1,
+                                "metric": "seastar_io_queue_delay",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Query I/O Queue IOPS",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "iops",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "decimals": 0,
+                        "editable": true,
+                        "error": false,
+                        "fill": 0,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)",
+                            "thresholdLine": false
+                        },
+                        "id": 50,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 4,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "1000000*max(seastar_io_queue{type=\"delay\", metric=~\"commitlog.*\"}) by (instance)",
+                                "intervalFactor": 1,
+                                "metric": "seastar_io_queue_delay",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Commitlog I/O Queue delay",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "µs",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "decimals": 0,
+                        "editable": true,
+                        "error": false,
+                        "fill": 0,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 51,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 4,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(seastar_io_queue{type=\"derive\", metric=~\"commitlog.*\"}[30s])) by (instance)",
+                                "intervalFactor": 1,
+                                "metric": "seastar_io_queue_delay",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Commitlog I/O Queue bandwidth",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "Bps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "decimals": 0,
+                        "editable": true,
+                        "error": false,
+                        "fill": 0,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 52,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 4,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(seastar_io_queue{type=\"total_operations\", metric=~\"commitlog.*\"}[30s])) by (instance)",
+                                "intervalFactor": 1,
+                                "metric": "seastar_io_queue_delay",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Commitlog I/O Queue IOPS",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "iops",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "decimals": 0,
+                        "editable": true,
+                        "error": false,
+                        "fill": 0,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 53,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 4,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "1000000*max(seastar_io_queue{type=\"delay\", metric=~\"memtable.*\"}) by (instance)",
+                                "intervalFactor": 1,
+                                "metric": "seastar_io_queue_delay",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Memtable Flush I/O Queue delay",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "µs",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "decimals": 0,
+                        "editable": true,
+                        "error": false,
+                        "fill": 0,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 54,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 4,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(seastar_io_queue{type=\"derive\", metric=~\"memtable.*\"}[30s])) by (instance)",
+                                "intervalFactor": 1,
+                                "metric": "seastar_io_queue_delay",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Memtable Flush I/O Queue bandwidth",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "Bps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "decimals": 0,
+                        "editable": true,
+                        "error": false,
+                        "fill": 0,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 55,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 4,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(seastar_io_queue{type=\"total_operations\", metric=~\"memtable.*\"}[30s])) by (instance)",
+                                "intervalFactor": 1,
+                                "metric": "seastar_io_queue_delay",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Memtable Flush I/O Queue IOPS",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "iops",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "decimals": 0,
+                        "editable": true,
+                        "error": false,
+                        "fill": 0,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 56,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 4,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "1000000*max(seastar_io_queue{type=\"delay\", metric=~\"streaming_read.*\"}) by (instance)",
+                                "intervalFactor": 1,
+                                "metric": "seastar_io_queue_delay",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Streaming Reads I/O Queue delay",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "µs",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "decimals": 0,
+                        "editable": true,
+                        "error": false,
+                        "fill": 0,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 57,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 4,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(seastar_io_queue{type=\"derive\", metric=~\"streaming_read.*\"}[30s])) by (instance)",
+                                "intervalFactor": 1,
+                                "metric": "seastar_io_queue_delay",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Streaming Reads I/O Queue bandwidth",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "Bps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "decimals": 0,
+                        "editable": true,
+                        "error": false,
+                        "fill": 0,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 58,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 4,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(seastar_io_queue{type=\"total_operations\", metric=~\"streaming_read.*\"}[30s])) by (instance)",
+                                "intervalFactor": 1,
+                                "metric": "seastar_io_queue_delay",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Streaming Reads I/O Queue IOPS",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "iops",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "decimals": 0,
+                        "editable": true,
+                        "error": false,
+                        "fill": 0,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 59,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 4,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "1000000*max(seastar_io_queue{type=\"delay\", metric=~\"streaming_write.*\"}) by (instance)",
+                                "intervalFactor": 1,
+                                "metric": "seastar_io_queue_delay",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Streaming Writes I/O Queue delay",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "µs",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "decimals": 0,
+                        "editable": true,
+                        "error": false,
+                        "fill": 0,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 60,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 4,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(seastar_io_queue{type=\"derive\", metric=~\"streaming_write.*\"}[30s])) by (instance)",
+                                "intervalFactor": 1,
+                                "metric": "seastar_io_queue_delay",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Streaming Writes I/O Queue bandwidth",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "Bps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "decimals": 0,
+                        "editable": true,
+                        "error": false,
+                        "fill": 0,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 61,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 4,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(seastar_io_queue{type=\"total_operations\", metric=~\"streaming_write.*\"}[30s])) by (instance)",
+                                "intervalFactor": 1,
+                                "metric": "seastar_io_queue_delay",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Streaming Writes I/O Queue IOPS",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "iops",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "title": "New row"
+            }
+        ],
+        "time": {
+            "from": "now-3h",
+            "to": "now"
+        },
+        "timepicker": {
+            "now": true,
+            "refresh_intervals": [
+                "5s",
+                "10s",
+                "30s",
+                "1m",
+                "5m",
+                "15m",
+                "30m",
+                "1h",
+                "2h",
+                "1d"
+            ],
+            "time_options": [
+                "5m",
+                "15m",
+                "1h",
+                "6h",
+                "12h",
+                "24h",
+                "2d",
+                "7d",
+                "30d"
+            ]
+        },
+        "templating": {
+            "list": [
+                {
+                    "type": "query",
+                    "datasource": "prometheus",
+                    "refresh": 1,
+                    "name": "monitor_disk",
+                    "hide": 0,
+                    "options": [
+
+                    ],
+                    "includeAll": false,
+                    "multi": false,
+                    "regex": "/.*device=\"([^\\\"]*)\".*/",
+                    "current": {
+
+                    },
+                    "query": "node_disk_bytes_read"
+                }
+            ]
+        },
+        "annotations": {
+            "list": [
+
+            ]
+        },
+        "refresh": "5s",
+        "schemaVersion": 12,
+        "version": 0,
+        "links": [
+
+        ],
+        "gnetId": null
     }
 }

--- a/grafana/scylla-dash-per-server.json
+++ b/grafana/scylla-dash-per-server.json
@@ -82,10 +82,10 @@
                         "targets": [
                             {
                                 "expr": "count(up{job=\"scylla\"})",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
-                                "step": 40
+                                "step": 1
                             }
                         ],
                         "thresholds": "",
@@ -165,7 +165,7 @@
                                 "expr": "count(up{job=\"scylla\"})-count(seastar_memory{metric=\"free\",shard=\"0\",type=\"total_operations\"})",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 20
+                                "step": 1
                             }
                         ],
                         "thresholds": "1,2",
@@ -265,9 +265,9 @@
                         "targets": [
                             {
                                 "expr": "sum(irate(seastar_transport{type=\"total_requests\", metric=\"requests_served\"}[30s])) + sum(irate(seastar_thrift{type=\"total_requests\", metric=\"served\"}[30s]))",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 4
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -377,7 +377,7 @@
                         "targets": [
                             {
                                 "expr": "avg(seastar_reactor{type=\"gauge\", metric=\"load\"} ) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
                                 "step": 4
                             }
@@ -458,10 +458,10 @@
                         "targets": [
                             {
                                 "expr": "sum(irate(seastar_transport{type=\"total_requests\", metric=\"requests_served\"}[30s])) by (instance) + sum(irate(seastar_thrift{type=\"total_requests\", metric=\"served\"}[30s])) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "step": 4
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -524,16 +524,16 @@
                         "targets": [
                             {
                                 "expr": "sum(node_filesystem_files_free{mountpoint=\"/var/lib/scylla\"})/1000000000",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "step": 1200
+                                "step": 1
                             },
                             {
                                 "expr": "(sum(node_filesystem_size{mountpoint=\"/var/lib/scylla\"})-sum(node_filesystem_files_free{mountpoint=\"/var/lib/scylla\"}))/1000000000",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "B",
-                                "step": 1200
+                                "step": 1
                             }
                         ],
                         "title": "Total Storage",
@@ -643,9 +643,9 @@
                         "targets": [
                             {
                                 "expr": "sum(seastar_storage_proxy{type=\"queue_length\", metric=\"foreground writes\"}) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 10
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -723,10 +723,10 @@
                         "targets": [
                             {
                                 "expr": "sum(seastar_storage_proxy{type=\"queue_length\", metric=\"reads\"}) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "step": 10
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -804,9 +804,9 @@
                         "targets": [
                             {
                                 "expr": "sum(irate(seastar_storage_proxy{type=\"total_operations\", metric=\"write timeouts\"}[30s])) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 10
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -884,9 +884,9 @@
                         "targets": [
                             {
                                 "expr": "sum(irate(seastar_storage_proxy{type=\"total_operations\", metric=\"write unavailable\"}[30s])) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 10
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -972,9 +972,9 @@
                         "targets": [
                             {
                                 "expr": "sum(seastar_storage_proxy{type=\"queue_length\", metric=\"background writes\"}) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 10
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -1052,9 +1052,9 @@
                         "targets": [
                             {
                                 "expr": "sum(seastar_storage_proxy{type=\"queue_length\", metric=\"background reads\"}) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 10
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -1132,9 +1132,9 @@
                         "targets": [
                             {
                                 "expr": "sum(irate(seastar_storage_proxy{type=\"total_operations\", metric=\"read timeouts\"}[30s])) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 10
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -1212,9 +1212,9 @@
                         "targets": [
                             {
                                 "expr": "sum(irate(seastar_storage_proxy{type=\"total_operations\", metric=\"read unavailable\"}[30s])) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 10
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -1344,11 +1344,11 @@
                         "targets": [
                             {
                                 "expr": "irate(node_disk_writes_completed{device=\"$monitor_disk\"}[30s])",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
-                                "step": 10
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -1426,9 +1426,9 @@
                         "targets": [
                             {
                                 "expr": "irate(node_disk_reads_completed{device=\"$monitor_disk\"}[30s])",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 10
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -1506,9 +1506,9 @@
                         "targets": [
                             {
                                 "expr": "sum(irate(seastar_cache{type=\"total_operations\", metric=\"hits\"}[30s])) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 10
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -1586,9 +1586,9 @@
                         "targets": [
                             {
                                 "expr": "sum(irate(seastar_cache{type=\"total_operations\", metric=\"misses\"}[30s])) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 10
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -1674,10 +1674,10 @@
                         "targets": [
                             {
                                 "expr": "irate(node_disk_bytes_written{device=\"$monitor_disk\"}[30s])",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "step": 10
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -1755,9 +1755,9 @@
                         "targets": [
                             {
                                 "expr": "irate(node_disk_bytes_read{device=\"$monitor_disk\"}[30s])",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 10
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -1791,7 +1791,9 @@
                         ]
                     },
                     {
-                        "aliasColors": {},
+                        "aliasColors": {
+
+                        },
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
@@ -1816,22 +1818,26 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [],
+                        "links": [
+
+                        ],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+
+                        ],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
                                 "expr": "sum(irate(seastar_cache{type=\"total_operations\", metric=\"insertions\"}[30s])) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 40
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -1865,7 +1871,9 @@
                         ]
                     },
                     {
-                        "aliasColors": {},
+                        "aliasColors": {
+
+                        },
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
@@ -1890,22 +1898,26 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [],
+                        "links": [
+
+                        ],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+
+                        ],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
                                 "expr": "sum(irate(seastar_cache{type=\"total_operations\", metric=\"evictions\"}[30s])) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 40
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -1944,7 +1956,9 @@
                         "error": false,
                         "id": 55,
                         "isNew": true,
-                        "links": [],
+                        "links": [
+
+                        ],
                         "mode": "html",
                         "span": 6,
                         "title": "",
@@ -1952,7 +1966,9 @@
                         "type": "text"
                     },
                     {
-                        "aliasColors": {},
+                        "aliasColors": {
+
+                        },
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
@@ -1977,22 +1993,26 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [],
+                        "links": [
+
+                        ],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+
+                        ],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
                                 "expr": "sum(irate(seastar_cache{type=\"total_operations\", metric=\"merges\"}[30s])) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 60
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -2026,7 +2046,9 @@
                         ]
                     },
                     {
-                        "aliasColors": {},
+                        "aliasColors": {
+
+                        },
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
@@ -2051,22 +2073,26 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [],
+                        "links": [
+
+                        ],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+
+                        ],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
                                 "expr": "sum(irate(seastar_cache{type=\"total_operations\", metric=\"removals\"}[30s])) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 60
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -2109,11 +2135,15 @@
                         "id": 52,
                         "mode": "html",
                         "content": "&nbsp;",
-                        "links": [],
+                        "links": [
+
+                        ],
                         "transparent": true
                     },
                     {
-                        "aliasColors": {},
+                        "aliasColors": {
+
+                        },
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
@@ -2138,22 +2168,26 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [],
+                        "links": [
+
+                        ],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+
+                        ],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
                                 "expr": "sum(seastar_cache{type=\"objects\", metric=\"partitions\"}) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 40
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -2187,7 +2221,9 @@
                         ]
                     },
                     {
-                        "aliasColors": {},
+                        "aliasColors": {
+
+                        },
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
@@ -2212,22 +2248,26 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [],
+                        "links": [
+
+                        ],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+
+                        ],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
                                 "expr": "sum(seastar_cache{type=\"bytes\", metric=\"total\"}) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 40
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -2275,10 +2315,14 @@
                         "error": false,
                         "id": 51,
                         "isNew": true,
-                        "links": [],
+                        "links": [
+
+                        ],
                         "mode": "html",
                         "span": 12,
-                        "style": {},
+                        "style": {
+
+                        },
                         "title": "",
                         "transparent": true,
                         "type": "text"
@@ -2292,7 +2336,9 @@
                 "collapse": false,
                 "panels": [
                     {
-                        "aliasColors": {},
+                        "aliasColors": {
+
+                        },
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
@@ -2317,22 +2363,26 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [],
+                        "links": [
+
+                        ],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+
+                        ],
                         "span": 6,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
                                 "expr": "sum(seastar_lsa{type=\"bytes\", metric=\"total_space\"}) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 20
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -2366,7 +2416,9 @@
                         ]
                     },
                     {
-                        "aliasColors": {},
+                        "aliasColors": {
+
+                        },
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
@@ -2391,22 +2443,26 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [],
+                        "links": [
+
+                        ],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+
+                        ],
                         "span": 6,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
                                 "expr": "sum(seastar_lsa{type=\"bytes\", metric=\"non_lsa_used_space\"}) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 20
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -2517,10 +2573,10 @@
                         "targets": [
                             {
                                 "expr": "irate(node_network_receive_packets{device=\"$monitor_network_interface\"}[30s])",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "step": 4
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -2598,10 +2654,10 @@
                         "targets": [
                             {
                                 "expr": "irate(node_network_transmit_packets{device=\"$monitor_network_interface\"}[30s])",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "step": 4
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -2687,10 +2743,10 @@
                         "targets": [
                             {
                                 "expr": "irate(node_network_receive_bytes{device=\"$monitor_network_interface\"}[30s])",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "step": 4
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -2768,10 +2824,10 @@
                         "targets": [
                             {
                                 "expr": "irate(node_network_transmit_bytes{device=\"$monitor_network_interface\"}[30s])",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "step": 4
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -2884,10 +2940,10 @@
                         "targets": [
                             {
                                 "expr": "sum(seastar_compaction_manager{type=\"objects\"}) by (instance)",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "step": 2
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -2955,32 +3011,40 @@
         },
         "templating": {
             "list": [
-		     {
-		        "type": "query",
-		        "datasource": "prometheus",
-		        "refresh": 1,
-		        "name": "monitor_disk",
-		        "hide": 0,
-		        "options": [],
-		        "includeAll": false,
-		        "multi": false,
-		        "regex": "/.*device=\"([^\\\"]*)\".*/",
-		        "current": {},
-		        "query": "node_disk_bytes_read"
-		      },
-		      {
-		        "type": "query",
-		        "datasource": "prometheus",
-		        "refresh": 1,
-		        "name": "monitor_network_interface",
-		        "hide": 0,
-		        "options": [],
-		        "includeAll": false,
-		        "multi": false,
-		        "regex": "/.*device=\"([^\\\"]*)\".*/",
-		        "current": {},
-		        "query": "node_network_receive_packets"
-		      }
+                {
+                    "type": "query",
+                    "datasource": "prometheus",
+                    "refresh": 1,
+                    "name": "monitor_disk",
+                    "hide": 0,
+                    "options": [
+
+                    ],
+                    "includeAll": false,
+                    "multi": false,
+                    "regex": "/.*device=\"([^\\\"]*)\".*/",
+                    "current": {
+
+                    },
+                    "query": "node_disk_bytes_read"
+                },
+                {
+                    "type": "query",
+                    "datasource": "prometheus",
+                    "refresh": 1,
+                    "name": "monitor_network_interface",
+                    "hide": 0,
+                    "options": [
+
+                    ],
+                    "includeAll": false,
+                    "multi": false,
+                    "regex": "/.*device=\"([^\\\"]*)\".*/",
+                    "current": {
+
+                    },
+                    "query": "node_network_receive_packets"
+                }
             ]
         },
         "annotations": {

--- a/grafana/scylla-dash.json
+++ b/grafana/scylla-dash.json
@@ -83,7 +83,7 @@
                         "targets": [
                             {
                                 "expr": "count(up{job=\"scylla\"})",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
                                 "step": 40
@@ -259,7 +259,7 @@
                         "targets": [
                             {
                                 "expr": "avg(seastar_reactor{type=\"gauge\", metric=\"load\"} ) ",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
                                 "step": 4
                             }
@@ -339,7 +339,7 @@
                         "targets": [
                             {
                                 "expr": "sum(irate(seastar_transport{type=\"total_requests\", metric=\"requests_served\"}[30s])) + sum(irate(seastar_thrift{type=\"total_requests\", metric=\"served\"}[30s]))",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
                                 "step": 4
@@ -404,14 +404,14 @@
                         "targets": [
                             {
                                 "expr": "sum(node_filesystem_files_free{mountpoint=\"/var/lib/scylla\"})/1000000000",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
                                 "step": 1200
                             },
                             {
                                 "expr": "(sum(node_filesystem_size{mountpoint=\"/var/lib/scylla\"})-sum(node_filesystem_files_free{mountpoint=\"/var/lib/scylla\"}))/1000000000",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "B",
                                 "step": 1200
                             }
@@ -427,7 +427,7 @@
                 "editable": true,
                 "height": "25px",
                 "panels": [
-		    {
+                    {
                         "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Reads and Writes</h1>",
                         "editable": true,
                         "error": false,
@@ -444,8 +444,8 @@
                         "title": "",
                         "transparent": true,
                         "type": "text"
-		    },
-		    {
+                    },
+                    {
                         "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Timeouts and Errors</h1>",
                         "editable": true,
                         "error": false,
@@ -517,7 +517,7 @@
                         "targets": [
                             {
                                 "expr": "sum(seastar_storage_proxy{type=\"queue_length\", metric=\"foreground writes\"}) ",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
                                 "step": 10
                             }
@@ -596,7 +596,7 @@
                         "targets": [
                             {
                                 "expr": "sum(seastar_storage_proxy{type=\"queue_length\", metric=\"reads\"}) ",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
                                 "step": 10
@@ -676,7 +676,7 @@
                         "targets": [
                             {
                                 "expr": "sum(irate(seastar_storage_proxy{type=\"total_operations\", metric=\"write timeouts\"}[30s])) ",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
                                 "step": 10
                             }
@@ -755,7 +755,7 @@
                         "targets": [
                             {
                                 "expr": "sum(irate(seastar_storage_proxy{type=\"total_operations\", metric=\"write unavailable\"}[30s])) ",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
                                 "step": 10
                             }
@@ -842,7 +842,7 @@
                         "targets": [
                             {
                                 "expr": "sum(seastar_storage_proxy{type=\"queue_length\", metric=\"background writes\"}) ",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
                                 "step": 10
                             }
@@ -921,7 +921,7 @@
                         "targets": [
                             {
                                 "expr": "sum(seastar_storage_proxy{type=\"queue_length\", metric=\"background reads\"}) ",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
                                 "step": 10
                             }
@@ -1000,7 +1000,7 @@
                         "targets": [
                             {
                                 "expr": "sum(irate(seastar_storage_proxy{type=\"total_operations\", metric=\"read timeouts\"}[30s])) ",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
                                 "step": 10
                             }
@@ -1079,7 +1079,7 @@
                         "targets": [
                             {
                                 "expr": "sum(irate(seastar_storage_proxy{type=\"total_operations\", metric=\"read unavailable\"}[30s])) ",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
                                 "step": 10
                             }
@@ -1192,7 +1192,7 @@
                         "targets": [
                             {
                                 "expr": "sum(irate(seastar_cache{type=\"total_operations\", metric=\"hits\"}[30s])) ",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
                                 "step": 10
                             }
@@ -1271,7 +1271,7 @@
                         "targets": [
                             {
                                 "expr": "sum(irate(seastar_cache{type=\"total_operations\", metric=\"misses\"}[30s])) ",
-                                "intervalFactor": 2,
+                                "intervalFactor": 1,
                                 "refId": "A",
                                 "step": 10
                             }


### PR DESCRIPTION
grafana: Use resolution of 1/1

When I set scraping interval to 1s I see graphs "jiggle" in a way that
historical data points change values. After looking closer at this it
turns out that graphs alternate on refreshes between showing samples
from only odd and only even timestamp values. This is because of
intervalFactor being set to 1/2, even when auto-tuned step is small.

Setting "resolution" parameter for queries from 1/2 to 1/1.

The problem may still happen when the step is larger than scrape
period, which can happen when viewing a long time range. There the
solution would be to set the step to 1s. But I am not sure we want to
do this by default, as it would make grafana unusuable when viewing
long time ranges due to amount of data which would need to be fetched.

Refs #45
