### PR TITLE
add Grafana admin password option

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,6 @@ ___
 ___
 
 
-
-
 #### Connecting Scylla and the Monitoring locally - the local flag
 When running the Prometheus and Grafana on the same host as scylla, use the local `-l` flag, so processes inside the
 containers will share the host network stack and would have access to the `localhost`.
@@ -117,7 +115,7 @@ containers will share the host network stack and would have access to the `local
 
 ### Use
 Direct your browser to `your-server-ip:3000`
-By default, Grafana authentication is disabled. To enable it and set password for user admin use the `-a` option
+By default, Grafana authentication is disabled. To enable it and set a password for user admin use the `-a` option
 
 #### Choose Disk and network interface
 The dashboard holds a drop down menu at its upper left corner for disk and network interface.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ ___
 ___
 
 
+
+
 #### Connecting Scylla and the Monitoring locally - the local flag
 When running the Prometheus and Grafana on the same host as scylla, use the local `-l` flag, so processes inside the
 containers will share the host network stack and would have access to the `localhost`.
@@ -115,6 +117,7 @@ containers will share the host network stack and would have access to the `local
 
 ### Use
 Direct your browser to `your-server-ip:3000`
+By default, Grafana authentication is disabled. To enable it and set password for user admin use the `-a` option
 
 #### Choose Disk and network interface
 The dashboard holds a drop down menu at its upper left corner for disk and network interface.

--- a/load-grafana.sh
+++ b/load-grafana.sh
@@ -5,9 +5,9 @@ VERSIONS=$DEFAULT_VERSION
 GRAFANA_PORT=3000
 DB_ADDRESS="127.0.0.1:9090"
 
-usage="$(basename "$0") [-h] [-v comma separated versions ] [-g grafana port ] [-p ip:port address of prometheus ] -- loads the prometheus datasource and the Scylla dashboards into an existing grafana installation"
+usage="$(basename "$0") [-h] [-v comma separated versions ] [-g grafana port ] [-p ip:port address of prometheus ] [-a admin password] -- loads the prometheus datasource and the Scylla dashboards into an existing grafana installation"
 
-while getopts ':hg:p:v:' option; do
+while getopts ':hg:p:v:a:' option; do
   case "$option" in
     h) echo "$usage"
        exit
@@ -18,15 +18,17 @@ while getopts ':hg:p:v:' option; do
        ;;
     p) DB_ADDRESS=$OPTARG
        ;;
+    a) GRAFANA_ADMIN_PASSWORD=$OPTARG
+       ;;
   esac
 done
 
-curl -XPOST -i http://localhost:$GRAFANA_PORT/api/datasources \
+curl -XPOST -i http://admin:$GRAFANA_ADMIN_PASSWORD@localhost:$GRAFANA_PORT/api/datasources \
      --data-binary '{"name":"prometheus", "type":"prometheus", "url":"'"http://$DB_ADDRESS"'", "access":"proxy", "basicAuth":false}' \
      -H "Content-Type: application/json"
 IFS=',' ;for v in $VERSIONS; do
-	curl -XPOST -i http://localhost:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/scylla-dash.$v.json -H "Content-Type: application/json"
-	curl -XPOST -i http://localhost:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/scylla-dash-per-server.$v.json -H "Content-Type: application/json"
-	curl -XPOST -i http://localhost:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/scylla-dash-io-per-server.$v.json -H "Content-Type: application/json"
+	curl -XPOST -i http://admin:$GRAFANA_ADMIN_PASSWORD@localhost:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/scylla-dash.$v.json -H "Content-Type: application/json"
+	curl -XPOST -i http://admin:$GRAFANA_ADMIN_PASSWORD@localhost:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/scylla-dash-per-server.$v.json -H "Content-Type: application/json"
+	curl -XPOST -i http://admin:$GRAFANA_ADMIN_PASSWORD@localhost:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/scylla-dash-io-per-server.$v.json -H "Content-Type: application/json"
 done
 


### PR DESCRIPTION
This PR add an option to change the Grafana admin password from the command line, by adding a `-a password` to start_all.sh
By adding a password option, one activates the following:
- Enabling basic Grafana auth
- Setting the Admin user password
- Disabling anonymous access to Grafana

Nothing in the UX change when admin password is not provided.

Fix #185 
