### PR TITLE
dots have feelings too.

### DIFF
--- a/grafana/scylla-dash-per-server.1.6.json
+++ b/grafana/scylla-dash-per-server.1.6.json
@@ -4066,7 +4066,7 @@
                     "options": [],
                     "query": "scylla_reactor_gauge_load",
                     "refresh": 2,
-                    "regex": "/instance=\"([a-zA-Z0-9\\-]*)\".*/",
+                    "regex": "/instance=\"([a-zA-Z0-9\\-\\.]*)\".*/",
                     "sort": 0,
                     "tagValuesQuery": "",
                     "tags": [],

--- a/grafana/scylla-dash-per-server.1.7.json
+++ b/grafana/scylla-dash-per-server.1.7.json
@@ -4472,7 +4472,7 @@
                     "options": [],
                     "query": "scylla_reactor_utilization",
                     "refresh": 2,
-                    "regex": "/instance=\"([a-zA-Z0-9\\-]*)\".*/",
+                    "regex": "/instance=\"([a-zA-Z0-9\\-\\.]*)\".*/",
                     "sort": 0,
                     "tagValuesQuery": "",
                     "tags": [],

--- a/grafana/scylla-dash-per-server.2017.1.json
+++ b/grafana/scylla-dash-per-server.2017.1.json
@@ -4066,7 +4066,7 @@
                     "options": [],
                     "query": "scylla_reactor_gauge_load",
                     "refresh": 2,
-                    "regex": "/instance=\"([a-zA-Z0-9\\-]*)\".*/",
+                    "regex": "/instance=\"([a-zA-Z0-9\\-\\.]*)\".*/",
                     "sort": 0,
                     "tagValuesQuery": "",
                     "tags": [],

--- a/grafana/scylla-dash-per-server.master.json
+++ b/grafana/scylla-dash-per-server.master.json
@@ -4469,7 +4469,7 @@
                     "options": [],
                     "query": "scylla_reactor_utilization",
                     "refresh": 2,
-                    "regex": "/instance=\"([a-zA-Z0-9\\-]*)\".*/",
+                    "regex": "/instance=\"([a-zA-Z0-9\\-\\.]*)\".*/",
                     "sort": 0,
                     "tagValuesQuery": "",
                     "tags": [],


### PR DESCRIPTION
Dots are also valid characters in instance names. The current regex
makes instances with dots in its name fail to show up.

Signed-off-by: Glauber Costa <glauber@scylladb.com>