### PR TITLE
Make Datasource name configurable.

### DIFF
--- a/grafana/scylla-dash-io-per-server.1.5.json
+++ b/grafana/scylla-dash-io-per-server.1.5.json
@@ -48,7 +48,7 @@
                             "rgba(237, 129, 40, 0.89)",
                             "rgba(50, 172, 45, 0.97)"
                         ],
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "none",
@@ -129,7 +129,7 @@
                             "rgba(250, 113, 0, 0.89)",
                             "rgba(255, 0, 0, 0.9)"
                         ],
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "none",
@@ -223,7 +223,7 @@
                             "{}": "#584477"
                         },
                         "bars": true,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -335,7 +335,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -418,7 +418,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -499,7 +499,7 @@
 
                         },
                         "cacheTimeout": null,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fontSize": "80%",
@@ -584,7 +584,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -666,7 +666,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -754,7 +754,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -835,7 +835,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -949,7 +949,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1031,7 +1031,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1113,7 +1113,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1195,7 +1195,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1277,7 +1277,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1359,7 +1359,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1441,7 +1441,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1524,7 +1524,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1606,7 +1606,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1688,7 +1688,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1770,7 +1770,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1852,7 +1852,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1934,7 +1934,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -2016,7 +2016,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -2098,7 +2098,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -2180,7 +2180,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -2262,7 +2262,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -2344,7 +2344,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -2459,7 +2459,7 @@
             "list": [
                 {
                     "type": "query",
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "refresh": 1,
                     "name": "monitor_disk",
                     "hide": 0,

--- a/grafana/scylla-dash-io-per-server.1.6.json
+++ b/grafana/scylla-dash-io-per-server.1.6.json
@@ -48,7 +48,7 @@
                             "rgba(237, 129, 40, 0.89)",
                             "rgba(50, 172, 45, 0.97)"
                         ],
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "none",
@@ -129,7 +129,7 @@
                             "rgba(250, 113, 0, 0.89)",
                             "rgba(255, 0, 0, 0.9)"
                         ],
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "none",
@@ -223,7 +223,7 @@
                             "{}": "#584477"
                         },
                         "bars": true,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -335,7 +335,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -418,7 +418,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -499,7 +499,7 @@
 
                         },
                         "cacheTimeout": null,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fontSize": "80%",
@@ -584,7 +584,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -666,7 +666,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -754,7 +754,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -835,7 +835,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -949,7 +949,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1031,7 +1031,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1113,7 +1113,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1195,7 +1195,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1277,7 +1277,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1359,7 +1359,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1441,7 +1441,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1524,7 +1524,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1606,7 +1606,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1688,7 +1688,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1770,7 +1770,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1852,7 +1852,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1934,7 +1934,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -2016,7 +2016,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -2098,7 +2098,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -2180,7 +2180,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -2262,7 +2262,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -2344,7 +2344,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -2459,7 +2459,7 @@
             "list": [
                 {
                     "type": "query",
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "refresh": 1,
                     "name": "monitor_disk",
                     "hide": 0,
@@ -2514,7 +2514,7 @@
                             "$__all"
                         ]
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                     "includeAll": true,
                     "label": "node",
@@ -2537,7 +2537,7 @@
                         "text": "All",
                         "value": "$__all"
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                       "includeAll": true,
                     "label": "shard",

--- a/grafana/scylla-dash-io-per-server.1.7.json
+++ b/grafana/scylla-dash-io-per-server.1.7.json
@@ -48,7 +48,7 @@
                             "rgba(237, 129, 40, 0.89)",
                             "rgba(50, 172, 45, 0.97)"
                         ],
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "none",
@@ -129,7 +129,7 @@
                             "rgba(250, 113, 0, 0.89)",
                             "rgba(255, 0, 0, 0.9)"
                         ],
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "none",
@@ -224,7 +224,7 @@
                             "{}": "#584477"
                         },
                         "bars": true,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -337,7 +337,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -421,7 +421,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -503,7 +503,7 @@
 
                         },
                         "cacheTimeout": null,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fontSize": "80%",
