### PR TITLE
Added support for Grafana environment variables to pass to Grafana docker

### DIFF
--- a/start-grafana.sh
+++ b/start-grafana.sh
@@ -14,9 +14,9 @@ GRAFANA_ADMIN_PASSWORD="admin"
 GRAFANA_AUTH=false
 GRAFANA_AUTH_ANONYMOUS=true
 
-usage="$(basename "$0") [-h] [-v comma separated versions ] [-g grafana port ] [-p ip:port address of prometheus ] [-x http_proxy_host:port] [-a admin password] -- loads the prometheus datasource and the Scylla dashboards into an existing grafana installation"
+usage="$(basename "$0") [-h] [-v comma separated versions ] [-g grafana port ] [-p ip:port address of prometheus ] [-c grafana enviroment variable, multiple params are supported] [-x http_proxy_host:port] [-a admin password] -- loads the prometheus datasource and the Scylla dashboards into an existing grafana installation"
 
-while getopts ':hlg:p:v:a:x:' option; do
+while getopts ':hlg:p:v:a:x:c:' option; do
   case "$option" in
     h) echo "$usage"
        exit
@@ -34,6 +34,8 @@ while getopts ':hlg:p:v:a:x:' option; do
        GRAFANA_AUTH_ANONYMOUS=false
        ;;
     x) HTTP_PROXY="$OPTARG"
+       ;;
+    c) GRAFANA_ENV_ARRAY+=("$OPTARG")
        ;;
     :) printf "missing argument for -%s\n" "$OPTARG" >&2
        echo "$usage" >&2
@@ -58,12 +60,17 @@ if [[ -n "$HTTP_PROXY" ]]; then
     proxy_args=(-e http_proxy="$HTTP_PROXY")
 fi
 
+for val in "${GRAFANA_ENV_ARRAY[@]}"; do
+        GRAFANA_ENV_COMMAND="$GRAFANA_ENV_COMMAND -e $val"
+done
+
 sudo docker run -d $LOCAL -i -p $GRAFANA_PORT:3000 \
      -e "GF_AUTH_BASIC_ENABLED=$GRAFANA_AUTH" \
      -e "GF_AUTH_ANONYMOUS_ENABLED=$GRAFANA_AUTH_ANONYMOUS" \
      -e "GF_AUTH_ANONYMOUS_ORG_ROLE=Admin" \
      -e "GF_INSTALL_PLUGINS=grafana-piechart-panel" \
      -e "GF_SECURITY_ADMIN_PASSWORD=$GRAFANA_ADMIN_PASSWORD" \
+     $GRAFANA_ENV_COMMAND \
      "${proxy_args[@]}" \
      --name $GRAFANA_NAME grafana/grafana:$GRAFANA_VERSION
 


### PR DESCRIPTION
For example if a user wants to change Grafana theme he can pass the env variable:
```
./start-all.sh -c "GF_USERS_DEFAULT_THEME=light"
```
The script supports multiple params:
```
./start-all.sh -c "GF_USERS_DEFAULT_THEME=light" -c "GF_SERVER_ROOT_URL=http://grafana.server.name"
```