### PR TITLE
allow using non default target files

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ For example, update targets in `prometheus/node_exporter_servers.yaml` :
   - 172.17.0.3:9100
 ```
 
+You can also use your own target files instead of updating `scylla_servers.yaml` and `node_exporter_servers.yaml`, using the `-s` for scylla target file and `-n` for node taget file. For example:
+
+```
+./start-all.sh -s my_scylla_server.yaml -n my_node_exporter_servers.yml -d data_dir
+```
 
 ### Run
 


### PR DESCRIPTION
This PR allows one to use his target files like

```
./start-all.sh -s my_scylla_servers.yaml -n my_node_exporter_servers.yml -d data_dir
```

In combination with the ports option `-g` and `-p` this can be used to run multiple Grafana/Prometheus stacks, each with different targets