### PR TITLE
Add option for per shard or per instance charts

### DIFF
--- a/grafana/scylla-dash-per-server.1.7.json
+++ b/grafana/scylla-dash-per-server.1.7.json
@@ -381,7 +381,7 @@
                                 "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\", shard=~\"[[shard]]\"} ) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} {{shard}}",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -464,7 +464,7 @@
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "{{instance}} {{shard}} -Requests Served per Server",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -656,7 +656,7 @@
                                 "expr": "sum(scylla_storage_proxy_coordinator_foreground_writes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} {{shard}} - Foreground Writes per Server",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -738,7 +738,7 @@
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "{{instance}} {{shard}} - Foreground Reads per Server",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -819,7 +819,7 @@
                                 "expr": "sum(irate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} {{shard}} - Write Timeouts per Second per Server",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -900,7 +900,7 @@
                                 "expr": "sum(irate(scylla_storage_proxy_coordinator_write_unavailable{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} {{shard}} - Write Unavailable per Second per Server",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -989,7 +989,7 @@
                                 "expr": "sum(scylla_storage_proxy_coordinator_background_writes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} {{shard}} - Background Writes per Server",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -1070,7 +1070,7 @@
                                 "expr": "sum(scylla_storage_proxy_coordinator_background_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} {{shard}} - Background Reads per Server",
+                                "legendFormat": "",
                                 "step": 4
                             }
                         ],
@@ -1151,7 +1151,7 @@
                                 "expr": "sum(irate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} {{shard}} - Read Timeouts per Second per Server",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -1232,7 +1232,7 @@
                                 "expr": "sum(irate(scylla_storage_proxy_coordinator_read_unavailable{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "metric": "",
-                                "legendFormat": "{{instance}} {{shard}} - Read Unavailable per Second per Server",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 4
                             }
@@ -1341,7 +1341,7 @@
                                 "expr": "sum(irate(scylla_database_total_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} {{shard}} - Reads",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -1423,7 +1423,7 @@
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "{{instance}} {{shard}} - Writes",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -1504,7 +1504,7 @@
                                 "expr": "sum(scylla_database_active_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by (instance)",
                                 "interv[[by]]": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} {{shard}} - Active sstable reads",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -1585,7 +1585,7 @@
                                 "expr": "sum(scylla_database_queued_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by (instance)",
                                 "interv[[by]]": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} {{shard}} - Queued sstable reads",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -1666,7 +1666,7 @@
                                 "expr": "sum(scylla_database_requests_blocked_memory{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by (instance)",
                                 "interv[[by]]": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} {{shard}} - Writes currently blocked on dirty",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -1747,7 +1747,7 @@
                                 "expr": "sum(scylla_commitlog_pending_allocations{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by (instance)",
                                 "interv[[by]]": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} {{shard}} - Writes currently blocked on commitlog",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -1843,7 +1843,7 @@
                                 "expr": "sum(irate(scylla_database_total_reads_failed{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} {{shard}} - Reads failed",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -1924,7 +1924,7 @@
                                 "expr": "sum(irate(scylla_database_requests_blocked_memory{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} {{shard}} - Writes blocked on dirty",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -2005,7 +2005,7 @@
                                 "expr": "sum(irate(scylla_commitlog_requests_blocked_memory{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} {{shard}} - Writes blocked on commitlog",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -2116,7 +2116,7 @@
                                 "expr": "sum(irate(scylla_database_total_writes_failed{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} {{shard}} - Writes failed",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -2197,7 +2197,7 @@
                                 "expr": "sum(irate(scylla_database_total_writes_timedout{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} {{shard}} - Writes timed out",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -2493,7 +2493,7 @@
                                 "expr": "sum(irate(scylla_cache_hits{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} {{shard}} - Cache Hits",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -2574,7 +2574,7 @@
                                 "expr": "sum(irate(scylla_cache_misses{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} {{shard}} - Cache Misses",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -2826,7 +2826,7 @@
                                 "expr": "sum(irate(scylla_cache_insertions{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} {{shard}} - Cache Insertions",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -2907,7 +2907,7 @@
                                 "expr": "sum(irate(scylla_cache_evictions{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} {{shard}} - Cache Evictions",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -3003,7 +3003,7 @@
                                 "expr": "sum(irate(scylla_cache_merges{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} {{shard}} - Cache Merges",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -3084,7 +3084,7 @@
                                 "expr": "sum(irate(scylla_cache_removals{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} {{shard}} - Cache Removals",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -3180,7 +3180,7 @@
                                 "expr": "sum(scylla_cache_partitions{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by (instance)",
                                 "interv[[by]]": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} {{shard}} - Cache Partitions",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -3261,7 +3261,7 @@
                                 "expr": "sum(scylla_cache_total{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by (instance)",
                                 "interv[[by]]": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} {{shard}} - Cache Total Bytes",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -3376,7 +3376,7 @@
                                 "expr": "sum(scylla_lsa_total_space_bytes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} {{shard}} - LSA total memory",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -3457,7 +3457,7 @@
                                 "expr": "sum(scylla_lsa_non_lsa_used_space_bytes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} {{shard}} - Non-LSA used memory",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -3943,7 +3943,7 @@
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "{{instance}} {{shard}} - Running Compactions",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],

