### PR TITLE
Change data retention when using external data to 5 years

### DIFF
--- a/start-all.sh
+++ b/start-all.sh
@@ -78,7 +78,10 @@ else
          -v $PWD/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:Z \
          -v $(readlink -m $SCYLLA_TARGET_FILE):/etc/scylla.d/prometheus/scylla_servers.yml:Z \
          -v $(readlink -m $NODE_TARGET_FILE):/etc/scylla.d/prometheus/node_exporter_servers.yml:Z \
-         -p $PROMETHEUS_PORT:9090 --name $PROMETHEUS_NAME prom/prometheus:$PROMETHEUS_VERSION
+         -p $PROMETHEUS_PORT:9090 --name $PROMETHEUS_NAME prom/prometheus:$PROMETHEUS_VERSION \
+         -storage.local.retention=43800h -config.file=/etc/prometheus/prometheus.yml \
+         -storage.local.path=/prometheus -web.console.libraries=/etc/prometheus/console_libraries \
+         -web.console.templates=/etc/prometheus/consoles
 fi
 
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
The default data retention for Prometheus is 15 days. That may be all right during normal usage, but doesn't work very well when we want to use it to analyse previously captured data (using the flag `-d`).

When the monitoring containers are started with an external source of data provided the data retention is set to 5 years to avoid this problem.