### PR TITLE
grafana: add option for HTTP proxy

### DIFF
--- a/start-grafana.sh
+++ b/start-grafana.sh
@@ -14,9 +14,9 @@ GRAFANA_ADMIN_PASSWORD="admin"
 GRAFANA_AUTH=false
 GRAFANA_AUTH_ANONYMOUS=true
 
-usage="$(basename "$0") [-h] [-v comma separated versions ] [-g grafana port ] [-p ip:port address of prometheus ] [-a admin password] -- loads the prometheus datasource and the Scylla dashboards into an existing grafana installation"
+usage="$(basename "$0") [-h] [-v comma separated versions ] [-g grafana port ] [-p ip:port address of prometheus ] [-x http_proxy_host:port] [-a admin password] -- loads the prometheus datasource and the Scylla dashboards into an existing grafana installation"
 
-while getopts ':hlg:p:v:a:' option; do
+while getopts ':hlg:p:v:a:x:' option; do
   case "$option" in
     h) echo "$usage"
        exit
@@ -32,6 +32,8 @@ while getopts ':hlg:p:v:a:' option; do
     a) GRAFANA_ADMIN_PASSWORD=$OPTARG
        GRAFANA_AUTH=true
        GRAFANA_AUTH_ANONYMOUS=false
+       ;;
+    x) HTTP_PROXY="$OPTARG"
        ;;
     :) printf "missing argument for -%s\n" "$OPTARG" >&2
        echo "$usage" >&2
@@ -51,12 +53,18 @@ else
     GRAFANA_NAME=agraf-$GRAFANA_PORT
 fi
 
+proxy_args=()
+if [[ -n "$HTTP_PROXY" ]]; then
+    proxy_args=(-e http_proxy="$HTTP_PROXY")
+fi
+
 sudo docker run -d $LOCAL -i -p $GRAFANA_PORT:3000 \
      -e "GF_AUTH_BASIC_ENABLED=$GRAFANA_AUTH" \
      -e "GF_AUTH_ANONYMOUS_ENABLED=$GRAFANA_AUTH_ANONYMOUS" \
      -e "GF_AUTH_ANONYMOUS_ORG_ROLE=Admin" \
      -e "GF_INSTALL_PLUGINS=grafana-piechart-panel" \
      -e "GF_SECURITY_ADMIN_PASSWORD=$GRAFANA_ADMIN_PASSWORD" \
+     "${proxy_args[@]}" \
      --name $GRAFANA_NAME grafana/grafana:$GRAFANA_VERSION
 
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
Often, the Prometheus database will only be open to a few static IPs.
Allow directing grafana to access Prometheus via a proxy (that is presumably
authorized to access Prometheus).

A new option -x proxy:port is provided.