@@ -591,7 +591,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -673,7 +673,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -762,7 +762,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -844,7 +844,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -959,7 +959,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1042,7 +1042,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1125,7 +1125,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1208,7 +1208,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1291,7 +1291,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1374,7 +1374,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1457,7 +1457,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1541,7 +1541,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1624,7 +1624,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1707,7 +1707,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1790,7 +1790,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1873,7 +1873,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1956,7 +1956,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -2039,7 +2039,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -2122,7 +2122,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -2205,7 +2205,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -2288,7 +2288,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -2371,7 +2371,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -2487,7 +2487,7 @@
             "list": [
                 {
                     "type": "query",
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "refresh": 1,
                     "name": "monitor_disk",
                     "hide": 0,
@@ -2542,7 +2542,7 @@
                             "$__all"
                         ]
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                     "includeAll": true,
                     "label": "node",
@@ -2565,7 +2565,7 @@
                         "text": "All",
                         "value": "$__all"
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                       "includeAll": true,
                     "label": "shard",

--- a/grafana/scylla-dash-io-per-server.2.0.json
+++ b/grafana/scylla-dash-io-per-server.2.0.json
@@ -48,7 +48,7 @@
                             "rgba(237, 129, 40, 0.89)",
                             "rgba(50, 172, 45, 0.97)"
                         ],
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "none",
@@ -129,7 +129,7 @@
                             "rgba(250, 113, 0, 0.89)",
                             "rgba(255, 0, 0, 0.9)"
                         ],
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "none",
@@ -224,7 +224,7 @@
                             "{}": "#584477"
                         },
                         "bars": true,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -337,7 +337,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -421,7 +421,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -503,7 +503,7 @@
 
                         },
                         "cacheTimeout": null,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fontSize": "80%",
@@ -591,7 +591,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -673,7 +673,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -762,7 +762,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -844,7 +844,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -959,7 +959,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1042,7 +1042,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1125,7 +1125,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1208,7 +1208,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1291,7 +1291,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1374,7 +1374,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1457,7 +1457,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1541,7 +1541,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1624,7 +1624,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1707,7 +1707,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1790,7 +1790,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1873,7 +1873,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1956,7 +1956,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -2039,7 +2039,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -2122,7 +2122,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -2205,7 +2205,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -2288,7 +2288,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -2371,7 +2371,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -2487,7 +2487,7 @@
             "list": [
                 {
                     "type": "query",
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "refresh": 1,
                     "name": "monitor_disk",
                     "hide": 0,
@@ -2542,7 +2542,7 @@
                             "$__all"
                         ]
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                     "includeAll": true,
                     "label": "node",
@@ -2565,7 +2565,7 @@
                         "text": "All",
                         "value": "$__all"
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                       "includeAll": true,
                     "label": "shard",

--- a/grafana/scylla-dash-io-per-server.2.1.template.json
+++ b/grafana/scylla-dash-io-per-server.2.1.template.json
@@ -886,7 +886,7 @@
             "list": [
                 {
                     "current": {},
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                     "includeAll": false,
                     "multi": false,
@@ -937,7 +937,7 @@
                             "$__all"
                         ]
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                     "includeAll": true,
                     "label": "node",
@@ -960,7 +960,7 @@
                         "text": "All",
                         "value": "$__all"
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                     "includeAll": true,
                     "label": "shard",

--- a/grafana/scylla-dash-io-per-server.2017.1.json
+++ b/grafana/scylla-dash-io-per-server.2017.1.json
@@ -48,7 +48,7 @@
                             "rgba(237, 129, 40, 0.89)",
                             "rgba(50, 172, 45, 0.97)"
                         ],
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "none",
@@ -129,7 +129,7 @@
                             "rgba(250, 113, 0, 0.89)",
                             "rgba(255, 0, 0, 0.9)"
                         ],
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "none",
@@ -223,7 +223,7 @@
                             "{}": "#584477"
                         },
                         "bars": true,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -335,7 +335,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -418,7 +418,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -499,7 +499,7 @@
 
                         },
                         "cacheTimeout": null,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fontSize": "80%",
