### PR TITLE
wrong metrics for streaming read/writes

### DIFF
--- a/grafana/scylla-dash-io-per-server.2.1.template.json
+++ b/grafana/scylla-dash-io-per-server.2.1.template.json
@@ -717,7 +717,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_io_queue_streaming_read_delay{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_io_queue_streaming_read_total_bytes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "seastar_io_queue_delay",
@@ -816,7 +816,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_io_queue_streaming_write_delay{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_io_queue_streaming_write_total_bytes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "seastar_io_queue_delay",

--- a/grafana/scylla-dash-io-per-server.2.2.template.json
+++ b/grafana/scylla-dash-io-per-server.2.2.template.json
@@ -436,7 +436,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_io_queue_streaming_read_delay{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_io_queue_streaming_read_total_bytes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "seastar_io_queue_delay",
@@ -481,7 +481,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_io_queue_streaming_write_delay{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_io_queue_streaming_write_total_bytes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "seastar_io_queue_delay",

--- a/grafana/scylla-dash-io-per-server.2018.1.template.json
+++ b/grafana/scylla-dash-io-per-server.2018.1.template.json
@@ -436,7 +436,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_io_queue_streaming_read_delay{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_io_queue_streaming_read_total_bytes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "seastar_io_queue_delay",
@@ -481,7 +481,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_io_queue_streaming_write_delay{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_io_queue_streaming_write_total_bytes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "seastar_io_queue_delay",

--- a/grafana/scylla-dash-io-per-server.master.template.json
+++ b/grafana/scylla-dash-io-per-server.master.template.json
@@ -436,7 +436,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_io_queue_streaming_read_delay{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_io_queue_streaming_read_total_bytes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "seastar_io_queue_delay",
@@ -481,7 +481,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_io_queue_streaming_write_delay{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_io_queue_streaming_write_total_bytes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "seastar_io_queue_delay",


### PR DESCRIPTION
Streaming read/write should use
scylla_io_queue_streaming_read_total_bytes and
scylla_io_queue_streaming_write_total_bytes.