### PR TITLE
Add graphs with replica-side counters

### DIFF
--- a/grafana/scylla-dash-per-server.json
+++ b/grafana/scylla-dash-per-server.json
@@ -65,6 +65,17 @@
                         "links": [
 
                         ],
+                        "mappingType": 1,
+                        "mappingTypes": [
+                            {
+                                "name": "value to text",
+                                "value": 1
+                            },
+                            {
+                                "name": "range to text",
+                                "value": 2
+                            }
+                        ],
                         "maxDataPoints": 100,
                         "nullPointMode": "connected",
                         "nullText": null,
@@ -72,6 +83,13 @@
                         "postfixFontSize": "50%",
                         "prefix": "",
                         "prefixFontSize": "50%",
+                        "rangeMaps": [
+                            {
+                                "from": "null",
+                                "text": "N/A",
+                                "to": "null"
+                            }
+                        ],
                         "span": 1,
                         "sparkline": {
                             "fillColor": "rgba(31, 118, 189, 0.18)",
@@ -100,25 +118,7 @@
                                 "value": "null"
                             }
                         ],
-                        "valueName": "current",
-                        "mappingTypes": [
-                            {
-                                "name": "value to text",
-                                "value": 1
-                            },
-                            {
-                                "name": "range to text",
-                                "value": 2
-                            }
-                        ],
-                        "rangeMaps": [
-                            {
-                                "from": "null",
-                                "to": "null",
-                                "text": "N/A"
-                            }
-                        ],
-                        "mappingType": 1
+                        "valueName": "current"
                     },
                     {
                         "cacheTimeout": null,
@@ -146,6 +146,17 @@
                         "links": [
 
                         ],
+                        "mappingType": 1,
+                        "mappingTypes": [
+                            {
+                                "name": "value to text",
+                                "value": 1
+                            },
+                            {
+                                "name": "range to text",
+                                "value": 2
+                            }
+                        ],
                         "maxDataPoints": 100,
                         "nullPointMode": "connected",
                         "nullText": null,
@@ -153,6 +164,13 @@
                         "postfixFontSize": "50%",
                         "prefix": "",
                         "prefixFontSize": "50%",
+                        "rangeMaps": [
+                            {
+                                "from": "null",
+                                "text": "N/A",
+                                "to": "null"
+                            }
+                        ],
                         "span": 1,
                         "sparkline": {
                             "fillColor": "rgba(31, 118, 189, 0.18)",
@@ -180,25 +198,7 @@
                                 "value": "null"
                             }
                         ],
-                        "valueName": "current",
-                        "mappingTypes": [
-                            {
-                                "name": "value to text",
-                                "value": 1
-                            },
-                            {
-                                "name": "range to text",
-                                "value": 2
-                            }
-                        ],
-                        "rangeMaps": [
-                            {
-                                "from": "null",
-                                "to": "null",
-                                "text": "N/A"
-                            }
-                        ],
-                        "mappingType": 1
+                        "valueName": "current"
                     },
                     {
                         "content": "##  ",
@@ -276,8 +276,8 @@
                         "tooltip": {
                             "msResolution": false,
                             "shared": true,
-                            "value_type": "cumulative",
-                            "sort": 0
+                            "sort": 0,
+                            "value_type": "cumulative"
                         },
                         "transparent": false,
                         "type": "graph",
@@ -379,7 +379,7 @@
                                 "expr": "avg(seastar_reactor{type=\"gauge\", metric=\"load\"} ) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 4
+                                "step": 1
                             }
                         ],
                         "timeFrom": null,
@@ -388,8 +388,8 @@
                         "tooltip": {
                             "msResolution": false,
                             "shared": true,
-                            "value_type": "cumulative",
-                            "sort": 0
+                            "sort": 0,
+                            "value_type": "cumulative"
                         },
                         "transparent": false,
                         "type": "graph",