@@ -584,7 +584,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -666,7 +666,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -754,7 +754,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -835,7 +835,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -949,7 +949,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1031,7 +1031,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1113,7 +1113,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1195,7 +1195,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1277,7 +1277,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1359,7 +1359,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1441,7 +1441,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1524,7 +1524,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1606,7 +1606,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1688,7 +1688,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1770,7 +1770,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1852,7 +1852,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -1934,7 +1934,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -2016,7 +2016,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -2098,7 +2098,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -2180,7 +2180,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -2262,7 +2262,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -2344,7 +2344,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "decimals": 0,
                         "editable": true,
                         "error": false,
@@ -2459,7 +2459,7 @@
             "list": [
                 {
                     "type": "query",
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "refresh": 1,
                     "name": "monitor_disk",
                     "hide": 0,
@@ -2514,7 +2514,7 @@
                             "$__all"
                         ]
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                     "includeAll": true,
                     "label": "node",
@@ -2537,7 +2537,7 @@
                         "text": "All",
                         "value": "$__all"
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                       "includeAll": true,
                     "label": "shard",

--- a/grafana/scylla-dash-io-per-server.master.template.json
+++ b/grafana/scylla-dash-io-per-server.master.template.json
@@ -886,7 +886,7 @@
             "list": [
                 {
                     "current": {},
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                     "includeAll": false,
                     "multi": false,
@@ -937,7 +937,7 @@
                             "$__all"
                         ]
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                     "includeAll": true,
                     "label": "node",
@@ -960,7 +960,7 @@
                         "text": "All",
                         "value": "$__all"
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                     "includeAll": true,
                     "label": "shard",

--- a/grafana/scylla-dash-per-server.1.5.json
+++ b/grafana/scylla-dash-per-server.1.5.json
@@ -48,7 +48,7 @@
                             "rgba(237, 129, 40, 0.89)",
                             "rgba(50, 172, 45, 0.97)"
                         ],
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "none",
@@ -129,7 +129,7 @@
                             "rgba(250, 113, 0, 0.89)",
                             "rgba(255, 0, 0, 0.9)"
                         ],
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "none",
@@ -223,7 +223,7 @@
                             "{}": "#584477"
                         },
                         "bars": true,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -335,7 +335,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -418,7 +418,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -499,7 +499,7 @@
 
                         },
                         "cacheTimeout": null,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fontSize": "80%",
@@ -607,7 +607,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -687,7 +687,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -768,7 +768,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -848,7 +848,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -936,7 +936,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1016,7 +1016,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1096,7 +1096,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -1176,7 +1176,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -1284,7 +1284,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1364,7 +1364,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1445,7 +1445,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1525,7 +1525,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1605,7 +1605,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1685,7 +1685,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1780,7 +1780,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1860,7 +1860,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1940,7 +1940,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2050,7 +2050,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2130,7 +2130,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2262,7 +2262,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2344,7 +2344,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2424,7 +2424,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -2504,7 +2504,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -2592,7 +2592,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2673,7 +2673,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2753,7 +2753,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -2833,7 +2833,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -2928,7 +2928,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3008,7 +3008,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3103,7 +3103,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3183,7 +3183,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3297,7 +3297,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3377,7 +3377,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3491,7 +3491,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3572,7 +3572,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3661,7 +3661,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3742,7 +3742,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3857,7 +3857,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3971,7 +3971,7 @@
             "list": [
                 {
                     "type": "query",
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "refresh": 1,
                     "name": "monitor_disk",
                     "hide": 0,
@@ -3988,7 +3988,7 @@
                 },
                 {
                     "type": "query",
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "refresh": 1,
                     "name": "monitor_network_interface",
                     "hide": 0,

--- a/grafana/scylla-dash-per-server.1.6.json
+++ b/grafana/scylla-dash-per-server.1.6.json
@@ -48,7 +48,7 @@
                             "rgba(237, 129, 40, 0.89)",
                             "rgba(50, 172, 45, 0.97)"
                         ],
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "none",
@@ -129,7 +129,7 @@
                             "rgba(250, 113, 0, 0.89)",
                             "rgba(255, 0, 0, 0.9)"
                         ],
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "none",
@@ -223,7 +223,7 @@
                             "{}": "#584477"
                         },
                         "bars": true,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -335,7 +335,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -418,7 +418,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -499,7 +499,7 @@
 
                         },
                         "cacheTimeout": null,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fontSize": "80%",
