### PR TITLE
Add sstables streaming charts

### DIFF
--- a/grafana/scylla-dash-per-server.2017.1.json
+++ b/grafana/scylla-dash-per-server.2017.1.json
@@ -1,7 +1,6 @@
 {
     "dashboard": {
         "id": null,
-        "title": "Scylla Enterprise Per Server Metrics 2017.1",
         "annotations": {
             "list": []
         },
@@ -10,7 +9,7 @@
         "graphTooltip": 1,
         "hideControls": false,
         "links": [],
-        "refresh": "30s",
+        "refresh": false,
         "rows": [
             {
                 "collapse": false,
@@ -500,13 +499,13 @@
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "step": 120
+                                "step": 60
                             },
                             {
                                 "expr": "(sum(node_filesystem_size{mountpoint=\"/var/lib/scylla\"})-sum(node_filesystem_avail{mountpoint=\"/var/lib/scylla\"}))/1000000000",
                                 "intervalFactor": 1,
                                 "refId": "B",
-                                "step": 120
+                                "step": 60
                             }
                         ],
                         "title": "Total Storage",
@@ -1497,158 +1496,6 @@
                         "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
-                        "fill": 1,
-                        "id": 75,
-                        "legend": {
-                            "avg": false,
-                            "current": false,
-                            "max": false,
-                            "min": false,
-                            "show": false,
-                            "total": false,
-                            "values": false
-                        },
-                        "lines": true,
-                        "linewidth": 1,
-                        "links": [],
-                        "nullPointMode": "null",
-                        "percentage": false,
-                        "pointradius": 5,
-                        "points": false,
-                        "renderer": "flot",
-                        "seriesOverrides": [],
-                        "span": 3,
-                        "stack": false,
-                        "steppedLine": false,
-                        "targets": [
-                            {
-                                "expr": "sum(scylla_database_queue_length_active_reads_streaming{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
-                                "intervalFactor": 2,
-                                "refId": "A",
-                                "step": 2
-                            }
-                        ],
-                        "thresholds": [],
-                        "timeFrom": null,
-                        "timeShift": null,
-                        "title": "Active SSTable Streaming",
-                        "tooltip": {
-                            "shared": true,
-                            "sort": 0,
-                            "value_type": "individual"
-                        },
-                        "type": "graph",
-                        "xaxis": {
-                            "mode": "time",
-                            "name": null,
-                            "show": true,
-                            "values": []
-                        },
-                        "yaxes": [
-                            {
-                                "format": "short",
-                                "label": null,
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "label": null,
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
-                    },
-                    {
-                        "aliasColors": {},
-                        "bars": false,
-                        "datasource": "prometheus",
-                        "fill": 1,
-                        "id": 76,
-                        "legend": {
-                            "avg": false,
-                            "current": false,
-                            "max": false,
-                            "min": false,
-                            "show": false,
-                            "total": false,
-                            "values": false
-                        },
-                        "lines": true,
-                        "linewidth": 1,
-                        "links": [],
-                        "nullPointMode": "null",
-                        "percentage": false,
-                        "pointradius": 5,
-                        "points": false,
-                        "renderer": "flot",
-                        "seriesOverrides": [],
-                        "span": 3,
-                        "stack": false,
-                        "steppedLine": false,
-                        "targets": [
-                            {
-                                "expr": "sum(scylla_database_queue_length_queued_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
-                                "intervalFactor": 2,
-                                "refId": "A",
-                                "step": 2
-                            }
-                        ],
-                        "thresholds": [],
-                        "timeFrom": null,
-                        "timeShift": null,
-                        "title": "Queued SSTable Streaming",
-                        "tooltip": {
-                            "shared": true,
-                            "sort": 0,
-                            "value_type": "individual"
-                        },
-                        "type": "graph",
-                        "xaxis": {
-                            "mode": "time",
-                            "name": null,
-                            "show": true,
-                            "values": []
-                        },
-                        "yaxes": [
-                            {
-                                "format": "short",
-                                "label": null,
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "label": null,
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
-                    }
-                ],
-                "repeat": null,
-                "repeatIteration": null,
-                "repeatRowId": null,
-                "showTitle": false,
-                "title": "SSTable metrics",
-                "titleSize": "h6"
-            },
-            {
-                "collapse": false,
-                "height": "250px",
-                "panels": [
-                    {
-                        "aliasColors": {},
-                        "bars": false,
-                        "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1788,150 +1635,40 @@
                                 "show": true
                             }
                         ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "SSTable metrics",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": "250px",
+                "panels": [
+                    {
+                        "content": "",
+                        "description": "Space",
+                        "id": 77,
+                        "links": [],
+                        "mode": "markdown",
+                        "span": 3,
+                        "title": "",
+                        "transparent": true,
+                        "type": "text"
                     },
                     {
-                        "aliasColors": {},
-                        "bars": false,
-                        "datasource": "prometheus",
-                        "editable": true,
-                        "error": false,
-                        "fill": 1,
-                        "grid": {},
-                        "id": 70,
-                        "legend": {
-                            "avg": false,
-                            "current": false,
-                            "max": false,
-                            "min": false,
-                            "show": false,
-                            "total": false,
-                            "values": false
-                        },
-                        "lines": true,
-                        "linewidth": 2,
+                        "content": "",
+                        "description": "Space",
+                        "id": 78,
                         "links": [],
-                        "nullPointMode": "null",
-                        "percentage": false,
-                        "pointradius": 5,
-                        "points": false,
-                        "renderer": "flot",
-                        "seriesOverrides": [],
+                        "mode": "markdown",
                         "span": 3,
-                        "stack": false,
-                        "steppedLine": false,
-                        "targets": [
-                            {
-                                "expr": "sum(irate(scylla_database_total_operations_total_writes_failed{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "thresholds": [],
-                        "timeFrom": null,
-                        "timeShift": null,
-                        "title": "Writes failed",
-                        "tooltip": {
-                            "msResolution": false,
-                            "shared": true,
-                            "sort": 0,
-                            "value_type": "cumulative"
-                        },
-                        "type": "graph",
-                        "xaxis": {
-                            "mode": "time",
-                            "name": null,
-                            "show": true,
-                            "values": []
-                        },
-                        "yaxes": [
-                            {
-                                "format": "wps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
-                    },
-                    {
-                        "aliasColors": {},
-                        "bars": false,
-                        "datasource": "prometheus",
-                        "editable": true,
-                        "error": false,
-                        "fill": 1,
-                        "grid": {},
-                        "id": 72,
-                        "legend": {
-                            "avg": false,
-                            "current": false,
-                            "max": false,
-                            "min": false,
-                            "show": false,
-                            "total": false,
-                            "values": false
-                        },
-                        "lines": true,
-                        "linewidth": 2,
-                        "links": [],
-                        "nullPointMode": "null",
-                        "percentage": false,
-                        "pointradius": 5,
-                        "points": false,
-                        "renderer": "flot",
-                        "seriesOverrides": [],
-                        "span": 3,
-                        "stack": false,
-                        "steppedLine": false,
-                        "targets": [
-                            {
-                                "expr": "sum(irate(scylla_database_total_operations_total_writes_timedout{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "thresholds": [],
-                        "timeFrom": null,
-                        "timeShift": null,
-                        "title": "Writes timed out",
-                        "tooltip": {
-                            "msResolution": false,
-                            "shared": true,
-                            "sort": 0,
-                            "value_type": "cumulative"
-                        },
-                        "type": "graph",
-                        "xaxis": {
-                            "mode": "time",
-                            "name": null,
-                            "show": true,
-                            "values": []
-                        },
-                        "yaxes": [
-                            {
-                                "format": "wps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "",
+                        "transparent": true,
+                        "type": "text"
                     },
                     {
                         "aliasColors": {},
@@ -2151,15 +1888,158 @@
                     },
                     {
                         "content": "",
-                        "editable": true,
-                        "error": false,
-                        "id": 73,
+                        "description": "Space",
+                        "id": 80,
                         "links": [],
                         "mode": "markdown",
                         "span": 3,
                         "title": "",
                         "transparent": true,
                         "type": "text"
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {},
+                        "id": 70,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "span": 3,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(scylla_database_total_operations_total_writes_failed{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Writes failed",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "wps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {},
+                        "id": 72,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "span": 3,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(scylla_database_total_operations_total_writes_timedout{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Writes timed out",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "wps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
                     }
                 ],
                 "repeat": null,
@@ -2167,6 +2047,158 @@
                 "repeatRowId": null,
                 "showTitle": false,
                 "title": "New row",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": 250,
+                "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "fill": 1,
+                        "id": 75,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "span": 6,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(scylla_database_queue_length_active_reads_streaming{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "intervalFactor": 2,
+                                "refId": "A",
+                                "step": 2
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Active SSTable Streaming",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "fill": 1,
+                        "id": 76,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "span": 6,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(scylla_database_queue_length_queued_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "intervalFactor": 2,
+                                "refId": "A",
+                                "step": 2
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Queued SSTable Streaming",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "Streaming",
                 "titleSize": "h6"
             },
             {
@@ -3765,8 +3797,9 @@
                 {
                     "allValue": null,
                     "current": {
-                        "text": "md0",
-                        "value": "md0"
+                        "isNone": true,
+                        "text": "None",
+                        "value": ""
                     },
                     "datasource": "prometheus",
                     "hide": 0,
@@ -3788,8 +3821,9 @@
                 {
                     "allValue": null,
                     "current": {
-                        "text": "eth0",
-                        "value": "eth0"
+                        "isNone": true,
+                        "text": "None",
+                        "value": ""
                     },
                     "datasource": "prometheus",
                     "hide": 0,
@@ -3891,8 +3925,8 @@
             ]
         },
         "time": {
-            "from": "now-5m",
-            "to": "now"
+            "from": "2017-08-10T09:57:28.531Z",
+            "to": "2017-08-10T10:00:47.229Z"
         },
         "timepicker": {
             "now": true,
@@ -3921,6 +3955,7 @@
             ]
         },
         "timezone": "browser",
+        "title": "Scylla Enterprise Per Server Metrics 2017.1",
         "version": 1
     }
 }

--- a/grafana/scylla-dash-per-server.2017.1.json
+++ b/grafana/scylla-dash-per-server.2017.1.json
@@ -2,18 +2,18 @@
     "dashboard": {
         "id": null,
         "title": "Scylla Enterprise Per Server Metrics 2017.1",
-        "tags": [
-            "2017.1"
-        ],
-        "style": "dark",
-        "timezone": "browser",
+        "annotations": {
+            "list": []
+        },
         "editable": true,
-        "hideControls": true,
-        "sharedCrosshair": true,
+        "gnetId": null,
+        "graphTooltip": 1,
+        "hideControls": false,
+        "links": [],
+        "refresh": "30s",
         "rows": [
             {
                 "collapse": false,
-                "editable": true,
                 "height": "25px",
                 "panels": [
                     {
@@ -21,10 +21,7 @@
                         "editable": true,
                         "error": false,
                         "id": 41,
-                        "isNew": true,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "mode": "html",
                         "span": 12,
                         "title": "",
@@ -32,11 +29,15 @@
                         "type": "text"
                     }
                 ],
-                "title": "New row"
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
             },
             {
                 "collapse": false,
-                "editable": true,
                 "height": "150px",
                 "panels": [
                     {
@@ -61,10 +62,7 @@
                         },
                         "id": 38,
                         "interval": null,
-                        "isNew": true,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "mappingType": 1,
                         "mappingTypes": [
                             {
@@ -103,7 +101,7 @@
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
-                                "step": 1
+                                "step": 2
                             }
                         ],
                         "thresholds": "",
@@ -142,10 +140,7 @@
                         },
                         "id": 33,
                         "interval": null,
-                        "isNew": true,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "mappingType": 1,
                         "mappingTypes": [
                             {
@@ -183,7 +178,7 @@
                                 "expr": "count(up{job=\"scylla\"})-count(scylla_memory_total_operations_free{shard=\"0\"})",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 1
+                                "step": 2
                             }
                         ],
                         "thresholds": "1,2",
@@ -205,15 +200,10 @@
                         "editable": true,
                         "error": false,
                         "id": 39,
-                        "isNew": true,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "mode": "markdown",
                         "span": 3,
-                        "style": {
-
-                        },
+                        "style": {},
                         "title": "",
                         "transparent": true,
                         "type": "text"
@@ -227,14 +217,8 @@
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 36,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -246,18 +230,14 @@
                         },
                         "lines": false,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
                         "seriesOverrides": [
-                            {
-
-                            }
+                            {}
                         ],
                         "span": 5,
                         "stack": false,
@@ -270,6 +250,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Total Requests",
@@ -282,7 +263,10 @@
                         "transparent": false,
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -306,11 +290,8 @@
                         "error": false,
                         "headings": false,
                         "id": 30,
-                        "isNew": true,
                         "limit": 10,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "query": "",
                         "recent": false,
                         "search": true,
@@ -323,30 +304,26 @@
                         "type": "dashlist"
                     }
                 ],
-                "title": "New row"
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
             },
             {
                 "collapse": false,
-                "editable": true,
                 "height": "250px",
                 "panels": [
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 12,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -358,18 +335,14 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
                         "seriesOverrides": [
-                            {
-
-                            }
+                            {}
                         ],
                         "span": 5,
                         "stack": false,
@@ -382,6 +355,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Load per [[by]]",
@@ -394,7 +368,10 @@
                         "transparent": false,
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -414,22 +391,14 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 3,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -441,17 +410,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 1,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 5,
                         "stack": false,
                         "steppedLine": false,
@@ -464,6 +429,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Requests Served per [[by]]",
@@ -475,7 +441,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -495,10 +464,12 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "cacheTimeout": null,
+                        "combine": {
+                            "label": "Others",
+                            "threshold": 0
+                        },
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
@@ -506,7 +477,6 @@
                         "format": "short",
                         "id": 40,
                         "interval": null,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -517,9 +487,7 @@
                             "values": false
                         },
                         "legendType": "rightSide",
-                        "links": [
-
-                        ],
+                        "links": [],
                         "maxDataPoints": 3,
                         "nullPointMode": "connected",
                         "nullText": null,
@@ -532,29 +500,29 @@
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "step": 1
+                                "step": 120
                             },
                             {
                                 "expr": "(sum(node_filesystem_size{mountpoint=\"/var/lib/scylla\"})-sum(node_filesystem_avail{mountpoint=\"/var/lib/scylla\"}))/1000000000",
                                 "intervalFactor": 1,
                                 "refId": "B",
-                                "step": 1
+                                "step": 120
                             }
                         ],
                         "title": "Total Storage",
                         "type": "grafana-piechart-panel",
-                        "valueName": "current",
-                        "combine": {
-                            "threshold": 0,
-                            "label": "Others"
-                        }
+                        "valueName": "current"
                     }
                 ],
-                "title": "New row"
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
             },
             {
                 "collapse": false,
-                "editable": true,
                 "height": "25px",
                 "panels": [
                     {
@@ -563,15 +531,10 @@
                         "error": false,
                         "height": "30",
                         "id": 8,
-                        "isNew": true,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "mode": "html",
                         "span": 6,
-                        "style": {
-
-                        },
+                        "style": {},
                         "title": "",
                         "transparent": true,
                         "type": "text"
@@ -581,44 +544,35 @@
                         "editable": true,
                         "error": false,
                         "id": 35,
-                        "isNew": true,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "mode": "html",
                         "span": 6,
-                        "style": {
-
-                        },
+                        "style": {},
                         "title": "",
                         "transparent": true,
                         "type": "text"
                     }
                 ],
-                "title": "New row"
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
             },
             {
                 "collapse": false,
-                "editable": true,
                 "height": "200px",
                 "panels": [
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 14,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -630,17 +584,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -652,6 +602,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Foreground Writes per [[by]]",
@@ -663,7 +614,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -683,22 +637,14 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 15,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -710,17 +656,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -733,6 +675,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Foreground Reads per [[by]]",
@@ -744,7 +687,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -764,22 +710,14 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 5,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -791,17 +729,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -813,6 +747,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Write Timeouts per Second per [[by]]",
@@ -824,7 +759,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -844,22 +782,14 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 6,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -871,17 +801,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -893,6 +819,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Write Unavailable per Second per [[by]]",
@@ -904,7 +831,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -924,30 +854,26 @@
                         ]
                     }
                 ],
-                "title": "New row"
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
             },
             {
                 "collapse": false,
-                "editable": true,
                 "height": "200px",
                 "panels": [
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 11,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -959,17 +885,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -981,6 +903,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Background Writes per [[by]]",
@@ -992,7 +915,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -1012,22 +938,14 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 10,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -1039,17 +957,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -1058,9 +972,10 @@
                                 "expr": "sum(scylla_storage_proxy_coordinator_background_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "step": 4
+                                "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Background Reads per [[by]]",
@@ -1072,7 +987,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -1092,22 +1010,14 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 7,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -1119,17 +1029,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -1141,6 +1047,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Read Timeouts per Second per [[by]]",
@@ -1152,7 +1059,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -1172,22 +1082,14 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 4,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -1199,17 +1101,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -1219,9 +1117,10 @@
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "step": 4
+                                "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Read Unavailable per Second per [[by]]",
@@ -1233,7 +1132,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -1253,49 +1155,52 @@
                         ]
                     }
                 ],
-                "title": "New row"
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
             },
             {
                 "collapse": false,
-                "editable": true,
-                "height": "250px",
+                "height": "25",
                 "panels": [
                     {
                         "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Replica</h1>",
                         "editable": true,
                         "error": false,
-                        "height": "30",
+                        "height": "25",
                         "id": 57,
-                        "isNew": true,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "mode": "html",
                         "span": 12,
-                        "style": {
-
-                        },
+                        "style": {},
                         "title": "",
                         "transparent": true,
                         "type": "text"
-                    },
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "Replica Header",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": 250,
+                "panels": [
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 60,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -1307,17 +1212,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 6,
                         "stack": false,
                         "steppedLine": false,
@@ -1329,6 +1230,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Reads",
@@ -1340,7 +1242,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -1360,22 +1265,14 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 59,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -1387,17 +1284,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 6,
                         "stack": false,
                         "steppedLine": false,
@@ -1410,6 +1303,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Writes",
@@ -1421,7 +1315,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -1439,24 +1336,28 @@
                                 "show": true
                             }
                         ]
-                    },
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "Replica Read and Writes",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": 250,
+                "panels": [
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 61,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -1468,17 +1369,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -1490,6 +1387,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Active sstable reads",
@@ -1501,7 +1399,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -1521,22 +1422,14 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 62,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -1548,17 +1441,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -1570,6 +1459,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Queued sstable reads",
@@ -1581,7 +1471,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -1601,22 +1494,166 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
+                        "aliasColors": {},
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "fill": 1,
+                        "id": 75,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
                         },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "span": 3,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(scylla_database_queue_length_active_reads_streaming{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "intervalFactor": 2,
+                                "refId": "A",
+                                "step": 2
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Active SSTable Streaming",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "fill": 1,
+                        "id": 76,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "span": 3,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(scylla_database_queue_length_queued_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "intervalFactor": 2,
+                                "refId": "A",
+                                "step": 2
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Queued SSTable Streaming",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "SSTable metrics",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": "250px",
+                "panels": [
+                    {
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 63,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -1628,17 +1665,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -1650,6 +1683,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Writes currently blocked on dirty",
@@ -1661,7 +1695,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -1681,22 +1718,14 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 64,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -1708,17 +1737,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -1730,6 +1755,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Writes currently blocked on commitlog",
@@ -1741,7 +1767,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -1761,37 +1790,14 @@
                         ]
                     },
                     {
-                        "content": "",
-                        "editable": true,
-                        "error": false,
-                        "id": 71,
-                        "isNew": true,
-                        "links": [
-
-                        ],
-                        "mode": "markdown",
-                        "span": 3,
-                        "title": "",
-                        "type": "text",
-                        "transparent": true
-                    },
-                    {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
-                        "id": 74,
-                        "isNew": true,
+                        "grid": {},
+                        "id": 70,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -1803,31 +1809,28 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_database_total_operations_total_reads_failed{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_database_total_operations_total_writes_failed{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "refId": "A",
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
-                        "title": "Reads failed",
+                        "title": "Writes failed",
                         "tooltip": {
                             "msResolution": false,
                             "shared": true,
@@ -1836,11 +1839,14 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
-                                "format": "rps",
+                                "format": "wps",
                                 "logBase": 1,
                                 "max": null,
                                 "min": 0,
@@ -1856,22 +1862,14 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
-                        "id": 67,
-                        "isNew": true,
+                        "grid": {},
+                        "id": 72,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -1883,17 +1881,85 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
+                        "seriesOverrides": [],
+                        "span": 3,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(scylla_database_total_operations_total_writes_timedout{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "refId": "A",
+                                "step": 1
+                            }
                         ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Writes timed out",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "wps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {},
+                        "id": 67,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -1905,6 +1971,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Writes blocked on dirty",
@@ -1916,7 +1983,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -1936,22 +2006,14 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 68,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -1963,17 +2025,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -1985,6 +2043,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Writes blocked on commitlog",
@@ -1996,11 +2055,86 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
                                 "format": "wps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {},
+                        "id": 74,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "span": 3,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(scylla_database_total_operations_total_reads_failed{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Reads failed",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "rps",
                                 "logBase": 1,
                                 "max": null,
                                 "min": 0,
@@ -2020,197 +2154,23 @@
                         "editable": true,
                         "error": false,
                         "id": 73,
-                        "isNew": true,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "mode": "markdown",
                         "span": 3,
                         "title": "",
-                        "type": "text",
-                        "transparent": true
-                    },
-                    {
-                        "content": "",
-                        "editable": true,
-                        "error": false,
-                        "id": 69,
-                        "isNew": true,
-                        "links": [
-
-                        ],
-                        "mode": "markdown",
-                        "span": 3,
-                        "title": "",
-                        "type": "text",
-                        "transparent": true
-                    },
-                    {
-                        "aliasColors": {
-
-                        },
-                        "bars": false,
-                        "datasource": "prometheus",
-                        "editable": true,
-                        "error": false,
-                        "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
-                        "id": 70,
-                        "isNew": true,
-                        "legend": {
-                            "avg": false,
-                            "current": false,
-                            "max": false,
-                            "min": false,
-                            "show": false,
-                            "total": false,
-                            "values": false
-                        },
-                        "lines": true,
-                        "linewidth": 2,
-                        "links": [
-
-                        ],
-                        "nullPointMode": "null",
-                        "percentage": false,
-                        "pointradius": 5,
-                        "points": false,
-                        "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
-                        "span": 3,
-                        "stack": false,
-                        "steppedLine": false,
-                        "targets": [
-                            {
-                                "expr": "sum(irate(scylla_database_total_operations_total_writes_failed{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "timeFrom": null,
-                        "timeShift": null,
-                        "title": "Writes failed",
-                        "tooltip": {
-                            "msResolution": false,
-                            "shared": true,
-                            "sort": 0,
-                            "value_type": "cumulative"
-                        },
-                        "type": "graph",
-                        "xaxis": {
-                            "show": true
-                        },
-                        "yaxes": [
-                            {
-                                "format": "wps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
-                    },
-                    {
-                        "aliasColors": {
-
-                        },
-                        "bars": false,
-                        "datasource": "prometheus",
-                        "editable": true,
-                        "error": false,
-                        "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
-                        "id": 72,
-                        "isNew": true,
-                        "legend": {
-                            "avg": false,
-                            "current": false,
-                            "max": false,
-                            "min": false,
-                            "show": false,
-                            "total": false,
-                            "values": false
-                        },
-                        "lines": true,
-                        "linewidth": 2,
-                        "links": [
-
-                        ],
-                        "nullPointMode": "null",
-                        "percentage": false,
-                        "pointradius": 5,
-                        "points": false,
-                        "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
-                        "span": 3,
-                        "stack": false,
-                        "steppedLine": false,
-                        "targets": [
-                            {
-                                "expr": "sum(irate(scylla_database_total_operations_total_writes_timedout{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "timeFrom": null,
-                        "timeShift": null,
-                        "title": "Writes timed out",
-                        "tooltip": {
-                            "msResolution": false,
-                            "shared": true,
-                            "sort": 0,
-                            "value_type": "cumulative"
-                        },
-                        "type": "graph",
-                        "xaxis": {
-                            "show": true
-                        },
-                        "yaxes": [
-                            {
-                                "format": "wps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "transparent": true,
+                        "type": "text"
                     }
                 ],
-                "title": "New row"
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
             },
             {
                 "collapse": false,
-                "editable": true,
                 "height": "25px",
                 "panels": [
                     {
@@ -2218,15 +2178,10 @@
                         "editable": true,
                         "error": false,
                         "id": 21,
-                        "isNew": true,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "mode": "html",
                         "span": 6,
-                        "style": {
-
-                        },
+                        "style": {},
                         "title": "",
                         "transparent": true,
                         "type": "text"
@@ -2236,44 +2191,35 @@
                         "editable": true,
                         "error": false,
                         "id": 18,
-                        "isNew": true,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "mode": "html",
                         "span": 6,
-                        "style": {
-
-                        },
+                        "style": {},
                         "title": "",
                         "transparent": true,
                         "type": "text"
                     }
                 ],
-                "title": "New row"
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
             },
             {
                 "collapse": false,
-                "editable": true,
                 "height": "250px",
                 "panels": [
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 19,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -2285,17 +2231,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -2309,6 +2251,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Disk Writes per Server per Second",
@@ -2320,7 +2263,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -2340,22 +2286,14 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 20,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -2367,17 +2305,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -2389,6 +2323,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Disk Reads per Server per Second",
@@ -2400,7 +2335,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -2420,22 +2358,14 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 16,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -2447,17 +2377,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -2469,6 +2395,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Cache Hits",
@@ -2480,7 +2407,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -2500,22 +2430,14 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 17,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -2527,17 +2449,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -2549,6 +2467,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Cache Misses",
@@ -2560,7 +2479,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -2580,30 +2502,26 @@
                         ]
                     }
                 ],
-                "title": "New row"
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
             },
             {
                 "collapse": false,
-                "editable": true,
                 "height": "250px",
                 "panels": [
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 22,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -2615,17 +2533,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -2638,6 +2552,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Disk Writes Bps per Server",
@@ -2649,7 +2564,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -2669,22 +2587,14 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 23,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -2696,17 +2606,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -2718,6 +2624,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Disk Read Bps per Server",
@@ -2729,7 +2636,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -2749,22 +2659,14 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 45,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -2776,17 +2678,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -2798,6 +2696,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Cache Insertions",
@@ -2809,7 +2708,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -2829,22 +2731,14 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 48,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -2856,17 +2750,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -2878,6 +2768,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Cache Evictions",
@@ -2889,7 +2780,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -2913,10 +2807,7 @@
                         "editable": true,
                         "error": false,
                         "id": 55,
-                        "isNew": true,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "mode": "html",
                         "span": 6,
                         "title": "",
@@ -2924,22 +2815,14 @@
                         "type": "text"
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 53,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -2951,17 +2834,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -2973,6 +2852,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Cache Merges",
@@ -2984,7 +2864,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -3004,22 +2887,14 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 54,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -3031,17 +2906,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -3053,6 +2924,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Cache Removals",
@@ -3064,7 +2936,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -3088,10 +2963,7 @@
                         "editable": true,
                         "error": false,
                         "id": 52,
-                        "isNew": true,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "mode": "html",
                         "span": 6,
                         "title": "",
@@ -3099,22 +2971,14 @@
                         "type": "text"
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 44,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -3126,17 +2990,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -3148,6 +3008,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Cache Partitions",
@@ -3159,7 +3020,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -3179,22 +3043,14 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 46,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -3206,17 +3062,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -3228,6 +3080,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Cache Total Bytes",
@@ -3239,7 +3092,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -3259,11 +3115,15 @@
                         ]
                     }
                 ],
-                "title": "New row"
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
             },
             {
                 "collapse": false,
-                "editable": true,
                 "height": "25px",
                 "panels": [
                     {
@@ -3271,44 +3131,35 @@
                         "editable": true,
                         "error": false,
                         "id": 51,
-                        "isNew": true,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "mode": "html",
                         "span": 12,
-                        "style": {
-
-                        },
+                        "style": {},
                         "title": "",
                         "transparent": true,
                         "type": "text"
                     }
                 ],
-                "title": "New row"
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
             },
             {
                 "collapse": false,
-                "editable": true,
                 "height": "250px",
                 "panels": [
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 49,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -3320,17 +3171,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 6,
                         "stack": false,
                         "steppedLine": false,
@@ -3342,6 +3189,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "LSA total memory",
@@ -3353,7 +3201,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -3373,22 +3224,14 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 50,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -3400,17 +3243,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 6,
                         "stack": false,
                         "steppedLine": false,
@@ -3422,6 +3261,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Non-LSA used memory",
@@ -3433,7 +3273,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -3453,11 +3296,15 @@
                         ]
                     }
                 ],
-                "title": "New row"
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
             },
             {
                 "collapse": false,
-                "editable": true,
                 "height": "25px",
                 "panels": [
                     {
@@ -3465,44 +3312,35 @@
                         "editable": true,
                         "error": false,
                         "id": 28,
-                        "isNew": true,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "mode": "html",
                         "span": 12,
-                        "style": {
-
-                        },
+                        "style": {},
                         "title": "",
                         "transparent": true,
                         "type": "text"
                     }
                 ],
-                "title": "New row"
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
             },
             {
                 "collapse": false,
-                "editable": true,
                 "height": "250px",
                 "panels": [
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 24,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -3514,17 +3352,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 6,
                         "stack": false,
                         "steppedLine": false,
@@ -3537,6 +3371,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Interface Rx Packets",
@@ -3548,7 +3383,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -3568,22 +3406,14 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 25,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -3595,17 +3425,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 6,
                         "stack": false,
                         "steppedLine": false,
@@ -3618,6 +3444,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Interface Tx Packets",
@@ -3629,7 +3456,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -3649,30 +3479,26 @@
                         ]
                     }
                 ],
-                "title": "New row"
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
             },
             {
                 "collapse": false,
-                "editable": true,
                 "height": "250px",
                 "panels": [
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 26,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -3684,17 +3510,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 6,
                         "stack": false,
                         "steppedLine": false,
@@ -3707,6 +3529,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Interface Rx Bps",
@@ -3718,7 +3541,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -3738,22 +3564,14 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 27,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -3765,17 +3583,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 6,
                         "stack": false,
                         "steppedLine": false,
@@ -3788,6 +3602,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Interface Tx Bps",
@@ -3799,7 +3614,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -3819,11 +3637,15 @@
                         ]
                     }
                 ],
-                "title": "New row"
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
             },
             {
                 "collapse": false,
-                "editable": true,
                 "height": "25px",
                 "panels": [
                     {
@@ -3831,44 +3653,35 @@
                         "editable": true,
                         "error": false,
                         "id": 42,
-                        "isNew": true,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "mode": "html",
                         "span": 12,
-                        "style": {
-
-                        },
+                        "style": {},
                         "title": "",
                         "transparent": true,
                         "type": "text"
                     }
                 ],
-                "title": "New row"
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
             },
             {
                 "collapse": false,
-                "editable": true,
                 "height": "250px",
                 "panels": [
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 43,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -3880,17 +3693,13 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
                         "span": 12,
                         "stack": false,
                         "steppedLine": false,
@@ -3903,6 +3712,7 @@
                                 "step": 1
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Running Compactions",
@@ -3914,7 +3724,10 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -3934,47 +3747,26 @@
                         ]
                     }
                 ],
-                "title": "New row"
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
             }
         ],
-        "time": {
-            "from": "now-30m",
-            "to": "now"
-        },
-        "timepicker": {
-            "now": true,
-            "refresh_intervals": [
-                "5s",
-                "10s",
-                "30s",
-                "1m",
-                "5m",
-                "15m",
-                "30m",
-                "1h",
-                "2h",
-                "1d"
-            ],
-            "time_options": [
-                "5m",
-                "15m",
-                "1h",
-                "6h",
-                "12h",
-                "24h",
-                "2d",
-                "7d",
-                "30d"
-            ]
-        },
+        "schemaVersion": 14,
+        "style": "dark",
+        "tags": [
+            "2017.1"
+        ],
         "templating": {
             "list": [
                 {
                     "allValue": null,
                     "current": {
-                        "isNone": true,
-                        "text": "None",
-                        "value": ""
+                        "text": "md0",
+                        "value": "md0"
                     },
                     "datasource": "prometheus",
                     "hide": 0,
@@ -3996,9 +3788,8 @@
                 {
                     "allValue": null,
                     "current": {
-                        "isNone": true,
-                        "text": "None",
-                        "value": ""
+                        "text": "eth0",
+                        "value": "eth0"
                     },
                     "datasource": "prometheus",
                     "hide": 0,
@@ -4082,7 +3873,7 @@
                     },
                     "datasource": "prometheus",
                     "hide": 0,
-                      "includeAll": true,
+                    "includeAll": true,
                     "label": "shard",
                     "multi": true,
                     "name": "shard",
@@ -4099,17 +3890,37 @@
                 }
             ]
         },
-        "annotations": {
-            "list": [
-
+        "time": {
+            "from": "now-5m",
+            "to": "now"
+        },
+        "timepicker": {
+            "now": true,
+            "refresh_intervals": [
+                "5s",
+                "10s",
+                "30s",
+                "1m",
+                "5m",
+                "15m",
+                "30m",
+                "1h",
+                "2h",
+                "1d"
+            ],
+            "time_options": [
+                "5m",
+                "15m",
+                "1h",
+                "6h",
+                "12h",
+                "24h",
+                "2d",
+                "7d",
+                "30d"
             ]
         },
-        "refresh": "30s",
-        "schemaVersion": 12,
-        "version": 5,
-        "links": [
-
-        ],
-        "gnetId": null
+        "timezone": "browser",
+        "version": 1
     }
 }


### PR DESCRIPTION
Add Active and Queued SSTable streaming chart to the Replica section
![image](https://user-images.githubusercontent.com/170200/29170282-7e48d634-7de0-11e7-977b-e17fce9a810d.png)
