### PR TITLE
break the Per Server dashboard to two new dashboard

### DIFF
--- a/grafana/scylla-dash-per-node.master.json
+++ b/grafana/scylla-dash-per-node.master.json
@@ -1,0 +1,854 @@
+{
+    "dashboard": {
+        "id": null,
+        "title": "Scylla - Per Node Dashboard master",
+        "annotations": {
+            "list": []
+        },
+        "editable": true,
+        "gnetId": null,
+        "graphTooltip": 1,
+        "hideControls": true,
+        "links": [],
+        "refresh": "30s",
+        "rows": [
+            {
+                "collapse": false,
+                "height": "25px",
+                "panels": [
+                    {
+                        "content": "<img src=\"http://www.scylladb.com/wp-content/uploads/logo-scylla-white-simple.png\" height=\"70\">\n<hr style=\"border-top: 3px solid #5780c1;\">",
+                        "editable": true,
+                        "error": false,
+                        "id": 41,
+                        "links": [],
+                        "mode": "html",
+                        "span": 12,
+                        "title": "",
+                        "transparent": true,
+                        "type": "text"
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": -67,
+                "panels": [
+                    {
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Disk $monitor_disk</h1>",
+                        "editable": true,
+                        "error": false,
+                        "id": 21,
+                        "links": [],
+                        "mode": "html",
+                        "span": 12,
+                        "style": {},
+                        "title": "",
+                        "transparent": true,
+                        "type": "text"
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": "250px",
+                "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {},
+                        "id": 19,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 6,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "irate(node_disk_writes_completed{device=\"$monitor_disk\"}[30s])",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "Disk Writes per Server per Second",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 2
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Disk Writes per Server per Second",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "wps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {},
+                        "id": 20,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 6,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "irate(node_disk_reads_completed{device=\"$monitor_disk\"}[30s])",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "Disk Reads per Server per Second",
+                                "refId": "A",
+                                "step": 2
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Disk Reads per Server per Second",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "rps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": "250px",
+                "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {},
+                        "id": 22,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 6,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "irate(node_disk_bytes_written{device=\"$monitor_disk\"}[30s])",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "Disk Writes Bps per Server",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 2
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Disk Writes Bps per Server",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "Bps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {},
+                        "id": 23,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 6,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "irate(node_disk_bytes_read{device=\"$monitor_disk\"}[30s])",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "Disk Read Bps per Server",
+                                "refId": "A",
+                                "step": 2
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Disk Read Bps per Server",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "Bps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": "25px",
+                "panels": [
+                    {
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Network $monitor_network_interface</h1>",
+                        "editable": true,
+                        "error": false,
+                        "id": 28,
+                        "links": [],
+                        "mode": "html",
+                        "span": 12,
+                        "style": {},
+                        "title": "",
+                        "transparent": true,
+                        "type": "text"
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": "250px",
+                "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 0,
+                        "grid": {},
+                        "id": 24,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 6,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "irate(node_network_receive_packets{device=\"$monitor_network_interface\"}[30s])",
+                                "intervalFactor": 1,
+                                "legendFormat": "Interface Rx Packets",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 2
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Interface Rx Packets",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "pps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 0,
+                        "grid": {},
+                        "id": 25,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 6,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "irate(node_network_transmit_packets{device=\"$monitor_network_interface\"}[30s])",
+                                "intervalFactor": 1,
+                                "legendFormat": "Interface Tx Packets",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 2
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Interface Tx Packets",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "pps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": "250px",
+                "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 0,
+                        "grid": {},
+                        "id": 26,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 6,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "irate(node_network_receive_bytes{device=\"$monitor_network_interface\"}[30s])",
+                                "intervalFactor": 1,
+                                "legendFormat": "Interface Rx Bps",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 2
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Interface Rx Bps",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "Bps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 0,
+                        "grid": {},
+                        "id": 27,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 6,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "irate(node_network_transmit_bytes{device=\"$monitor_network_interface\"}[30s])",
+                                "intervalFactor": 1,
+                                "legendFormat": "Interface Tx Bps",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 2
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Interface Tx Bps",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "Bps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
+            }
+        ],
+        "schemaVersion": 14,
+        "style": "dark",
+        "tags": [
+            "master"
+        ],
+        "templating": {
+            "list": [
+                {
+                    "allValue": null,
+                    "current": {
+                        "isNone": true,
+                        "text": "None",
+                        "value": ""
+                    },
+                    "datasource": "prometheus",
+                    "hide": 0,
+                    "includeAll": false,
+                    "label": null,
+                    "multi": false,
+                    "name": "monitor_disk",
+                    "options": [],
+                    "query": "node_disk_bytes_read",
+                    "refresh": 1,
+                    "regex": "/.*device=\"([^\\\"]*)\".*/",
+                    "sort": 0,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                },
+                {
+                    "allValue": null,
+                    "current": {
+                        "isNone": true,
+                        "text": "None",
+                        "value": ""
+                    },
+                    "datasource": "prometheus",
+                    "hide": 0,
+                    "includeAll": false,
+                    "label": null,
+                    "multi": false,
+                    "name": "monitor_network_interface",
+                    "options": [],
+                    "query": "node_network_receive_packets",
+                    "refresh": 1,
+                    "regex": "/.*device=\"([^\\\"]*)\".*/",
+                    "sort": 0,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                }
+            ]
+        },
+        "time": {
+            "from": "now-30m",
+            "to": "now"
+        },
+        "timepicker": {
+            "now": true,
+            "refresh_intervals": [
+                "5s",
+                "10s",
+                "30s",
+                "1m",
+                "5m",
+                "15m",
+                "30m",
+                "1h",
+                "2h",
+                "1d"
+            ],
+            "time_options": [
+                "5m",
+                "15m",
+                "1h",
+                "6h",
+                "12h",
+                "24h",
+                "2d",
+                "7d",
+                "30d"
+            ]
+        },
+        "timezone": "browser",
+        "version": 1
+    }
+}

--- a/grafana/scylla-dash-per-scylla-server.master.json
+++ b/grafana/scylla-dash-per-scylla-server.master.json
@@ -1,19 +1,19 @@
 {
     "dashboard": {
         "id": null,
-        "title": "Scylla Per Server Metrics master",
-        "tags": [
-            "master"
-        ],
-        "style": "dark",
-        "timezone": "browser",
+        "title": "Scylla - Per Scylla Server Dasboard master",
+        "annotations": {
+            "list": []
+        },
         "editable": true,
+        "gnetId": null,
+        "graphTooltip": 1,
         "hideControls": true,
-        "sharedCrosshair": true,
+        "links": [],
+        "refresh": false,
         "rows": [
             {
                 "collapse": false,
-                "editable": true,
                 "height": "25px",
                 "panels": [
                     {
@@ -21,10 +21,7 @@
                         "editable": true,
                         "error": false,
                         "id": 41,
-                        "isNew": true,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "mode": "html",
                         "span": 12,
                         "title": "",
@@ -32,12 +29,16 @@
                         "type": "text"
                     }
                 ],
-                "title": "New row"
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
             },
             {
                 "collapse": false,
-                "editable": true,
-                "height": "150px",
+                "height": 226,
                 "panels": [
                     {
                         "cacheTimeout": null,
@@ -61,10 +62,7 @@
                         },
                         "id": 38,
                         "interval": null,
-                        "isNew": true,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "mappingType": 1,
                         "mappingTypes": [
                             {
@@ -97,13 +95,15 @@
                             "lineColor": "rgb(31, 120, 193)",
                             "show": false
                         },
+                        "tableColumn": "",
                         "targets": [
                             {
                                 "expr": "count(up{job=\"scylla\"})",
+                                "format": "time_series",
                                 "intervalFactor": 1,
                                 "legendFormat": "Total Nodes",
                                 "refId": "A",
-                                "step": 1
+                                "step": 300
                             }
                         ],
                         "thresholds": "",
@@ -140,12 +140,10 @@
                             "thresholdLabels": false,
                             "thresholdMarkers": false
                         },
+                        "height": "",
                         "id": 33,
                         "interval": null,
-                        "isNew": true,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "mappingType": 1,
                         "mappingTypes": [
                             {
@@ -178,13 +176,15 @@
                             "lineColor": "rgb(31, 120, 193)",
                             "show": false
                         },
+                        "tableColumn": "",
                         "targets": [
                             {
-                                "legendFormat": "Unreachable",
                                 "expr": "count(scrape_samples_scraped{job=\"scylla\"}==0) OR vector(0)",
+                                "format": "time_series",
                                 "intervalFactor": 1,
+                                "legendFormat": "Unreachable",
                                 "refId": "A",
-                                "step": 1
+                                "step": 300
                             }
                         ],
                         "thresholds": "1,2",
@@ -206,15 +206,10 @@
                         "editable": true,
                         "error": false,
                         "id": 39,
-                        "isNew": true,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "mode": "markdown",
                         "span": 3,
-                        "style": {
-
-                        },
+                        "style": {},
                         "title": "",
                         "transparent": true,
                         "type": "text"
@@ -224,18 +219,14 @@
                             "{}": "#584477"
                         },
                         "bars": true,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 36,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -247,19 +238,16 @@
                         },
                         "lines": false,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
                         "seriesOverrides": [
-                            {
-
-                            }
+                            {}
                         ],
+                        "spaceLength": 10,
                         "span": 5,
                         "stack": false,
                         "steppedLine": false,
@@ -267,11 +255,12 @@
                             {
                                 "expr": "sum(irate(scylla_transport_requests_served{}[30s])) + sum(irate(scylla_thrift_served{}[30s]))",
                                 "intervalFactor": 1,
-                                "refId": "A",
                                 "legendFormat": "Total Requests",
-                                "step": 1
+                                "refId": "A",
+                                "step": 30
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Total Requests",
@@ -284,7 +273,11 @@
                         "transparent": false,
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -308,11 +301,8 @@
                         "error": false,
                         "headings": false,
                         "id": 30,
-                        "isNew": true,
                         "limit": 10,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "query": "",
                         "recent": false,
                         "search": true,
@@ -325,30 +315,28 @@
                         "type": "dashlist"
                     }
                 ],
-                "title": "New row"
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
             },
             {
                 "collapse": false,
-                "editable": true,
                 "height": "250px",
                 "panels": [
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 12,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -360,19 +348,16 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
                         "seriesOverrides": [
-                            {
-
-                            }
+                            {}
                         ],
+                        "spaceLength": 10,
                         "span": 5,
                         "stack": false,
                         "steppedLine": false,
@@ -380,11 +365,12 @@
                             {
                                 "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\", shard=~\"[[shard]]\"} ) by ([[by]])",
                                 "intervalFactor": 1,
-                                "refId": "A",
                                 "legendFormat": "",
-                                "step": 1
+                                "refId": "A",
+                                "step": 30
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Load per [[by]]",
@@ -397,7 +383,11 @@
                         "transparent": false,
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -417,22 +407,16 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 3,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -444,17 +428,14 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 1,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
                         "span": 5,
                         "stack": false,
                         "steppedLine": false,
@@ -462,12 +443,13 @@
                             {
                                 "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "",
-                                "step": 1
+                                "step": 30
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Requests Served per [[by]]",
@@ -479,7 +461,11 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -497,71 +483,17 @@
                                 "show": true
                             }
                         ]
-                    },
-                    {
-                        "aliasColors": {
-
-                        },
-                        "cacheTimeout": null,
-                        "datasource": "prometheus",
-                        "editable": true,
-                        "error": false,
-                        "fontSize": "80%",
-                        "format": "bytes",
-                        "id": 40,
-                        "interval": null,
-                        "isNew": true,
-                        "legend": {
-                            "avg": false,
-                            "current": false,
-                            "max": false,
-                            "min": false,
-                            "show": true,
-                            "total": false,
-                            "values": true
-                        },
-                        "legendType": "On graph",
-                        "links": [
-
-                        ],
-                        "maxDataPoints": 3,
-                        "nullPointMode": "connected",
-                        "nullText": null,
-                        "pieType": "pie",
-                        "span": 2,
-                        "strokeWidth": 1,
-                        "targets": [
-                            {
-                                "expr": "sum(node_filesystem_avail{mountpoint=\"/var/lib/scylla\"})",
-                                "intervalFactor": 1,
-                                "metric": "",
-                                "refId": "A",
-                                "step": 1,
-                                "legendFormat": "Free",
-                                "interval": ""
-                            },
-                            {
-                                "expr": "(sum(node_filesystem_size{mountpoint=\"/var/lib/scylla\"})-sum(node_filesystem_avail{mountpoint=\"/var/lib/scylla\"}))",
-                                "intervalFactor": 1,
-                                "refId": "B",
-                                "step": 1,
-                                "legendFormat": "Used"
-                            }
-                        ],
-                        "title": "Total Storage",
-                        "type": "grafana-piechart-panel",
-                        "valueName": "current",
-                        "combine": {
-                            "threshold": 0,
-                            "label": "Others"
-                        }
                     }
                 ],
-                "title": "New row"
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
             },
             {
                 "collapse": false,
-                "editable": true,
                 "height": "25px",
                 "panels": [
                     {
@@ -570,15 +502,10 @@
                         "error": false,
                         "height": "30",
                         "id": 8,
-                        "isNew": true,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "mode": "html",
                         "span": 6,
-                        "style": {
-
-                        },
+                        "style": {},
                         "title": "",
                         "transparent": true,
                         "type": "text"
@@ -588,44 +515,37 @@
                         "editable": true,
                         "error": false,
                         "id": 35,
-                        "isNew": true,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "mode": "html",
                         "span": 6,
-                        "style": {
-
-                        },
+                        "style": {},
                         "title": "",
                         "transparent": true,
                         "type": "text"
                     }
                 ],
-                "title": "New row"
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
             },
             {
                 "collapse": false,
-                "editable": true,
                 "height": "200px",
                 "panels": [
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 14,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -637,17 +557,14 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -655,11 +572,12 @@
                             {
                                 "expr": "sum(scylla_storage_proxy_coordinator_foreground_writes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
-                                "refId": "A",
                                 "legendFormat": "",
-                                "step": 1
+                                "refId": "A",
+                                "step": 60
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Foreground Writes per [[by]]",
@@ -671,7 +589,11 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -691,22 +613,16 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 15,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -718,17 +634,14 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -736,12 +649,13 @@
                             {
                                 "expr": "sum(scylla_storage_proxy_coordinator_foreground_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "",
-                                "step": 1
+                                "step": 60
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Foreground Reads per [[by]]",
@@ -753,7 +667,11 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -773,22 +691,16 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 5,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -800,17 +712,14 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -818,11 +727,12 @@
                             {
                                 "expr": "sum(irate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "refId": "A",
                                 "legendFormat": "",
-                                "step": 1
+                                "refId": "A",
+                                "step": 60
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Write Timeouts per Second per [[by]]",
@@ -834,7 +744,11 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -854,22 +768,16 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 6,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -881,17 +789,14 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -899,11 +804,12 @@
                             {
                                 "expr": "sum(irate(scylla_storage_proxy_coordinator_write_unavailable{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "refId": "A",
                                 "legendFormat": "",
-                                "step": 1
+                                "refId": "A",
+                                "step": 60
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Write Unavailable per Second per [[by]]",
@@ -915,7 +821,11 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -935,30 +845,28 @@
                         ]
                     }
                 ],
-                "title": "New row"
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
             },
             {
                 "collapse": false,
-                "editable": true,
                 "height": "200px",
                 "panels": [
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 11,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -970,17 +878,14 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -988,11 +893,12 @@
                             {
                                 "expr": "sum(scylla_storage_proxy_coordinator_background_writes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
-                                "refId": "A",
                                 "legendFormat": "",
-                                "step": 1
+                                "refId": "A",
+                                "step": 60
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Background Writes per [[by]]",
@@ -1004,7 +910,11 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -1024,22 +934,16 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 10,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -1051,17 +955,14 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -1069,11 +970,12 @@
                             {
                                 "expr": "sum(scylla_storage_proxy_coordinator_background_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
-                                "refId": "A",
                                 "legendFormat": "",
-                                "step": 4
+                                "refId": "A",
+                                "step": 60
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Background Reads per [[by]]",
@@ -1085,7 +987,11 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -1105,22 +1011,16 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 7,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -1132,17 +1032,14 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -1150,11 +1047,12 @@
                             {
                                 "expr": "sum(irate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "refId": "A",
                                 "legendFormat": "",
-                                "step": 1
+                                "refId": "A",
+                                "step": 60
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Read Timeouts per Second per [[by]]",
@@ -1166,7 +1064,11 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -1186,22 +1088,16 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 4,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -1213,17 +1109,14 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -1231,12 +1124,13 @@
                             {
                                 "expr": "sum(irate(scylla_storage_proxy_coordinator_read_unavailable{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "metric": "",
                                 "legendFormat": "",
+                                "metric": "",
                                 "refId": "A",
-                                "step": 4
+                                "step": 60
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Read Unavailable per Second per [[by]]",
@@ -1248,7 +1142,11 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -1268,11 +1166,15 @@
                         ]
                     }
                 ],
-                "title": "New row"
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
             },
             {
                 "collapse": false,
-                "editable": true,
                 "height": "250px",
                 "panels": [
                     {
@@ -1281,36 +1183,25 @@
                         "error": false,
                         "height": "30",
                         "id": 57,
-                        "isNew": true,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "mode": "html",
                         "span": 12,
-                        "style": {
-
-                        },
+                        "style": {},
                         "title": "",
                         "transparent": true,
                         "type": "text"
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 60,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -1322,17 +1213,14 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
                         "span": 6,
                         "stack": false,
                         "steppedLine": false,
@@ -1340,11 +1228,12 @@
                             {
                                 "expr": "sum(irate(scylla_database_total_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "refId": "A",
                                 "legendFormat": "",
-                                "step": 1
+                                "refId": "A",
+                                "step": 30
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Reads",
@@ -1356,7 +1245,11 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -1376,22 +1269,16 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 59,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -1403,17 +1290,14 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
                         "span": 6,
                         "stack": false,
                         "steppedLine": false,
@@ -1421,12 +1305,13 @@
                             {
                                 "expr": "sum(irate(scylla_database_total_writes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "",
-                                "step": 1
+                                "step": 30
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Writes",
@@ -1438,7 +1323,11 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -1458,22 +1347,16 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 61,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -1485,17 +1368,14 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -1503,11 +1383,12 @@
                             {
                                 "expr": "sum(scylla_database_active_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
-                                "refId": "A",
                                 "legendFormat": "",
-                                "step": 1
+                                "refId": "A",
+                                "step": 60
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Active sstable reads",
@@ -1519,7 +1400,11 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -1539,22 +1424,16 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 62,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -1566,17 +1445,14 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -1584,11 +1460,12 @@
                             {
                                 "expr": "sum(scylla_database_queued_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
-                                "refId": "A",
                                 "legendFormat": "",
-                                "step": 1
+                                "refId": "A",
+                                "step": 60
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Queued sstable reads",
@@ -1600,7 +1477,11 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -1620,22 +1501,16 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 63,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -1647,17 +1522,14 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -1665,11 +1537,12 @@
                             {
                                 "expr": "sum(scylla_database_requests_blocked_memory_current{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
-                                "refId": "A",
                                 "legendFormat": "",
-                                "step": 1
+                                "refId": "A",
+                                "step": 60
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Writes currently blocked on dirty",
@@ -1681,7 +1554,11 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -1701,22 +1578,16 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 64,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -1728,17 +1599,14 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -1746,11 +1614,12 @@
                             {
                                 "expr": "sum(scylla_commitlog_pending_allocations{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
-                                "refId": "A",
                                 "legendFormat": "",
-                                "step": 1
+                                "refId": "A",
+                                "step": 60
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Writes currently blocked on commitlog",
@@ -1762,7 +1631,11 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -1786,33 +1659,24 @@
                         "editable": true,
                         "error": false,
                         "id": 71,
-                        "isNew": true,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "mode": "markdown",
                         "span": 3,
                         "title": "",
-                        "type": "text",
-                        "transparent": true
+                        "transparent": true,
+                        "type": "text"
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 74,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -1824,17 +1688,14 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -1842,11 +1703,12 @@
                             {
                                 "expr": "sum(irate(scylla_database_total_reads_failed{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "refId": "A",
                                 "legendFormat": "",
-                                "step": 1
+                                "refId": "A",
+                                "step": 60
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Reads failed",
@@ -1858,7 +1720,11 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -1878,22 +1744,16 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 67,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -1905,17 +1765,14 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -1923,11 +1780,12 @@
                             {
                                 "expr": "sum(irate(scylla_database_requests_blocked_memory{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "refId": "A",
                                 "legendFormat": "",
-                                "step": 1
+                                "refId": "A",
+                                "step": 60
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Writes blocked on dirty",
@@ -1939,7 +1797,11 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -1959,22 +1821,16 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 68,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -1986,17 +1842,14 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -2004,11 +1857,12 @@
                             {
                                 "expr": "sum(irate(scylla_commitlog_requests_blocked_memory{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "refId": "A",
                                 "legendFormat": "",
-                                "step": 1
+                                "refId": "A",
+                                "step": 60
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Writes blocked on commitlog",
@@ -2020,7 +1874,11 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -2044,48 +1902,36 @@
                         "editable": true,
                         "error": false,
                         "id": 73,
-                        "isNew": true,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "mode": "markdown",
                         "span": 3,
                         "title": "",
-                        "type": "text",
-                        "transparent": true
+                        "transparent": true,
+                        "type": "text"
                     },
                     {
                         "content": "",
                         "editable": true,
                         "error": false,
                         "id": 69,
-                        "isNew": true,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "mode": "markdown",
                         "span": 3,
                         "title": "",
-                        "type": "text",
-                        "transparent": true
+                        "transparent": true,
+                        "type": "text"
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 70,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -2097,17 +1943,14 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -2115,11 +1958,12 @@
                             {
                                 "expr": "sum(irate(scylla_database_total_writes_failed{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "refId": "A",
                                 "legendFormat": "",
-                                "step": 1
+                                "refId": "A",
+                                "step": 60
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Writes failed",
@@ -2131,7 +1975,11 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -2151,22 +1999,16 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 72,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -2178,17 +2020,14 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -2196,11 +2035,12 @@
                             {
                                 "expr": "sum(irate(scylla_database_total_writes_timedout{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "refId": "A",
                                 "legendFormat": "",
-                                "step": 1
+                                "refId": "A",
+                                "step": 60
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Writes timed out",
@@ -2212,7 +2052,11 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -2232,237 +2076,53 @@
                         ]
                     }
                 ],
-                "title": "New row"
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
             },
             {
                 "collapse": false,
-                "editable": true,
-                "height": "25px",
+                "height": 16,
                 "panels": [
-                    {
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Disk $monitor_disk</h1>",
-                        "editable": true,
-                        "error": false,
-                        "id": 21,
-                        "isNew": true,
-                        "links": [
-
-                        ],
-                        "mode": "html",
-                        "span": 6,
-                        "style": {
-
-                        },
-                        "title": "",
-                        "transparent": true,
-                        "type": "text"
-                    },
                     {
                         "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Cache</h1>",
                         "editable": true,
                         "error": false,
                         "id": 18,
-                        "isNew": true,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "mode": "html",
-                        "span": 6,
-                        "style": {
-
-                        },
+                        "span": 12,
+                        "style": {},
                         "title": "",
                         "transparent": true,
                         "type": "text"
                     }
                 ],
-                "title": "New row"
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
             },
             {
                 "collapse": false,
-                "editable": true,
                 "height": "250px",
                 "panels": [
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
-                        "datasource": "prometheus",
-                        "editable": true,
-                        "error": false,
-                        "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
-                        "id": 19,
-                        "isNew": true,
-                        "legend": {
-                            "avg": false,
-                            "current": false,
-                            "max": false,
-                            "min": false,
-                            "show": false,
-                            "total": false,
-                            "values": false
-                        },
-                        "lines": true,
-                        "linewidth": 2,
-                        "links": [
-
-                        ],
-                        "nullPointMode": "connected",
-                        "percentage": false,
-                        "pointradius": 5,
-                        "points": false,
-                        "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
-                        "span": 3,
-                        "stack": false,
-                        "steppedLine": false,
-                        "targets": [
-                            {
-                                "expr": "irate(node_disk_writes_completed{device=\"$monitor_disk\"}[30s])",
-                                "intervalFactor": 1,
-                                "legendFormat": "Disk Writes per Server per Second",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "timeFrom": null,
-                        "timeShift": null,
-                        "title": "Disk Writes per Server per Second",
-                        "tooltip": {
-                            "msResolution": false,
-                            "shared": true,
-                            "sort": 0,
-                            "value_type": "cumulative"
-                        },
-                        "type": "graph",
-                        "xaxis": {
-                            "show": true
-                        },
-                        "yaxes": [
-                            {
-                                "format": "wps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
-                    },
-                    {
-                        "aliasColors": {
-
-                        },
-                        "bars": false,
-                        "datasource": "prometheus",
-                        "editable": true,
-                        "error": false,
-                        "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
-                        "id": 20,
-                        "isNew": true,
-                        "legend": {
-                            "avg": false,
-                            "current": false,
-                            "max": false,
-                            "min": false,
-                            "show": false,
-                            "total": false,
-                            "values": false
-                        },
-                        "lines": true,
-                        "linewidth": 2,
-                        "links": [
-
-                        ],
-                        "nullPointMode": "connected",
-                        "percentage": false,
-                        "pointradius": 5,
-                        "points": false,
-                        "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
-                        "span": 3,
-                        "stack": false,
-                        "steppedLine": false,
-                        "targets": [
-                            {
-                                "expr": "irate(node_disk_reads_completed{device=\"$monitor_disk\"}[30s])",
-                                "intervalFactor": 1,
-                                "refId": "A",
-                                "legendFormat": "Disk Reads per Server per Second",
-                                "step": 1
-                            }
-                        ],
-                        "timeFrom": null,
-                        "timeShift": null,
-                        "title": "Disk Reads per Server per Second",
-                        "tooltip": {
-                            "msResolution": false,
-                            "shared": true,
-                            "sort": 0,
-                            "value_type": "cumulative"
-                        },
-                        "type": "graph",
-                        "xaxis": {
-                            "show": true
-                        },
-                        "yaxes": [
-                            {
-                                "format": "rps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
-                    },
-                    {
-                        "aliasColors": {
-
-                        },
-                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 16,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -2474,17 +2134,14 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -2492,11 +2149,12 @@
                             {
                                 "expr": "sum(irate(scylla_cache_row_hits{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "refId": "A",
                                 "legendFormat": "",
-                                "step": 1
+                                "refId": "A",
+                                "step": 60
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Cache Hits",
@@ -2508,7 +2166,11 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -2528,22 +2190,16 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 17,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -2555,17 +2211,14 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -2573,11 +2226,12 @@
                             {
                                 "expr": "sum(irate(scylla_cache_row_misses{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "refId": "A",
                                 "legendFormat": "",
-                                "step": 1
+                                "refId": "A",
+                                "step": 60
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Cache Misses",
@@ -2589,259 +2243,11 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
-                        },
-                        "yaxes": [
-                            {
-                                "format": "rps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "collapse": false,
-                "editable": true,
-                "height": "250px",
-                "panels": [
-                    {
-                        "aliasColors": {
-
-                        },
-                        "bars": false,
-                        "datasource": "prometheus",
-                        "editable": true,
-                        "error": false,
-                        "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
-                        "id": 22,
-                        "isNew": true,
-                        "legend": {
-                            "avg": false,
-                            "current": false,
-                            "max": false,
-                            "min": false,
-                            "show": false,
-                            "total": false,
-                            "values": false
-                        },
-                        "lines": true,
-                        "linewidth": 2,
-                        "links": [
-
-                        ],
-                        "nullPointMode": "connected",
-                        "percentage": false,
-                        "pointradius": 5,
-                        "points": false,
-                        "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
-                        "span": 3,
-                        "stack": false,
-                        "steppedLine": false,
-                        "targets": [
-                            {
-                                "expr": "irate(node_disk_bytes_written{device=\"$monitor_disk\"}[30s])",
-                                "intervalFactor": 1,
-                                "metric": "",
-                                "refId": "A",
-                                "legendFormat": "Disk Writes Bps per Server",
-                                "step": 1
-                            }
-                        ],
-                        "timeFrom": null,
-                        "timeShift": null,
-                        "title": "Disk Writes Bps per Server",
-                        "tooltip": {
-                            "msResolution": false,
-                            "shared": true,
-                            "sort": 0,
-                            "value_type": "cumulative"
-                        },
-                        "type": "graph",
-                        "xaxis": {
-                            "show": true
-                        },
-                        "yaxes": [
-                            {
-                                "format": "Bps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
-                    },
-                    {
-                        "aliasColors": {
-
-                        },
-                        "bars": false,
-                        "datasource": "prometheus",
-                        "editable": true,
-                        "error": false,
-                        "fill": 1,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
-                        "id": 23,
-                        "isNew": true,
-                        "legend": {
-                            "avg": false,
-                            "current": false,
-                            "max": false,
-                            "min": false,
-                            "show": false,
-                            "total": false,
-                            "values": false
-                        },
-                        "lines": true,
-                        "linewidth": 2,
-                        "links": [
-
-                        ],
-                        "nullPointMode": "connected",
-                        "percentage": false,
-                        "pointradius": 5,
-                        "points": false,
-                        "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
-                        "span": 3,
-                        "stack": false,
-                        "steppedLine": false,
-                        "targets": [
-                            {
-                                "expr": "irate(node_disk_bytes_read{device=\"$monitor_disk\"}[30s])",
-                                "intervalFactor": 1,
-                                "refId": "A",
-                                "legendFormat": "Disk Read Bps per Server",
-                                "step": 1
-                            }
-                        ],
-                        "timeFrom": null,
-                        "timeShift": null,
-                        "title": "Disk Read Bps per Server",
-                        "tooltip": {
-                            "msResolution": false,
-                            "shared": true,
-                            "sort": 0,
-                            "value_type": "cumulative"
-                        },
-                        "type": "graph",
-                        "xaxis": {
-                            "show": true
-                        },
-                        "yaxes": [
-                            {
-                                "format": "Bps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
-                    },
-                    {
-                        "aliasColors": {
-
-                        },
-                        "bars": false,
-                        "datasource": "prometheus",
-                        "editable": true,
-                        "error": false,
-                        "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
-                        "id": 145,
-                        "isNew": true,
-                        "legend": {
-                            "avg": false,
-                            "current": false,
-                            "max": false,
-                            "min": false,
-                            "show": false,
-                            "total": false,
-                            "values": false
-                        },
-                        "lines": true,
-                        "linewidth": 2,
-                        "links": [
-
-                        ],
-                        "nullPointMode": "connected",
-                        "percentage": false,
-                        "pointradius": 5,
-                        "points": false,
-                        "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
-                        "span": 3,
-                        "stack": false,
-                        "steppedLine": false,
-                        "targets": [
-                            {
-                                "expr": "sum(irate(scylla_cache_row_insertions{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "refId": "A",
-                                "legendFormat": "",
-                                "step": 1
-                            }
-                        ],
-                        "timeFrom": null,
-                        "timeShift": null,
-                        "title": "Cache Insertions",
-                        "tooltip": {
-                            "msResolution": false,
-                            "shared": true,
-                            "sort": 0,
-                            "value_type": "cumulative"
-                        },
-                        "type": "graph",
-                        "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -2861,118 +2267,16 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
-                        "id": 148,
-                        "isNew": true,
-                        "legend": {
-                            "avg": false,
-                            "current": false,
-                            "max": false,
-                            "min": false,
-                            "show": false,
-                            "total": false,
-                            "values": false
-                        },
-                        "lines": true,
-                        "linewidth": 2,
-                        "links": [
-
-                        ],
-                        "nullPointMode": "connected",
-                        "percentage": false,
-                        "pointradius": 5,
-                        "points": false,
-                        "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
-                        "span": 3,
-                        "stack": false,
-                        "steppedLine": false,
-                        "targets": [
-                            {
-                                "expr": "sum(irate(scylla_cache_partition_evictions{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "refId": "A",
-                                "legendFormat": "",
-                                "step": 1
-                            }
-                        ],
-                        "timeFrom": null,
-                        "timeShift": null,
-                        "title": "Cache Evictions",
-                        "tooltip": {
-                            "msResolution": false,
-                            "shared": true,
-                            "sort": 0,
-                            "value_type": "cumulative"
-                        },
-                        "type": "graph",
-                        "xaxis": {
-                            "show": true
-                        },
-                        "yaxes": [
-                            {
-                                "format": "ops",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
-                    },
-                    {
-                        "content": "&nbsp;",
-                        "editable": true,
-                        "error": false,
-                        "id": 55,
-                        "isNew": true,
-                        "links": [
-
-                        ],
-                        "mode": "html",
-                        "span": 6,
-                        "title": "",
-                        "transparent": true,
-                        "type": "text"
-                    },
-                    {
-                        "aliasColors": {
-
-                        },
-                        "bars": false,
-                        "datasource": "prometheus",
-                        "editable": true,
-                        "error": false,
-                        "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 53,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -2984,29 +2288,28 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
                                 "expr": "sum(irate(scylla_cache_partition_merges{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "format": "time_series",
                                 "intervalFactor": 1,
-                                "refId": "A",
                                 "legendFormat": "",
-                                "step": 1
+                                "refId": "A",
+                                "step": 60
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Cache Merges",
@@ -3018,7 +2321,11 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -3038,199 +2345,16 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
-                        "id": 54,
-                        "isNew": true,
-                        "legend": {
-                            "avg": false,
-                            "current": false,
-                            "max": false,
-                            "min": false,
-                            "show": false,
-                            "total": false,
-                            "values": false
-                        },
-                        "lines": true,
-                        "linewidth": 2,
-                        "links": [
-
-                        ],
-                        "nullPointMode": "connected",
-                        "percentage": false,
-                        "pointradius": 5,
-                        "points": false,
-                        "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
-                        "span": 3,
-                        "stack": false,
-                        "steppedLine": false,
-                        "targets": [
-                            {
-                                "expr": "sum(irate(scylla_cache_partition_removals{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "refId": "A",
-                                "legendFormat": "",
-                                "step": 1
-                            }
-                        ],
-                        "timeFrom": null,
-                        "timeShift": null,
-                        "title": "Cache Removals",
-                        "tooltip": {
-                            "msResolution": false,
-                            "shared": true,
-                            "sort": 0,
-                            "value_type": "cumulative"
-                        },
-                        "type": "graph",
-                        "xaxis": {
-                            "show": true
-                        },
-                        "yaxes": [
-                            {
-                                "format": "ops",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
-                    },
-                    {
-                        "content": "&nbsp;",
-                        "editable": true,
-                        "error": false,
-                        "id": 52,
-                        "isNew": true,
-                        "links": [
-
-                        ],
-                        "mode": "html",
-                        "span": 6,
-                        "title": "",
-                        "transparent": true,
-                        "type": "text"
-                    },
-                    {
-                        "aliasColors": {
-
-                        },
-                        "bars": false,
-                        "datasource": "prometheus",
-                        "editable": true,
-                        "error": false,
-                        "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
-                        "id": 44,
-                        "isNew": true,
-                        "legend": {
-                            "avg": false,
-                            "current": false,
-                            "max": false,
-                            "min": false,
-                            "show": false,
-                            "total": false,
-                            "values": false
-                        },
-                        "lines": true,
-                        "linewidth": 2,
-                        "links": [
-
-                        ],
-                        "nullPointMode": "connected",
-                        "percentage": false,
-                        "pointradius": 5,
-                        "points": false,
-                        "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
-                        "span": 3,
-                        "stack": false,
-                        "steppedLine": false,
-                        "targets": [
-                            {
-                                "expr": "sum(scylla_cache_partitions{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
-                                "intervalFactor": 1,
-                                "refId": "A",
-                                "legendFormat": "",
-                                "step": 1
-                            }
-                        ],
-                        "timeFrom": null,
-                        "timeShift": null,
-                        "title": "Cache Partitions",
-                        "tooltip": {
-                            "msResolution": false,
-                            "shared": true,
-                            "sort": 0,
-                            "value_type": "cumulative"
-                        },
-                        "type": "graph",
-                        "xaxis": {
-                            "show": true
-                        },
-                        "yaxes": [
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
-                    },
-                    {
-                        "aliasColors": {
-
-                        },
-                        "bars": false,
-                        "datasource": "prometheus",
-                        "editable": true,
-                        "error": false,
-                        "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 46,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -3242,17 +2366,14 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -3260,11 +2381,12 @@
                             {
                                 "expr": "sum(scylla_cache_bytes_total{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
-                                "refId": "A",
                                 "legendFormat": "",
-                                "step": 1
+                                "refId": "A",
+                                "step": 60
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Cache Total Bytes",
@@ -3276,7 +2398,11 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -3296,56 +2422,28 @@
                         ]
                     }
                 ],
-                "title": "New row"
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
             },
             {
                 "collapse": false,
-                "editable": true,
-                "height": "25px",
+                "height": 230,
                 "panels": [
                     {
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Memory</h1>",
-                        "editable": true,
-                        "error": false,
-                        "id": 51,
-                        "isNew": true,
-                        "links": [
-
-                        ],
-                        "mode": "html",
-                        "span": 12,
-                        "style": {
-
-                        },
-                        "title": "",
-                        "transparent": true,
-                        "type": "text"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "collapse": false,
-                "editable": true,
-                "height": "250px",
-                "panels": [
-                    {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
-                        "id": 49,
-                        "isNew": true,
+                        "grid": {},
+                        "id": 145,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -3357,17 +2455,359 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 3,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(scylla_cache_row_insertions{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 60
+                            }
                         ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Cache Insertions",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "rps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 0,
+                        "grid": {},
+                        "id": 148,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 3,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(scylla_cache_partition_evictions{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 60
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Cache Evictions",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "ops",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 0,
+                        "grid": {},
+                        "id": 54,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 3,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(scylla_cache_partition_removals{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 60
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Cache Removals",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "ops",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 0,
+                        "grid": {},
+                        "id": 44,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 3,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(scylla_cache_partitions{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 60
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Cache Partitions",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": "25px",
+                "panels": [
+                    {
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Memory</h1>",
+                        "editable": true,
+                        "error": false,
+                        "id": 51,
+                        "links": [],
+                        "mode": "html",
+                        "span": 12,
+                        "style": {},
+                        "title": "",
+                        "transparent": true,
+                        "type": "text"
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": "250px",
+                "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": "prometheus",
+                        "editable": true,
+                        "error": false,
+                        "fill": 0,
+                        "grid": {},
+                        "id": 49,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": false,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
                         "span": 6,
                         "stack": false,
                         "steppedLine": false,
@@ -3375,11 +2815,12 @@
                             {
                                 "expr": "sum(scylla_lsa_total_space_bytes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
-                                "refId": "A",
                                 "legendFormat": "",
-                                "step": 1
+                                "refId": "A",
+                                "step": 30
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "LSA total memory",
@@ -3391,7 +2832,11 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -3411,22 +2856,16 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 50,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -3438,17 +2877,14 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
                         "span": 6,
                         "stack": false,
                         "steppedLine": false,
@@ -3456,11 +2892,12 @@
                             {
                                 "expr": "sum(scylla_lsa_non_lsa_used_space_bytes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
-                                "refId": "A",
                                 "legendFormat": "",
-                                "step": 1
+                                "refId": "A",
+                                "step": 30
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Non-LSA used memory",
@@ -3472,7 +2909,11 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -3492,381 +2933,15 @@
                         ]
                     }
                 ],
-                "title": "New row"
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
             },
             {
                 "collapse": false,
-                "editable": true,
-                "height": "25px",
-                "panels": [
-                    {
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Network $monitor_network_interface</h1>",
-                        "editable": true,
-                        "error": false,
-                        "id": 28,
-                        "isNew": true,
-                        "links": [
-
-                        ],
-                        "mode": "html",
-                        "span": 12,
-                        "style": {
-
-                        },
-                        "title": "",
-                        "transparent": true,
-                        "type": "text"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "collapse": false,
-                "editable": true,
-                "height": "250px",
-                "panels": [
-                    {
-                        "aliasColors": {
-
-                        },
-                        "bars": false,
-                        "datasource": "prometheus",
-                        "editable": true,
-                        "error": false,
-                        "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
-                        "id": 24,
-                        "isNew": true,
-                        "legend": {
-                            "avg": false,
-                            "current": false,
-                            "max": false,
-                            "min": false,
-                            "show": false,
-                            "total": false,
-                            "values": false
-                        },
-                        "lines": true,
-                        "linewidth": 2,
-                        "links": [
-
-                        ],
-                        "nullPointMode": "connected",
-                        "percentage": false,
-                        "pointradius": 5,
-                        "points": false,
-                        "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
-                        "span": 6,
-                        "stack": false,
-                        "steppedLine": false,
-                        "targets": [
-                            {
-                                "expr": "irate(node_network_receive_packets{device=\"$monitor_network_interface\"}[30s])",
-                                "intervalFactor": 1,
-                                "metric": "",
-                                "refId": "A",
-                                "legendFormat": "Interface Rx Packets",
-                                "step": 1
-                            }
-                        ],
-                        "timeFrom": null,
-                        "timeShift": null,
-                        "title": "Interface Rx Packets",
-                        "tooltip": {
-                            "msResolution": false,
-                            "shared": true,
-                            "sort": 0,
-                            "value_type": "cumulative"
-                        },
-                        "type": "graph",
-                        "xaxis": {
-                            "show": true
-                        },
-                        "yaxes": [
-                            {
-                                "format": "pps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
-                    },
-                    {
-                        "aliasColors": {
-
-                        },
-                        "bars": false,
-                        "datasource": "prometheus",
-                        "editable": true,
-                        "error": false,
-                        "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
-                        "id": 25,
-                        "isNew": true,
-                        "legend": {
-                            "avg": false,
-                            "current": false,
-                            "max": false,
-                            "min": false,
-                            "show": false,
-                            "total": false,
-                            "values": false
-                        },
-                        "lines": true,
-                        "linewidth": 2,
-                        "links": [
-
-                        ],
-                        "nullPointMode": "connected",
-                        "percentage": false,
-                        "pointradius": 5,
-                        "points": false,
-                        "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
-                        "span": 6,
-                        "stack": false,
-                        "steppedLine": false,
-                        "targets": [
-                            {
-                                "expr": "irate(node_network_transmit_packets{device=\"$monitor_network_interface\"}[30s])",
-                                "intervalFactor": 1,
-                                "metric": "",
-                                "refId": "A",
-                                "legendFormat": "Interface Tx Packets",
-                                "step": 1
-                            }
-                        ],
-                        "timeFrom": null,
-                        "timeShift": null,
-                        "title": "Interface Tx Packets",
-                        "tooltip": {
-                            "msResolution": false,
-                            "shared": true,
-                            "sort": 0,
-                            "value_type": "cumulative"
-                        },
-                        "type": "graph",
-                        "xaxis": {
-                            "show": true
-                        },
-                        "yaxes": [
-                            {
-                                "format": "pps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "collapse": false,
-                "editable": true,
-                "height": "250px",
-                "panels": [
-                    {
-                        "aliasColors": {
-
-                        },
-                        "bars": false,
-                        "datasource": "prometheus",
-                        "editable": true,
-                        "error": false,
-                        "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
-                        "id": 26,
-                        "isNew": true,
-                        "legend": {
-                            "avg": false,
-                            "current": false,
-                            "max": false,
-                            "min": false,
-                            "show": false,
-                            "total": false,
-                            "values": false
-                        },
-                        "lines": true,
-                        "linewidth": 2,
-                        "links": [
-
-                        ],
-                        "nullPointMode": "connected",
-                        "percentage": false,
-                        "pointradius": 5,
-                        "points": false,
-                        "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
-                        "span": 6,
-                        "stack": false,
-                        "steppedLine": false,
-                        "targets": [
-                            {
-                                "expr": "irate(node_network_receive_bytes{device=\"$monitor_network_interface\"}[30s])",
-                                "intervalFactor": 1,
-                                "metric": "",
-                                "refId": "A",
-                                "legendFormat": "Interface Rx Bps",
-                                "step": 1
-                            }
-                        ],
-                        "timeFrom": null,
-                        "timeShift": null,
-                        "title": "Interface Rx Bps",
-                        "tooltip": {
-                            "msResolution": false,
-                            "shared": true,
-                            "sort": 0,
-                            "value_type": "cumulative"
-                        },
-                        "type": "graph",
-                        "xaxis": {
-                            "show": true
-                        },
-                        "yaxes": [
-                            {
-                                "format": "Bps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
-                    },
-                    {
-                        "aliasColors": {
-
-                        },
-                        "bars": false,
-                        "datasource": "prometheus",
-                        "editable": true,
-                        "error": false,
-                        "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
-                        "id": 27,
-                        "isNew": true,
-                        "legend": {
-                            "avg": false,
-                            "current": false,
-                            "max": false,
-                            "min": false,
-                            "show": false,
-                            "total": false,
-                            "values": false
-                        },
-                        "lines": true,
-                        "linewidth": 2,
-                        "links": [
-
-                        ],
-                        "nullPointMode": "connected",
-                        "percentage": false,
-                        "pointradius": 5,
-                        "points": false,
-                        "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
-                        "span": 6,
-                        "stack": false,
-                        "steppedLine": false,
-                        "targets": [
-                            {
-                                "expr": "irate(node_network_transmit_bytes{device=\"$monitor_network_interface\"}[30s])",
-                                "intervalFactor": 1,
-                                "metric": "",
-                                "refId": "A",
-                                "legendFormat": "Interface Tx Bps",
-                                "step": 1
-                            }
-                        ],
-                        "timeFrom": null,
-                        "timeShift": null,
-                        "title": "Interface Tx Bps",
-                        "tooltip": {
-                            "msResolution": false,
-                            "shared": true,
-                            "sort": 0,
-                            "value_type": "cumulative"
-                        },
-                        "type": "graph",
-                        "xaxis": {
-                            "show": true
-                        },
-                        "yaxes": [
-                            {
-                                "format": "Bps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "collapse": false,
-                "editable": true,
                 "height": "25px",
                 "panels": [
                     {
@@ -3874,44 +2949,37 @@
                         "editable": true,
                         "error": false,
                         "id": 42,
-                        "isNew": true,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "mode": "html",
                         "span": 12,
-                        "style": {
-
-                        },
+                        "style": {},
                         "title": "",
                         "transparent": true,
                         "type": "text"
                     }
                 ],
-                "title": "New row"
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
             },
             {
                 "collapse": false,
-                "editable": true,
                 "height": "250px",
                 "panels": [
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 43,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -3923,17 +2991,14 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
                         "span": 12,
                         "stack": false,
                         "steppedLine": false,
@@ -3941,12 +3006,13 @@
                             {
                                 "expr": "sum(scylla_compaction_manager_compactions{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "",
-                                "step": 1
+                                "step": 15
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "Running Compactions",
@@ -3958,7 +3024,11 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -3978,11 +3048,15 @@
                         ]
                     }
                 ],
-                "title": "New row"
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
             },
             {
                 "collapse": false,
-                "editable": true,
                 "height": "25px",
                 "panels": [
                     {
@@ -3990,44 +3064,37 @@
                         "editable": true,
                         "error": false,
                         "id": 144,
-                        "isNew": true,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "mode": "html",
                         "span": 12,
-                        "style": {
-
-                        },
+                        "style": {},
                         "title": "",
                         "transparent": true,
                         "type": "text"
                     }
                 ],
-                "title": "New row"
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
             },
             {
                 "collapse": false,
-                "editable": true,
                 "height": "250px",
                 "panels": [
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 45,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -4039,17 +3106,14 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -4057,12 +3121,13 @@
                             {
                                 "expr": "sum(scylla_cql_inserts{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
+                                "legendFormat": "CQL Inserts",
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "CQL Inserts",
-                                "step": 1
+                                "step": 60
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "CQL Insert",
@@ -4074,7 +3139,11 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -4094,22 +3163,16 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 146,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -4121,17 +3184,14 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -4139,12 +3199,13 @@
                             {
                                 "expr": "sum(scylla_cql_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
+                                "legendFormat": "CQL Reads",
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "CQL Reads",
-                                "step": 1
+                                "step": 60
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "CQL Reads",
@@ -4156,7 +3217,11 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -4176,22 +3241,16 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 47,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -4203,17 +3262,14 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -4221,12 +3277,13 @@
                             {
                                 "expr": "sum(scylla_cql_deletes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
+                                "legendFormat": "CQL Deletes",
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "CQL Deletes",
-                                "step": 1
+                                "step": 60
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "CQL Deletes",
@@ -4238,7 +3295,11 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -4258,22 +3319,16 @@
                         ]
                     },
                     {
-                        "aliasColors": {
-
-                        },
+                        "aliasColors": {},
                         "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": "prometheus",
                         "editable": true,
                         "error": false,
                         "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-                        },
+                        "grid": {},
                         "id": 48,
-                        "isNew": true,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -4285,17 +3340,14 @@
                         },
                         "lines": true,
                         "linewidth": 2,
-                        "links": [
-
-                        ],
+                        "links": [],
                         "nullPointMode": "connected",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
-
-                        ],
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
@@ -4303,12 +3355,13 @@
                             {
                                 "expr": "sum(scylla_cql_updates{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
+                                "legendFormat": "CQL Updates",
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "CQL Updates",
-                                "step": 1
+                                "step": 60
                             }
                         ],
+                        "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
                         "title": "CQL Updates",
@@ -4320,7 +3373,11 @@
                         },
                         "type": "graph",
                         "xaxis": {
-                            "show": true
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
                         },
                         "yaxes": [
                             {
@@ -4340,89 +3397,21 @@
                         ]
                     }
                 ],
-                "title": "New row"
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
             }
         ],
-        "time": {
-            "from": "now-30m",
-            "to": "now"
-        },
-        "timepicker": {
-            "now": true,
-            "refresh_intervals": [
-                "5s",
-                "10s",
-                "30s",
-                "1m",
-                "5m",
-                "15m",
-                "30m",
-                "1h",
-                "2h",
-                "1d"
-            ],
-            "time_options": [
-                "5m",
-                "15m",
-                "1h",
-                "6h",
-                "12h",
-                "24h",
-                "2d",
-                "7d",
-                "30d"
-            ]
-        },
+        "schemaVersion": 14,
+        "style": "dark",
+        "tags": [
+            "master"
+        ],
         "templating": {
             "list": [
-                {
-                    "allValue": null,
-                    "current": {
-                        "isNone": true,
-                        "text": "None",
-                        "value": ""
-                    },
-                    "datasource": "prometheus",
-                    "hide": 0,
-                    "includeAll": false,
-                    "label": null,
-                    "multi": false,
-                    "name": "monitor_disk",
-                    "options": [],
-                    "query": "node_disk_bytes_read",
-                    "refresh": 1,
-                    "regex": "/.*device=\"([^\\\"]*)\".*/",
-                    "sort": 0,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
-                },
-                {
-                    "allValue": null,
-                    "current": {
-                        "isNone": true,
-                        "text": "None",
-                        "value": ""
-                    },
-                    "datasource": "prometheus",
-                    "hide": 0,
-                    "includeAll": false,
-                    "label": null,
-                    "multi": false,
-                    "name": "monitor_network_interface",
-                    "options": [],
-                    "query": "node_network_receive_packets",
-                    "refresh": 1,
-                    "regex": "/.*device=\"([^\\\"]*)\".*/",
-                    "sort": 0,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
-                },
                 {
                     "allValue": null,
                     "current": {
@@ -4488,7 +3477,7 @@
                     },
                     "datasource": "prometheus",
                     "hide": 0,
-                      "includeAll": true,
+                    "includeAll": true,
                     "label": "shard",
                     "multi": true,
                     "name": "shard",
@@ -4505,16 +3494,37 @@
                 }
             ]
         },
-        "annotations": {
-            "list": [
+        "time": {
+            "from": "now-30m",
+            "to": "now"
+        },
+        "timepicker": {
+            "now": true,
+            "refresh_intervals": [
+                "5s",
+                "10s",
+                "30s",
+                "1m",
+                "5m",
+                "15m",
+                "30m",
+                "1h",
+                "2h",
+                "1d"
+            ],
+            "time_options": [
+                "5m",
+                "15m",
+                "1h",
+                "6h",
+                "12h",
+                "24h",
+                "2d",
+                "7d",
+                "30d"
             ]
         },
-        "refresh": "30s",
-        "schemaVersion": 12,
-        "version": 5,
-        "links": [
-
-        ],
-        "gnetId": null
+        "timezone": "browser",
+        "version": 1
     }
 }

--- a/grafana/scylla-dash-per-scylla-server.master.json
+++ b/grafana/scylla-dash-per-scylla-server.master.json
@@ -10,7 +10,7 @@
         "graphTooltip": 1,
         "hideControls": true,
         "links": [],
-        "refresh": false,
+        "refresh": "30s",
         "rows": [
             {
                 "collapse": false,

--- a/load-grafana.sh
+++ b/load-grafana.sh
@@ -30,7 +30,8 @@ curl -XPOST -i http://admin:$GRAFANA_ADMIN_PASSWORD@localhost:$GRAFANA_PORT/api/
      -H "Content-Type: application/json"
 IFS=',' ;for v in $VERSIONS; do
 	curl -XPOST -i http://admin:$GRAFANA_ADMIN_PASSWORD@localhost:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/scylla-dash.$v.json -H "Content-Type: application/json"
-	curl -XPOST -i http://admin:$GRAFANA_ADMIN_PASSWORD@localhost:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/scylla-dash-per-server.$v.json -H "Content-Type: application/json"
+	curl -XPOST -i http://admin:$GRAFANA_ADMIN_PASSWORD@localhost:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/scylla-dash-per-scylla-server.$v.json -H "Content-Type: application/json"
+        curl -XPOST -i http://admin:$GRAFANA_ADMIN_PASSWORD@localhost:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/scylla-dash-per-node.$v.json -H "Content-Type: application/json"
 	curl -XPOST -i http://admin:$GRAFANA_ADMIN_PASSWORD@localhost:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/scylla-dash-io-per-server.$v.json -H "Content-Type: application/json"
 done
 


### PR DESCRIPTION
This PR break the Per Server dashboard to two new dashboard Scylla server and per node. The first for Scylla metrics, the second for node_exporter (OS level) metrics.

In other words: it moves the disk and network chart to the node dashboard, the rest to Scylla server dashboard.

Fix #233 

