### PR TITLE
split grafana loading phase into its own script

### DIFF
--- a/load-grafana.sh
+++ b/load-grafana.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+. versions.sh
+VERSIONS=$DEFAULT_VERSION
+GRAFANA_PORT=3000
+DB_ADDRESS="127.0.0.1:9090"
+
+while getopts 'g:p:v:' option; do
+  case "$option" in
+    v) VERSIONS=$OPTARG
+       ;;
+    g) GRAFANA_PORT=$OPTARG
+       ;;
+    p) DB_ADDRESS=$OPTARG
+       ;;
+  esac
+done
+
+curl -XPOST -i http://localhost:$GRAFANA_PORT/api/datasources \
+     --data-binary '{"name":"prometheus", "type":"prometheus", "url":"'"http://$DB_ADDRESS"'", "access":"proxy", "basicAuth":false}' \
+     -H "Content-Type: application/json"
+IFS=',' ;for v in $VERSIONS; do
+	curl -XPOST -i http://localhost:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/scylla-dash.$v.json -H "Content-Type: application/json"
+	curl -XPOST -i http://localhost:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/scylla-dash-per-server.$v.json -H "Content-Type: application/json"
+	curl -XPOST -i http://localhost:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/scylla-dash-io-per-server.$v.json -H "Content-Type: application/json"
+done
+

--- a/start-all.sh
+++ b/start-all.sh
@@ -138,11 +138,4 @@ fi
 # Also note that the port to which we need to connect is 9090, regardless of which port we bind to at localhost.
 DB_ADDRESS="$(sudo docker inspect --format '{{ .NetworkSettings.IPAddress }}' $PROMETHEUS_NAME):9090"
 
-curl -XPOST -i http://localhost:$GRAFANA_PORT/api/datasources \
-     --data-binary '{"name":"prometheus", "type":"prometheus", "url":"'"http://$DB_ADDRESS"'", "access":"proxy", "basicAuth":false}' \
-     -H "Content-Type: application/json"
-IFS=',' ;for v in $VERSIONS; do
-	curl -XPOST -i http://localhost:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/scylla-dash.$v.json -H "Content-Type: application/json"
-	curl -XPOST -i http://localhost:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/scylla-dash-per-server.$v.json -H "Content-Type: application/json"
-	curl -XPOST -i http://localhost:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/scylla-dash-io-per-server.$v.json -H "Content-Type: application/json"
-done
+./load-grafana.sh -p $DB_ADDRESS -g $GRAFANA_PORT -v $VERSIONS


### PR DESCRIPTION
There are deployments in which, due to firewall rules or other issues,
once has issues pulling docker images. Or alternatively, an user may
already have a prometheus/grafana installation that they may want to
reuse.

For situations like that, it will be useful to extract the container
setup phase from the data loading phase. Users can then call just the
latter.

Signed-off-by: Glauber Costa <glauber@scylladb.com>