### PR TITLE
Support for loading additional dashboard

### DIFF
--- a/load-grafana.sh
+++ b/load-grafana.sh
@@ -5,9 +5,9 @@ VERSIONS=$DEFAULT_VERSION
 GRAFANA_PORT=3000
 DB_ADDRESS="127.0.0.1:9090"
 
-usage="$(basename "$0") [-h] [-v comma separated versions ] [-g grafana port ] [-p ip:port address of prometheus ] [-a admin password] -- loads the prometheus datasource and the Scylla dashboards into an existing grafana installation"
+usage="$(basename "$0") [-h] [-v comma separated versions ] [-g grafana port ] [-p ip:port address of prometheus ] [-a admin password] [-j additional dashboard to load to Grafana, multiple params are supported] -- loads the prometheus datasource and the Scylla dashboards into an existing grafana installation"
 
-while getopts ':hg:p:v:a:' option; do
+while getopts ':hg:p:v:a:j:' option; do
   case "$option" in
     h) echo "$usage"
        exit
@@ -15,6 +15,8 @@ while getopts ':hg:p:v:a:' option; do
     v) VERSIONS=$OPTARG
        ;;
     g) GRAFANA_PORT=$OPTARG
+       ;;
+    j) GRAFANA_DASHBOARD_ARRAY+=("$OPTARG")
        ;;
     p) DB_ADDRESS=$OPTARG
        ;;
@@ -32,3 +34,6 @@ IFS=',' ;for v in $VERSIONS; do
 	curl -XPOST -i http://admin:$GRAFANA_ADMIN_PASSWORD@localhost:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/scylla-dash-io-per-server.$v.json -H "Content-Type: application/json"
 done
 
+for val in "${GRAFANA_DASHBOARD_ARRAY[@]}"; do
+        curl -XPOST -i http://admin:$GRAFANA_ADMIN_PASSWORD@localhost:$GRAFANA_PORT/api/dashboards/db --data-binary @$val -H "Content-Type: application/json"
+done

--- a/start-all.sh
+++ b/start-all.sh
@@ -6,7 +6,7 @@ else
 . versions.sh
 fi
 VERSIONS=$DEFAULT_VERSION
-usage="$(basename "$0") [-h] [-e] [-d Prometheus data-dir] [-s scylla-target-file] [-n node-target-file] [-l] [-v comma seperated versions] [-c grafana enviroment variable, multiple params are supported] [-g grafana port ] [ -p prometheus port ] [-a admin password] -- starts Grafana and Prometheus Docker instances"
+usage="$(basename "$0") [-h] [-e] [-d Prometheus data-dir] [-s scylla-target-file] [-n node-target-file] [-l] [-v comma seperated versions] [-j additional dashboard to load to Grafana, multiple params are supported] [-c grafana enviroment variable, multiple params are supported] [-g grafana port ] [ -p prometheus port ] [-a admin password] -- starts Grafana and Prometheus Docker instances"
 
 GRAFANA_VERSION=4.1.1
 PROMETHEUS_VERSION=v1.5.2
@@ -16,7 +16,7 @@ NODE_TARGET_FILE=$PWD/prometheus/node_exporter_servers.yml
 
 GRAFANA_ADMIN_PASSWORD=""
 
-while getopts ':hled:g:p:v:s:n:a:c:' option; do
+while getopts ':hled:g:p:v:s:n:a:c:j:' option; do
   case "$option" in
     h) echo "$usage"
        exit
@@ -36,6 +36,8 @@ while getopts ':hled:g:p:v:s:n:a:c:' option; do
     l) LOCAL="--net=host"
        ;;
     a) GRAFANA_ADMIN_PASSWORD="-a $OPTARG"
+       ;;
+    j) GRAFANA_DASHBOARD_ARRAY+=("$OPTARG")
        ;;
     c) GRAFANA_ENV_ARRAY+=("$OPTARG")
        ;;
@@ -126,5 +128,10 @@ for val in "${GRAFANA_ENV_ARRAY[@]}"; do
         GRAFANA_ENV_COMMAND="$GRAFANA_ENV_COMMAND -c $val"
 done
 
+for val in "${GRAFANA_DASHBOARD_ARRAY[@]}"; do
+        GRAFANA_DASHBOARD_COMMAND="$GRAFANA_DASHBOARD_COMMAND -j $val"
+done
 
-./start-grafana.sh -p $DB_ADDRESS $GRAFANA_PORT -v $VERSIONS $GRAFANA_ENV_COMMAND $GRAFANA_ADMIN_PASSWORD $GRAFANA_LOCAL 
+
+
+./start-grafana.sh -p $DB_ADDRESS $GRAFANA_PORT -v $VERSIONS $GRAFANA_ENV_COMMAND $GRAFANA_DASHBOARD_COMMAND $GRAFANA_ADMIN_PASSWORD $GRAFANA_LOCAL 

--- a/start-grafana.sh
+++ b/start-grafana.sh
@@ -14,9 +14,9 @@ GRAFANA_ADMIN_PASSWORD="admin"
 GRAFANA_AUTH=false
 GRAFANA_AUTH_ANONYMOUS=true
 
-usage="$(basename "$0") [-h] [-v comma separated versions ] [-g grafana port ] [-p ip:port address of prometheus ] [-c grafana enviroment variable, multiple params are supported] [-x http_proxy_host:port] [-a admin password] -- loads the prometheus datasource and the Scylla dashboards into an existing grafana installation"
+usage="$(basename "$0") [-h] [-v comma separated versions ] [-g grafana port ] [-p ip:port address of prometheus ] [-j additional dashboard to load to Grafana, multiple params are supported] [-c grafana enviroment variable, multiple params are supported] [-x http_proxy_host:port] [-a admin password] -- loads the prometheus datasource and the Scylla dashboards into an existing grafana installation"
 
-while getopts ':hlg:p:v:a:x:c:' option; do
+while getopts ':hlg:p:v:a:x:c:j:' option; do
   case "$option" in
     h) echo "$usage"
        exit
@@ -36,6 +36,8 @@ while getopts ':hlg:p:v:a:x:c:' option; do
     x) HTTP_PROXY="$OPTARG"
        ;;
     c) GRAFANA_ENV_ARRAY+=("$OPTARG")
+       ;;
+    j) GRAFANA_DASHBOARD_ARRAY+=("$OPTARG")
        ;;
     :) printf "missing argument for -%s\n" "$OPTARG" >&2
        echo "$usage" >&2
@@ -95,4 +97,8 @@ then
         exit 1
 fi
 
-./load-grafana.sh -p $DB_ADDRESS -g $GRAFANA_PORT -v $VERSIONS -a $GRAFANA_ADMIN_PASSWORD
+for val in "${GRAFANA_DASHBOARD_ARRAY[@]}"; do
+        GRAFANA_DASHBOARD_COMMAND="$GRAFANA_DASHBOARD_COMMAND -j $val"
+done
+
+./load-grafana.sh -p $DB_ADDRESS -g $GRAFANA_PORT -v $VERSIONS -a $GRAFANA_ADMIN_PASSWORD $GRAFANA_DASHBOARD_COMMAND


### PR DESCRIPTION
A user can load additional dashboard json for example:
```
./start-all.sh -j grafana/cassandra-stress.json
```
It support multiple dashboard loading:
```
./start-all.sh -j grafana/cassandra-stress.json -j /tmp/my_dashboard.json
```