@@ -607,7 +607,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -687,7 +687,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -768,7 +768,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -848,7 +848,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -936,7 +936,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1016,7 +1016,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1096,7 +1096,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -1176,7 +1176,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -1284,7 +1284,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1364,7 +1364,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1445,7 +1445,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1525,7 +1525,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1605,7 +1605,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1685,7 +1685,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1780,7 +1780,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1860,7 +1860,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1940,7 +1940,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2050,7 +2050,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2130,7 +2130,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2262,7 +2262,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2344,7 +2344,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2424,7 +2424,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -2504,7 +2504,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -2592,7 +2592,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2673,7 +2673,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2753,7 +2753,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -2833,7 +2833,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -2928,7 +2928,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3008,7 +3008,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3103,7 +3103,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3183,7 +3183,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3297,7 +3297,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3377,7 +3377,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3491,7 +3491,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3572,7 +3572,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3661,7 +3661,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3742,7 +3742,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3857,7 +3857,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3976,7 +3976,7 @@
                         "text": "None",
                         "value": ""
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                     "includeAll": false,
                     "label": null,
@@ -4000,7 +4000,7 @@
                         "text": "None",
                         "value": ""
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                     "includeAll": false,
                     "label": null,
@@ -4057,7 +4057,7 @@
                             "$__all"
                         ]
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                     "includeAll": true,
                     "label": "node",
@@ -4080,7 +4080,7 @@
                         "text": "All",
                         "value": "$__all"
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                       "includeAll": true,
                     "label": "shard",

--- a/grafana/scylla-dash-per-server.1.7.json
+++ b/grafana/scylla-dash-per-server.1.7.json
@@ -48,7 +48,7 @@
                             "rgba(237, 129, 40, 0.89)",
                             "rgba(50, 172, 45, 0.97)"
                         ],
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "none",
@@ -129,7 +129,7 @@
                             "rgba(250, 113, 0, 0.89)",
                             "rgba(255, 0, 0, 0.9)"
                         ],
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "none",
@@ -224,7 +224,7 @@
                             "{}": "#584477"
                         },
                         "bars": true,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -337,7 +337,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -421,7 +421,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -503,7 +503,7 @@
 
                         },
                         "cacheTimeout": null,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fontSize": "80%",
@@ -614,7 +614,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -695,7 +695,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -777,7 +777,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -858,7 +858,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -947,7 +947,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1028,7 +1028,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1109,7 +1109,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -1190,7 +1190,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -1299,7 +1299,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1380,7 +1380,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1462,7 +1462,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1543,7 +1543,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1624,7 +1624,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1705,7 +1705,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1801,7 +1801,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1882,7 +1882,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1963,7 +1963,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2074,7 +2074,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2155,7 +2155,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2288,7 +2288,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2370,7 +2370,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2451,7 +2451,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -2532,7 +2532,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -2621,7 +2621,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2703,7 +2703,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2784,7 +2784,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -2865,7 +2865,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -2961,7 +2961,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3042,7 +3042,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3138,7 +3138,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3219,7 +3219,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3334,7 +3334,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3415,7 +3415,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3530,7 +3530,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3612,7 +3612,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3702,7 +3702,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3784,7 +3784,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3900,7 +3900,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -4016,7 +4016,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -4098,7 +4098,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -4180,7 +4180,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -4262,7 +4262,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -4382,7 +4382,7 @@
                         "text": "None",
                         "value": ""
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                     "includeAll": false,
                     "label": null,
