### PR TITLE
bring back proxy mode

### DIFF
--- a/start-all.sh
+++ b/start-all.sh
@@ -113,8 +113,12 @@ then
         exit 1
 fi
 
+# Can't use localhost here, because the monitoring may be running remotely.
+# Also note that the port to which we need to connect is 9090, regardless of which port we bind to at localhost.
+DB_ADDRESS="$(sudo docker inspect --format '{{ .NetworkSettings.IPAddress }}' $PROMETHEUS_NAME):9090"
+
 curl -XPOST -i http://localhost:$GRAFANA_PORT/api/datasources \
-     --data-binary '{"name":"prometheus", "type":"prometheus", "url":"'"http://127.0.0.1:$PROMETHEUS_PORT"'", "access":"direct", "basicAuth":false}' \
+     --data-binary '{"name":"prometheus", "type":"prometheus", "url":"'"http://$DB_ADDRESS"'", "access":"proxy", "basicAuth":false}' \
      -H "Content-Type: application/json"
 IFS=',' ;for v in $VERSIONS; do
 	curl -XPOST -i http://localhost:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/scylla-dash.$v.json -H "Content-Type: application/json"


### PR DESCRIPTION
Local mode, albeit much simpler, doesn't work in remote installations.
In those, the browser will probe for prometheus directly and at
localhost it will be nowhere to be found.

We can still have multi-port mode working in proxy mode by making sure
we probe the correct container and noticing that we always have to
connect to its port 9090, and not the locally bound port.

Fixes #115

Signed-off-by: Glauber Costa <glommer@scylladb.com>