### PR TITLE
add option to specify nodes

### DIFF
--- a/gen-prometheus.py
+++ b/gen-prometheus.py
@@ -1,0 +1,27 @@
+template = """
+global:
+  scrape_interval: 1s # By default, scrape targets every 1 second.
+
+  # Attach these labels to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  external_labels:
+    monitor: 'scylla-monitor'
+
+scrape_configs:
+- job_name: scylla
+  honor_labels: true
+  static_configs:
+  - targets: %s
+
+- job_name: node_exporter
+  honor_labels: true
+  static_configs:
+  - targets: %s
+"""
+
+from sys import argv
+from string import split
+ips=split(argv[1],",")
+def add_port(vec, port):
+    return str(map(lambda x: x + ":" + port, vec))
+print template%(add_port(ips, "9180"), add_port(ips, "9100"))

--- a/kill-all.sh
+++ b/kill-all.sh
@@ -32,7 +32,8 @@ if [ -z $PROMETHEUS_PORT ]; then
 else
     PROMETHEUS_NAME=aprom-$PROMETHEUS_PORT
 fi
-
+PROMETHEUS_FILE="$PWD/prometheus/prometheus-$PROMETHEUS_PORT.yml"
 
 sudo docker kill $GRAFANA_NAME $PROMETHEUS_NAME
 sudo docker rm $GRAFANA_NAME $PROMETHEUS_NAME
+rm $PROMETHEUS_FILE 2>/dev/null


### PR DESCRIPTION
Editing prometheus.yml is a bit of a pain, and now more so that we have
to add each node twice. Add an option in start-all.sh to do it
automatically given nodes passed in the command line.

Signed-off-by: Glauber Costa <glommer@scylladb.com>