### PR TITLE
Add instance name to per instance graph

### DIFF
--- a/grafana/scylla-dash-io-per-server.master.json
+++ b/grafana/scylla-dash-io-per-server.master.json
@@ -381,7 +381,7 @@
                                 "expr": "avg(scylla_reactor_utilization{} ) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "Load per Server",
+                                "legendFormat": "{{instance}} - Load per Server",
                                 "step": 30
                             }
                         ],
@@ -464,7 +464,7 @@
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "Requests Served per Server",
+                                "legendFormat": "{{instance}} - Requests Served per Server",
                                 "step": 30
                             }
                         ],
@@ -1000,7 +1000,7 @@
                                 "intervalFactor": 1,
                                 "metric": "seastar_io_queue_delay",
                                 "refId": "A",
-                                "legendFormat": "Compactions I/O Queue delay",
+                                "legendFormat": "{{instance}} - Compactions I/O Queue delay",
                                 "step": 30
                             }
                         ],
@@ -1083,7 +1083,7 @@
                                 "intervalFactor": 1,
                                 "metric": "seastar_io_queue_delay",
                                 "refId": "A",
-                                "legendFormat": "Compactions I/O Queue bandwidth",
+                                "legendFormat": "{{instance}} - Compactions I/O Queue bandwidth",
                                 "step": 30
                             }
                         ],
@@ -1166,7 +1166,7 @@
                                 "intervalFactor": 1,
                                 "metric": "seastar_io_queue_delay",
                                 "refId": "A",
-                                "legendFormat": "Compactions I/O Queue IOPS",
+                                "legendFormat": "{{instance}} - Compactions I/O Queue IOPS",
                                 "step": 30
                             }
                         ],
@@ -1249,7 +1249,7 @@
                                 "intervalFactor": 1,
                                 "metric": "seastar_io_queue_delay",
                                 "refId": "A",
-                                "legendFormat": "Query I/O Queue delay",
+                                "legendFormat": "{{instance}} - Query I/O Queue delay",
                                 "step": 30
                             }
                         ],
@@ -1332,7 +1332,7 @@
                                 "intervalFactor": 1,
                                 "metric": "seastar_io_queue_delay",
                                 "refId": "A",
-                                "legendFormat": "Query I/O Queue bandwidth",
+                                "legendFormat": "{{instance}} - Query I/O Queue bandwidth",
                                 "step": 30
                             }
                         ],
@@ -1415,7 +1415,7 @@
                                 "intervalFactor": 1,
                                 "metric": "seastar_io_queue_delay",
                                 "refId": "A",
-                                "legendFormat": "Query I/O Queue IOPS",
+                                "legendFormat": "{{instance}} - Query I/O Queue IOPS",
                                 "step": 30
                             }
                         ],
@@ -1499,7 +1499,7 @@
                                 "intervalFactor": 1,
                                 "metric": "seastar_io_queue_delay",
                                 "refId": "A",
-                                "legendFormat": "Commitlog I/O Queue delay",
+                                "legendFormat": "{{instance}} - Commitlog I/O Queue delay",
                                 "step": 30
                             }
                         ],
@@ -1582,7 +1582,7 @@
                                 "intervalFactor": 1,
                                 "metric": "seastar_io_queue_delay",
                                 "refId": "A",
-                                "legendFormat": "Commitlog I/O Queue bandwidth",
+                                "legendFormat": "{{instance}} - Commitlog I/O Queue bandwidth",
                                 "step": 30
                             }
                         ],
@@ -1665,7 +1665,7 @@
                                 "intervalFactor": 1,
                                 "metric": "seastar_io_queue_delay",
                                 "refId": "A",
-                                "legendFormat": "Commitlog I/O Queue IOPS",
+                                "legendFormat": "{{instance}} - Commitlog I/O Queue IOPS",
                                 "step": 30
                             }
                         ],
@@ -1748,7 +1748,7 @@
                                 "intervalFactor": 1,
                                 "metric": "seastar_io_queue_delay",
                                 "refId": "A",
