### PR TITLE
Add latencies and overview

### DIFF
--- a/grafana/scylla-dash.2.1.template.json
+++ b/grafana/scylla-dash.2.1.template.json
@@ -165,6 +165,221 @@
             },
             {
                 "class": "row",
+                "panels": [
+                    {
+                        "class": "graph_panel",
+                        "fill": 0,
+                        "span": 4,
+                        "seriesOverrides": [
+                            {}
+                        ],
+                        "targets": [
+                            {
+                                "expr": "sum(rate(scylla_storage_proxy_coordinator_write_latency_sum{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])/sum(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Average write latency by [[by]]",
+                        "transparent": false,
+                        "yaxes": [
+                            {
+                                "format": "\u00b5s",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "class": "graph_panel",
+                        "fill": 0,
+                        "span": 4,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]], le))",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "95th percentile write latency by [[by]]",
+                        "yaxes": [
+                            {
+                                "format": "\u00b5s",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span": 4,
+                        "fill": 0,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]], le))",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "99th percentile write latency by [[by]]",
+                        "yaxes": [
+                            {
+                                "format": "\u00b5s",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "graph_panel",
+                        "span": 4,
+                        "fill": 0,
+                        "seriesOverrides": [
+                            {}
+                        ],
+                        "targets": [
+                            {
+                                "expr": "sum(rate(scylla_storage_proxy_coordinator_read_latency_sum{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])/sum(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Average read latency by [[by]]",
+                        "transparent": false,
+                        "yaxes": [
+                            {
+                                "format": "\u00b5s",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "class": "graph_panel",
+                        "fill": 0,
+                        "span": 4,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]], le))",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "95th percentile read latency by [[by]]",
+                        "yaxes": [
+                            {
+                                "format": "\u00b5s",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "class": "graph_panel",
+                        "fill": 0,
+                        "span": 4,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]], le))",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "99th percentile read latency by [[by]]",
+                        "yaxes": [
+                            {
+                                "format": "\u00b5s",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "title": "New row"
+            },
+
+            {
+                "class": "row",
                 "height": "25px",
                 "panels": [
                     {

--- a/grafana/scylla-dash.2.1.template.json
+++ b/grafana/scylla-dash.2.1.template.json
@@ -70,7 +70,7 @@
                         ],
                         "targets": [
                             {
-                                "expr": "avg(scylla_reactor_utilization{} ) ",
+                                "expr": "avg(scylla_reactor_utilization{} ) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "Load",
                                 "refId": "A",
@@ -107,7 +107,7 @@
                         "pointradius": 1,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_transport_requests_served{}[30s])) + sum(irate(scylla_thrift_served{}[30s]))",
+                                "expr": "sum(irate(scylla_transport_requests_served{}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "Requests Served",
                                 "metric": "",
@@ -188,7 +188,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_writes{}) ",
+                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_writes{}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "Foreground Writes",
                                 "refId": "A",
@@ -224,7 +224,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_reads{}) ",
+                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_reads{}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "Foreground Reads",
                                 "metric": "",
@@ -262,7 +262,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_timeouts{}[30s])) ",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_timeouts{}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "Write Timeouts per Second",
                                 "refId": "A",
@@ -298,7 +298,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_unavailable{}[30s])) ",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_unavailable{}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "Write Unavailable per Second",
                                 "refId": "A",
@@ -340,7 +340,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_background_writes{}) ",
+                                "expr": "sum(scylla_storage_proxy_coordinator_background_writes{}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "Background Writes",
                                 "refId": "A",
@@ -376,7 +376,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_background_reads{}) ",
+                                "expr": "sum(scylla_storage_proxy_coordinator_background_reads{}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "Background Reads",
                                 "refId": "A",
@@ -413,7 +413,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_timeouts{}[30s])) ",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_timeouts{}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "Read Timeouts per Second",
                                 "refId": "A",
@@ -449,7 +449,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_unavailable{}[30s])) ",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_unavailable{}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "Read Unavailable per Second",
                                 "refId": "A",
@@ -512,7 +512,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_row_hits{}[30s])) ",
+                                "expr": "sum(irate(scylla_cache_row_hits{}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "Cache Hits",
                                 "refId": "A",
@@ -551,7 +551,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_row_misses{}[30s])) ",
+                                "expr": "sum(irate(scylla_cache_row_misses{}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "Cache Misses",
                                 "refId": "A",
@@ -615,17 +615,98 @@
                 "title": "New row"
             }
         ],