--- a/grafana/scylla-dash-per-server.1.7.json
+++ b/grafana/scylla-dash-per-server.1.7.json
@@ -378,10 +378,10 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "avg(scylla_reactor_utilization{} ) by (instance)",
+                                "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\", shard=~\"[[shard]]\"} ) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} - Load per Server",
+                                "legendFormat": "{{instance}} {{shard}}",
                                 "step": 1
                             }
                         ],
@@ -460,11 +460,11 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_transport_requests_served{}[30s])) by (instance) + sum(irate(scylla_thrift_served{}[30s])) by (instance)",
+                                "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "{{instance}} -Requests Served per Server",
+                                "legendFormat": "{{instance}} {{shard}} -Requests Served per Server",
                                 "step": 1
                             }
                         ],
@@ -653,10 +653,10 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_writes{}) by (instance)",
+                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_writes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} - Foreground Writes per Server",
+                                "legendFormat": "{{instance}} {{shard}} - Foreground Writes per Server",
                                 "step": 1
                             }
                         ],
@@ -734,11 +734,11 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_reads{}) by (instance)",
+                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "{{instance}} - Foreground Reads per Server",
+                                "legendFormat": "{{instance}} {{shard}} - Foreground Reads per Server",
                                 "step": 1
                             }
                         ],
@@ -816,10 +816,10 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_timeouts{}[30s])) by (instance)",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} - Write Timeouts per Second per Server",
+                                "legendFormat": "{{instance}} {{shard}} - Write Timeouts per Second per Server",
                                 "step": 1
                             }
                         ],
@@ -897,10 +897,10 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_unavailable{}[30s])) by (instance)",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_unavailable{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} - Write Unavailable per Second per Server",
+                                "legendFormat": "{{instance}} {{shard}} - Write Unavailable per Second per Server",
                                 "step": 1
                             }
                         ],
@@ -986,10 +986,10 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_background_writes{}) by (instance)",
+                                "expr": "sum(scylla_storage_proxy_coordinator_background_writes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} - Background Writes per Server",
+                                "legendFormat": "{{instance}} {{shard}} - Background Writes per Server",
                                 "step": 1
                             }
                         ],
@@ -1067,10 +1067,10 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_background_reads{}) by (instance)",
+                                "expr": "sum(scylla_storage_proxy_coordinator_background_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} - Background Reads per Server",
+                                "legendFormat": "{{instance}} {{shard}} - Background Reads per Server",
                                 "step": 4
                             }
                         ],
@@ -1148,10 +1148,10 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_timeouts{}[30s])) by (instance)",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} - Read Timeouts per Second per Server",
+                                "legendFormat": "{{instance}} {{shard}} - Read Timeouts per Second per Server",
                                 "step": 1
                             }
                         ],
@@ -1229,10 +1229,10 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_unavailable{}[30s])) by (instance)",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_unavailable{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "metric": "",
-                                "legendFormat": "{{instance}} - Read Unavailable per Second per Server",
+                                "legendFormat": "{{instance}} {{shard}} - Read Unavailable per Second per Server",
                                 "refId": "A",
                                 "step": 4
                             }
