### PR TITLE
disk pie chart legend format should appear once

### DIFF
--- a/grafana/scylla-dash.1.7.json
+++ b/grafana/scylla-dash.1.7.json
@@ -410,7 +410,6 @@
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "Total Storage",
                                 "step": 1200,
                                 "legendFormat": "Free",
                                 "interval": ""

--- a/grafana/scylla-dash.master.json
+++ b/grafana/scylla-dash.master.json
@@ -410,7 +410,6 @@
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "Total Storage",
                                 "step": 1200,
                                 "legendFormat": "Free",
                                 "interval": ""


### PR DESCRIPTION
The legend format of the disk pie chart was modified, instead of
removing the old one and additional entry was added.
This patch removes it from 1.7 and master.

Signed-off-by: Amnon Heiman <amnon@scylladb.com>