### PR TITLE
grafana container name should not includ the default port

### DIFF
--- a/start-grafana.sh
+++ b/start-grafana.sh
@@ -54,6 +54,9 @@ done
 
 if [ -z $GRAFANA_PORT ]; then
     GRAFANA_PORT=3000
+    if [ -z $GRAFANA_NAME ]; then
+        GRAFANA_NAME=agraf
+    fi
 fi
 
 if [ -z $GRAFANA_NAME ]; then


### PR DESCRIPTION
the default grafana container name should not contain the default port.

Fixes: #265

Signed-off-by: Amnon Heiman <amnon@scylladb.com>