### PR TITLE
Alternative ports

### DIFF
--- a/kill-all.sh
+++ b/kill-all.sh
@@ -1,4 +1,38 @@
 #!/usr/bin/env bash
 
-sudo docker kill agraf aprom
-sudo docker rm agraf aprom
+usage="$(basename "$0") [-h] [-g grafana port ] [ -p prometheus port ] -- kills existing Grafana and Prometheus Docker instances at given ports"
+
+while getopts ':hg:p:' option; do
+  case "$option" in
+    h) echo "$usage"
+       exit
+       ;;
+    g) GRAFANA_PORT=$OPTARG
+       ;;
+    p) PROMETHEUS_PORT=$OPTARG
+       ;;
+    :) printf "missing argument for -%s\n" "$OPTARG" >&2
+       echo "$usage" >&2
+       exit 1
+       ;;
+   \?) printf "illegal option: -%s\n" "$OPTARG" >&2
+       echo "$usage" >&2
+       exit 1
+       ;;
+  esac
+done
+
+if [ -z $GRAFANA_PORT ]; then
+    GRAFANA_NAME=agraf
+else
+    GRAFANA_NAME=agraf-$GRAFANA_PORT
+fi
+if [ -z $PROMETHEUS_PORT ]; then
+    PROMETHEUS_NAME=aprom
+else
+    PROMETHEUS_NAME=aprom-$PROMETHEUS_PORT
+fi
+
+
+sudo docker kill $GRAFANA_NAME $PROMETHEUS_NAME
+sudo docker rm $GRAFANA_NAME $PROMETHEUS_NAME

--- a/start-all.sh
+++ b/start-all.sh
@@ -2,9 +2,9 @@
 
 . versions.sh
 VERSIONS=$DEFAULT_VERSION
-usage="$(basename "$0") [-h] [-d Prometheus data-dir] [-v comma seperated versions] -- starts Grafana and Prometheus Docker instances"
+usage="$(basename "$0") [-h] [-d Prometheus data-dir] [-v comma seperated versions] [-g grafana port ] [ -p prometheus port ] -- starts Grafana and Prometheus Docker instances"
 
-while getopts ':hd:v:' option; do
+while getopts ':hd:g:p:v:' option; do
   case "$option" in
     h) echo "$usage"
        exit
@@ -12,6 +12,10 @@ while getopts ':hd:v:' option; do
     v) VERSIONS=$OPTARG
        ;;
     d) DATA_DIR=$OPTARG
+       ;;
+    g) GRAFANA_PORT=$OPTARG
+       ;;
+    p) PROMETHEUS_PORT=$OPTARG
        ;;
     :) printf "missing argument for -%s\n" "$OPTARG" >&2
        echo "$usage" >&2
@@ -24,6 +28,19 @@ while getopts ':hd:v:' option; do
   esac
 done
 
+if [ -z $GRAFANA_PORT ]; then
+    GRAFANA_PORT=3000
+    GRAFANA_NAME=agraf
+else
+    GRAFANA_NAME=agraf-$GRAFANA_PORT
+fi
+if [ -z $PROMETHEUS_PORT ]; then
+    PROMETHEUS_PORT=9090
+    PROMETHEUS_NAME=aprom
+else
+    PROMETHEUS_NAME=aprom-$PROMETHEUS_PORT
+fi
+
 # Exit if Docker engine is not running
 if [ ! "$(sudo docker ps)" ]
 then
@@ -33,10 +50,10 @@ fi
 
 if [ -z $DATA_DIR ]
 then
-    sudo docker run -d -v $PWD/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:Z -p 9090:9090 --name aprom prom/prometheus:v1.0.0
+    sudo docker run -d -v $PWD/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:Z -p $PROMETHEUS_PORT:9090 --name $PROMETHEUS_NAME prom/prometheus:v1.0.0
 else
     echo "Loading prometheus data from $DATA_DIR"
-    sudo docker run -d -v $DATA_DIR:/prometheus:Z -v $PWD/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:Z -p 9090:9090 --name aprom prom/prometheus:v1.0.0
+    sudo docker run -d -v $DATA_DIR:/prometheus:Z -v $PWD/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:Z -p $PROMETHEUS_PORT:9090 --name $PROMETHEUS_NAME prom/prometheus:v1.0.0
 fi
 
 if [ $? -ne 0 ]; then
@@ -57,24 +74,24 @@ RETRIES=7
 # Wait till Prometheus is available
 printf "Wait for Prometheus container to start."
 TRIES=0
