### PR TITLE
move referred files to a more specific path

### DIFF
--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -11,10 +11,10 @@ scrape_configs:
   honor_labels: true
   file_sd_configs:
     - files:
-      - /etc/prometheus/scylla_servers.yml
+      - /etc/scylla.d/prometheus/scylla_servers.yml
 
 - job_name: node_exporter
   honor_labels: true
   file_sd_configs:
     - files:
-      - /etc/prometheus/node_exporter_servers.yml
+      - /etc/scylla.d/prometheus/node_exporter_servers.yml

--- a/start-all.sh
+++ b/start-all.sh
@@ -65,15 +65,15 @@ if [ -z $DATA_DIR ]
 then
     sudo docker run -d $LOCAL \
          -v $PWD/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:Z \
-         -v $(readlink -m $SCYLLA_TARGET_FILE):/etc/prometheus/scylla_servers.yml:Z \
-         -v $(readlink -m $NODE_TARGET_FILE):/etc/prometheus/node_exporter_servers.yml:Z \
+         -v $(readlink -m $SCYLLA_TARGET_FILE):/etc/scylla.d/prometheus/scylla_servers.yml:Z \
+         -v $(readlink -m $NODE_TARGET_FILE):/etc/scylla.d/prometheus/node_exporter_servers.yml:Z \
          -p $PROMETHEUS_PORT:9090 --name $PROMETHEUS_NAME prom/prometheus:$PROMETHEUS_VERSION
 else
     echo "Loading prometheus data from $DATA_DIR"
     sudo docker run -d $LOCAL -v $DATA_DIR:/prometheus:Z \
          -v $PWD/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:Z \
-         -v $(readlink -m $SCYLLA_TARGET_FILE):/etc/prometheus/scylla_servers.yml:Z \
-         -v $(readlink -m $NODE_TARGET_FILE):/etc/prometheus/node_exporter_servers.yml:Z \
+         -v $(readlink -m $SCYLLA_TARGET_FILE):/etc/scylla.d/prometheus/scylla_servers.yml:Z \
+         -v $(readlink -m $NODE_TARGET_FILE):/etc/scylla.d/prometheus/node_exporter_servers.yml:Z \
          -p $PROMETHEUS_PORT:9090 --name $PROMETHEUS_NAME prom/prometheus:$PROMETHEUS_VERSION
 fi
 


### PR DESCRIPTION
Right now we are copying our files into /etc/prometheus. However, for
existing prometheus installations, that directory may already exist, and
we will have no control over its contents.

In particular, "node_exporter_servers.yml" is a quite obvious name for
someone using node_exporter, and copying our files there can override
existing ones.

This is important because although the user can put prometheus.yml
anywhere - and point to it with -config.file <something>, the files that
are referred to in the main configuration file are expected to be listed
in absolute paths.

In our container, that we control, we can leave the main prometheus.yaml
in /etc/prometheus, to avoid having to pass extra options, but we will
move the remaining files to /etc/scylla.d/prometheus. This way both the
docker environment and externally-installed environments can use the
same files, pointing to the same path, without fear of overriding
anything.

Signed-off-by: Glauber Costa <glauber@scylladb.com>