### PR TITLE
set maximum for load graph higher

### DIFF
--- a/grafana/scylla-dash-per-server.1.6.json
+++ b/grafana/scylla-dash-per-server.1.6.json
@@ -400,7 +400,7 @@
                             {
                                 "format": "short",
                                 "logBase": 1,
-                                "max": null,
+                                "max": 101,
                                 "min": 0,
                                 "show": true
                             },

--- a/grafana/scylla-dash-per-server.1.7.json
+++ b/grafana/scylla-dash-per-server.1.7.json
@@ -403,7 +403,7 @@
                             {
                                 "format": "short",
                                 "logBase": 1,
-                                "max": null,
+                                "max": 101,
                                 "min": 0,
                                 "show": true
                             },

--- a/grafana/scylla-dash-per-server.2.0.json
+++ b/grafana/scylla-dash-per-server.2.0.json
@@ -403,7 +403,7 @@
                             {
                                 "format": "short",
                                 "logBase": 1,
-                                "max": null,
+                                "max": 101,
                                 "min": 0,
                                 "show": true
                             },

--- a/grafana/scylla-dash-per-server.2017.1.json
+++ b/grafana/scylla-dash-per-server.2017.1.json
@@ -400,7 +400,7 @@
                             {
                                 "format": "short",
                                 "logBase": 1,
-                                "max": null,
+                                "max": 101,
                                 "min": 0,
                                 "show": true
                             },

--- a/grafana/scylla-dash-per-server.master.json
+++ b/grafana/scylla-dash-per-server.master.json
@@ -403,7 +403,7 @@
                             {
                                 "format": "percent",
                                 "logBase": 1,
-                                "max": 100,
+                                "max": 101,
                                 "min": 0,
                                 "show": true
                             },


### PR DESCRIPTION
We are currently setting the graph for Load at a maximum of 100.  This
change seems to be made for the master graph only, and not for any of
the versions (which reminds me that this week, I haven't said we need to
automate this yet).

The problem with that is that when the load is at exactly 100 %, grafana
may not show the point as it coincides with the upper bar. I was left
out with a graph full of "holes".

Putting the max a bit higher - at 101 - guarantees that the bar is
always shown.

Fixes #236

Signed-off-by: Glauber Costa <glauber@scylladb.com>