-until $(curl --output /dev/null -f --silent http://localhost:9090) || [ $TRIES -eq $RETRIES ]; do
+until $(curl --output /dev/null -f --silent http://localhost:$PROMETHEUS_PORT) || [ $TRIES -eq $RETRIES ]; do
     printf '.'
     ((TRIES=TRIES+1))
     sleep 5
 done
 
-if [ ! "$(sudo docker ps -q -f name=aprom)" ]
+if [ ! "$(sudo docker ps -q -f name=$PROMETHEUS_NAME)" ]
 then
         echo "Error: Prometheus container failed to start"
         exit 1
 fi
 
-sudo docker run -d -i -p 3000:3000 \
+sudo docker run -d -i -p $GRAFANA_PORT:3000 \
      -e "GF_AUTH_BASIC_ENABLED=false" \
      -e "GF_AUTH_ANONYMOUS_ENABLED=true" \
      -e "GF_AUTH_ANONYMOUS_ORG_ROLE=Admin" \
      -e "GF_INSTALL_PLUGINS=grafana-piechart-panel" \
-     --name agraf grafana/grafana:3.1.0
+     --name $GRAFANA_NAME grafana/grafana:3.1.0
 
 if [ $? -ne 0 ]; then
     echo "Error: Grafana container failed to start"
@@ -84,23 +101,23 @@ fi
 # Wait till Grafana API is available
 printf "Wait for Grafana container to start."
 TRIES=0
-until $(curl --output /dev/null -f --silent http://localhost:3000/api/org) || [ $TRIES -eq $RETRIES ] ; do
+until $(curl --output /dev/null -f --silent http://localhost:$GRAFANA_PORT/api/org) || [ $TRIES -eq $RETRIES ] ; do
     printf '.'
     ((TRIES=TRIES+1))
     sleep 5
 done
 
-if [ ! "$(sudo docker ps -q -f name=agraf)" ]
+if [ ! "$(sudo docker ps -q -f name=$GRAFANA_NAME)" ]
 then
         echo "Error: Grafana container failed to start"
         exit 1
 fi
 
 curl -XPOST -i http://localhost:$GRAFANA_PORT/api/datasources \
-     --data-binary '{"name":"prometheus", "type":"prometheus", "url":"'"http://127.0.0.1:9090"'", "access":"direct", "basicAuth":false}' \
+     --data-binary '{"name":"prometheus", "type":"prometheus", "url":"'"http://127.0.0.1:$PROMETHEUS_PORT"'", "access":"direct", "basicAuth":false}' \
      -H "Content-Type: application/json"
 IFS=',' ;for v in $VERSIONS; do
-	curl -XPOST -i http://localhost:3000/api/dashboards/db --data-binary @./grafana/scylla-dash.$v.json -H "Content-Type: application/json"
-	curl -XPOST -i http://localhost:3000/api/dashboards/db --data-binary @./grafana/scylla-dash-per-server.$v.json -H "Content-Type: application/json"
-	curl -XPOST -i http://localhost:3000/api/dashboards/db --data-binary @./grafana/scylla-dash-io-per-server.$v.json -H "Content-Type: application/json"
+	curl -XPOST -i http://localhost:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/scylla-dash.$v.json -H "Content-Type: application/json"
+	curl -XPOST -i http://localhost:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/scylla-dash-per-server.$v.json -H "Content-Type: application/json"
+	curl -XPOST -i http://localhost:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/scylla-dash-io-per-server.$v.json -H "Content-Type: application/json"
 done

--- a/start-all.sh
+++ b/start-all.sh
@@ -96,10 +96,8 @@ then
         exit 1
 fi
 
-DB_IP="$(sudo docker inspect --format '{{ .NetworkSettings.IPAddress }}' aprom)"
-
-curl -XPOST -i http://localhost:3000/api/datasources \
-     --data-binary '{"name":"prometheus", "type":"prometheus", "url":"'"http://$DB_IP:9090"'", "access":"proxy", "basicAuth":false}' \
+curl -XPOST -i http://localhost:$GRAFANA_PORT/api/datasources \
+     --data-binary '{"name":"prometheus", "type":"prometheus", "url":"'"http://127.0.0.1:9090"'", "access":"direct", "basicAuth":false}' \
      -H "Content-Type: application/json"
 IFS=',' ;for v in $VERSIONS; do
 	curl -XPOST -i http://localhost:3000/api/dashboards/db --data-binary @./grafana/scylla-dash.$v.json -H "Content-Type: application/json"


### PR DESCRIPTION
I often find myself with 3 or 4 monitoring instances running, so I can monitor many customer sites at the same time. So far, I have been manually starting and tweaking the containers. This patchset adds two new options, -g and -p, that can be used to start grafana and prometheus in non-standard ports.