-                                "legendFormat": "Memtable Flush I/O Queue delay",
+                                "legendFormat": "{{instance}} - Memtable Flush I/O Queue delay",
                                 "step": 30
                             }
                         ],
@@ -1831,7 +1831,7 @@
                                 "intervalFactor": 1,
                                 "metric": "seastar_io_queue_delay",
                                 "refId": "A",
-                                "legendFormat": "Memtable Flush I/O Queue bandwidth",
+                                "legendFormat": "{{instance}} - Memtable Flush I/O Queue bandwidth",
                                 "step": 30
                             }
                         ],
@@ -1914,7 +1914,7 @@
                                 "intervalFactor": 1,
                                 "metric": "seastar_io_queue_delay",
                                 "refId": "A",
-                                "legendFormat": "Memtable Flush I/O Queue IOPS",
+                                "legendFormat": "{{instance}} - Memtable Flush I/O Queue IOPS",
                                 "step": 30
                             }
                         ],
@@ -1997,7 +1997,7 @@
                                 "intervalFactor": 1,
                                 "metric": "seastar_io_queue_delay",
                                 "refId": "A",
-                                "legendFormat": "Streaming Reads I/O Queue delay",
+                                "legendFormat": "{{instance}} - Streaming Reads I/O Queue delay",
                                 "step": 30
                             }
                         ],
@@ -2080,7 +2080,7 @@
                                 "intervalFactor": 1,
                                 "metric": "seastar_io_queue_delay",
                                 "refId": "A",
-                                "legendFormat": "Streaming Reads I/O Queue bandwidth",
+                                "legendFormat": "{{instance}} - Streaming Reads I/O Queue bandwidth",
                                 "step": 30
                             }
                         ],
@@ -2163,7 +2163,7 @@
                                 "intervalFactor": 1,
                                 "metric": "seastar_io_queue_delay",
                                 "refId": "A",
-                                "legendFormat": "Streaming Reads I/O Queue IOPS",
+                                "legendFormat": "{{instance}} - Streaming Reads I/O Queue IOPS",
                                 "step": 30
                             }
                         ],
@@ -2246,7 +2246,7 @@
                                 "intervalFactor": 1,
                                 "metric": "seastar_io_queue_delay",
                                 "refId": "A",
-                                "legendFormat": "Streaming Writes I/O Queue delay",
+                                "legendFormat": "{{instance}} - Streaming Writes I/O Queue delay",
                                 "step": 30
                             }
                         ],
@@ -2329,7 +2329,7 @@
                                 "intervalFactor": 1,
                                 "metric": "seastar_io_queue_delay",
                                 "refId": "A",
-                                "legendFormat": "Streaming Writes I/O Queue bandwidth",
+                                "legendFormat": "{{instance}} - Streaming Writes I/O Queue bandwidth",
                                 "step": 30
                             }
                         ],
@@ -2412,7 +2412,7 @@
                                 "intervalFactor": 1,
                                 "metric": "seastar_io_queue_delay",
                                 "refId": "A",
-                                "legendFormat": "Streaming Writes I/O Queue IOPS",
+                                "legendFormat": "{{instance}} - Streaming Writes I/O Queue IOPS",
                                 "step": 30
                             }
                         ],

--- a/grafana/scylla-dash-per-server.master.json
+++ b/grafana/scylla-dash-per-server.master.json
@@ -381,7 +381,7 @@
                                 "expr": "avg(scylla_reactor_utilization{} ) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "Load per Server",
+                                "legendFormat": "{{instance}} - Load per Server",
                                 "step": 1
                             }
                         ],
@@ -464,7 +464,7 @@
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "Requests Served per Server",
+                                "legendFormat": "{{instance}} -Requests Served per Server",
                                 "step": 1
                             }
                         ],
@@ -653,7 +653,7 @@
                                 "expr": "sum(scylla_storage_proxy_coordinator_foreground_writes{}) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "Foreground Writes per Server",
+                                "legendFormat": "{{instance}} - Foreground Writes per Server",
                                 "step": 1
                             }
                         ],