@@ -4406,7 +4406,7 @@
                         "text": "None",
                         "value": ""
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                     "includeAll": false,
                     "label": null,
@@ -4463,7 +4463,7 @@
                             "$__all"
                         ]
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                     "includeAll": true,
                     "label": "node",
@@ -4486,7 +4486,7 @@
                         "text": "All",
                         "value": "$__all"
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                       "includeAll": true,
                     "label": "shard",

--- a/grafana/scylla-dash-per-server.2.0.json
+++ b/grafana/scylla-dash-per-server.2.0.json
@@ -48,7 +48,7 @@
                             "rgba(237, 129, 40, 0.89)",
                             "rgba(50, 172, 45, 0.97)"
                         ],
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "none",
@@ -129,7 +129,7 @@
                             "rgba(250, 113, 0, 0.89)",
                             "rgba(255, 0, 0, 0.9)"
                         ],
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "none",
@@ -224,7 +224,7 @@
                             "{}": "#584477"
                         },
                         "bars": true,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -337,7 +337,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -421,7 +421,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -503,7 +503,7 @@
 
                         },
                         "cacheTimeout": null,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fontSize": "80%",
@@ -614,7 +614,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -695,7 +695,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -777,7 +777,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -858,7 +858,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -947,7 +947,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1028,7 +1028,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1109,7 +1109,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -1190,7 +1190,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -1299,7 +1299,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1380,7 +1380,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1462,7 +1462,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1543,7 +1543,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1624,7 +1624,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1705,7 +1705,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1801,7 +1801,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1882,7 +1882,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1963,7 +1963,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2074,7 +2074,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2155,7 +2155,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2288,7 +2288,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2370,7 +2370,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2451,7 +2451,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -2532,7 +2532,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -2621,7 +2621,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2703,7 +2703,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2784,7 +2784,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -2865,7 +2865,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -2961,7 +2961,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3042,7 +3042,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3138,7 +3138,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3219,7 +3219,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3334,7 +3334,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3415,7 +3415,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3530,7 +3530,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3612,7 +3612,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3702,7 +3702,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3784,7 +3784,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3900,7 +3900,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -4016,7 +4016,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -4098,7 +4098,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -4180,7 +4180,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -4262,7 +4262,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -4382,7 +4382,7 @@
                         "text": "None",
                         "value": ""
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                     "includeAll": false,
                     "label": null,
@@ -4406,7 +4406,7 @@
                         "text": "None",
                         "value": ""
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                     "includeAll": false,
                     "label": null,
@@ -4463,7 +4463,7 @@
                             "$__all"
                         ]
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                     "includeAll": true,
                     "label": "node",
@@ -4486,7 +4486,7 @@
                         "text": "All",
                         "value": "$__all"
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                       "includeAll": true,
                     "label": "shard",

--- a/grafana/scylla-dash-per-server.2.1.template.json
+++ b/grafana/scylla-dash-per-server.2.1.template.json
@@ -1591,7 +1591,7 @@
                         "text": "None",
                         "value": ""
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                     "includeAll": false,
                     "label": null,
@@ -1615,7 +1615,7 @@
                         "text": "None",
                         "value": ""
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                     "includeAll": false,
                     "label": null,
@@ -1672,7 +1672,7 @@
                             "$__all"
                         ]
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                     "includeAll": true,
                     "label": "node",
@@ -1695,7 +1695,7 @@
                         "text": "All",
                         "value": "$__all"
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                     "includeAll": true,
                     "label": "shard",