@@ -1338,10 +1338,10 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_database_total_reads{}[30s])) by (instance)",
+                                "expr": "sum(irate(scylla_database_total_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} - Reads",
+                                "legendFormat": "{{instance}} {{shard}} - Reads",
                                 "step": 1
                             }
                         ],
@@ -1419,11 +1419,11 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_database_total_writes{}[30s])) by (instance)",
+                                "expr": "sum(irate(scylla_database_total_writes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "{{instance}} - Writes",
+                                "legendFormat": "{{instance}} {{shard}} - Writes",
                                 "step": 1
                             }
                         ],
@@ -1501,10 +1501,10 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(scylla_database_active_reads{}) by (instance)",
-                                "intervalFactor": 1,
+                                "expr": "sum(scylla_database_active_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by (instance)",
+                                "interv[[by]]": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} - Active sstable reads",
+                                "legendFormat": "{{instance}} {{shard}} - Active sstable reads",
                                 "step": 1
                             }
                         ],
@@ -1582,10 +1582,10 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(scylla_database_queued_reads{}) by (instance)",
-                                "intervalFactor": 1,
+                                "expr": "sum(scylla_database_queued_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by (instance)",
+                                "interv[[by]]": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} - Queued sstable reads",
+                                "legendFormat": "{{instance}} {{shard}} - Queued sstable reads",
                                 "step": 1
                             }
                         ],
@@ -1663,10 +1663,10 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(scylla_database_requests_blocked_memory{}) by (instance)",
-                                "intervalFactor": 1,
+                                "expr": "sum(scylla_database_requests_blocked_memory{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by (instance)",
+                                "interv[[by]]": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} - Writes currently blocked on dirty",
+                                "legendFormat": "{{instance}} {{shard}} - Writes currently blocked on dirty",
                                 "step": 1
                             }
                         ],
@@ -1744,10 +1744,10 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(scylla_commitlog_pending_allocations{}) by (instance)",
-                                "intervalFactor": 1,
+                                "expr": "sum(scylla_commitlog_pending_allocations{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by (instance)",
+                                "interv[[by]]": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} - Writes currently blocked on commitlog",
+                                "legendFormat": "{{instance}} {{shard}} - Writes currently blocked on commitlog",
                                 "step": 1
                             }
                         ],
@@ -1840,10 +1840,10 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_database_total_reads_failed{}[30s])) by (instance)",
+                                "expr": "sum(irate(scylla_database_total_reads_failed{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} - Reads failed",
+                                "legendFormat": "{{instance}} {{shard}} - Reads failed",
                                 "step": 1
                             }
                         ],
@@ -1921,10 +1921,10 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_database_requests_blocked_memory{}[30s])) by (instance)",
+                                "expr": "sum(irate(scylla_database_requests_blocked_memory{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} - Writes blocked on dirty",
+                                "legendFormat": "{{instance}} {{shard}} - Writes blocked on dirty",
                                 "step": 1
                             }
                         ],
@@ -2002,10 +2002,10 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_commitlog_requests_blocked_memory{}[30s])) by (instance)",
+                                "expr": "sum(irate(scylla_commitlog_requests_blocked_memory{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} - Writes blocked on commitlog",
+                                "legendFormat": "{{instance}} {{shard}} - Writes blocked on commitlog",
                                 "step": 1
                             }
                         ],
@@ -2113,10 +2113,10 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_database_total_writes_failed{}[30s])) by (instance)",
+                                "expr": "sum(irate(scylla_database_total_writes_failed{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} - Writes failed",
+                                "legendFormat": "{{instance}} {{shard}} - Writes failed",
                                 "step": 1
                             }
                         ],
@@ -2194,10 +2194,10 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_database_total_writes_timedout{}[30s])) by (instance)",
+                                "expr": "sum(irate(scylla_database_total_writes_timedout{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} - Writes timed out",
+                                "legendFormat": "{{instance}} {{shard}} - Writes timed out",
                                 "step": 1
                             }
                         ],