@@ -735,7 +735,7 @@
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "Foreground Reads per Server",
+                                "legendFormat": "{{instance}} - Foreground Reads per Server",
                                 "step": 1
                             }
                         ],
@@ -816,7 +816,7 @@
                                 "expr": "sum(irate(scylla_storage_proxy_coordinator_write_timeouts{}[30s])) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "Write Timeouts per Second per Server",
+                                "legendFormat": "{{instance}} - Write Timeouts per Second per Server",
                                 "step": 1
                             }
                         ],
@@ -897,7 +897,7 @@
                                 "expr": "sum(irate(scylla_storage_proxy_coordinator_write_unavailable{}[30s])) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "Write Unavailable per Second per Server",
+                                "legendFormat": "{{instance}} - Write Unavailable per Second per Server",
                                 "step": 1
                             }
                         ],
@@ -986,7 +986,7 @@
                                 "expr": "sum(scylla_storage_proxy_coordinator_background_writes{}) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "Background Writes per Server",
+                                "legendFormat": "{{instance}} - Background Writes per Server",
                                 "step": 1
                             }
                         ],
@@ -1067,7 +1067,7 @@
                                 "expr": "sum(scylla_storage_proxy_coordinator_background_reads{}) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "Background Reads per Server",
+                                "legendFormat": "{{instance}} - Background Reads per Server",
                                 "step": 4
                             }
                         ],
@@ -1148,7 +1148,7 @@
                                 "expr": "sum(irate(scylla_storage_proxy_coordinator_read_timeouts{}[30s])) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "Read Timeouts per Second per Server",
+                                "legendFormat": "{{instance}} - Read Timeouts per Second per Server",
                                 "step": 1
                             }
                         ],
@@ -1229,7 +1229,7 @@
                                 "expr": "sum(irate(scylla_storage_proxy_coordinator_read_unavailable{}[30s])) by (instance)",
                                 "intervalFactor": 1,
                                 "metric": "",
-                                "legendFormat": "Read Unavailable per Second per Server",
+                                "legendFormat": "{{instance}} - Read Unavailable per Second per Server",
                                 "refId": "A",
                                 "step": 4
                             }
@@ -1338,7 +1338,7 @@
                                 "expr": "sum(irate(scylla_database_total_reads{}[30s])) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "Reads",
+                                "legendFormat": "{{instance}} - Reads",
                                 "step": 1
                             }
                         ],
@@ -1420,7 +1420,7 @@
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "Writes",
+                                "legendFormat": "{{instance}} - Writes",
                                 "step": 1
                             }
                         ],
@@ -1501,7 +1501,7 @@
                                 "expr": "sum(scylla_database_active_reads{}) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "Active sstable reads",
+                                "legendFormat": "{{instance}} - Active sstable reads",
                                 "step": 1
                             }
                         ],
@@ -1582,7 +1582,7 @@
                                 "expr": "sum(scylla_database_queued_reads{}) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "Queued sstable reads",
+                                "legendFormat": "{{instance}} - Queued sstable reads",
                                 "step": 1
                             }
                         ],
@@ -1663,7 +1663,7 @@
                                 "expr": "sum(scylla_database_requests_blocked_memory{}) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "Writes currently blocked on dirty",
+                                "legendFormat": "{{instance}} - Writes currently blocked on dirty",
                                 "step": 1
                             }
                         ],
@@ -1744,7 +1744,7 @@
                                 "expr": "sum(scylla_commitlog_pending_allocations{}) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "Writes currently blocked on commitlog",
+                                "legendFormat": "{{instance}} - Writes currently blocked on commitlog",
                                 "step": 1
                             }
                         ],
@@ -1840,7 +1840,7 @@
                                 "expr": "sum(irate(scylla_database_total_reads_failed{}[30s])) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "Reads failed",
+                                "legendFormat": "{{instance}} - Reads failed",
                                 "step": 1
                             }
                         ],
