### PR TITLE
Set the prometheus timeout to be lower the scrape interval

### DIFF
--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,5 +1,6 @@
 global:
-  scrape_interval: 1s # By default, scrape targets every 1 second.
+  scrape_interval: 5s # By default, scrape targets every 5 second.
+  scrape_timeout: 4s # Timeout before trying to scape a target again
 
   # Attach these labels to any time series or alerts when communicating with
   # external systems (federation, remote storage, Alertmanager).


### PR DESCRIPTION
The prometheus server does not handle correctly a situation where the
scrape interval is shorter han the scrape timeout.

This patch set the scrape interval to 5s and the timeout to 4s

Fixes #235

Signed-off-by: Amnon Heiman <amnon@scylladb.com>