### PR TITLE
add option to specify nodes

### DIFF
--- a/gen-prometheus.py
+++ b/gen-prometheus.py
@@ -1,0 +1,7 @@
+from sys import argv
+from string import split
+ips=split(argv[1],",")
+port=argv[2]
+print "- targets:"
+for addr in map(lambda x: x + ":" + port, ips):
+    print "  - " + addr

--- a/kill-all.sh
+++ b/kill-all.sh
@@ -32,7 +32,10 @@ if [ -z $PROMETHEUS_PORT ]; then
 else
     PROMETHEUS_NAME=aprom-$PROMETHEUS_PORT
 fi
-
+SCYLLA_NODES_FILE="$PWD/prometheus/scylla-$PROMETHEUS_PORT.yml"
+NODE_EXPORTER_NODES_FILE="$PWD/prometheus/node-$PROMETHEUS_PORT.yml"
 
 sudo docker kill $GRAFANA_NAME $PROMETHEUS_NAME
 sudo docker rm $GRAFANA_NAME $PROMETHEUS_NAME
+rm $SCYLLA_NODES_FILE 2>/dev/null
+rm $NODE_EXPORTER_NODES_FILE 2>/dev/null


### PR DESCRIPTION
Editing the configuration files manually  is a bit of a pain, and now
more so that we have to add each node twice. Add an option in
start-all.sh to do it automatically given nodes passed in the command
line.

Signed-off-by: Glauber Costa <glommer@scylladb.com>