### PR TITLE
Node exporter instance by hostid

### DIFF
--- a/grafana/scylla-dash-per-machine.master.template.json
+++ b/grafana/scylla-dash-per-machine.master.template.json
@@ -1,0 +1,319 @@
+{
+    "dashboard": {
+        "class": "dashboard",
+        "rows": [
+            {
+                "class": "logo_row",
+                "panels": [
+                    {
+                        "class": "text_panel",
+                        "content": "<img src=\"http://www.scylladb.com/wp-content/uploads/logo-scylla-white-simple.png\" height=\"70\">\n<hr style=\"border-top: 3px solid #5780c1;\">"
+                    }
+                ]
+            },
+            {
+                "class": "row",
+                "height": "200px",
+                "panels": [
+                    {
+                        "class": "pie_chart_panel",
+                        "repeat": "node",
+                        "height": "250px",
+                        "targets": [
+                            {
+                                "expr": "sum(node_filesystem_avail{mountpoint=\"$mount_point\"})",
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "Free",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 7200
+                            },
+                            {
+                                "expr": "(sum(node_filesystem_size{mountpoint=\"$mount_point\"})-sum(node_filesystem_avail{mountpoint=\"$mount_point\"}))",
+                                "intervalFactor": 1,
+                                "legendFormat": "Used",
+                                "refId": "B",
+                                "step": 7200
+                            }
+                        ],
+                        "title": "Total Storage $node"
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "class": "row",
+                "height": "25px",
+                "panels": [
+                    {
+                        "class": "text_panel",
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Disk $monitor_disk</h1>",
+                        "style": {}
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "wps_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(node_disk_writes_completed{instance=~\"[[node]]\", device=\"$monitor_disk\"}[30s])) by (instance)",
+                                "intervalFactor": 1,
+                                "legendFormat": "Disk Writes per Server per Second",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Disk Writes per Server per Second"
+                    },
+                    {
+                        "class": "rps_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(node_disk_reads_completed{instance=~\"[[node]]\", device=\"$monitor_disk\"}[30s])) by (instance)",
+                                "intervalFactor": 1,
+                                "legendFormat": "Disk Reads per Server per Second",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Disk Reads per Server per Second"
+                    },
+                    {
+                        "class": "bps_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(node_disk_bytes_written{instance=~\"[[node]]\", device=\"$monitor_disk\"}[30s])) by (instance)",
+                                "intervalFactor": 1,
+                                "legendFormat": "Disk Writes Bps per Server",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Disk Writes Bps per Server"
+                    },
+                    {
+                        "class": "bps_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(node_disk_bytes_read{instance=~\"[[node]]\", device=\"$monitor_disk\"}[30s])) by (instance)",
+                                "intervalFactor": 1,
+                                "legendFormat": "Disk Read Bps per Server",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Disk Read Bps per Server"
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "class": "row",
+                "height": "25px",
+                "panels": [
+                    {
+                        "class": "text_panel",
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Network $monitor_network_interface</h1>",
+                        "style": {}
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "pps_panel",
+                        "span": 6,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(node_network_receive_packets{instance=~\"[[node]]\", device=\"$monitor_network_interface\"}[30s])) by (instance)",
+                                "intervalFactor": 1,
+                                "legendFormat": "Interface Rx Packets",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Interface Rx Packets"
+                    },
+                    {
+                        "class": "pps_panel",
+                        "span": 6,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(node_network_transmit_packets{instance=~\"[[node]]\", device=\"$monitor_network_interface\"}[30s])) by (instance)",
+                                "intervalFactor": 1,
+                                "legendFormat": "Interface Tx Packets",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Interface Tx Packets"
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "bps_panel",
+                        "span": 6,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(node_network_receive_bytes{instance=~\"[[node]]\", device=\"$monitor_network_interface\"}[30s])) by (instance)",
+                                "intervalFactor": 1,
+                                "legendFormat": "Interface Rx Bps",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Interface Rx Bps"
+                    },
+                    {
+                        "class": "bps_panel",
+                        "span": 6,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(node_network_transmit_bytes{instance=~\"[[node]]\", device=\"$monitor_network_interface\"}[30s])) by (instance)",
+                                "intervalFactor": 1,
+                                "legendFormat": "Interface Tx Bps",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Interface Tx Bps"
+                    }
+                ],
+                "title": "New row"
+            }
+        ],
+        "templating": {
+            "list": [
+                {
+                    "allValue": null,
+                    "current": {
+                        "text": "All",
+                        "value": [
+                            "$__all"
+                        ]
+                    },
+                    "datasource": "prometheus",
+                    "hide": 0,
+                    "includeAll": true,
+                    "label": "node",
+                    "multi": true,
+                    "name": "node",
+                    "options": [],
+                    "query": "node_uname_info",
+                    "refresh": 2,
+                    "regex": "/instance=\"([a-zA-Z0-9\\-\\.:]*)\".*/",
+                    "sort": 0,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                },
+                {
+                    "allValue": null,
+                    "current": {
+                        "isNone": true,
+                        "text": "None",
+                        "value": ""
+                    },
+                    "datasource": "prometheus",
+                    "hide": 0,
+                    "includeAll": false,
+                    "label": null,
+                    "multi": false,
+                    "name": "monitor_disk",
+                    "options": [],
+                    "query": "node_disk_bytes_read",
+                    "refresh": 2,
+                    "regex": "/.*device=\"([^\\\"]*)\".*/",
+                    "sort": 0,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                },
+                {
+                    "allValue": null,
+                    "current": {
+                        "isNone": true,
+                        "text": "None",
+                        "value": ""
+                    },
+                    "datasource": "prometheus",
+                    "hide": 0,
+                    "includeAll": false,
+                    "label": null,
+                    "multi": false,
+                    "name": "monitor_network_interface",
+                    "options": [],
+                    "query": "node_network_receive_packets",
+                    "refresh": 2,
+                    "regex": "/.*device=\"([^\\\"]*)\".*/",
+                    "sort": 0,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                },
+                {
+                    "allValue": null,
+                    "current": {
+                        "text": "/var/lib/scylla",
+                        "value": "/var/lib/scylla"
+                    },
+                    "datasource": "prometheus",
+                    "hide": 0,
+                    "includeAll": false,
+                    "label": "Mounnt path",
+                    "multi": false,
+                    "name": "mount_point",
+                    "options": [],
+                    "query": "node_filesystem_avail",
+                    "refresh": 2,
+                    "regex": "/mountpoint=\"([^\"]*)\".*/",
+                    "sort": 0,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                }
+                
+                
+                
+            ]
+        },
+		"tags": [
+			"master"
+		],
+        "time": {
+            "from": "now-30m",
+            "to": "now"
+        },
+        "title": "Scylla Per Machine Metrics",
+        "version": 5
+    }
+}

--- a/load-grafana.sh
+++ b/load-grafana.sh
@@ -45,7 +45,7 @@ fi
 
 mkdir -p grafana/build
 IFS=',' ;for v in $VERSIONS; do
-for f in scylla-dash scylla-dash-per-server scylla-dash-io-per-server; do
+for f in scylla-dash scylla-dash-per-server scylla-dash-io-per-server scylla-dash-per-machine; do
     if [ -e grafana/$f.$v.template.json ]
     then
         if [ ! -f "grafana/build/$f.$v.json" ] || [ "grafana/build/$f.$v.json" -ot "grafana/$f.$v.template.json" ]; then


### PR DESCRIPTION
Adding a dashboard with the node_exporter metrics.
This patch only adds the metrics. After we'll be happy with the results a followup patch will remove those metrics from other dashboards.
![image](https://user-images.githubusercontent.com/2118079/39535062-fcf15538-4e00-11e8-94dc-17824f3e4487.png)