@@ -2490,10 +2490,10 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_hits{}[30s])) by (instance)",
+                                "expr": "sum(irate(scylla_cache_hits{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} - Cache Hits",
+                                "legendFormat": "{{instance}} {{shard}} - Cache Hits",
                                 "step": 1
                             }
                         ],
@@ -2571,10 +2571,10 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_misses{}[30s])) by (instance)",
+                                "expr": "sum(irate(scylla_cache_misses{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} - Cache Misses",
+                                "legendFormat": "{{instance}} {{shard}} - Cache Misses",
                                 "step": 1
                             }
                         ],
@@ -2823,10 +2823,10 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_insertions{}[30s])) by (instance)",
+                                "expr": "sum(irate(scylla_cache_insertions{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} - Cache Insertions",
+                                "legendFormat": "{{instance}} {{shard}} - Cache Insertions",
                                 "step": 1
                             }
                         ],
@@ -2904,10 +2904,10 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_evictions{}[30s])) by (instance)",
+                                "expr": "sum(irate(scylla_cache_evictions{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} - Cache Evictions",
+                                "legendFormat": "{{instance}} {{shard}} - Cache Evictions",
                                 "step": 1
                             }
                         ],
@@ -3000,10 +3000,10 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_merges{}[30s])) by (instance)",
+                                "expr": "sum(irate(scylla_cache_merges{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} - Cache Merges",
+                                "legendFormat": "{{instance}} {{shard}} - Cache Merges",
                                 "step": 1
                             }
                         ],
@@ -3081,10 +3081,10 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_removals{}[30s])) by (instance)",
+                                "expr": "sum(irate(scylla_cache_removals{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} - Cache Removals",
+                                "legendFormat": "{{instance}} {{shard}} - Cache Removals",
                                 "step": 1
                             }
                         ],
@@ -3177,10 +3177,10 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(scylla_cache_partitions{}) by (instance)",
-                                "intervalFactor": 1,
+                                "expr": "sum(scylla_cache_partitions{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by (instance)",
+                                "interv[[by]]": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} - Cache Partitions",
+                                "legendFormat": "{{instance}} {{shard}} - Cache Partitions",
                                 "step": 1
                             }
                         ],
@@ -3258,10 +3258,10 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(scylla_cache_total{}) by (instance)",
-                                "intervalFactor": 1,
+                                "expr": "sum(scylla_cache_total{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by (instance)",
+                                "interv[[by]]": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} - Cache Total Bytes",
+                                "legendFormat": "{{instance}} {{shard}} - Cache Total Bytes",
                                 "step": 1
                             }
                         ],
@@ -3373,10 +3373,10 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(scylla_lsa_total_space_bytes{}) by (instance)",
+                                "expr": "sum(scylla_lsa_total_space_bytes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} - LSA total memory",
+                                "legendFormat": "{{instance}} {{shard}} - LSA total memory",
                                 "step": 1
                             }
                         ],
@@ -3454,10 +3454,10 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(scylla_lsa_non_lsa_used_space_bytes{}) by (instance)",
+                                "expr": "sum(scylla_lsa_non_lsa_used_space_bytes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "{{instance}} - Non-LSA used memory",
+                                "legendFormat": "{{instance}} {{shard}} - Non-LSA used memory",
                                 "step": 1
                             }
                         ],
@@ -3939,11 +3939,11 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(scylla_compaction_manager_compactions{}) by (instance)",
+                                "expr": "sum(scylla_compaction_manager_compactions{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "{{instance}} - Running Compactions",
+                                "legendFormat": "{{instance}} {{shard}} - Running Compactions",
                                 "step": 1
                             }
                         ],
