### PR TITLE
Unreachable node behavior

### DIFF
--- a/grafana/scylla-dash-io-per-server.master.json
+++ b/grafana/scylla-dash-io-per-server.master.json
@@ -180,7 +180,7 @@
                         },
                         "targets": [
                             {
-                                "expr": "count(up{job=\"scylla\"})-count(round(rate(scylla_gossip_heart_beat{shard=\"0\"}[10s])))",
+                                "expr": "count(up{job=\"scylla\"})-sum(floor(rate(scylla_gossip_heart_beat{shard=\"0\"}[10s]) + 0.2))",
                                 "intervalFactor": 1,
                                 "refId": "A",
                                 "legendFormat": "Dead Nodes",

--- a/grafana/scylla-dash-io-per-server.master.json
+++ b/grafana/scylla-dash-io-per-server.master.json
@@ -180,7 +180,7 @@
                         },
                         "targets": [
                             {
-                                "expr": "count(up{job=\"scylla\"})-count(scylla_memory_free_operations{shard=\"0\"})",
+                                "expr": "count(up{job=\"scylla\"})-count(round(rate(scylla_gossip_heart_beat{shard=\"0\"}[10s])))",
                                 "intervalFactor": 1,
                                 "refId": "A",
                                 "legendFormat": "Dead Nodes",
@@ -188,7 +188,7 @@
                             }
                         ],
                         "thresholds": "1,2",
-                        "title": "Dead Nodes",
+                        "title": "Unreachable Nodes",
                         "transparent": true,
                         "type": "singlestat",
                         "valueFontSize": "150%",

--- a/grafana/scylla-dash-io-per-server.master.json
+++ b/grafana/scylla-dash-io-per-server.master.json
@@ -180,10 +180,10 @@
                         },
                         "targets": [
                             {
-                                "expr": "count(up{job=\"scylla\"})-sum(floor(rate(scylla_gossip_heart_beat{shard=\"0\"}[10s]) + 0.2))",
+                                "expr": "count(scrape_samples_scraped{job=\"scylla\"}==0) OR vector(0)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "Dead Nodes",
+                                "legendFormat": "Unreachable Nodes",
                                 "step": 120
                             }
                         ],

--- a/grafana/scylla-dash-per-server.master.json
+++ b/grafana/scylla-dash-per-server.master.json
@@ -181,7 +181,7 @@
                         "targets": [
                             {
                                 "legendFormat": "Unreachable Nodes",
-                                "expr": "count(up{job=\"scylla\"})-sum(floor(rate(scylla_gossip_heart_beat{shard=\"0\"}[10s]) + 0.2))",
+                                "expr": "count(scrape_samples_scraped{job=\"scylla\"}==0) OR vector(0)",
                                 "intervalFactor": 1,
                                 "refId": "A",
                                 "step": 1

--- a/grafana/scylla-dash-per-server.master.json
+++ b/grafana/scylla-dash-per-server.master.json
@@ -180,15 +180,15 @@
                         },
                         "targets": [
                             {
-                                "expr": "count(up{job=\"scylla\"})-count(scylla_memory_free_operations{shard=\"0\"})",
-                                "legendFormat": "Dead Nodes",
+                                "legendFormat": "Unreachable Nodes",
+                                "expr": "count(up{job=\"scylla\"})-count(round(rate(scylla_gossip_heart_beat{shard=\"0\"}[10s])))",
                                 "intervalFactor": 1,
                                 "refId": "A",
                                 "step": 1
                             }
                         ],
                         "thresholds": "1,2",
-                        "title": "Dead Nodes",
+                        "title": "Unreachable Nodes",
                         "transparent": true,
                         "type": "singlestat",
                         "valueFontSize": "150%",

--- a/grafana/scylla-dash-per-server.master.json
+++ b/grafana/scylla-dash-per-server.master.json
@@ -181,7 +181,7 @@
                         "targets": [
                             {
                                 "legendFormat": "Unreachable Nodes",
-                                "expr": "count(up{job=\"scylla\"})-count(round(rate(scylla_gossip_heart_beat{shard=\"0\"}[10s])))",
+                                "expr": "count(up{job=\"scylla\"})-sum(floor(rate(scylla_gossip_heart_beat{shard=\"0\"}[10s]) + 0.2))",
                                 "intervalFactor": 1,
                                 "refId": "A",
                                 "step": 1

--- a/grafana/scylla-dash.master.json
+++ b/grafana/scylla-dash.master.json
@@ -145,10 +145,10 @@
                         },
                         "targets": [
                             {
-                                "expr": "count(up{job=\"scylla\"})-sum(floor(rate(scylla_gossip_heart_beat{shard=\"0\"}[10s]) + 0.2))",
+                                "expr": "count(scrape_samples_scraped{job=\"scylla\"}==0) OR vector(0)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "Dead Nodes",
+                                "legendFormat": "Unreachable Nodes",
                                 "step": 20
                             }
                         ],

--- a/grafana/scylla-dash.master.json
+++ b/grafana/scylla-dash.master.json
@@ -145,7 +145,7 @@
                         },
                         "targets": [
                             {
-                                "expr": "count(up{job=\"scylla\"})-count(scylla_memory_free_operations{shard=\"0\"})",
+                                "expr": "count(up{job=\"scylla\"})-count(round(rate(scylla_gossip_heart_beat{shard=\"0\"}[10s])))",
                                 "intervalFactor": 1,
                                 "refId": "A",
                                 "legendFormat": "Dead Nodes",
@@ -153,7 +153,7 @@
                             }
                         ],
                         "thresholds": "1,2",
-                        "title": "Dead Nodes",
+                        "title": "Unreachable Nodes",
                         "transparent": true,
                         "type": "singlestat",
                         "valueFontSize": "150%",

--- a/grafana/scylla-dash.master.json
+++ b/grafana/scylla-dash.master.json
@@ -145,7 +145,7 @@
                         },
                         "targets": [
                             {
-                                "expr": "count(up{job=\"scylla\"})-count(round(rate(scylla_gossip_heart_beat{shard=\"0\"}[10s])))",
+                                "expr": "count(up{job=\"scylla\"})-sum(floor(rate(scylla_gossip_heart_beat{shard=\"0\"}[10s]) + 0.2))",
                                 "intervalFactor": 1,
                                 "refId": "A",
                                 "legendFormat": "Dead Nodes",


### PR DESCRIPTION
This patch handle two issues in the dashboards:
* Dead nodes are actually unreachable nodes.
* A Quicker way to identify that a node is done based on the gossip
heart beat

Fixes #83
Fixes #65

Signed-off-by: Amnon Heiman <amnon@scylladb.com>