### PR TITLE
grafana: replica: Add failure counters

### DIFF
--- a/grafana/scylla-dash-per-server.json
+++ b/grafana/scylla-dash-per-server.json
@@ -1256,10 +1256,9 @@
                 "title": "New row"
             },
             {
-                "title": "New row",
-                "height": "250px",
-                "editable": true,
                 "collapse": false,
+                "editable": true,
+                "height": "250px",
                 "panels": [
                     {
                         "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Replica</h1>",
@@ -1762,17 +1761,98 @@
                         ]
                     },
                     {
-                        "title": "",
-                        "error": false,
-                        "span": 6,
-                        "editable": true,
-                        "type": "text",
-                        "isNew": true,
-                        "id": 69,
-                        "mode": "markdown",
                         "content": "",
+                        "editable": true,
+                        "error": false,
+                        "id": 71,
+                        "isNew": true,
                         "links": [
 
+                        ],
+                        "mode": "markdown",
+                        "span": 3,
+                        "title": "",
+                        "type": "text",
+                        "transparent": true
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 74,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 3,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(seastar_database{type=\"total_operations\", metric=\"total_reads_failed\"}[30s])) by (instance)",
+                                "intervalFactor": 1,
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Reads failed",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "rps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
                         ]
                     },
                     {
@@ -1934,8 +2014,199 @@
                                 "show": true
                             }
                         ]
+                    },
+                    {
+                        "content": "",
+                        "editable": true,
+                        "error": false,
+                        "id": 73,
+                        "isNew": true,
+                        "links": [
+
+                        ],
+                        "mode": "markdown",
+                        "span": 3,
+                        "title": "",
+                        "type": "text",
+                        "transparent": true
+                    },
+                    {
+                        "content": "",
+                        "editable": true,
+                        "error": false,
+                        "id": 69,
+                        "isNew": true,
+                        "links": [
+
+                        ],
+                        "mode": "markdown",
+                        "span": 3,
+                        "title": "",
+                        "type": "text",
+                        "transparent": true
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 70,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 3,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(seastar_database{type=\"total_operations\", metric=\"total_writes_failed\"}[30s])) by (instance)",
+                                "intervalFactor": 1,
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Writes failed",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "wps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {
+
+                        },
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 72,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [
+
+                        ],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+
+                        ],
+                        "span": 3,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(seastar_database{type=\"total_operations\", metric=\"total_writes_timedout\"}[30s])) by (instance)",
+                                "intervalFactor": 1,
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Writes timed out",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "wps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
                     }
-                ]
+                ],
+                "title": "New row"
             },
             {
                 "collapse": false,


### PR DESCRIPTION
New graphs with rates of :
  - failed reads
  - failed writes
  - timedout writes

![failure_counters](https://cloud.githubusercontent.com/assets/283695/20747840/ec406628-b6eb-11e6-9836-ea483379a860.png)