@@ -470,8 +470,8 @@
                         "tooltip": {
                             "msResolution": false,
                             "shared": true,
-                            "value_type": "cumulative",
-                            "sort": 0
+                            "sort": 0,
+                            "value_type": "cumulative"
                         },
                         "type": "graph",
                         "xaxis": {
@@ -495,10 +495,14 @@
                         ]
                     },
                     {
+                        "aliasColors": {
+
+                        },
                         "cacheTimeout": null,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
+                        "fontSize": "80%",
                         "format": "short",
                         "id": 40,
                         "interval": null,
@@ -521,6 +525,7 @@
                         "nullText": null,
                         "pieType": "pie",
                         "span": 2,
+                        "strokeWidth": 1,
                         "targets": [
                             {
                                 "expr": "sum(node_filesystem_files_free{mountpoint=\"/var/lib/scylla\"})/1000000000",
@@ -538,12 +543,11 @@
                         ],
                         "title": "Total Storage",
                         "type": "grafana-piechart-panel",
-                        "aliasColors": {
-
-                        },
                         "valueName": "current",
-                        "strokeWidth": 1,
-                        "fontSize": "80%"
+                        "combine": {
+                            "threshold": 0,
+                            "label": "Others"
+                        }
                     }
                 ],
                 "title": "New row"
