### PR TITLE
prometheus: Reduce scrape period to 1 second

### DIFF
--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,5 +1,5 @@
 global:
-  scrape_interval: 15s # By default, scrape targets every 15 seconds.
+  scrape_interval: 1s # By default, scrape targets every 1 second.
 
   # Attach these labels to any time series or alerts when communicating with
   # external systems (federation, remote storage, Alertmanager).


### PR DESCRIPTION
Current period of 15 seconds will average out variations in
utilization which happen with period shorter than 15 seconds. Using
shorter interval will give us more information about system's
behavior. 1s should be still large enough to not put significant load
on the system.

Fixes #93.