@@ -4055,7 +4055,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(scylla_cql_inserts{}) by (instance)",
+                                "expr": "sum(scylla_cql_inserts{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
@@ -4137,7 +4137,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(scylla_cql_reads{}) by (instance)",
+                                "expr": "sum(scylla_cql_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
@@ -4219,7 +4219,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(scylla_cql_deletes{}) by (instance)",
+                                "expr": "sum(scylla_cql_deletes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
@@ -4301,7 +4301,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(scylla_cql_updates{}) by (instance)",
+                                "expr": "sum(scylla_cql_updates{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
@@ -4376,44 +4376,137 @@
         "templating": {
             "list": [
                 {
-                    "type": "query",
-                    "datasource": "prometheus",
-                    "refresh": 1,
-                    "name": "monitor_disk",
-                    "hide": 0,
-                    "options": [
-
-                    ],
-                    "includeAll": false,
-                    "multi": false,
-                    "regex": "/.*device=\"([^\\\"]*)\".*/",
+                    "allValue": null,
                     "current": {
-
+                        "isNone": true,
+                        "text": "None",
+                        "value": ""
                     },
-                    "query": "node_disk_bytes_read"
+                    "datasource": "prometheus",
+                    "hide": 0,
+                    "includeAll": false,
+                    "label": null,
+                    "multi": false,
+                    "name": "monitor_disk",
+                    "options": [],
+                    "query": "node_disk_bytes_read",
+                    "refresh": 1,
+                    "regex": "/.*device=\"([^\\\"]*)\".*/",
+                    "sort": 0,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
                 },
                 {
-                    "type": "query",
-                    "datasource": "prometheus",
-                    "refresh": 1,
-                    "name": "monitor_network_interface",
-                    "hide": 0,
-                    "options": [
-
-                    ],
-                    "includeAll": false,
-                    "multi": false,
-                    "regex": "/.*device=\"([^\\\"]*)\".*/",
+                    "allValue": null,
                     "current": {
-
+                        "isNone": true,
+                        "text": "None",
+                        "value": ""
                     },
-                    "query": "node_network_receive_packets"
+                    "datasource": "prometheus",
+                    "hide": 0,
+                    "includeAll": false,
+                    "label": null,
+                    "multi": false,
+                    "name": "monitor_network_interface",
+                    "options": [],
+                    "query": "node_network_receive_packets",
+                    "refresh": 1,
+                    "regex": "/.*device=\"([^\\\"]*)\".*/",
+                    "sort": 0,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                },
+                {
+                    "allValue": null,
+                    "current": {
+                        "tags": [],
+                        "text": "instance",
+                        "value": "instance"
+                    },
+                    "hide": 0,
+                    "includeAll": false,
+                    "label": "by",
+                    "multi": false,
+                    "name": "by",
+                    "options": [
+                        {
+                            "selected": true,
+                            "text": "instance",
+                            "value": "instance"
+                        },
+                        {
+                            "selected": false,
+                            "text": "shard",
+                            "value": "shard"
+                        },
+                        {
+                            "selected": false,
+                            "text": "cluster",
+                            "value": "cluster"
+                        }
+                    ],
+                    "query": "instance,shard,cluster",
+                    "type": "custom"
+                },
+                {
+                    "allValue": null,
+                    "current": {
+                        "text": "All",
+                        "value": [
+                            "$__all"
+                        ]
+                    },
+                    "datasource": "prometheus",
+                    "hide": 0,
+                    "includeAll": true,
+                    "label": "node",
+                    "multi": true,
+                    "name": "node",
+                    "options": [],
+                    "query": "scylla_reactor_utilization",
+                    "refresh": 2,
+                    "regex": "/instance=\"([a-zA-Z0-9\\-]*)\".*/",
+                    "sort": 0,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                },
+                {
+                    "allValue": null,
+                    "current": {
+                        "text": "All",
+                        "value": "$__all"
+                    },
+                    "datasource": "prometheus",
+                    "hide": 0,
+                      "includeAll": true,
+                    "label": "shard",
+                    "multi": true,
+                    "name": "shard",
+                    "options": [],
+                    "query": "scylla_reactor_utilization{instance=~\"$node\"}",
+                    "refresh": 2,
+                    "regex": "/shard=\"([0-9]*)\".*/",
+                    "sort": 0,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
                 }
             ]
         },
         "annotations": {
             "list": [
-
             ]
         },
         "refresh": "30s",


### PR DESCRIPTION
This PR add 3 new selectors to the per server dashboard:
- Level: Cluster, Instance or shard
- Instance: select which instance to present
- Shard: select which shard present

This allows, for example to select one instance, and break it to its shards

![image](https://user-images.githubusercontent.com/170200/27450872-ca0d60ec-5795-11e7-9a47-d0baf8224e81.png)