@@ -1921,7 +1921,7 @@
                                 "expr": "sum(irate(scylla_database_requests_blocked_memory{}[30s])) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "Writes blocked on dirty",
+                                "legendFormat": "{{instance}} - Writes blocked on dirty",
                                 "step": 1
                             }
                         ],
@@ -2002,7 +2002,7 @@
                                 "expr": "sum(irate(scylla_commitlog_requests_blocked_memory{}[30s])) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "Writes blocked on commitlog",
+                                "legendFormat": "{{instance}} - Writes blocked on commitlog",
                                 "step": 1
                             }
                         ],
@@ -2113,7 +2113,7 @@
                                 "expr": "sum(irate(scylla_database_total_writes_failed{}[30s])) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "Writes failed",
+                                "legendFormat": "{{instance}} - Writes failed",
                                 "step": 1
                             }
                         ],
@@ -2194,7 +2194,7 @@
                                 "expr": "sum(irate(scylla_database_total_writes_timedout{}[30s])) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "Writes timed out",
+                                "legendFormat": "{{instance}} - Writes timed out",
                                 "step": 1
                             }
                         ],
@@ -2490,7 +2490,7 @@
                                 "expr": "sum(irate(scylla_cache_hits{}[30s])) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "Cache Hits",
+                                "legendFormat": "{{instance}} - Cache Hits",
                                 "step": 1
                             }
                         ],
@@ -2571,7 +2571,7 @@
                                 "expr": "sum(irate(scylla_cache_misses{}[30s])) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "Cache Misses",
+                                "legendFormat": "{{instance}} - Cache Misses",
                                 "step": 1
                             }
                         ],
@@ -2823,7 +2823,7 @@
                                 "expr": "sum(irate(scylla_cache_insertions{}[30s])) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "Cache Insertions",
+                                "legendFormat": "{{instance}} - Cache Insertions",
                                 "step": 1
                             }
                         ],
@@ -2904,7 +2904,7 @@
                                 "expr": "sum(irate(scylla_cache_evictions{}[30s])) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "Cache Evictions",
+                                "legendFormat": "{{instance}} - Cache Evictions",
                                 "step": 1
                             }
                         ],
@@ -3000,7 +3000,7 @@
                                 "expr": "sum(irate(scylla_cache_merges{}[30s])) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "Cache Merges",
+                                "legendFormat": "{{instance}} - Cache Merges",
                                 "step": 1
                             }
                         ],
@@ -3081,7 +3081,7 @@
                                 "expr": "sum(irate(scylla_cache_removals{}[30s])) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "Cache Removals",
+                                "legendFormat": "{{instance}} - Cache Removals",
                                 "step": 1
                             }
                         ],
@@ -3177,7 +3177,7 @@
                                 "expr": "sum(scylla_cache_partitions{}) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "Cache Partitions",
+                                "legendFormat": "{{instance}} - Cache Partitions",
                                 "step": 1
                             }
                         ],
@@ -3258,7 +3258,7 @@
                                 "expr": "sum(scylla_cache_total{}) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "Cache Total Bytes",
+                                "legendFormat": "{{instance}} - Cache Total Bytes",
                                 "step": 1
                             }
                         ],
@@ -3373,7 +3373,7 @@
                                 "expr": "sum(scylla_lsa_total_space_bytes{}) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "LSA total memory",
+                                "legendFormat": "{{instance}} - LSA total memory",
                                 "step": 1
                             }
                         ],
@@ -3454,7 +3454,7 @@
                                 "expr": "sum(scylla_lsa_non_lsa_used_space_bytes{}) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "Non-LSA used memory",
+                                "legendFormat": "{{instance}} - Non-LSA used memory",
                                 "step": 1
                             }
                         ],
@@ -3940,7 +3940,7 @@
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "Running Compactions",
+                                "legendFormat": "{{instance}} - Running Compactions",
                                 "step": 1
                             }
                         ],


### PR DESCRIPTION
This patch adds the instane name to the hover option on graphs that are
per instance.

Fixes #149

Signed-off-by: Amnon Heiman <amnon@scylladb.com>