### PR TITLE
Update example prometheus.yml

### DIFF
--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -10,10 +10,12 @@ scrape_configs:
 - job_name: scylla
   honor_labels: true
   static_configs:
-  - targets: ["127.0.0.1:9180"]
+  - targets: ['127.0.0.1:9180']
+# two servers example: - targets: ['172.17.0.3:9180','172.17.0.2:9180']
+
 - job_name: node_exporter
   honor_labels: true
   static_configs:
-  - targets: ['127.0.0.1:9100']
+  - targets: ['127.0.0.1:9100'
+# two servers example: - targets: ['172.17.0.3:9100','172.17.0.2:9100']
 
-## two servers example: - targets: ["172.17.0.3:9103","172.17.0.2:9103"]

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -16,6 +16,5 @@ scrape_configs:
 - job_name: node_exporter
   honor_labels: true
   static_configs:
-  - targets: ['127.0.0.1:9100'
+  - targets: ['127.0.0.1:9100']
 # two servers example: - targets: ['172.17.0.3:9100','172.17.0.2:9100']
-


### PR DESCRIPTION
This PR improve the usability of prometheus.yml:

* update the examples to include two servers with relevant ports
* consistently use ```'``` rather than a mix of ```"``` and ```'```