### PR TITLE
Clean types and dashboard

### DIFF
--- a/grafana/scylla-dash-io-per-server.master.template.json
+++ b/grafana/scylla-dash-io-per-server.master.template.json
@@ -56,7 +56,6 @@
                         },
                         "bars": true,
                         "class": "graph_panel",
-                        "fill": 0,
                         "lines": false,
                         "seriesOverrides": [
                             {}
@@ -87,7 +86,6 @@
                 "panels": [
                     {
                         "class": "graph_panel",
-                        "fill": 0,
                         "seriesOverrides": [
                             {}
                         ],
@@ -105,7 +103,6 @@
                     },
                     {
                         "class": "graph_panel",
-                        "fill": 0,
                         "pointradius": 1,
                         "targets": [
                             {
@@ -194,10 +191,7 @@
                 "class": "row",
                 "panels": [
                     {
-                        "class": "graph_panel",
-                        "legend": {
-                            "class": "empty_legend"
-                        },
+                        "class": "bps_panel",
                         "span": 6,
                         "targets": [
                             {
@@ -209,26 +203,10 @@
                                 "step": 20
                             }
                         ],
-                        "title": "Disk Writes Bps per Server",
-                        "yaxes": [
-                            {
-                                "format": "Bps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Disk Writes Bps per Server"
                     },
                     {
-                        "class": "graph_panel",
+                        "class": "bps_panel",
                         "span": 6,
                         "targets": [
                             {
@@ -239,23 +217,7 @@
                                 "step": 20
                             }
                         ],
-                        "title": "Disk Read Bps per Server",
-                        "yaxes": [
-                            {
-                                "format": "Bps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Disk Read Bps per Server"
                     }
                 ],
                 "title": "New row"
@@ -275,9 +237,7 @@
                 "class": "row",
                 "panels": [
                     {
-                        "class": "graph_panel",
-                        "decimals": 0,
-                        "fill": 0,
+                        "class": "ms_panel",
                         "span": 4,
                         "targets": [
                             {
@@ -289,28 +249,10 @@
                                 "step": 30
                             }
                         ],
-                        "title": "Compactions I/O Queue delay by [[by]]",
-                        "yaxes": [
-                            {
-                                "format": "\u00b5s",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Compactions I/O Queue delay by [[by]]"
                     },
                     {
-                        "class": "graph_panel",
-                        "decimals": 0,
-                        "fill": 0,
+                        "class": "bps_panel",
                         "span": 4,
                         "targets": [
                             {
@@ -322,28 +264,10 @@
                                 "step": 30
                             }
                         ],
-                        "title": "Compactions I/O Queue bandwidth by [[by]]",
-                        "yaxes": [
-                            {
-                                "format": "Bps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Compactions I/O Queue bandwidth by [[by]]"
                     },
                     {
-                        "class": "graph_panel",
-                        "decimals": 0,
-                        "fill": 0,
+                        "class": "iops_panel",
                         "span": 4,
                         "targets": [
                             {
@@ -355,28 +279,10 @@
                                 "step": 30
                             }
                         ],
-                        "title": "Compactions I/O Queue IOPS by [[by]]",
-                        "yaxes": [
-                            {
-                                "format": "iops",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Compactions I/O Queue IOPS by [[by]]"
                     },
                     {
-                        "class": "graph_panel",
-                        "decimals": 0,
-                        "fill": 0,
+                        "class": "ms_panel",
                         "span": 4,
                         "targets": [
                             {
@@ -388,28 +294,10 @@
                                 "step": 30
                             }
                         ],
-                        "title": "Query I/O Queue delay by [[by]]",
-                        "yaxes": [
-                            {
-                                "format": "\u00b5s",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Query I/O Queue delay by [[by]]"
                     },
                     {
-                        "class": "graph_panel",
-                        "decimals": 0,
-                        "fill": 0,
+                        "class": "bps_panel",
                         "span": 4,
                         "targets": [
                             {
@@ -421,28 +309,10 @@
                                 "step": 30
                             }
                         ],
-                        "title": "Query I/O Queue bandwidth by [[by]]",
-                        "yaxes": [
-                            {
-                                "format": "Bps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Query I/O Queue bandwidth by [[by]]"
                     },
                     {
-                        "class": "graph_panel",
-                        "decimals": 0,
-                        "fill": 0,
+                        "class": "iops_panel",
                         "span": 4,
                         "targets": [
                             {
@@ -454,35 +324,10 @@
                                 "step": 30
                             }
                         ],
-                        "title": "Query I/O Queue IOPS by [[by]]",
-                        "yaxes": [
-                            {
-                                "format": "iops",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Query I/O Queue IOPS by [[by]]"
                     },
                     {
-                        "class": "graph_panel",
-                        "decimals": 0,
-                        "fill": 0,
-                        "grid": {
-                            "threshold1": null,
-                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                            "threshold2": null,
-                            "threshold2Color": "rgba(234, 112, 112, 0.22)",
-                            "thresholdLine": false
-                        },
+                        "class": "ms_panel",
                         "span": 4,
                         "targets": [
                             {
@@ -494,28 +339,10 @@
                                 "step": 30
                             }
                         ],
-                        "title": "Commitlog I/O Queue delay by [[by]]",
-                        "yaxes": [
-                            {
-                                "format": "\u00b5s",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Commitlog I/O Queue delay by [[by]]"
                     },
                     {
-                        "class": "graph_panel",
-                        "decimals": 0,
-                        "fill": 0,
+                        "class": "bps_panel",
                         "span": 4,
                         "targets": [
                             {
@@ -527,28 +354,10 @@
                                 "step": 30
                             }
                         ],
-                        "title": "Commitlog I/O Queue bandwidth by [[by]]",
-                        "yaxes": [
-                            {
-                                "format": "Bps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Commitlog I/O Queue bandwidth by [[by]]"
                     },
                     {
-                        "class": "graph_panel",
-                        "decimals": 0,
-                        "fill": 0,
+                        "class": "iops_panel",
                         "span": 4,
                         "targets": [
                             {
@@ -560,28 +369,10 @@
                                 "step": 30
                             }
                         ],
-                        "title": "Commitlog I/O Queue IOPS by [[by]]",
-                        "yaxes": [
-                            {
-                                "format": "iops",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Commitlog I/O Queue IOPS by [[by]]"
                     },
                     {
-                        "class": "graph_panel",
-                        "decimals": 0,
-                        "fill": 0,
+                        "class": "ms_panel",
                         "span": 4,
                         "targets": [
                             {
@@ -593,28 +384,10 @@
                                 "step": 30
                             }
                         ],
-                        "title": "Memtable Flush I/O Queue delay by [[by]]",
-                        "yaxes": [
-                            {
-                                "format": "\u00b5s",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Memtable Flush I/O Queue delay by [[by]]"
                     },
                     {
-                        "class": "graph_panel",
-                        "decimals": 0,
-                        "fill": 0,
+                        "class": "bps_panel",
                         "span": 4,
                         "targets": [
                             {
@@ -626,28 +399,10 @@
                                 "step": 30
                             }
                         ],
-                        "title": "Memtable Flush I/O Queue bandwidth by [[by]]",
-                        "yaxes": [
-                            {
-                                "format": "Bps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Memtable Flush I/O Queue bandwidth by [[by]]"
                     },
                     {
-                        "class": "graph_panel",
-                        "decimals": 0,
-                        "fill": 0,
+                        "class": "iops_panel",
                         "span": 4,
                         "targets": [
                             {
@@ -659,28 +414,10 @@
                                 "step": 30
                             }
                         ],
-                        "title": "Memtable Flush I/O Queue IOPS by [[by]]",
-                        "yaxes": [
-                            {
-                                "format": "iops",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Memtable Flush I/O Queue IOPS by [[by]]"
                     },
                     {
-                        "class": "graph_panel",
-                        "decimals": 0,
-                        "fill": 0,
+                        "class": "ms_panel",
                         "span": 4,
                         "targets": [
                             {
@@ -692,28 +429,10 @@
                                 "step": 30
                             }
                         ],
-                        "title": "Streaming Reads I/O Queue delay by [[by]]",
-                        "yaxes": [
-                            {
-                                "format": "\u00b5s",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Streaming Reads I/O Queue delay by [[by]]"
                     },
                     {
-                        "class": "graph_panel",
-                        "decimals": 0,
-                        "fill": 0,
+                        "class": "bps_panel",
                         "span": 4,
                         "targets": [
                             {
@@ -725,28 +444,10 @@
                                 "step": 30
                             }
                         ],
-                        "title": "Streaming Reads I/O Queue bandwidth by [[by]]",
-                        "yaxes": [
-                            {
-                                "format": "Bps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Streaming Reads I/O Queue bandwidth by [[by]]"
                     },
                     {
-                        "class": "graph_panel",
-                        "decimals": 0,
-                        "fill": 0,
+                        "class": "iops_panel",
                         "span": 4,
                         "targets": [
                             {
@@ -758,28 +459,10 @@
                                 "step": 30
                             }
                         ],
-                        "title": "Streaming Reads I/O Queue IOPS by [[by]]",
-                        "yaxes": [
-                            {
-                                "format": "iops",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Streaming Reads I/O Queue IOPS by [[by]]"
                     },
                     {
-                        "class": "graph_panel",
-                        "decimals": 0,
-                        "fill": 0,
+                        "class": "ms_panel",
                         "span": 4,
                         "targets": [
                             {
@@ -791,28 +474,10 @@
                                 "step": 30
                             }
                         ],
-                        "title": "Streaming Writes I/O Queue delay by [[by]]",
-                        "yaxes": [
-                            {
-                                "format": "\u00b5s",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Streaming Writes I/O Queue delay by [[by]]"
                     },
                     {
-                        "class": "graph_panel",
-                        "decimals": 0,
-                        "fill": 0,
+                        "class": "bps_panel",
                         "span": 4,
                         "targets": [
                             {
@@ -824,28 +489,10 @@
                                 "step": 30
                             }
                         ],
-                        "title": "Streaming Writes I/O Queue bandwidth by [[by]]",
-                        "yaxes": [
-                            {
-                                "format": "Bps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Streaming Writes I/O Queue bandwidth by [[by]]"
                     },
                     {
-                        "class": "graph_panel",
-                        "decimals": 0,
-                        "fill": 0,
+                        "class": "iops_panel",
                         "span": 4,
                         "targets": [
                             {
@@ -857,23 +504,7 @@
                                 "step": 30
                             }
                         ],
-                        "title": "Streaming Writes I/O Queue IOPS by [[by]]",
-                        "yaxes": [
-                            {
-                                "format": "iops",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Streaming Writes I/O Queue IOPS by [[by]]"
                     }
                 ],
                 "title": "New row"

--- a/grafana/scylla-dash-per-server.master.template.json
+++ b/grafana/scylla-dash-per-server.master.template.json
@@ -50,16 +50,8 @@
                         "style": {}
                     },
                     {
-                        "aliasColors": {
-                            "{}": "#584477"
-                        },
+                        "class": "ops_panel",
                         "bars": true,
-                        "class": "graph_panel",
-                        "fill": 0,
-                        "lines": false,
-                        "seriesOverrides": [
-                            {}
-                        ],
                         "targets": [
                             {
                                 "expr": "sum(irate(scylla_transport_requests_served{}[30s])) + sum(irate(scylla_thrift_served{}[30s]))",
@@ -69,24 +61,7 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Total Requests",
-                        "transparent": false,
-                        "yaxes": [
-                            {
-                                "format": "ops",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Total Requests"
                     },
                     {
                         "class": "dashlist",
@@ -114,9 +89,7 @@
                         "title": "Load per [[by]]"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
-                        "pointradius": 1,
+                        "class": "ops_panel",
                         "targets": [
                             {
                                 "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
@@ -127,23 +100,7 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Requests Served per [[by]]",
-                        "yaxes": [
-                            {
-                                "format": "ops",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Requests Served per [[by]]"
                     },
                     {
                         "class": "pie_chart_panel",
@@ -224,8 +181,7 @@
                         "title": "Foreground Reads per [[by]]"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "wps_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -236,27 +192,10 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Write Timeouts per Second per [[by]]",
-                        "yaxes": [
-                            {
-                                "format": "wps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Write Timeouts per Second per [[by]]"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "wps_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -267,23 +206,7 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Write Unavailable per Second per [[by]]",
-                        "yaxes": [
-                            {
-                                "format": "wps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Write Unavailable per Second per [[by]]"
                     }
                 ],
                 "title": "New row"
@@ -321,8 +244,7 @@
                         "title": "Background Reads per [[by]]"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "rps_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -333,27 +255,10 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Read Timeouts per Second per [[by]]",
-                        "yaxes": [
-                            {
-                                "format": "rps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Read Timeouts per Second per [[by]]"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "rps_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -365,23 +270,7 @@
                                 "step": 4
                             }
                         ],
-                        "title": "Read Unavailable per Second per [[by]]",
-                        "yaxes": [
-                            {
-                                "format": "rps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Read Unavailable per Second per [[by]]"
                     }
                 ],
                 "title": "New row"
@@ -395,8 +284,7 @@
                         "height": "30"
                     },
                     {
-                        "class": "graph_panel",
-                        "nullPointMode": "null",
+                        "class": "rps_panel",
                         "span": 6,
                         "targets": [
                             {
@@ -407,27 +295,10 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Reads",
-                        "yaxes": [
-                            {
-                                "format": "rps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Reads"
                     },
                     {
-                        "class": "graph_panel",
-                        "nullPointMode": "null",
+                        "class": "wps_panel",
                         "span": 6,
                         "targets": [
                             {
@@ -439,27 +310,10 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Writes",
-                        "yaxes": [
-                            {
-                                "format": "wps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Writes"
                     },
                     {
                         "class": "graph_panel",
-                        "nullPointMode": "null",
                         "span": 3,
                         "targets": [
                             {
@@ -470,27 +324,10 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Active sstable reads",
-                        "yaxes": [
-                            {
-                                "format": "none",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Active sstable reads"
                     },
                     {
                         "class": "graph_panel",
-                        "nullPointMode": "null",
                         "span": 3,
                         "targets": [
                             {
@@ -501,27 +338,10 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Queued sstable reads",
-                        "yaxes": [
-                            {
-                                "format": "none",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Queued sstable reads"
                     },
                     {
                         "class": "graph_panel",
-                        "nullPointMode": "null",
                         "span": 3,
                         "targets": [
                             {
@@ -532,27 +352,10 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Writes currently blocked on dirty",
-                        "yaxes": [
-                            {
-                                "format": "none",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Writes currently blocked on dirty"
                     },
                     {
                         "class": "graph_panel",
-                        "nullPointMode": "null",
                         "span": 3,
                         "targets": [
                             {
@@ -563,23 +366,7 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Writes currently blocked on commitlog",
-                        "yaxes": [
-                            {
-                                "format": "none",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Writes currently blocked on commitlog"
                     },
                     {
                         "class": "text_panel",
@@ -588,8 +375,7 @@
                         "span": 3
                     },
                     {
-                        "class": "graph_panel",
-                        "nullPointMode": "null",
+                        "class": "rps_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -600,27 +386,10 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Reads failed",
-                        "yaxes": [
-                            {
-                                "format": "rps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Reads failed"
                     },
                     {
-                        "class": "graph_panel",
-                        "nullPointMode": "null",
+                        "class": "wps_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -631,27 +400,10 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Writes blocked on dirty",
-                        "yaxes": [
-                            {
-                                "format": "wps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Writes blocked on dirty"
                     },
                     {
-                        "class": "graph_panel",
-                        "nullPointMode": "null",
+                        "class": "wps_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -662,23 +414,7 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Writes blocked on commitlog",
-                        "yaxes": [
-                            {
-                                "format": "wps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Writes blocked on commitlog"
                     },
                     {
                         "class": "text_panel",
@@ -693,8 +429,7 @@
                         "span": 3
                     },
                     {
-                        "class": "graph_panel",
-                        "nullPointMode": "null",
+                        "class": "wps_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -705,27 +440,10 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Writes failed",
-                        "yaxes": [
-                            {
-                                "format": "wps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Writes failed"
                     },
                     {
-                        "class": "graph_panel",
-                        "nullPointMode": "null",
+                        "class": "wps_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -736,23 +454,7 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Writes timed out",
-                        "yaxes": [
-                            {
-                                "format": "wps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Writes timed out"
                     }
                 ],
                 "title": "New row"
@@ -773,7 +475,7 @@
                 "class": "row",
                 "panels": [
                     {
-                        "class": "graph_panel",
+                        "class": "wps_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -785,26 +487,10 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Disk Writes per Server per Second",
-                        "yaxes": [
-                            {
-                                "format": "wps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Disk Writes per Server per Second"
                     },
                     {
-                        "class": "graph_panel",
+                        "class": "rps_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -815,26 +501,10 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Disk Reads per Server per Second",
-                        "yaxes": [
-                            {
-                                "format": "rps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Disk Reads per Server per Second"
                     },
                     {
-                        "class": "graph_panel",
+                        "class": "bps_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -846,26 +516,10 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Disk Writes Bps per Server",
-                        "yaxes": [
-                            {
-                                "format": "Bps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Disk Writes Bps per Server"
                     },
                     {
-                        "class": "graph_panel",
+                        "class": "bps_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -876,23 +530,7 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Disk Read Bps per Server",
-                        "yaxes": [
-                            {
-                                "format": "Bps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Disk Read Bps per Server"
                     }
                 ],
                 "title": "New row"
@@ -913,8 +551,7 @@
                 "class": "row",
                 "panels": [
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "rps_panel",
                         "span": 6,
                         "targets": [
                             {
@@ -925,27 +562,10 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Reads with no misses",
-                        "yaxes": [
-                            {
-                                "format": "rps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Reads with no misses"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "rps_panel",
                         "span": 6,
                         "targets": [
                             {
@@ -956,23 +576,7 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Reads with misses",
-                        "yaxes": [
-                            {
-                                "format": "rps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Reads with misses"
                     }
                 ]
             },
@@ -980,8 +584,7 @@
                 "class" : "row",
                 "panels": [
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "rps_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -992,27 +595,10 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Row Hits",
-                        "yaxes": [
-                            {
-                                "format": "rps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Row Hits"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "rps_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -1023,27 +609,10 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Partition Hits",
-                        "yaxes": [
-                            {
-                                "format": "rps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Partition Hits"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "rps_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -1054,27 +623,10 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Row Misses",
-                        "yaxes": [
-                            {
-                                "format": "rps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Row Misses"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "rps_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -1085,23 +637,7 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Partition Misses",
-                        "yaxes": [
-                            {
-                                "format": "rps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Partition Misses"
                     }
                 ],
                 "title": "New row"
@@ -1110,8 +646,7 @@
                 "class": "row",
                 "panels": [
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "rps_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -1122,27 +657,10 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Row Insertions",
-                        "yaxes": [
-                            {
-                                "format": "rps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Row Insertions"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "rps_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -1153,27 +671,10 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Partition Insertions",
-                        "yaxes": [
-                            {
-                                "format": "rps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Partition Insertions"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "ops_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -1184,27 +685,10 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Row Evictions",
-                        "yaxes": [
-                            {
-                                "format": "ops",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Row Evictions"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "ops_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -1215,23 +699,7 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Partition Evictions",
-                        "yaxes": [
-                            {
-                                "format": "ops",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Partition Evictions"
                     }
                 ]
             },
@@ -1239,8 +707,7 @@
                 "class": "row",
                 "panels": [
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "ops_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -1251,27 +718,10 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Row Merges",
-                        "yaxes": [
-                            {
-                                "format": "ops",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Row Merges"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "ops_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -1282,27 +732,10 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Partition Merges",
-                        "yaxes": [
-                            {
-                                "format": "ops",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Partition Merges"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "ops_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -1313,27 +746,10 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Row Removals",
-                        "yaxes": [
-                            {
-                                "format": "ops",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Row Removals"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "ops_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -1344,23 +760,7 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Partition Removals",
-                        "yaxes": [
-                            {
-                                "format": "ops",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Partition Removals"
                     }
                 ]
             },
@@ -1369,7 +769,6 @@
                 "panels": [
                     {
                         "class": "graph_panel",
-                        "fill": 0,
                         "span": 3,
                         "targets": [
                             {
@@ -1384,7 +783,6 @@
                     },
                     {
                         "class": "graph_panel",
-                        "fill": 0,
                         "span": 3,
                         "targets": [
                             {
@@ -1398,8 +796,7 @@
                         "title": "Partitions"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "bytes_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -1410,27 +807,10 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Used Bytes",
-                        "yaxes": [
-                            {
-                                "format": "bytes",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Used Bytes"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "bytes_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -1441,23 +821,7 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Total Bytes",
-                        "yaxes": [
-                            {
-                                "format": "bytes",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Total Bytes"
                     }
                 ],
                 "title": "New row"
@@ -1478,8 +842,7 @@
                 "class": "row",
                 "panels": [
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "bytes_panel",
                         "span": 6,
                         "targets": [
                             {
@@ -1490,27 +853,10 @@
                                 "step": 1
                             }
                         ],
-                        "title": "LSA total memory",
-                        "yaxes": [
-                            {
-                                "format": "bytes",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "LSA total memory"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "bytes_panel",
                         "span": 6,
                         "targets": [
                             {
@@ -1521,23 +867,7 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Non-LSA used memory",
-                        "yaxes": [
-                            {
-                                "format": "bytes",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Non-LSA used memory"
                     }
                 ],
                 "title": "New row"
@@ -1558,8 +888,7 @@
                 "class": "row",
                 "panels": [
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "pps_panel",
                         "span": 6,
                         "targets": [
                             {
@@ -1571,27 +900,10 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Interface Rx Packets",
-                        "yaxes": [
-                            {
-                                "format": "pps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Interface Rx Packets"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "pps_panel",
                         "span": 6,
                         "targets": [
                             {
@@ -1603,23 +915,7 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Interface Tx Packets",
-                        "yaxes": [
-                            {
-                                "format": "pps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Interface Tx Packets"
                     }
                 ],
                 "title": "New row"
@@ -1628,8 +924,7 @@
                 "class": "row",
                 "panels": [
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "bps_panel",
                         "span": 6,
                         "targets": [
                             {
@@ -1641,27 +936,10 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Interface Rx Bps",
-                        "yaxes": [
-                            {
-                                "format": "Bps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Interface Rx Bps"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "bps_panel",
                         "span": 6,
                         "targets": [
                             {
@@ -1673,23 +951,7 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Interface Tx Bps",
-                        "yaxes": [
-                            {
-                                "format": "Bps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Interface Tx Bps"
                     }
                 ],
                 "title": "New row"
@@ -1711,7 +973,6 @@
                 "panels": [
                     {
                         "class": "graph_panel",
-                        "fill": 0,
                         "span": 12,
                         "targets": [
                             {
@@ -1744,8 +1005,7 @@
                 "class": "row",
                 "panels": [
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "ops_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -1757,27 +1017,10 @@
                                 "step": 1
                             }
                         ],
-                        "title": "CQL Insert",
-                        "yaxes": [
-                            {
-                                "format": "ops",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "CQL Insert"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "ops_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -1789,27 +1032,10 @@
                                 "step": 1
                             }
                         ],
-                        "title": "CQL Reads",
-                        "yaxes": [
-                            {
-                                "format": "ops",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "CQL Reads"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "ops_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -1821,27 +1047,10 @@
                                 "step": 1
                             }
                         ],
-                        "title": "CQL Deletes",
-                        "yaxes": [
-                            {
-                                "format": "ops",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "CQL Deletes"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "ops_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -1853,23 +1062,7 @@
                                 "step": 1
                             }
                         ],
-                        "title": "CQL Updates",
-                        "yaxes": [
-                            {
-                                "format": "ops",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "CQL Updates"
                     }
                 ],
                 "title": "New row"

--- a/grafana/scylla-dash.master.template.json
+++ b/grafana/scylla-dash.master.template.json
@@ -80,9 +80,7 @@
                         "title": "Load"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
-                        "pointradius": 1,
+                        "class": "ops_panel",
                         "targets": [
                             {
                                 "expr": "sum(irate(scylla_transport_requests_served{}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{}[30s])) by ([[by]])",
@@ -93,28 +91,7 @@
                                 "step": 4
                             }
                         ],
-                        "title": "Requests Served",
-                        "tooltip": {
-                            "msResolution": false,
-                            "shared": true,
-                            "value_type": "cumulative"
-                        },
-                        "yaxes": [
-                            {
-                                "format": "ops",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Requests Served"
                     },
                     {
                         "class": "pie_chart_panel",
@@ -145,12 +122,8 @@
                 "class": "row",
                 "panels": [
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "ms_panel",
                         "span": 4,
-                        "seriesOverrides": [
-                            {}
-                        ],
                         "targets": [
                             {
                                 "expr": "sum(rate(scylla_storage_proxy_coordinator_write_latency_sum{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])/sum(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
@@ -160,30 +133,11 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Average write latency by [[by]]",
-                        "transparent": false,
-                        "yaxes": [
-                            {
-                                "format": "\u00b5s",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Average write latency by [[by]]"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "ms_panel",
                         "span": 4,
-                        "pointradius": 1,
                         "targets": [
                             {
                                 "expr": "histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]], le))",
@@ -194,29 +148,11 @@
                                 "step": 1
                             }
                         ],
-                        "title": "95th percentile write latency by [[by]]",
-                        "yaxes": [
-                            {
-                                "format": "\u00b5s",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "95th percentile write latency by [[by]]"
                     },
                     {
-                        "class": "graph_panel",
+                        "class": "ms_panel",
                         "span": 4,
-                        "fill": 0,
-                        "pointradius": 1,
                         "targets": [
                             {
                                 "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]], le))",
@@ -227,23 +163,7 @@
                                 "step": 1
                             }
                         ],
-                        "title": "99th percentile write latency by [[by]]",
-                        "yaxes": [
-                            {
-                                "format": "\u00b5s",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "99th percentile write latency by [[by]]"
                     }
                 ],
                 "title": "New row"
@@ -252,12 +172,8 @@
                 "class": "row",
                 "panels": [
                     {
-                        "class": "graph_panel",
+                        "class": "ms_panel",
                         "span": 4,
-                        "fill": 0,
-                        "seriesOverrides": [
-                            {}
-                        ],
                         "targets": [
                             {
                                 "expr": "sum(rate(scylla_storage_proxy_coordinator_read_latency_sum{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])/sum(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
@@ -267,30 +183,11 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Average read latency by [[by]]",
-                        "transparent": false,
-                        "yaxes": [
-                            {
-                                "format": "\u00b5s",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Average read latency by [[by]]"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "ms_panel",
                         "span": 4,
-                        "pointradius": 1,
                         "targets": [
                             {
                                 "expr": "histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]], le))",
@@ -301,29 +198,11 @@
                                 "step": 1
                             }
                         ],
-                        "title": "95th percentile read latency by [[by]]",
-                        "yaxes": [
-                            {
-                                "format": "\u00b5s",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "95th percentile read latency by [[by]]"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "ms_panel",
                         "span": 4,
-                        "pointradius": 1,
                         "targets": [
                             {
                                 "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]], le))",
@@ -334,23 +213,7 @@
                                 "step": 1
                             }
                         ],
-                        "title": "99th percentile read latency by [[by]]",
-                        "yaxes": [
-                            {
-                                "format": "\u00b5s",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "99th percentile read latency by [[by]]"
                     }
                 ],
                 "title": "New row"
@@ -377,7 +240,7 @@
                 "height": "200px",
                 "panels": [
                     {
-                        "class": "graph_panel",
+                        "class": "pps_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -388,32 +251,10 @@
                                 "step": 10
                             }
                         ],
-                        "title": "Foreground Writes",
-                        "tooltip": {
-                            "msResolution": false,
-                            "shared": true,
-                            "value_type": "cumulative"
-                        },
-                        "yaxes": [
-                            {
-                                "format": "short",
-                                "label": "Queue Length",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Foreground Writes"
                     },
                     {
-                        "class": "graph_panel",
+                        "class": "queue_lenght_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -425,33 +266,10 @@
                                 "step": 10
                             }
                         ],
-                        "title": "Foreground Reads",
-                        "tooltip": {
-                            "msResolution": false,
-                            "shared": true,
-                            "value_type": "cumulative"
-                        },
-                        "yaxes": [
-                            {
-                                "format": "short",
-                                "label": "Queue Length",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Foreground Reads"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "wps_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -462,32 +280,10 @@
                                 "step": 10
                             }
                         ],
-                        "title": "Write Timeouts per Second",
-                        "tooltip": {
-                            "msResolution": false,
-                            "shared": true,
-                            "value_type": "cumulative"
-                        },
-                        "yaxes": [
-                            {
-                                "format": "wps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Write Timeouts per Second"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "wps_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -498,28 +294,7 @@
                                 "step": 10
                             }
                         ],
-                        "title": "Write Unavailable per Second",
-                        "tooltip": {
-                            "msResolution": false,
-                            "shared": true,
-                            "value_type": "cumulative"
-                        },
-                        "yaxes": [
-                            {
-                                "format": "wps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Write Unavailable per Second"
                     }
                 ],
                 "title": "New row"
@@ -529,7 +304,7 @@
                 "height": "200px",
                 "panels": [
                     {
-                        "class": "graph_panel",
+                        "class": "queue_lenght_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -540,32 +315,10 @@
                                 "step": 10
                             }
                         ],
-                        "title": "Background Writes",
-                        "tooltip": {
-                            "msResolution": false,
-                            "shared": true,
-                            "value_type": "cumulative"
-                        },
-                        "yaxes": [
-                            {
-                                "format": "short",
-                                "label": "Queue Length",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "wps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Background Writes"
                     },
                     {
-                        "class": "graph_panel",
+                        "class": "queue_lenght_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -576,33 +329,10 @@
                                 "step": 10
                             }
                         ],
-                        "title": "Background Reads",
-                        "tooltip": {
-                            "msResolution": false,
-                            "shared": true,
-                            "value_type": "cumulative"
-                        },
-                        "yaxes": [
-                            {
-                                "format": "short",
-                                "label": "Queue Length",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Background Reads"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "rps_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -613,32 +343,10 @@
                                 "step": 10
                             }
                         ],
-                        "title": "Read Timeouts per Second",
-                        "tooltip": {
-                            "msResolution": false,
-                            "shared": true,
-                            "value_type": "cumulative"
-                        },
-                        "yaxes": [
-                            {
-                                "format": "rps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Read Timeouts per Second"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "rps_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -649,28 +357,7 @@
                                 "step": 10
                             }
                         ],
-                        "title": "Read Unavailable per Second",
-                        "tooltip": {
-                            "msResolution": false,
-                            "shared": true,
-                            "value_type": "cumulative"
-                        },
-                        "yaxes": [
-                            {
-                                "format": "rps",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Read Unavailable per Second"
                     }
                 ],
                 "title": "New row"
@@ -700,8 +387,7 @@
                 "class": "row",
                 "panels": [
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "ops_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -712,35 +398,10 @@
                                 "step": 10
                             }
                         ],
-                        "title": "Cache Hits",
-                        "tooltip": {
-                            "msResolution": false,
-                            "shared": true,
-                            "value_type": "cumulative"
-                        },
-                        "xaxis": {
-                            "show": false
-                        },
-                        "yaxes": [
-                            {
-                                "format": "ops",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Cache Hits"
                     },
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
+                        "class": "ops_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -751,59 +412,13 @@
                                 "step": 10
                             }
                         ],
-                        "title": "Cache Misses",
-                        "tooltip": {
-                            "msResolution": false,
-                            "shared": true,
-                            "value_type": "cumulative"
-                        },
-                        "xaxis": {
-                            "show": false
-                        },
-                        "yaxes": [
-                            {
-                                "format": "ops",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Cache Misses"
                     }
                 ],
                 "title": "New row"
             },
             {
                 "class": "row",
-                "panels": [],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "height": "25px",
-                "panels": [],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "height": "25px",
                 "panels": [],
                 "title": "New row"
             }

--- a/grafana/scylla-manager.master.template.json
+++ b/grafana/scylla-manager.master.template.json
@@ -47,11 +47,7 @@
                 "class": "row",
                 "panels": [
                     {
-                        "class": "graph_panel",
-                        "fill": 0,
-                        "seriesOverrides": [
-                            {}
-                        ],
+                        "class": "ops_panel",
                         "targets": [
                             {
                                 "expr": "avg(repair_segments_total{} ) by ([[by]])",
@@ -61,29 +57,7 @@
                                 "step": 4
                             }
                         ],
-                        "title": "Repair Segments Rate",
-                        "tooltip": {
-                            "msResolution": false,
-                            "shared": true,
-                            "value_type": "cumulative"
-                        },
-                        "transparent": false,
-                        "yaxes": [
-                            {
-                                "format": "ops",
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "max": null,
-                                "min": null,
-                                "show": true
-                            }
-                        ]
+                        "title": "Repair Segments Rate"
                     }
                 ],
                 "title": "Main graphs"

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -132,7 +132,7 @@
         "bars": false,
         "lines": true,
         "nullPointMode": "connected",
-		"fill": 1,
+		"fill": 0,
 		"grid": {
 			"threshold1": null,
 			"threshold1Color": "rgba(216, 200, 27, 0.27)",
@@ -188,7 +188,6 @@
 	},
 	"percent_panel": {
 		"class": "graph_panel",
-        "fill": 0,
         "seriesOverrides": [
             {}
         ],
@@ -210,6 +209,196 @@
             }
         ]
 	},
+	"ops_panel": {
+        "class": "graph_panel",
+        "seriesOverrides": [
+            {}
+        ],
+        "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "value_type": "cumulative"
+        },
+        "transparent": false,
+        "yaxes": [
+            {
+                "format": "ops",
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+            },
+            {
+                "format": "short",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+            }
+        ]
+    },
+    "iops_panel": {
+        "class": "graph_panel",
+        "yaxes": [
+            {
+                "format": "iops",
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+            },
+            {
+                "format": "short",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+            }
+        ]
+    },
+    "ms_panel": {
+        "class": "graph_panel",
+        "seriesOverrides": [
+            {}
+        ],
+        "transparent": false,
+        "yaxes": [
+            {
+                "format": "\u00b5s",
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+            },
+            {
+                "format": "short",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+            }
+        ]
+    },
+    "bps_panel": {
+        "class": "iops_panel",
+        "yaxes": [
+            {
+                "format": "Bps",
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+            },
+            {
+                "format": "short",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+            }
+        ]
+    },
+    "wps_panel": {
+        "class": "iops_panel",
+        "yaxes": [
+            {
+                "format": "wps",
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+            },
+            {
+                "format": "short",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+            }
+        ]
+    },
+    "rps_panel": {
+        "class": "iops_panel",
+        "yaxes": [
+            {
+                "format": "rps",
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+            },
+            {
+                "format": "short",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+            }
+        ]
+    },
+    "queue_lenght_panel": {
+        "class": "iops_panel",
+        "yaxes": [
+            {
+                "format": "short",
+                "label": "Queue Length",
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+            },
+            {
+                "format": "short",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+            }
+        ]
+    },
+    "bytes_panel": {
+        "class": "iops_panel",
+        "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "value_type": "cumulative"
+        },
+        "yaxes": [
+            {
+                "format": "bytes",
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+            },
+            {
+                "format": "short",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+            }
+        ]
+    },
+    "pps_panel": {
+        "class": "iops_panel",
+        "yaxes": [
+            {
+                "format": "pps",
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+            },
+            {
+                "format": "short",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+            }
+        ]
+    },
 	"pie_chart_panel": {
         "aliasColors": {},
         "cacheTimeout": null,


### PR DESCRIPTION
This is a preparation series before creating dashboards for 2018.1 and 2.2

Both will be based on master, this series reduce drastically the duplications in the dashboards and remove almost all formatting from the dashboard and place them in the types.