### PR TITLE
sort shardlist in numerical order

### DIFF
--- a/grafana/scylla-dash-io-per-server.master.template.json
+++ b/grafana/scylla-dash-io-per-server.master.template.json
@@ -601,7 +601,7 @@
                     "query": "scylla_reactor_utilization{instance=~\"$node\"}",
                     "refresh": 2,
                     "regex": "/shard=\"([0-9]*)\".*/",
-                    "sort": 0,
+                    "sort": 3,
                     "tagValuesQuery": "",
                     "tags": [],
                     "tagsQuery": "",

--- a/grafana/scylla-dash-per-server.master.template.json
+++ b/grafana/scylla-dash-per-server.master.template.json
@@ -1191,7 +1191,7 @@
                     "query": "scylla_reactor_utilization{instance=~\"$node\"}",
                     "refresh": 2,
                     "regex": "/shard=\"([0-9]*)\".*/",
-                    "sort": 0,
+                    "sort": 3,
                     "tagValuesQuery": "",
                     "tags": [],
                     "tagsQuery": "",

--- a/grafana/scylla-dash.master.template.json
+++ b/grafana/scylla-dash.master.template.json
@@ -498,7 +498,7 @@
                     "query": "scylla_reactor_utilization{instance=~\"$node\"}",
                     "refresh": 2,
                     "regex": "/shard=\"([0-9]*)\".*/",
-                    "sort": 0,
+                    "sort": 3,
                     "tagValuesQuery": "",
                     "tags": [],
                     "tagsQuery": "",


### PR DESCRIPTION
Currently the shard list is not sorted. Users have complained
that if they have 80+ shards it is hard to find the shards they
are interested at.

Sorting helps a lot with that.

Signed-off-by: Glauber Costa <glauber@scylladb.com>