@@ -654,8 +658,8 @@
                         "tooltip": {
                             "msResolution": false,
                             "shared": true,
-                            "value_type": "cumulative",
-                            "sort": 0
+                            "sort": 0,
+                            "value_type": "cumulative"
                         },
                         "type": "graph",
                         "xaxis": {
@@ -735,8 +739,8 @@
                         "tooltip": {
                             "msResolution": false,
                             "shared": true,
-                            "value_type": "cumulative",
-                            "sort": 0
+                            "sort": 0,
+                            "value_type": "cumulative"
                         },
                         "type": "graph",
                         "xaxis": {
@@ -815,8 +819,8 @@
                         "tooltip": {
                             "msResolution": false,
                             "shared": true,
-                            "value_type": "cumulative",
-                            "sort": 0
+                            "sort": 0,
+                            "value_type": "cumulative"
                         },
                         "type": "graph",
                         "xaxis": {
@@ -895,8 +899,8 @@
                         "tooltip": {
                             "msResolution": false,
                             "shared": true,
-                            "value_type": "cumulative",
-                            "sort": 0
+                            "sort": 0,
+                            "value_type": "cumulative"
                         },
                         "type": "graph",
                         "xaxis": {
@@ -983,8 +987,8 @@
                         "tooltip": {
                             "msResolution": false,
                             "shared": true,
-                            "value_type": "cumulative",
-                            "sort": 0
+                            "sort": 0,
+                            "value_type": "cumulative"
                         },
                         "type": "graph",
                         "xaxis": {
@@ -1054,7 +1058,7 @@
                                 "expr": "sum(seastar_storage_proxy{type=\"queue_length\", metric=\"background reads\"}) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 1
+                                "step": 4
                             }
                         ],
                         "timeFrom": null,
@@ -1063,8 +1067,8 @@
                         "tooltip": {
                             "msResolution": false,
                             "shared": true,
-                            "value_type": "cumulative",
-                            "sort": 0
+                            "sort": 0,
+                            "value_type": "cumulative"
                         },
                         "type": "graph",
                         "xaxis": {
@@ -1143,8 +1147,8 @@
                         "tooltip": {
                             "msResolution": false,
                             "shared": true,
-                            "value_type": "cumulative",
-                            "sort": 0
+                            "sort": 0,
+                            "value_type": "cumulative"
                         },
                         "type": "graph",
                         "xaxis": {
@@ -1213,8 +1217,9 @@
                             {
                                 "expr": "sum(irate(seastar_storage_proxy{type=\"total_operations\", metric=\"read unavailable\"}[30s])) by (instance)",
                                 "intervalFactor": 1,
+                                "metric": "",
                                 "refId": "A",
-                                "step": 1
+                                "step": 4
                             }
                         ],
                         "timeFrom": null,
@@ -1223,8 +1228,8 @@
                         "tooltip": {
                             "msResolution": false,
                             "shared": true,
-                            "value_type": "cumulative",
-                            "sort": 0
+                            "sort": 0,
+                            "value_type": "cumulative"
                         },
                         "type": "graph",
                         "xaxis": {
@@ -1249,6 +1254,688 @@
                     }
                 ],
                 "title": "New row"
+            },
+            {
+                "title": "New row",
+                "height": "250px",
+                "editable": true,
+                "collapse": false,
+                "panels": [
+                    {
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Replica</h1>",
+                        "editable": true,
+                        "error": false,
+                        "height": "30",
+                        "id": 57,
+                        "isNew": true,
+                        "links": [
+
+                        ],
+                        "mode": "html",
+                        "span": 12,
+                        "style": {
+
+                        },
+                        "title": "",
+                        "transparent": true,
+                        "type": "text"
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 60,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 6,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(seastar_database{type=\"total_operations\", metric=\"total_reads\"}[30s])) by (instance)",
+                                "intervalFactor": 1,
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Reads",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "rps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 59,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 6,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(seastar_database{type=\"total_operations\", metric=\"total_writes\"}[30s])) by (instance)",
+                                "intervalFactor": 1,
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Writes",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "wps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 61,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 3,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(seastar_database{type=\"queue_length\", metric=\"active_reads\"}) by (instance)",
+                                "intervalFactor": 1,
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Active sstable reads",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "none",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 62,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 3,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(seastar_database{type=\"queue_length\", metric=\"queued_reads\"}) by (instance)",
+                                "intervalFactor": 1,
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Queued sstable reads",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "none",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 63,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 3,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(seastar_database{type=\"queue_length\", metric=\"requests_blocked_memory\"}) by (instance)",
+                                "intervalFactor": 1,
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Writes currently blocked on dirty",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "none",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 64,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 3,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(seastar_commitlog{type=\"queue_length\", metric=\"pending_allocations\"}) by (instance)",
+                                "intervalFactor": 1,
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Writes currently blocked on commitlog",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "none",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "title": "",
+                        "error": false,
+                        "span": 6,
+                        "editable": true,
+                        "type": "text",
+                        "isNew": true,
+                        "id": 69,
+                        "mode": "markdown",
+                        "content": "",
+                        "links": [
+
+                        ]
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 67,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 3,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(seastar_database{type=\"total_operations\", metric=\"requests_blocked_memory\"}[30s])) by (instance)",
+                                "intervalFactor": 1,
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Writes blocked on dirty",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "wps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 68,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 3,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(seastar_commitlog{type=\"total_operations\", metric=\"requests_blocked_memory\"}[30s])) by (instance)",
+                                "intervalFactor": 1,
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Writes blocked on commitlog",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "wps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ]
             },
             {
                 "collapse": false,
@@ -1357,8 +2044,8 @@
                         "tooltip": {
                             "msResolution": false,
                             "shared": true,
-                            "value_type": "cumulative",
-                            "sort": 0
+                            "sort": 0,
+                            "value_type": "cumulative"
                         },
                         "type": "graph",
                         "xaxis": {
@@ -1437,8 +2124,8 @@
                         "tooltip": {
                             "msResolution": false,
                             "shared": true,
-                            "value_type": "cumulative",
-                            "sort": 0
+                            "sort": 0,
+                            "value_type": "cumulative"
                         },
                         "type": "graph",
                         "xaxis": {
@@ -1517,8 +2204,8 @@
                         "tooltip": {
                             "msResolution": false,
                             "shared": true,
-                            "value_type": "cumulative",
-                            "sort": 0
+                            "sort": 0,
+                            "value_type": "cumulative"
                         },
                         "type": "graph",
                         "xaxis": {
@@ -1597,8 +2284,8 @@
                         "tooltip": {
                             "msResolution": false,
                             "shared": true,
-                            "value_type": "cumulative",
-                            "sort": 0
+                            "sort": 0,
+                            "value_type": "cumulative"
                         },
                         "type": "graph",
                         "xaxis": {
@@ -1686,8 +2373,8 @@
                         "tooltip": {
                             "msResolution": false,
                             "shared": true,
-                            "value_type": "cumulative",
-                            "sort": 0
+                            "sort": 0,
+                            "value_type": "cumulative"
                         },
                         "type": "graph",
                         "xaxis": {
@@ -1766,8 +2453,8 @@
                         "tooltip": {
                             "msResolution": false,
                             "shared": true,
-                            "value_type": "cumulative",
-                            "sort": 0
+                            "sort": 0,
+                            "value_type": "cumulative"
                         },
                         "type": "graph",
                         "xaxis": {
@@ -2126,19 +2813,19 @@
                         ]
                     },
                     {
-                        "title": "",
-                        "error": false,
-                        "span": 6,
-                        "editable": true,
-                        "type": "text",
-                        "isNew": true,
-                        "id": 52,
-                        "mode": "html",
                         "content": "&nbsp;",
+                        "editable": true,
+                        "error": false,
+                        "id": 52,
+                        "isNew": true,
                         "links": [
 
                         ],
-                        "transparent": true
+                        "mode": "html",
+                        "span": 6,
+                        "title": "",
+                        "transparent": true,
+                        "type": "text"
                     },
                     {
                         "aliasColors": {
@@ -2304,10 +2991,9 @@
                 "title": "New row"
             },
             {
-                "title": "New row",
-                "height": "25px",
-                "editable": true,
                 "collapse": false,
+                "editable": true,
+                "height": "25px",
                 "panels": [
                     {
                         "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Memory</h1>",
@@ -2327,13 +3013,13 @@
                         "transparent": true,
                         "type": "text"
                     }
-                ]
+                ],
+                "title": "New row"
             },
             {
-                "title": "New row",
-                "height": "250px",
-                "editable": true,
                 "collapse": false,
+                "editable": true,
+                "height": "250px",
                 "panels": [
                     {
                         "aliasColors": {
@@ -2495,7 +3181,8 @@
                             }
                         ]
                     }
-                ]
+                ],
+                "title": "New row"
             },
             {
                 "collapse": false,
@@ -2585,8 +3272,8 @@
                         "tooltip": {
                             "msResolution": false,
                             "shared": true,
-                            "value_type": "cumulative",
-                            "sort": 0
+                            "sort": 0,
+                            "value_type": "cumulative"
                         },
                         "type": "graph",
                         "xaxis": {
@@ -2666,8 +3353,8 @@
                         "tooltip": {
                             "msResolution": false,
                             "shared": true,
-                            "value_type": "cumulative",
-                            "sort": 0
+                            "sort": 0,
+                            "value_type": "cumulative"
                         },
                         "type": "graph",
                         "xaxis": {
@@ -2755,8 +3442,8 @@
                         "tooltip": {
                             "msResolution": false,
                             "shared": true,
-                            "value_type": "cumulative",
-                            "sort": 0
+                            "sort": 0,
+                            "value_type": "cumulative"
                         },
                         "type": "graph",
                         "xaxis": {
@@ -2836,8 +3523,8 @@
                         "tooltip": {
                             "msResolution": false,
                             "shared": true,
-                            "value_type": "cumulative",
-                            "sort": 0
+                            "sort": 0,
+                            "value_type": "cumulative"
                         },
                         "type": "graph",
                         "xaxis": {
@@ -2890,10 +3577,9 @@
                 "title": "New row"
             },
             {
-                "title": "New row",
-                "height": "250px",
-                "editable": true,
                 "collapse": false,
+                "editable": true,
+                "height": "250px",
                 "panels": [
                     {
                         "aliasColors": {
@@ -2952,8 +3638,8 @@
                         "tooltip": {
                             "msResolution": false,
                             "shared": true,
-                            "value_type": "cumulative",
-                            "sort": 0
+                            "sort": 0,
+                            "value_type": "cumulative"
                         },
                         "type": "graph",
                         "xaxis": {
@@ -2976,7 +3662,8 @@
                             }
                         ]
                     }
-                ]
+                ],
+                "title": "New row"
             }
         ],
         "time": {
@@ -3054,7 +3741,7 @@
         },
         "refresh": "5s",
         "schemaVersion": 12,
-        "version": 2,
+        "version": 5,
         "links": [
 
         ],


### PR DESCRIPTION
Right below the storage proxy section. Preview:

![new_graphs](https://cloud.githubusercontent.com/assets/283695/20715269/f35a12b2-b64e-11e6-83db-6163efb9a891.png)
