### PR TITLE
add units to cluster dashboard

### DIFF
--- a/grafana/scylla-dash.1.7.json
+++ b/grafana/scylla-dash.1.7.json
@@ -281,9 +281,9 @@
                         },
                         "yaxes": [
                             {
-                                "format": "short",
+                                "format": "percent",
                                 "logBase": 1,
-                                "max": null,
+                                "max": 100,
                                 "min": 0,
                                 "show": true
                             },
@@ -362,7 +362,7 @@
                         },
                         "yaxes": [
                             {
-                                "format": "short",
+                                "format": "ops",
                                 "logBase": 1,
                                 "max": null,
                                 "min": 0,
@@ -544,7 +544,7 @@
                         },
                         "yaxes": [
                             {
-                                "format": "short",
+                                "format": "wps",
                                 "logBase": 1,
                                 "max": null,
                                 "min": 0,
@@ -625,7 +625,7 @@
                         },
                         "yaxes": [
                             {
-                                "format": "short",
+                                "format": "rps",
                                 "logBase": 1,
                                 "max": null,
                                 "min": 0,
@@ -880,7 +880,7 @@
                                 "show": true
                             },
                             {
-                                "format": "short",
+                                "format": "wps",
                                 "logBase": 1,
                                 "max": null,
                                 "min": null,
@@ -953,7 +953,7 @@
                         },
                         "yaxes": [
                             {
-                                "format": "short",
+                                "format": "rps",
                                 "logBase": 1,
                                 "max": null,
                                 "min": 0,

--- a/grafana/scylla-dash.1.7.json
+++ b/grafana/scylla-dash.1.7.json
@@ -544,11 +544,12 @@
                         },
                         "yaxes": [
                             {
-                                "format": "wps",
+                                "format": "short",
                                 "logBase": 1,
                                 "max": null,
                                 "min": 0,
-                                "show": true
+                                "show": true,
+                                "label": "Queue Length"
                             },
                             {
                                 "format": "short",
@@ -625,11 +626,12 @@
                         },
                         "yaxes": [
                             {
-                                "format": "rps",
+                                "format": "short",
                                 "logBase": 1,
                                 "max": null,
                                 "min": 0,
-                                "show": true
+                                "show": true,
+                                "label": "Queue Length"
                             },
                             {
                                 "format": "short",
@@ -705,7 +707,7 @@
                         },
                         "yaxes": [
                             {
-                                "format": "short",
+                                "format": "wps",
                                 "logBase": 1,
                                 "max": null,
                                 "min": 0,
@@ -785,7 +787,7 @@
                         },
                         "yaxes": [
                             {
-                                "format": "short",
+                                "format": "wps",
                                 "logBase": 1,
                                 "max": null,
                                 "min": 0,
@@ -877,7 +879,8 @@
                                 "logBase": 1,
                                 "max": null,
                                 "min": 0,
-                                "show": true
+                                "show": true,
+                                "label": "Queue Length"
                             },
                             {
                                 "format": "wps",
@@ -953,11 +956,12 @@
                         },
                         "yaxes": [
                             {
-                                "format": "rps",
+                                "format": "short",
                                 "logBase": 1,
                                 "max": null,
                                 "min": 0,
-                                "show": true
+                                "show": true,
+                                "label": "Queue Length"
                             },
                             {
                                 "format": "short",
@@ -1033,7 +1037,7 @@
                         },
                         "yaxes": [
                             {
-                                "format": "short",
+                                "format": "rps",
                                 "logBase": 1,
                                 "max": null,
                                 "min": 0,
@@ -1113,7 +1117,7 @@
                         },
                         "yaxes": [
                             {
-                                "format": "short",
+                                "format": "rps",
                                 "logBase": 1,
                                 "max": null,
                                 "min": 0,
@@ -1227,7 +1231,7 @@
                         },
                         "yaxes": [
                             {
-                                "format": "short",
+                                "format": "ops",
                                 "logBase": 1,
                                 "max": null,
                                 "min": 0,
@@ -1307,7 +1311,7 @@
                         },
                         "yaxes": [
                             {
-                                "format": "short",
+                                "format": "ops",
                                 "logBase": 1,
                                 "max": null,
                                 "min": 0,


### PR DESCRIPTION
This PR is an initial attempt to fix #182, limited to cluster dashboard, 1.7 release
The following table describe the update metric for each chart:

Name | Metric | New Unit
---------|---------|---------------
Load | avg(scylla_reactor_utilization{} ) | percent (max: 100, min: 0) |
Requests Served| sum(irate(scylla_transport_requests_served{}[30s])) + sum(irate(scylla_thrift_served{}[30s])) |  ops
Foreground Writes | sum(scylla_storage_proxy_coordinator_foreground_writes{}) | wps
Foreground Reads | sum(scylla_storage_proxy_coordinator_foreground_reads{}) | rps
Background Writes | sum(scylla_storage_proxy_coordinator_background_writes{}) | wps
Background Reads | sum(scylla_storage_proxy_coordinator_background_reads{}) | rps

The following metrics does not match any existing Grafana unit, so left unchanged. Once custom metric are available[1] we can revisit them.

* Write Timeouts per Second
* Write Unavailable per Second
* Read Timeouts per Second
* Read Unavailable per Second
* Cache Hits
* Cache Misses

[1] https://github.com/grafana/grafana/issues/2968