--- a/grafana/scylla-dash-per-server.2017.1.json
+++ b/grafana/scylla-dash-per-server.2017.1.json
@@ -48,7 +48,7 @@
                             "rgba(237, 129, 40, 0.89)",
                             "rgba(50, 172, 45, 0.97)"
                         ],
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "none",
@@ -129,7 +129,7 @@
                             "rgba(250, 113, 0, 0.89)",
                             "rgba(255, 0, 0, 0.9)"
                         ],
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "none",
@@ -223,7 +223,7 @@
                             "{}": "#584477"
                         },
                         "bars": true,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -335,7 +335,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -418,7 +418,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -499,7 +499,7 @@
 
                         },
                         "cacheTimeout": null,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fontSize": "80%",
@@ -607,7 +607,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -687,7 +687,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -768,7 +768,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -848,7 +848,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -936,7 +936,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1016,7 +1016,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1096,7 +1096,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -1176,7 +1176,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -1284,7 +1284,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1364,7 +1364,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1445,7 +1445,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1525,7 +1525,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1605,7 +1605,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1685,7 +1685,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1780,7 +1780,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1860,7 +1860,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -1940,7 +1940,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2050,7 +2050,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2130,7 +2130,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2262,7 +2262,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2344,7 +2344,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2424,7 +2424,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -2504,7 +2504,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -2592,7 +2592,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2673,7 +2673,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -2753,7 +2753,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -2833,7 +2833,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -2928,7 +2928,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3008,7 +3008,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3103,7 +3103,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3183,7 +3183,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3297,7 +3297,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3377,7 +3377,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3491,7 +3491,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3572,7 +3572,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3661,7 +3661,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3742,7 +3742,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3857,7 +3857,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -3976,7 +3976,7 @@
                         "text": "None",
                         "value": ""
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                     "includeAll": false,
                     "label": null,
@@ -4000,7 +4000,7 @@
                         "text": "None",
                         "value": ""
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                     "includeAll": false,
                     "label": null,
@@ -4057,7 +4057,7 @@
                             "$__all"
                         ]
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                     "includeAll": true,
                     "label": "node",
@@ -4080,7 +4080,7 @@
                         "text": "All",
                         "value": "$__all"
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                       "includeAll": true,
                     "label": "shard",

--- a/grafana/scylla-dash-per-server.master.template.json
+++ b/grafana/scylla-dash-per-server.master.template.json
@@ -1591,7 +1591,7 @@
                         "text": "None",
                         "value": ""
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                     "includeAll": false,
                     "label": null,
@@ -1615,7 +1615,7 @@
                         "text": "None",
                         "value": ""
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                     "includeAll": false,
                     "label": null,
@@ -1672,7 +1672,7 @@
                             "$__all"
                         ]
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                     "includeAll": true,
                     "label": "node",
@@ -1695,7 +1695,7 @@
                         "text": "All",
                         "value": "$__all"
                     },
-                    "datasource": "prometheus",
+                    "datasource": "DATASOURCE_NAME",
                     "hide": 0,
                     "includeAll": true,
                     "label": "shard",

