### PR TITLE
change the cql metrics to use irate instead of sum

### DIFF
--- a/grafana/scylla-dash-per-server.1.7.json
+++ b/grafana/scylla-dash-per-server.1.7.json
@@ -4055,7 +4055,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(scylla_cql_inserts{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(irate(scylla_cql_inserts{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
@@ -4137,7 +4137,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(scylla_cql_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(irate(scylla_cql_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
@@ -4219,7 +4219,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(scylla_cql_deletes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(irate(scylla_cql_deletes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
@@ -4301,7 +4301,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(scylla_cql_updates{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(irate(scylla_cql_updates{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",

--- a/grafana/scylla-dash-per-server.2.0.json
+++ b/grafana/scylla-dash-per-server.2.0.json
@@ -4055,7 +4055,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(scylla_cql_inserts{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(irate(scylla_cql_inserts{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
@@ -4137,7 +4137,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(scylla_cql_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(irate(scylla_cql_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
@@ -4219,7 +4219,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(scylla_cql_deletes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(irate(scylla_cql_deletes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
@@ -4301,7 +4301,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(scylla_cql_updates{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(irate(scylla_cql_updates{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",

--- a/grafana/scylla-dash-per-server.2.1.template.json
+++ b/grafana/scylla-dash-per-server.2.1.template.json
@@ -1456,7 +1456,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_cql_inserts{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(irate(scylla_cql_inserts{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "CQL Inserts",
                                 "metric": "",
@@ -1488,7 +1488,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_cql_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(irate(scylla_cql_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "CQL Reads",
                                 "metric": "",
@@ -1520,7 +1520,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_cql_deletes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(irate(scylla_cql_deletes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "CQL Deletes",
                                 "metric": "",
@@ -1552,7 +1552,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_cql_updates{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(irate(scylla_cql_updates{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "CQL Updates",
                                 "metric": "",

--- a/grafana/scylla-dash-per-server.master.template.json
+++ b/grafana/scylla-dash-per-server.master.template.json
@@ -1456,7 +1456,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_cql_inserts{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(irate(scylla_cql_inserts{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "CQL Inserts",
                                 "metric": "",
@@ -1488,7 +1488,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_cql_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(irate(scylla_cql_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "CQL Reads",
                                 "metric": "",
@@ -1520,7 +1520,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_cql_deletes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(irate(scylla_cql_deletes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "CQL Deletes",
                                 "metric": "",
@@ -1552,7 +1552,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_cql_updates{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(irate(scylla_cql_updates{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "CQL Updates",
                                 "metric": "",


### PR DESCRIPTION
Instead of just summing the cql metrics, do an irate on them, to get the
rate of the operation.

Fixes #158

Signed-off-by: Amnon Heiman <amnon@scylladb.com>