### PR TITLE
script to generate yaml configuration files

### DIFF
--- a/genconfig.py
+++ b/genconfig.py
@@ -1,0 +1,39 @@
+#!/usr/bin/python
+
+import argparse
+import os
+import yaml
+
+scylla_port=9180
+node_exporter_port=9100
+
+def append_port(ips, port):
+    return [ "%s:%s"%(x, port) for x in ips ]
+
+def gen_targets(servers, port):
+    return {"targets" : append_port(servers, port) }
+
+def dump_yaml(directory, filename, servers, port):
+    try:
+        os.mkdir(directory)
+    except OSError, err:
+        if err.errno != 17:
+            raise
+        pass 
+    stream = file(os.path.join(directory, filename), 'w')
+    yaml.dump([gen_targets(servers, port)], stream)
+    
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate configuration for prometheus")
+    parser.add_argument('-d', '--directory', help="directory where to generate the configuration files", type=str, default="./")
+    parser.add_argument('-s', '--scylla', help="Generate scylla_servers.yml file", action='store_true')
+    parser.add_argument('-n', '--node', help="Generate node_exporter_servers.yml file", action='store_true')
+    parser.add_argument('servers', help="list of nodes to configure, separated by space", nargs='+', type=str, metavar='node_ip')
+    arguments = parser.parse_args()
+
+    if arguments.scylla:
+        dump_yaml(arguments.directory, 'scylla_servers.yaml', arguments.servers, scylla_port)
+    
+    if arguments.node:
+        dump_yaml(arguments.directory, 'node_exporter_servers.yaml', arguments.servers, node_exporter_port)
+    


### PR DESCRIPTION
We currently have to edit the yml files by hand to add the nodes ip
addresses to the files. This is hard to automate, and for this reason
I am bringing this script:

It will generate scylla_servers.yml and node_exporter.yml files into
a directory of the user's choosing. It can write both files or one of
them only, which we can control by the -s and -n flags respectively.

usage: genconfig.py [-h] [-d DIRECTORY] [-s] [-n] node_ip [node_ip ...]

Generate configuration for prometheus

positional arguments:
  node_ip               list of nodes to configure, separated by space

optional arguments:
  -h, --help            show this help message and exit
  -d DIRECTORY, --directory DIRECTORY
                        directory where to generate the configuration files
  -s, --scylla          Generate scylla_servers.yml file
  -n, --node            Generate node_exporter_servers.yml file

Signed-off-by: Glauber Costa <glauber@scylladb.com>