--- a/grafana/scylla-dash.1.5.json
+++ b/grafana/scylla-dash.1.5.json
@@ -49,7 +49,7 @@
                             "rgba(237, 129, 40, 0.89)",
                             "rgba(50, 172, 45, 0.97)"
                         ],
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "none",
@@ -112,7 +112,7 @@
                             "rgba(250, 113, 0, 0.89)",
                             "rgba(255, 0, 0, 0.9)"
                         ],
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "none",
@@ -217,7 +217,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -299,7 +299,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -376,7 +376,7 @@
                     },
                     {
                         "cacheTimeout": null,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "short",
@@ -477,7 +477,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -556,7 +556,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -636,7 +636,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -715,7 +715,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -802,7 +802,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -881,7 +881,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -960,7 +960,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -1039,7 +1039,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -1152,7 +1152,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -1231,7 +1231,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,

--- a/grafana/scylla-dash.1.6.json
+++ b/grafana/scylla-dash.1.6.json
@@ -49,7 +49,7 @@
                             "rgba(237, 129, 40, 0.89)",
                             "rgba(50, 172, 45, 0.97)"
                         ],
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "none",
@@ -112,7 +112,7 @@
                             "rgba(250, 113, 0, 0.89)",
                             "rgba(255, 0, 0, 0.9)"
                         ],
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "none",
@@ -217,7 +217,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -299,7 +299,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -376,7 +376,7 @@
                     },
                     {
                         "cacheTimeout": null,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "short",
@@ -477,7 +477,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -556,7 +556,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -636,7 +636,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -715,7 +715,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -802,7 +802,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -881,7 +881,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -960,7 +960,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -1039,7 +1039,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -1152,7 +1152,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -1231,7 +1231,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,

--- a/grafana/scylla-dash.1.7.json
+++ b/grafana/scylla-dash.1.7.json
@@ -49,7 +49,7 @@
                             "rgba(237, 129, 40, 0.89)",
                             "rgba(50, 172, 45, 0.97)"
                         ],
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "none",
@@ -112,7 +112,7 @@
                             "rgba(250, 113, 0, 0.89)",
                             "rgba(255, 0, 0, 0.9)"
                         ],
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "none",
@@ -218,7 +218,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -301,7 +301,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -379,7 +379,7 @@
                     },
                     {
                         "cacheTimeout": null,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "bytes",
@@ -483,7 +483,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -564,7 +564,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -646,7 +646,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -726,7 +726,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -814,7 +814,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -895,7 +895,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -976,7 +976,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -1056,7 +1056,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -1170,7 +1170,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -1250,7 +1250,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,

--- a/grafana/scylla-dash.2.0.json
+++ b/grafana/scylla-dash.2.0.json
@@ -49,7 +49,7 @@
                             "rgba(237, 129, 40, 0.89)",
                             "rgba(50, 172, 45, 0.97)"
                         ],
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "none",
@@ -112,7 +112,7 @@
                             "rgba(250, 113, 0, 0.89)",
                             "rgba(255, 0, 0, 0.9)"
                         ],
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "none",
@@ -218,7 +218,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -301,7 +301,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -379,7 +379,7 @@
                     },
                     {
                         "cacheTimeout": null,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "bytes",
@@ -484,7 +484,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -565,7 +565,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -647,7 +647,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -727,7 +727,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -815,7 +815,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -896,7 +896,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -977,7 +977,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -1057,7 +1057,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -1171,7 +1171,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -1251,7 +1251,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,

--- a/grafana/scylla-dash.2017.1.json
+++ b/grafana/scylla-dash.2017.1.json
@@ -48,7 +48,7 @@
                             "rgba(237, 129, 40, 0.89)",
                             "rgba(50, 172, 45, 0.97)"
                         ],
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "none",
@@ -111,7 +111,7 @@
                             "rgba(250, 113, 0, 0.89)",
                             "rgba(255, 0, 0, 0.9)"
                         ],
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "none",
@@ -216,7 +216,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -298,7 +298,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -375,7 +375,7 @@
                     },
                     {
                         "cacheTimeout": null,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "format": "short",
@@ -476,7 +476,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -555,7 +555,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -635,7 +635,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -714,7 +714,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -801,7 +801,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -880,7 +880,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 1,
@@ -959,7 +959,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -1038,7 +1038,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -1151,7 +1151,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,
@@ -1230,7 +1230,7 @@
 
                         },
                         "bars": false,
