### PR TITLE
fix cache metrics graphs

### DIFF
--- a/grafana/scylla-dash-per-server.1.7.json
+++ b/grafana/scylla-dash-per-server.1.7.json
@@ -2820,7 +2820,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_insertions{}[30s])) by (instance)",
+                                "expr": "sum(irate(scylla_cache_total_operations_insertions{}[30s])) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
                                 "legendFormat": "{{instance}} - Cache Insertions",
@@ -2901,7 +2901,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_evictions{}[30s])) by (instance)",
+                                "expr": "sum(irate(scylla_cache_total_operations_evictions{}[30s])) by (instance)",
                                 "intervalFactor": 1,
                                 "refId": "A",
                                 "legendFormat": "{{instance}} - Cache Evictions",


### PR DESCRIPTION
Graphs showing currently blank, since metrics had their names changed in
1.7. Fix them, so they'll start showing.

Signed-off-by: Glauber Costa <glauber@scylladb.com>