+        "templating": {
+            "list": [
+                {
+                    "allValue": null,
+                    "current": {
+                        "tags": [],
+                        "text": "Instance",
+                        "value": "instance"
+                    },
+                    "hide": 0,
+                    "includeAll": false,
+                    "label": "by",
+                    "multi": false,
+                    "name": "by",
+                    "options": [
+                        {
+                            "selected": true,
+                            "text": "Instance",
+                            "value": "instance"
+                        },
+                        {
+                            "selected": false,
+                            "text": "Shard",
+                            "value": "shard"
+                        },
+                        {
+                            "selected": false,
+                            "text": "Cluster",
+                            "value": "cluster"
+                        }
+                    ],
+                    "query": "Instance,Shard,Cluster",
+                    "type": "custom"
+                },
+                {
+                    "allValue": null,
+                    "current": {
+                        "text": "All",
+                        "value": [
+                            "$__all"
+                        ]
+                    },
+                    "datasource": "prometheus",
+                    "hide": 0,
+                    "includeAll": true,
+                    "label": "node",
+                    "multi": true,
+                    "name": "node",
+                    "options": [],
+                    "query": "scylla_reactor_utilization",
+                    "refresh": 2,
+                    "regex": "/instance=\"([a-zA-Z0-9\\-\\.]*)\".*/",
+                    "sort": 0,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                },
+                {
+                    "allValue": null,
+                    "current": {
+                        "text": "All",
+                        "value": "$__all"
+                    },
+                    "datasource": "prometheus",
+                    "hide": 0,
+                    "includeAll": true,
+                    "label": "shard",
+                    "multi": true,
+                    "name": "shard",
+                    "options": [],
+                    "query": "scylla_reactor_utilization{instance=~\"$node\"}",
+                    "refresh": 2,
+                    "regex": "/shard=\"([0-9]*)\".*/",
+                    "sort": 0,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                }
+            ]
+        },
 		"tags": [
 			"2.1"
 		],
-        "templating": {
-            "list": []
-        },
         "time": {
             "from": "now-30m",
             "to": "now"
         },
-        "title": "Scylla Cluster Metrics 2.1",
+        "title": "Scylla Overview Metrics 2.1",
         "version": 3
     }
 }

--- a/grafana/scylla-dash.master.template.json
+++ b/grafana/scylla-dash.master.template.json
@@ -165,6 +165,221 @@
             },
             {
                 "class": "row",
+                "panels": [
+                    {
+                        "class": "graph_panel",
+                        "fill": 0,
+                        "span": 4,
+                        "seriesOverrides": [
+                            {}
+                        ],
+                        "targets": [
+                            {
+                                "expr": "sum(rate(scylla_storage_proxy_coordinator_write_latency_sum{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])/sum(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Average write latency by [[by]]",
+                        "transparent": false,
+                        "yaxes": [
+                            {
+                                "format": "\u00b5s",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "class": "graph_panel",
+                        "fill": 0,
+                        "span": 4,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]], le))",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "95th percentile write latency by [[by]]",
+                        "yaxes": [
+                            {
+                                "format": "\u00b5s",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span": 4,
+                        "fill": 0,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]], le))",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "99th percentile write latency by [[by]]",
+                        "yaxes": [
+                            {
+                                "format": "\u00b5s",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "graph_panel",
+                        "span": 4,
+                        "fill": 0,
+                        "seriesOverrides": [
+                            {}
+                        ],
+                        "targets": [
+                            {
+                                "expr": "sum(rate(scylla_storage_proxy_coordinator_read_latency_sum{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])/sum(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Average read latency by [[by]]",
+                        "transparent": false,
+                        "yaxes": [
+                            {
+                                "format": "\u00b5s",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "class": "graph_panel",
+                        "fill": 0,
+                        "span": 4,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]], le))",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "95th percentile read latency by [[by]]",
+                        "yaxes": [
+                            {
+                                "format": "\u00b5s",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "class": "graph_panel",
+                        "fill": 0,
+                        "span": 4,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]], le))",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "99th percentile read latency by [[by]]",
+                        "yaxes": [
+                            {
+                                "format": "\u00b5s",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "title": "New row"
+            },
+
+            {
+                "class": "row",
                 "height": "25px",
                 "panels": [
                     {

--- a/grafana/scylla-dash.master.template.json
+++ b/grafana/scylla-dash.master.template.json
@@ -70,7 +70,7 @@
                         ],
                         "targets": [
                             {
-                                "expr": "avg(scylla_reactor_utilization{} ) ",
+                                "expr": "avg(scylla_reactor_utilization{} ) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "Load",
                                 "refId": "A",
@@ -107,7 +107,7 @@
                         "pointradius": 1,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_transport_requests_served{}[30s])) + sum(irate(scylla_thrift_served{}[30s]))",
+                                "expr": "sum(irate(scylla_transport_requests_served{}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "Requests Served",
                                 "metric": "",
@@ -188,7 +188,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_writes{}) ",
+                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_writes{}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "Foreground Writes",
                                 "refId": "A",
@@ -224,7 +224,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_reads{}) ",
+                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_reads{}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "Foreground Reads",
                                 "metric": "",
@@ -262,7 +262,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_timeouts{}[30s])) ",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_timeouts{}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "Write Timeouts per Second",
                                 "refId": "A",