-                        "datasource": "prometheus",
+                        "datasource": "DATASOURCE_NAME",
                         "editable": true,
                         "error": false,
                         "fill": 0,

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -34,7 +34,7 @@
 		"height": "250px"
 	},
 	"base_panel": {
-		"datasource": "prometheus",
+		"datasource": "DATASOURCE_NAME",
 		"editable": true,
 		"error": false,
 		"id": "auto",
@@ -265,7 +265,7 @@
         "aliasColors": {},
         "cacheTimeout": null,
         "class": "base_panel",
-        "datasource": "prometheus",
+        "datasource": "DATASOURCE_NAME",
         "editable": true,
         "error": false,
         "fontSize": "80%",

--- a/load-grafana.sh
+++ b/load-grafana.sh
@@ -4,8 +4,11 @@
 VERSIONS=$DEFAULT_VERSION
 GRAFANA_PORT=3000
 DB_ADDRESS="127.0.0.1:9090"
+DATASOURCE_NAME='prometheus'
 
-usage="$(basename "$0") [-h] [-v comma separated versions ] [-g grafana port ] [-p ip:port address of prometheus ] [-a admin password] [-j additional dashboard to load to Grafana, multiple params are supported] -- loads the prometheus datasource and the Scylla dashboards into an existing grafana installation"
+usage="$(basename "$0") [-h] [-v comma separated versions ] [-g grafana port ] [-p ip:port address of prometheus ] [-a admin password] [-j additional dashboard to load to Grafana, multiple params are supported] [-d name to use for added datasource]
+
+loads the prometheus datasource and the Scylla dashboards into an existing grafana installation"
 
 while getopts ':hg:p:v:a:j:' option; do
   case "$option" in
@@ -22,24 +25,28 @@ while getopts ':hg:p:v:a:j:' option; do
        ;;
     a) GRAFANA_ADMIN_PASSWORD=$OPTARG
        ;;
+    d) DATASOURCE_NAME=$OPTARG
+       ;;
   esac
 done
 
 curl -XPOST -i http://admin:$GRAFANA_ADMIN_PASSWORD@localhost:$GRAFANA_PORT/api/datasources \
-     --data-binary '{"name":"prometheus", "type":"prometheus", "url":"'"http://$DB_ADDRESS"'", "access":"proxy", "basicAuth":false}' \
+     --data-binary '{"name":"'$DATASOURCE_NAME'", "type":"prometheus", "url":"'"http://$DB_ADDRESS"'", "access":"proxy", "basicAuth":false}' \
      -H "Content-Type: application/json"
 
 mkdir -p grafana/build
+sed "s/DATASOURCE_NAME/$DATASOURCE_NAME/" ./grafana/types.json > ./grafana/build/types.json
 IFS=',' ;for v in $VERSIONS; do
 for f in scylla-dash scylla-dash-per-server scylla-dash-io-per-server; do
 	if [ -e grafana/$f.$v.template.json ]
 	then
-		./make_dashboards.py -t grafana/types.json -d grafana/$f.$v.template.json
-		curl -XPOST -i http://admin:$GRAFANA_ADMIN_PASSWORD@localhost:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/build/$f.$v.json -H "Content-Type: application/json"
-  else
-    curl -XPOST -i http://admin:$GRAFANA_ADMIN_PASSWORD@localhost:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/$f.$v.json -H "Content-Type: application/json"  
+		./make_dashboards.py -t grafana/build/types.json -d grafana/$f.$v.template.json
+        sed -i "s/DATASOURCE_NAME/$DATASOURCE_NAME/" ./grafana/build/$f.$v.json
+    else
+        sed "s/DATASOURCE_NAME/$DATASOURCE_NAME/" ./grafana/$f.$v.json > ./grafana/build/$f.$v.json
 	fi
-	
+	curl -XPOST -i http://admin:$GRAFANA_ADMIN_PASSWORD@localhost:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/build/$f.$v.json -H "Content-Type: application/json"
+
 done
 done
 


### PR DESCRIPTION
load-grafana.sh is intended for users with existing Grafana installations, who may already have another datasource named 'prometheus,' making the name unavailable for use by the Scylla prometheus service.

Alternatively, a user may wish to run separate Prometheus services for different scylla clusters, but monitor them in the same Grafana. (This was my particular use case.)

This branch leaves the default behavior of load-grafana.sh unchanged, but adds the option to provide a `-d DATASOURCE_NAME` parameter to allow a different name. The only new dependency is the standard unix `sed` utility which should be available on any system capable of executing the current script.

A more elegant solution than this would be to integrate this feature into make_dashboards.py, but that script is not used by all of the dashboards, and the approach in this branch was easier to implement quickly. 