### PR TITLE
enhance per server dashboard with useful metrics

### DIFF
--- a/grafana/scylla-dash-per-server.master.template.json
+++ b/grafana/scylla-dash-per-server.master.template.json
@@ -51,17 +51,18 @@
                     },
                     {
                         "class": "ops_panel",
-                        "bars": true,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_transport_requests_served{}[30s])) + sum(irate(scylla_thrift_served{}[30s]))",
+                                "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Total Requests",
+                                "legendFormat": "",
+                                "metric": "",
                                 "refId": "A",
                                 "step": 1
                             }
                         ],
-                        "title": "Total Requests"
+                        "title": "Requests Served per [[by]]",
+                        "description": "Amount of requests served as the coordinator. Imbalances here represent dispersion at the connection level, not your data model."
                     },
                     {
                         "class": "dashlist",
@@ -86,21 +87,24 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Load per [[by]]"
+                        "title": "CPU Utilization per [[by]]",
+                        "description" : "the percentage of the time during which the CPU is utilized by Scylla. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high"
                     },
                     {
-                        "class": "ops_panel",
+                        "class": "percent_panel",
+                        "pointradius": 1,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "avg(irate(scylla_scheduler_runtime_ms{group=\"main\", instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])/10 + avg(irate(scylla_scheduler_runtime_ms{group=\"statement\", instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])/10",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
-                                "step": 1
+                                "step": 30
                             }
                         ],
-                        "title": "Requests Served per [[by]]"
+                        "title": "Foreground CPU Utilization by [[by]]",
+                        "description": "Time spent handling foreground requests (like reads, writes, and some system tasks). The remaining time is either idle, or used by background load like compactions and repairs. Background load in Scylla is opportunistic: background requests will try to use all resources available to complete as fast as possible and rely on the schedulers to provide isolation. This graph is better understood in conjunction with the main CPU load graph. For example, if there are spikes in CPU load that are not present in this graph, that indicates that the foreground load itself is stable."
                     },
                     {
                         "class": "pie_chart_panel",
@@ -127,6 +131,39 @@
                             }
                         ],
                         "title": "Total Storage"
+                    },
+
+                    {
+                        "class": "ns_panel",
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(scylla_scheduler_time_spent_on_task_quota_violations_ns{group=\"main\", instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "Time spent in task quota violations by [[by]]",
+                        "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. The maximum amount of time during which a task group can run is called the \"task quota\". Some task groups may disrespect that and run for longer. This may cause latency issues"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "sum(scylla_transport_cql_connections{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "Client CQL connections by [[by]]",
+                        "description": "amount of CQL connections currently established\nTest"
                     }
                 ],
                 "title": "New row"

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -279,6 +279,30 @@
             }
         ]
     },
+    "ns_panel": {
+        "class": "graph_panel",
+        "seriesOverrides": [
+            {}
+        ],
+        "transparent": false,
+        "yaxes": [
+            {
+                "format": "ns",
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+            },
+            {
+                "format": "short",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+            }
+        ]
+    },
+
     "bps_panel": {
         "class": "iops_panel",
         "yaxes": [


### PR DESCRIPTION
First, to open up some real estate in the dashboard, I am removing the total
operations graph that sits on top: it is now redundant, because the user
can aggregate per Cluster in the entire dashboard.

With this out of the way, I am doing the following:
- Adding a graph with foreground CPU utilization. That is the CPU used by
  request processing, excluding compaction, flushes and other things. The reason
  for that is that users are usually scared of spikes. Even if we tell them that
  spikes are fine because they are the result of isolatable background processes,
  it is hard to *prove* that without further analysis. This graph will help.

- time spent in violations: A lot of the latency issues we have, specially in
  higher percentiles come from task quota violations. We have a metric for this
  now and it will help us correlate latency spikes in time

- Client connections: in the past few months, this is *THE* top metric we
  have been looking at to detect problems. It harms us a lot that it is not
  part of the main dashboard.

In the process of doing the above, I am also doing my best to document the new
graphs. The text will appear in the tooltip in the top left corner of the graph.

Caveat: The request per sec graph, where it is, becomes too narrow. I don't
know how to make it wider.

Signed-off-by: Glauber Costa <glauber@scylladb.com>