### PR TITLE
add kill-grafana and kill-prometheus

### DIFF
--- a/kill-grafana.sh
+++ b/kill-grafana.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-usage="$(basename "$0") [-h] [-g grafana port ] -- kills existing Prometheus Docker instances at given ports"
+usage="$(basename "$0") [-h] [-g grafana port ] -- kills existing Grafana Docker instances at given ports"
 
 while getopts ':hg:' option; do
   case "$option" in

--- a/kill-grafana.sh
+++ b/kill-grafana.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+usage="$(basename "$0") [-h] [-g grafana port ] -- kills existing Prometheus Docker instances at given ports"
+
+while getopts ':hg:' option; do
+  case "$option" in
+    h) echo "$usage"
+       exit
+       ;;
+    g) GRAFANA_PORT=$OPTARG
+       ;;
+    :) printf "missing argument for -%s\n" "$OPTARG" >&2
+       echo "$usage" >&2
+       exit 1
+       ;;
+   \?) printf "illegal option: -%s\n" "$OPTARG" >&2
+       echo "$usage" >&2
+       exit 1
+       ;;
+  esac
+done
+
+if [ -z $GRAFANA_PORT ]; then
+    GRAFANA_NAME=agraf
+else
+    GRAFANA_NAME=agraf-$GRAFANA_PORT
+fi
+
+sudo docker kill $GRAFANA_NAME
+sudo docker rm -v $GRAFANA_NAME

--- a/kill-prometheus.sh
+++ b/kill-prometheus.sh
@@ -1,13 +1,11 @@
 #!/usr/bin/env bash
 
-usage="$(basename "$0") [-h] [-g grafana port ] [ -p prometheus port ] -- kills existing Grafana and Prometheus Docker instances at given ports"
+usage="$(basename "$0") [-h] [ -p prometheus port ] -- kills existing Prometheus Docker instances at given ports"
 
-while getopts ':hg:p:' option; do
+while getopts ':hp:' option; do
   case "$option" in
     h) echo "$usage"
        exit
-       ;;
-    g) GRAFANA_PORT=$OPTARG
        ;;
     p) PROMETHEUS_PORT=$OPTARG
        ;;
@@ -23,17 +21,11 @@ while getopts ':hg:p:' option; do
 done
 
 if [ -z $PROMETHEUS_PORT ]; then
-    ./kill-prometheus.sh
+    PROMETHEUS_NAME=aprom
 else
-    ./kill-prometheus.sh -p $PROMETHEUS_PORT
-fi
-
-if [ -z $GRAFANA_PORT ]; then
-    ./kill-grafana.sh
-else
-    ./kill-grafana.sh -g $GRAFANA_PORT
+    PROMETHEUS_NAME=aprom-$PROMETHEUS_PORT
 fi
 
 
-
-
+sudo docker kill $PROMETHEUS_NAME
+sudo docker rm -v $PROMETHEUS_NAME


### PR DESCRIPTION
This allows one to kill just the prometheus or just grafana with
```
kill-prometheus.sh
```
and
```
kill-grafana.sh
```
respectively.
kill-all.sh now calls the two new scripts above.

With #210 it allows one to restart just the Grafana as follows:
```
kill-grafana.sh
start-grafana,sh
```