@@ -298,7 +298,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_unavailable{}[30s])) ",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_unavailable{}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "Write Unavailable per Second",
                                 "refId": "A",
@@ -340,7 +340,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_background_writes{}) ",
+                                "expr": "sum(scylla_storage_proxy_coordinator_background_writes{}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "Background Writes",
                                 "refId": "A",
@@ -376,7 +376,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_background_reads{}) ",
+                                "expr": "sum(scylla_storage_proxy_coordinator_background_reads{}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "Background Reads",
                                 "refId": "A",
@@ -413,7 +413,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_timeouts{}[30s])) ",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_timeouts{}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "Read Timeouts per Second",
                                 "refId": "A",
@@ -449,7 +449,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_unavailable{}[30s])) ",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_unavailable{}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "Read Unavailable per Second",
                                 "refId": "A",
@@ -512,7 +512,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_row_hits{}[30s])) ",
+                                "expr": "sum(irate(scylla_cache_row_hits{}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "Cache Hits",
                                 "refId": "A",
@@ -551,7 +551,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_row_misses{}[30s])) ",
+                                "expr": "sum(irate(scylla_cache_row_misses{}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "Cache Misses",
                                 "refId": "A",
@@ -615,17 +615,98 @@
                 "title": "New row"
             }
         ],
+        "templating": {
+            "list": [
+                {
+                    "allValue": null,
+                    "current": {
+                        "tags": [],
+                        "text": "Instance",
+                        "value": "instance"
+                    },
+                    "hide": 0,
+                    "includeAll": false,
+                    "label": "by",
+                    "multi": false,
+                    "name": "by",
+                    "options": [
+                        {
+                            "selected": true,
+                            "text": "Instance",
+                            "value": "instance"
+                        },
+                        {
+                            "selected": false,
+                            "text": "Shard",
+                            "value": "shard"
+                        },
+                        {
+                            "selected": false,
+                            "text": "Cluster",
+                            "value": "cluster"
+                        }
+                    ],
+                    "query": "Instance,Shard,Cluster",
+                    "type": "custom"
+                },
+                {
+                    "allValue": null,
+                    "current": {
+                        "text": "All",
+                        "value": [
+                            "$__all"
+                        ]
+                    },
+                    "datasource": "prometheus",
+                    "hide": 0,
+                    "includeAll": true,
+                    "label": "node",
+                    "multi": true,
+                    "name": "node",
+                    "options": [],
+                    "query": "scylla_reactor_utilization",
+                    "refresh": 2,
+                    "regex": "/instance=\"([a-zA-Z0-9\\-\\.]*)\".*/",
+                    "sort": 0,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                },
+                {
+                    "allValue": null,
+                    "current": {
+                        "text": "All",
+                        "value": "$__all"
+                    },
+                    "datasource": "prometheus",
+                    "hide": 0,
+                    "includeAll": true,
+                    "label": "shard",
+                    "multi": true,
+                    "name": "shard",
+                    "options": [],
+                    "query": "scylla_reactor_utilization{instance=~\"$node\"}",
+                    "refresh": 2,
+                    "regex": "/shard=\"([0-9]*)\".*/",
+                    "sort": 0,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                }
+            ]
+        },
 		"tags": [
 			"master"
 		],
-        "templating": {
-            "list": []
-        },
         "time": {
             "from": "now-30m",
             "to": "now"
         },
-        "title": "Scylla Cluster Metrics master",
+        "title": "Scylla Overview Metrics master",
         "version": 3
     }
 }


### PR DESCRIPTION
This series add latency metrics to our dashboard - one long requested feature that we can now support, thanks to the storage proxy histograms that we export.

I found that they don't quite fit that well to the per-server dashboard, which is already packed with so much information.

So in preparation to that, I changed the Cluster dashboard into an "overview" dashboard - which is something we needed to have anyway.
