### PR TITLE
start-all.sh: support local flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ ___
 **For systems in production it is recommended to use an external directory.**
 ___
 
+
+#### Connecting Scylla and the Monitoring locally - the local flag
+When runing the prometheus and grafan on the same host as scylla, use the local `-l` flag, so processes inside the
+containers will share the host network stack and would have access to the `localhost`.
+
 ### Kill
 
 ```


### PR DESCRIPTION
When running the docker containers on the same host is scylla, the
net=host should be set when running the docker containers.

This patch adds the -l flag that can be used so the containers would
share the host network stack.

Signed-off-by: Amnon Heiman <amnon@scylladb.com>