### PR TITLE
Total storage should use node_filesystem_avail

### DIFF
--- a/grafana/scylla-dash-io-per-server.json
+++ b/grafana/scylla-dash-io-per-server.json
@@ -528,14 +528,14 @@
                         "strokeWidth": 1,
                         "targets": [
                             {
-                                "expr": "sum(node_filesystem_files_free{mountpoint=\"/var/lib/scylla\"})/1000000000",
+                                "expr": "sum(node_filesystem_avail{mountpoint=\"/var/lib/scylla\"})/1000000000",
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
                                 "step": 7200
                             },
                             {
-                                "expr": "(sum(node_filesystem_size{mountpoint=\"/var/lib/scylla\"})-sum(node_filesystem_files_free{mountpoint=\"/var/lib/scylla\"}))/1000000000",
+                                "expr": "(sum(node_filesystem_size{mountpoint=\"/var/lib/scylla\"})-sum(node_filesystem_avail{mountpoint=\"/var/lib/scylla\"}))/1000000000",
                                 "intervalFactor": 1,
                                 "refId": "B",
                                 "step": 7200

--- a/grafana/scylla-dash-per-server.json
+++ b/grafana/scylla-dash-per-server.json
@@ -528,14 +528,14 @@
                         "strokeWidth": 1,
                         "targets": [
                             {
-                                "expr": "sum(node_filesystem_files_free{mountpoint=\"/var/lib/scylla\"})/1000000000",
+                                "expr": "sum(node_filesystem_avail{mountpoint=\"/var/lib/scylla\"})/1000000000",
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                                "expr": "(sum(node_filesystem_size{mountpoint=\"/var/lib/scylla\"})-sum(node_filesystem_files_free{mountpoint=\"/var/lib/scylla\"}))/1000000000",
+                                "expr": "(sum(node_filesystem_size{mountpoint=\"/var/lib/scylla\"})-sum(node_filesystem_avail{mountpoint=\"/var/lib/scylla\"}))/1000000000",
                                 "intervalFactor": 1,
                                 "refId": "B",
                                 "step": 1

--- a/grafana/scylla-dash.json
+++ b/grafana/scylla-dash.json
@@ -403,14 +403,14 @@
                         "span": 2,
                         "targets": [
                             {
-                                "expr": "sum(node_filesystem_files_free{mountpoint=\"/var/lib/scylla\"})/1000000000",
+                                "expr": "sum(node_filesystem_avail{mountpoint=\"/var/lib/scylla\"})/1000000000",
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
                                 "step": 1200
                             },
                             {
-                                "expr": "(sum(node_filesystem_size{mountpoint=\"/var/lib/scylla\"})-sum(node_filesystem_files_free{mountpoint=\"/var/lib/scylla\"}))/1000000000",
+                                "expr": "(sum(node_filesystem_size{mountpoint=\"/var/lib/scylla\"})-sum(node_filesystem_avail{mountpoint=\"/var/lib/scylla\"}))/1000000000",
                                 "intervalFactor": 1,
                                 "refId": "B",
                                 "step": 1200


### PR DESCRIPTION
To get the available memory in the file system the formula needs to use
node_filesystem_avail and not free.

Fixes #102

Signed-off-by: Amnon Heiman <amnon@scylladb.com>