### PR TITLE
Cluster dc

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ The monitoring infrastructure consists of several components, wrapped in Docker 
 
 ### Prerequisites
 
-* git
 * docker
 * python module pyyaml (for `genconfig.py`)
 * python module json (for `make_dashboards`)
@@ -73,6 +72,7 @@ ubuntu $ sudo systemctl restart docker
 centos $ sudo service docker start
 ```
 
+### Configuration
 Update `prometheus/scylla_servers.yml` and `prometheus/node_exporter_servers.yml` with the targets (server you wish to monitor).
 
 For every server, there are two targets, one under `scylla` job which is used for the scylla metrics.
@@ -82,8 +82,11 @@ For example, update targets in `prometheus/scylla_servers.yml` :
 
 ```
 - targets:
-  - 172.17.0.2:9180
-  - 172.17.0.3:9180
+      - 172.17.0.2:9180
+      - 172.17.0.3:9180
+  labels:
+       cluster: cluster1
+       dc: dc1
 ```
 
 Second, for general node information (disk, network, etc.) add the server under `node_exporter` job. Use port 9100.
@@ -91,10 +94,17 @@ For example, update targets in `prometheus/node_exporter_servers.yml` :
 
 ```
 - targets:
-  - 172.17.0.2:9100
-  - 172.17.0.3:9100
+      - 172.17.0.2:9100
+      - 172.17.0.3:9100
+  labels:
+       cluster: cluster1
+       dc: dc1
 ```
+#### Clusters and Data centers
+Note that each targets (there could be more than one) come with its own cluster and dc labels.
+For multiple DC or multiple cluster create multiple targets entries, each with the right cluster or dc.
 
+#### Using your own target files
 You can also use your own target files instead of updating `scylla_servers.yml` and `node_exporter_servers.yml`, using the `-s` for scylla target file and `-n` for node taget file. For example:
 
 ```

--- a/grafana/scylla-dash-cpu-per-server.master.template.json
+++ b/grafana/scylla-dash-cpu-per-server.master.template.json
@@ -18,7 +18,7 @@
                         "class": "percent_panel",
                         "targets": [
                             {
-                                "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\", shard=~\"[[shard]]\"} ) by ([[by]])",
+                                "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -52,7 +52,7 @@
                         "pointradius": 1,
                         "targets": [
                             {
-                                "expr": "avg(irate(scylla_scheduler_runtime_ms{group=\"main\", instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])/10 + avg(irate(scylla_scheduler_runtime_ms{group=\"statement\", instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])/10",
+                                "expr": "avg(irate(scylla_scheduler_runtime_ms{group=\"main\",instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])/10 + avg(irate(scylla_scheduler_runtime_ms{group=\"statement\",instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])/10",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -68,7 +68,7 @@
                         "pointradius": 1,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_scheduler_time_spent_on_task_quota_violations_ns{group=\"main\", instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_scheduler_time_spent_on_task_quota_violations_ns{group=\"main\",instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -99,6 +99,16 @@
                     "name": "by",
                     "options": [
                         {
+                            "selected": false,
+                            "text": "Cluster",
+                            "value": "cluster"
+                        },
+                        {
+                            "selected": false,
+                            "text": "DC",
+                            "value": "dc"
+                        },
+                        {
                             "selected": true,
                             "text": "Instance",
                             "value": "instance"
@@ -107,14 +117,9 @@
                             "selected": false,
                             "text": "Shard",
                             "value": "shard"
-                        },
-                        {
-                            "selected": false,
-                            "text": "Cluster",
-                            "value": "cluster"
                         }
                     ],
-                    "query": "Instance,Shard,Cluster",
+                    "query": "Cluster,DC,Instance,Shard",
                     "type": "custom"
                 },
                 {

--- a/grafana/scylla-dash-cpu-per-server.master.template.json
+++ b/grafana/scylla-dash-cpu-per-server.master.template.json
@@ -118,52 +118,29 @@
                     "type": "custom"
                 },
                 {
-                    "allValue": null,
-                    "current": {
-                        "text": "All",
-                        "value": [
-                            "$__all"
-                        ]
-                    },
-                    "datasource": "prometheus",
-                    "hide": 0,
-                    "includeAll": true,
-                    "label": "node",
-                    "multi": true,
-                    "name": "node",
-                    "options": [],
-                    "query": "label_values(scylla_reactor_utilization, instance)",
-                    "refresh": 2,
-                    "regex": "",
-                    "sort": 1,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
+                    "class": "template_variable_single",
+                    "label": "cluster",
+                    "name": "cluster",
+                    "query": "label_values(scylla_reactor_utilization, cluster)"
                 },
                 {
-                    "allValue": null,
-                    "current": {
-                        "text": "All",
-                        "value": "$__all"
-                    },
-                    "datasource": "prometheus",
-                    "hide": 0,
-                    "includeAll": true,
+                    "class": "template_variable_all",
+                    "label": "dc",
+                    "name": "dc",
+                    "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster\"}, dc)"
+                },
+                {
+                    "class": "template_variable_all",
+                    "label": "node",
+                    "name": "node",
+                    "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster|$^\", dc=~\"$dc\"}, instance)"
+                },
+                {
+                    "class": "template_variable_all",
                     "label": "shard",
-                    "multi": true,
                     "name": "shard",
-                    "options": [],
-                    "query": "scylla_reactor_utilization{instance=~\"$node\"}",
-                    "refresh": 2,
-                    "regex": "/shard=\"([0-9]*)\".*/",
-                    "sort": 3,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
+                    "query": "label_values(scylla_reactor_utilization,shard)",
+                    "sort": 3
                 }
             ]
         },

--- a/grafana/scylla-dash-io-per-server.master.template.json
+++ b/grafana/scylla-dash-io-per-server.master.template.json
@@ -561,52 +561,29 @@
                     "type": "custom"
                 },
                 {
-                    "allValue": null,
-                    "current": {
-                        "text": "All",
-                        "value": [
-                            "$__all"
-                        ]
-                    },
-                    "datasource": "prometheus",
-                    "hide": 0,
-                    "includeAll": true,
-                    "label": "node",
-                    "multi": true,
-                    "name": "node",
-                    "options": [],
-                    "query": "label_values(scylla_reactor_utilization, instance)",
-                    "refresh": 2,
-                    "regex": "",
-                    "sort": 1,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
+                    "class": "template_variable_single",
+                    "label": "cluster",
+                    "name": "cluster",
+                    "query": "label_values(scylla_reactor_utilization, cluster)"
                 },
                 {
-                    "allValue": null,
-                    "current": {
-                        "text": "All",
-                        "value": "$__all"
-                    },
-                    "datasource": "prometheus",
-                    "hide": 0,
-                    "includeAll": true,
+                    "class": "template_variable_all",
+                    "label": "dc",
+                    "name": "dc",
+                    "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster\"}, dc)"
+                },
+                {
+                    "class": "template_variable_all",
+                    "label": "node",
+                    "name": "node",
+                    "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster|$^\", dc=~\"$dc\"}, instance)"
+                },
+                {
+                    "class": "template_variable_all",
                     "label": "shard",
-                    "multi": true,
                     "name": "shard",
-                    "options": [],
-                    "query": "scylla_reactor_utilization{instance=~\"$node\"}",
-                    "refresh": 2,
-                    "regex": "/shard=\"([0-9]*)\".*/",
-                    "sort": 3,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
+                    "query": "label_values(scylla_reactor_utilization,shard)",
+                    "sort": 3
                 }
             ]
         },

--- a/grafana/scylla-dash-io-per-server.master.template.json
+++ b/grafana/scylla-dash-io-per-server.master.template.json
@@ -20,7 +20,7 @@
                         "class": "single_stat_panel",
                         "targets": [
                             {
-                                "expr": "count(up{job=\"scylla\"})",
+                                "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
                                 "intervalFactor": 1,
                                 "legendFormat": "Total Nodes",
                                 "refId": "A",
@@ -33,7 +33,7 @@
                         "class": "single_stat_panel_fail",
                         "targets": [
                             {
-                                "expr": "count(scrape_samples_scraped{job=\"scylla\"}==0) OR vector(0)",
+                                "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
                                 "intervalFactor": 1,
                                 "legendFormat": "Unreachable",
                                 "refId": "A",
@@ -62,7 +62,7 @@
                         ],
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_transport_requests_served{}[30s])) + sum(irate(scylla_thrift_served{}[30s]))",
+                                "expr": "sum(irate(scylla_transport_requests_served{cluster=~\"$cluster|$^\"}[30s])) + sum(irate(scylla_thrift_served{cluster=~\"$cluster|$^\"}[30s]))",
                                 "intervalFactor": 1,
                                 "legendFormat": "Total Requests",
                                 "refId": "A",
@@ -91,7 +91,7 @@
                         ],
                         "targets": [
                             {
-                                "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\", shard=~\"[[shard]]\"} ) by ([[by]])",
+                                "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -106,7 +106,7 @@
                         "pointradius": 1,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -115,28 +115,6 @@
                             }
                         ],
                         "title": "Requests Served per [[by]]"
-                    },
-                    {
-                        "class": "pie_chart_panel",
-                        "targets": [
-                            {
-                                "expr": "sum(node_filesystem_avail{mountpoint=\"/var/lib/scylla\"})",
-                                "interval": "",
-                                "intervalFactor": 1,
-                                "legendFormat": "Free",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 7200
-                            },
-                            {
-                                "expr": "(sum(node_filesystem_size{mountpoint=\"/var/lib/scylla\"})-sum(node_filesystem_avail{mountpoint=\"/var/lib/scylla\"}))",
-                                "intervalFactor": 1,
-                                "legendFormat": "Used",
-                                "refId": "B",
-                                "step": 7200
-                            }
-                        ],
-                        "title": "Total Storage"
                     }
                 ],
                 "title": "New row"
@@ -160,7 +138,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "irate(node_disk_writes_completed{device=\"$monitor_disk\"}[30s])",
+                                "expr": "irate(node_disk_writes_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s]) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -175,7 +153,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "irate(node_disk_reads_completed{device=\"$monitor_disk\"}[30s])",
+                                "expr": "irate(node_disk_reads_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s]) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -195,7 +173,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "irate(node_disk_bytes_written{device=\"$monitor_disk\"}[30s])",
+                                "expr": "irate(node_disk_bytes_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s]) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -210,7 +188,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "irate(node_disk_bytes_read{device=\"$monitor_disk\"}[30s])",
+                                "expr": "irate(node_disk_bytes_read{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s]) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -241,7 +219,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "1000000*max(scylla_io_queue_compaction_delay{instance=~\"[[node]]\", shard=~\"[[shard]]\"} ) by ([[by]])",
+                                "expr": "1000000*max(scylla_io_queue_compaction_delay{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "seastar_io_queue_delay",
@@ -256,7 +234,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_io_queue_compaction_total_bytes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_io_queue_compaction_total_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "seastar_io_queue_delay",
@@ -271,7 +249,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_io_queue_compaction_total_operations{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_io_queue_compaction_total_operations{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "seastar_io_queue_delay",
@@ -286,7 +264,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "1000000*max(scylla_io_queue_query_delay{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "1000000*max(scylla_io_queue_query_delay{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "seastar_io_queue_delay",
@@ -301,7 +279,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_io_queue_query_total_bytes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_io_queue_query_total_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "seastar_io_queue_delay",
@@ -316,7 +294,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_io_queue_query_total_operations{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_io_queue_query_total_operations{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "seastar_io_queue_delay",
@@ -331,7 +309,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "1000000*max(scylla_io_queue_commitlog_delay{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "1000000*max(scylla_io_queue_commitlog_delay{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "seastar_io_queue_delay",
@@ -346,7 +324,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_io_queue_commitlog_total_bytes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_io_queue_commitlog_total_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "seastar_io_queue_delay",
@@ -361,7 +339,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_io_queue_commitlog_total_operations{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_io_queue_commitlog_total_operations{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "seastar_io_queue_delay",
@@ -376,7 +354,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "1000000*max(scylla_io_queue_memtable_flush_delay{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "1000000*max(scylla_io_queue_memtable_flush_delay{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "seastar_io_queue_delay",
@@ -391,7 +369,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_io_queue_memtable_flush_total_bytes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_io_queue_memtable_flush_total_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "seastar_io_queue_delay",
@@ -406,7 +384,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_io_queue_memtable_flush_total_operations{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_io_queue_memtable_flush_total_operations{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "seastar_io_queue_delay",
@@ -421,7 +399,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "1000000*max(scylla_io_queue_streaming_read_delay{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "1000000*max(scylla_io_queue_streaming_read_delay{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "seastar_io_queue_delay",
@@ -436,7 +414,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_io_queue_streaming_read_total_bytes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_io_queue_streaming_read_total_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "seastar_io_queue_delay",
@@ -451,7 +429,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_io_queue_streaming_read_total_operations{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_io_queue_streaming_read_total_operations{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "seastar_io_queue_delay",
@@ -466,7 +444,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "1000000*max(scylla_io_queue_streaming_write_delay{instance=~\"[[node]]\", shard=~\"[[shard]]\"} ) by ([[by]])",
+                                "expr": "1000000*max(scylla_io_queue_streaming_write_delay{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "seastar_io_queue_delay",
@@ -481,7 +459,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_io_queue_streaming_write_total_bytes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_io_queue_streaming_write_total_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "seastar_io_queue_delay",
@@ -496,7 +474,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_io_queue_streaming_write_total_operations{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_io_queue_streaming_write_total_operations{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "seastar_io_queue_delay",
@@ -542,6 +520,16 @@
                     "name": "by",
                     "options": [
                         {
+                            "selected": false,
+                            "text": "Cluster",
+                            "value": "cluster"
+                        },
+                        {
+                            "selected": false,
+                            "text": "DC",
+                            "value": "dc"
+                        },
+                        {
                             "selected": true,
                             "text": "Instance",
                             "value": "instance"
@@ -550,14 +538,9 @@
                             "selected": false,
                             "text": "Shard",
                             "value": "shard"
-                        },
-                        {
-                            "selected": false,
-                            "text": "Cluster",
-                            "value": "cluster"
                         }
                     ],
-                    "query": "Instance,Shard,Cluster",
+                    "query": "Cluster,DC,Instance,Shard",
                     "type": "custom"
                 },
                 {

--- a/grafana/scylla-dash-per-machine.master.template.json
+++ b/grafana/scylla-dash-per-machine.master.template.json
@@ -62,7 +62,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_disk_writes_completed{instance=~\"[[node]]\", device=\"$monitor_disk\"}[30s])) by (instance)",
+                                "expr": "sum(irate(node_disk_writes_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by (instance)",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -77,7 +77,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_disk_reads_completed{instance=~\"[[node]]\", device=\"$monitor_disk\"}[30s])) by (instance)",
+                                "expr": "sum(irate(node_disk_reads_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by (instance)",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -91,7 +91,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_disk_bytes_written{instance=~\"[[node]]\", device=\"$monitor_disk\"}[30s])) by (instance)",
+                                "expr": "sum(irate(node_disk_bytes_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by (instance)",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -106,7 +106,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_disk_bytes_read{instance=~\"[[node]]\", device=\"$monitor_disk\"}[30s])) by (instance)",
+                                "expr": "sum(irate(node_disk_bytes_read{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by (instance)",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -138,7 +138,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_network_receive_packets{instance=~\"[[node]]\", device=\"$monitor_network_interface\"}[30s])) by (instance)",
+                                "expr": "sum(irate(node_network_receive_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[30s])) by (instance)",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -153,7 +153,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_network_transmit_packets{instance=~\"[[node]]\", device=\"$monitor_network_interface\"}[30s])) by (instance)",
+                                "expr": "sum(irate(node_network_transmit_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[30s])) by (instance)",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -174,7 +174,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_network_receive_bytes{instance=~\"[[node]]\", device=\"$monitor_network_interface\"}[30s])) by (instance)",
+                                "expr": "sum(irate(node_network_receive_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[30s])) by (instance)",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -189,7 +189,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_network_transmit_bytes{instance=~\"[[node]]\", device=\"$monitor_network_interface\"}[30s])) by (instance)",
+                                "expr": "sum(irate(node_network_transmit_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[30s])) by (instance)",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -206,29 +206,22 @@
         "templating": {
             "list": [
                 {
-                    "allValue": null,
-                    "current": {
-                        "text": "All",
-                        "value": [
-                            "$__all"
-                        ]
-                    },
-                    "datasource": "prometheus",
-                    "hide": 0,
-                    "includeAll": true,
+                    "class": "template_variable_single",
+                    "label": "cluster",
+                    "name": "cluster",
+                    "query": "label_values(node_filesystem_avail, cluster)"
+                },
+                {
+                    "class": "template_variable_all",
+                    "label": "dc",
+                    "name": "dc",
+                    "query": "label_values(node_filesystem_avail{cluster=~\"$cluster\"}, dc)"
+                },
+                {
+                    "class": "template_variable_all",
                     "label": "node",
-                    "multi": true,
                     "name": "node",
-                    "options": [],
-                    "query": "label_values(node_filesystem_avail, instance)",
-                    "refresh": 2,
-                    "regex": "",
-                    "sort": 1,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
+                    "query": "label_values(node_filesystem_avail{cluster=~\"$cluster|$^\", dc=~\"$dc\"}, instance)"
                 },
                 {
                     "allValue": null,

--- a/grafana/scylla-dash-per-server.master.template.json
+++ b/grafana/scylla-dash-per-server.master.template.json
@@ -1160,60 +1160,42 @@
                         },
                         {
                             "selected": false,
+                            "text": "DC",
+                            "value": "dc"
+                        },
+                        {
+                            "selected": false,
                             "text": "Cluster",
                             "value": "cluster"
                         }
                     ],
-                    "query": "Instance,Shard,Cluster",
+                    "query": "Instance,Shard,DC,Cluster",
                     "type": "custom"
                 },
                 {
-                    "allValue": null,
-                    "current": {
-                        "text": "All",
-                        "value": [
-                            "$__all"
-                        ]
-                    },
-                    "datasource": "prometheus",
-                    "hide": 0,
-                    "includeAll": true,
-                    "label": "node",
-                    "multi": true,
-                    "name": "node",
-                    "options": [],
-                    "query": "label_values(scylla_reactor_utilization, instance)",
-                    "refresh": 2,
-                    "regex": "",
-                    "sort": 1,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
+                    "class": "template_variable_single",
+                    "label": "cluster",
+                    "name": "cluster",
+                    "query": "label_values(scylla_reactor_utilization, cluster)"
                 },
                 {
-                    "allValue": null,
-                    "current": {
-                        "text": "All",
-                        "value": "$__all"
-                    },
-                    "datasource": "prometheus",
-                    "hide": 0,
-                    "includeAll": true,
+                    "class": "template_variable_all",
+                    "label": "dc",
+                    "name": "dc",
+                    "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster\"}, dc)"
+                },
+                {
+                    "class": "template_variable_all",
+                    "label": "node",
+                    "name": "node",
+                    "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster|$^\", dc=~\"$dc\"}, instance)"
+                },
+                {
+                    "class": "template_variable_all",
                     "label": "shard",
-                    "multi": true,
                     "name": "shard",
-                    "options": [],
-                    "query": "scylla_reactor_utilization{instance=~\"$node\"}",
-                    "refresh": 2,
-                    "regex": "/shard=\"([0-9]*)\".*/",
-                    "sort": 3,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
+                    "query": "label_values(scylla_reactor_utilization,shard)",
+                    "sort": 3
                 }
             ]
         },

--- a/grafana/scylla-dash-per-server.master.template.json
+++ b/grafana/scylla-dash-per-server.master.template.json
@@ -18,7 +18,7 @@
                         "class": "single_stat_panel",
                         "targets": [
                             {
-                                "expr": "count(up{job=\"scylla\"})",
+                                "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
                                 "intervalFactor": 1,
                                 "legendFormat": "Total Nodes",
                                 "refId": "A",
@@ -31,7 +31,7 @@
                         "class": "single_stat_panel_fail",
                         "targets": [
                             {
-                                "expr": "count(scrape_samples_scraped{job=\"scylla\"}==0) OR vector(0)",
+                                "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
                                 "intervalFactor": 1,
                                 "legendFormat": "Unreachable",
                                 "refId": "A",
@@ -53,7 +53,7 @@
                         "bars": true,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_transport_requests_served{}[30s])) + sum(irate(scylla_thrift_served{}[30s]))",
+                                "expr": "sum(irate(scylla_transport_requests_served{cluster=~\"$cluster|$^\"}[30s])) + sum(irate(scylla_thrift_served{cluster=~\"$cluster|$^\"}[30s]))",
                                 "intervalFactor": 1,
                                 "legendFormat": "Total Requests",
                                 "refId": "A",
@@ -78,7 +78,7 @@
                         "class": "percent_panel",
                         "targets": [
                             {
-                                "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\", shard=~\"[[shard]]\"} ) by ([[by]])",
+                                "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -91,7 +91,7 @@
                         "class": "ops_panel",
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -101,32 +101,6 @@
                         ],
                         "description": "Amount of requests served as the coordinator. Imbalances here represent dispersion at the connection level, not your data model.",
                         "title": "Requests Served per [[by]]"
-                    },
-                    {
-                        "class": "pie_chart_panel",
-                        "combine": {
-                            "label": "Others",
-                            "threshold": 0
-                        },
-                        "targets": [
-                            {
-                                "expr": "sum(node_filesystem_avail{mountpoint=\"/var/lib/scylla\"})",
-                                "interval": "",
-                                "intervalFactor": 1,
-                                "legendFormat": "Free",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 1
-                            },
-                            {
-                                "expr": "(sum(node_filesystem_size{mountpoint=\"/var/lib/scylla\"})-sum(node_filesystem_avail{mountpoint=\"/var/lib/scylla\"}))",
-                                "intervalFactor": 1,
-                                "legendFormat": "Used",
-                                "refId": "B",
-                                "step": 1
-                            }
-                        ],
-                        "title": "Total Storage"
                     }
                 ],
                 "title": "New row"
@@ -156,7 +130,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_writes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -170,7 +144,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -185,7 +159,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -199,7 +173,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_unavailable{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_unavailable{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -220,7 +194,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_background_writes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(scylla_storage_proxy_coordinator_background_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -234,7 +208,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_background_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(scylla_storage_proxy_coordinator_background_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -248,7 +222,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -262,7 +236,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_unavailable{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_unavailable{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -288,7 +262,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_database_total_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_database_total_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -302,7 +276,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_database_total_writes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_database_total_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -317,7 +291,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_database_active_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(scylla_database_active_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -331,7 +305,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_database_queued_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(scylla_database_queued_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -345,7 +319,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_database_requests_blocked_memory_current{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(scylla_database_requests_blocked_memory_current{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -359,7 +333,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_commitlog_pending_allocations{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(scylla_commitlog_pending_allocations{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -379,7 +353,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_database_total_reads_failed{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_database_total_reads_failed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -393,7 +367,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_database_requests_blocked_memory{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_database_requests_blocked_memory{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -407,7 +381,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_commitlog_requests_blocked_memory{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_commitlog_requests_blocked_memory{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -433,7 +407,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_database_total_writes_failed{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_database_total_writes_failed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -447,7 +421,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_database_total_writes_timedout{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_database_total_writes_timedout{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -455,82 +429,6 @@
                             }
                         ],
                         "title": "Writes timed out"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "height": "25px",
-                "panels": [
-                    {
-                        "class": "text_panel",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Disk $monitor_disk</h1>",
-                        "style": {}
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
-                        "class": "wps_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "irate(node_disk_writes_completed{device=\"$monitor_disk\"}[30s])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "Disk Writes per Server per Second"
-                    },
-                    {
-                        "class": "rps_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "irate(node_disk_reads_completed{device=\"$monitor_disk\"}[30s])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "Disk Reads per Server per Second"
-                    },
-                    {
-                        "class": "bps_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "irate(node_disk_bytes_written{device=\"$monitor_disk\"}[30s])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "Disk Writes Bps per Server"
-                    },
-                    {
-                        "class": "bps_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "irate(node_disk_bytes_read{device=\"$monitor_disk\"}[30s])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "Disk Read Bps per Server"
                     }
                 ],
                 "title": "New row"
@@ -555,7 +453,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s]) - irate(scylla_cache_reads_with_misses{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cache_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s]) - irate(scylla_cache_reads_with_misses{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -569,7 +467,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_reads_with_misses{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cache_reads_with_misses{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -588,7 +486,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_row_hits{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cache_row_hits{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -602,7 +500,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_partition_hits{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cache_partition_hits{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -616,7 +514,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_row_misses{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cache_row_misses{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -630,7 +528,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_partition_misses{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cache_partition_misses{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -650,7 +548,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_row_insertions{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cache_row_insertions{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -664,7 +562,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_partition_insertions{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cache_partition_insertions{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -678,7 +576,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_row_evictions{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cache_row_evictions{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -692,7 +590,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_partition_evictions{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cache_partition_evictions{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -711,7 +609,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_rows_merged_from_memtable{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cache_rows_merged_from_memtable{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -725,7 +623,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_partition_merges{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cache_partition_merges{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -739,7 +637,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_row_removals{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cache_row_removals{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -753,7 +651,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_partition_removals{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cache_partition_removals{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -772,7 +670,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_cache_rows{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(scylla_cache_rows{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -786,7 +684,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_cache_partitions{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(scylla_cache_partitions{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -800,7 +698,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_cache_bytes_used{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(scylla_cache_bytes_used{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -814,7 +712,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_cache_bytes_total{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(scylla_cache_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -846,7 +744,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "sum(scylla_lsa_total_space_bytes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(scylla_lsa_total_space_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -860,7 +758,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "sum(scylla_lsa_non_lsa_used_space_bytes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(scylla_lsa_non_lsa_used_space_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -868,90 +766,6 @@
                             }
                         ],
                         "title": "Non-LSA used memory"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "height": "25px",
-                "panels": [
-                    {
-                        "class": "text_panel",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Network $monitor_network_interface</h1>",
-                        "style": {}
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
-                        "class": "pps_panel",
-                        "span": 6,
-                        "targets": [
-                            {
-                                "expr": "irate(node_network_receive_packets{device=\"$monitor_network_interface\"}[30s])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "Interface Rx Packets"
-                    },
-                    {
-                        "class": "pps_panel",
-                        "span": 6,
-                        "targets": [
-                            {
-                                "expr": "irate(node_network_transmit_packets{device=\"$monitor_network_interface\"}[30s])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "Interface Tx Packets"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
-                        "class": "bps_panel",
-                        "span": 6,
-                        "targets": [
-                            {
-                                "expr": "irate(node_network_receive_bytes{device=\"$monitor_network_interface\"}[30s])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "Interface Rx Bps"
-                    },
-                    {
-                        "class": "bps_panel",
-                        "span": 6,
-                        "targets": [
-                            {
-                                "expr": "irate(node_network_transmit_bytes{device=\"$monitor_network_interface\"}[30s])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "Interface Tx Bps"
                     }
                 ],
                 "title": "New row"
@@ -976,7 +790,7 @@
                         "span": 12,
                         "targets": [
                             {
-                                "expr": "sum(scylla_compaction_manager_compactions{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(scylla_compaction_manager_compactions{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -1009,7 +823,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cql_inserts{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -1024,7 +838,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cql_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -1039,7 +853,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cql_deletes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -1054,7 +868,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cql_updates{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -1070,7 +884,7 @@
                         "pointradius": 1,
                         "targets": [
                             {
-                                "expr": "sum(scylla_transport_current_connections{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "expr": "sum(scylla_transport_current_connections{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -1090,54 +904,6 @@
                 {
                     "allValue": null,
                     "current": {
-                        "isNone": true,
-                        "text": "None",
-                        "value": ""
-                    },
-                    "datasource": "prometheus",
-                    "hide": 0,
-                    "includeAll": false,
-                    "label": null,
-                    "multi": false,
-                    "name": "monitor_disk",
-                    "options": [],
-                    "query": "node_disk_bytes_read",
-                    "refresh": 2,
-                    "regex": "/.*device=\"([^\\\"]*)\".*/",
-                    "sort": 0,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
-                },
-                {
-                    "allValue": null,
-                    "current": {
-                        "isNone": true,
-                        "text": "None",
-                        "value": ""
-                    },
-                    "datasource": "prometheus",
-                    "hide": 0,
-                    "includeAll": false,
-                    "label": null,
-                    "multi": false,
-                    "name": "monitor_network_interface",
-                    "options": [],
-                    "query": "node_network_receive_packets",
-                    "refresh": 2,
-                    "regex": "/.*device=\"([^\\\"]*)\".*/",
-                    "sort": 0,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
-                },
-                {
-                    "allValue": null,
-                    "current": {
                         "tags": [],
                         "text": "Instance",
                         "value": "instance"
@@ -1149,6 +915,16 @@
                     "name": "by",
                     "options": [
                         {
+                            "selected": false,
+                            "text": "Cluster",
+                            "value": "cluster"
+                        },
+                        {
+                            "selected": false,
+                            "text": "DC",
+                            "value": "dc"
+                        },
+                        {
                             "selected": true,
                             "text": "Instance",
                             "value": "instance"
@@ -1157,19 +933,9 @@
                             "selected": false,
                             "text": "Shard",
                             "value": "shard"
-                        },
-                        {
-                            "selected": false,
-                            "text": "DC",
-                            "value": "dc"
-                        },
-                        {
-                            "selected": false,
-                            "text": "Cluster",
-                            "value": "cluster"
                         }
                     ],
-                    "query": "Instance,Shard,DC,Cluster",
+                    "query": "Cluster,DC,Instance,Shard",
                     "type": "custom"
                 },
                 {

--- a/grafana/scylla-dash.master.template.json
+++ b/grafana/scylla-dash.master.template.json
@@ -452,58 +452,40 @@
                             "selected": false,
                             "text": "Cluster",
                             "value": "cluster"
+                        },
+                        {
+                            "selected": false,
+                            "text": "DC",
+                            "value": "dc"
                         }
                     ],
-                    "query": "Instance,Shard,Cluster",
+                    "query": "Instance,Shard,DC,Cluster",
                     "type": "custom"
                 },
                 {
-                    "allValue": null,
-                    "current": {
-                        "text": "All",
-                        "value": [
-                            "$__all"
-                        ]
-                    },
-                    "datasource": "prometheus",
-                    "hide": 0,
-                    "includeAll": true,
-                    "label": "node",
-                    "multi": true,
-                    "name": "node",
-                    "options": [],
-                    "query": "label_values(scylla_reactor_utilization, instance)",
-                    "refresh": 2,
-                    "regex": "",
-                    "sort": 1,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
+                    "class": "template_variable_single",
+                    "label": "cluster",
+                    "name": "cluster",
+                    "query": "label_values(scylla_reactor_utilization, cluster)"
                 },
                 {
-                    "allValue": null,
-                    "current": {
-                        "text": "All",
-                        "value": "$__all"
-                    },
-                    "datasource": "prometheus",
-                    "hide": 0,
-                    "includeAll": true,
+                    "class": "template_variable_all",
+                    "label": "dc",
+                    "name": "dc",
+                    "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster\"}, dc)"
+                },
+                {
+                    "class": "template_variable_all",
+                    "label": "node",
+                    "name": "node",
+                    "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster|$^\", dc=~\"$dc\"}, instance)"
+                },
+                {
+                    "class": "template_variable_all",
                     "label": "shard",
-                    "multi": true,
                     "name": "shard",
-                    "options": [],
-                    "query": "scylla_reactor_utilization{instance=~\"$node\"}",
-                    "refresh": 2,
-                    "regex": "/shard=\"([0-9]*)\".*/",
-                    "sort": 3,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
+                    "query": "label_values(scylla_reactor_utilization,shard)",
+                    "sort": 3
                 }
             ]
         },

--- a/grafana/scylla-dash.master.template.json
+++ b/grafana/scylla-dash.master.template.json
@@ -20,7 +20,7 @@
                         "class": "single_stat_panel",
                         "targets": [
                             {
-                                "expr": "count(up{job=\"scylla\"})",
+                                "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
                                 "intervalFactor": 1,
                                 "legendFormat": "Total Nodes",
                                 "refId": "A",
@@ -33,7 +33,7 @@
                         "class": "single_stat_panel_fail",
                         "targets": [
                             {
-                                "expr": "count(scrape_samples_scraped{job=\"scylla\"}==0) OR vector(0)",
+                                "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
                                 "intervalFactor": 1,
                                 "legendFormat": "Unreachable",
                                 "refId": "A",
@@ -70,7 +70,7 @@
                         "class": "percent_panel",
                         "targets": [
                             {
-                                "expr": "avg(scylla_reactor_utilization{} ) by ([[by]])",
+                                "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -83,7 +83,7 @@
                         "class": "ops_panel",
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_transport_requests_served{}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -92,28 +92,6 @@
                             }
                         ],
                         "title": "Requests Served"
-                    },
-                    {
-                        "class": "pie_chart_panel",
-                        "targets": [
-                            {
-                                "expr": "sum(node_filesystem_avail{mountpoint=\"/var/lib/scylla\"})",
-                                "interval": "",
-                                "intervalFactor": 1,
-                                "legendFormat": "Free",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 1200
-                            },
-                            {
-                                "expr": "(sum(node_filesystem_size{mountpoint=\"/var/lib/scylla\"})-sum(node_filesystem_avail{mountpoint=\"/var/lib/scylla\"}))",
-                                "intervalFactor": 1,
-                                "legendFormat": "Used",
-                                "refId": "B",
-                                "step": 1200
-                            }
-                        ],
-                        "title": "Total Storage"
                     }
                 ],
                 "title": "New row"
@@ -126,7 +104,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "sum(rate(scylla_storage_proxy_coordinator_write_latency_sum{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])/sum(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(rate(scylla_storage_proxy_coordinator_write_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])/(sum(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]]) + 1)",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -140,7 +118,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]], le))",
+                                "expr": "histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]], le))",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -155,7 +133,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]], le))",
+                                "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]], le))",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -176,7 +154,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "sum(rate(scylla_storage_proxy_coordinator_read_latency_sum{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])/sum(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(rate(scylla_storage_proxy_coordinator_read_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])/(sum(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]]) + 1)",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -190,7 +168,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]], le))",
+                                "expr": "histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]], le))",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -205,7 +183,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]], le))",
+                                "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]], le))",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -244,7 +222,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_writes{}) by ([[by]])",
+                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -258,7 +236,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_reads{}) by ([[by]])",
+                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -273,7 +251,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_timeouts{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -287,7 +265,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_unavailable{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_unavailable{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -308,7 +286,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_background_writes{}) by ([[by]])",
+                                "expr": "sum(scylla_storage_proxy_coordinator_background_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -322,7 +300,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_background_reads{}) by ([[by]])",
+                                "expr": "sum(scylla_storage_proxy_coordinator_background_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -336,7 +314,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_timeouts{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -350,7 +328,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_unavailable{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_unavailable{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -391,7 +369,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_row_hits{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cache_row_hits{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -405,7 +383,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_row_misses{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cache_row_misses{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -439,16 +417,6 @@
                     "name": "by",
                     "options": [
                         {
-                            "selected": true,
-                            "text": "Instance",
-                            "value": "instance"
-                        },
-                        {
-                            "selected": false,
-                            "text": "Shard",
-                            "value": "shard"
-                        },
-                        {
                             "selected": false,
                             "text": "Cluster",
                             "value": "cluster"
@@ -457,9 +425,19 @@
                             "selected": false,
                             "text": "DC",
                             "value": "dc"
+                        },
+                        {
+                            "selected": true,
+                            "text": "Instance",
+                            "value": "instance"
+                        },
+                        {
+                            "selected": false,
+                            "text": "Shard",
+                            "value": "shard"
                         }
                     ],
-                    "query": "Instance,Shard,DC,Cluster",
+                    "query": "Cluster,DC,Instance,Shard",
                     "type": "custom"
                 },
                 {

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -633,5 +633,45 @@
         ],
         "transform": "table",
         "type": "table"
-    }
-}
+    },
+    "template_variable_single" : {
+            "allValue": null,
+            "current": {
+            },
+            "datasource": "prometheus",
+            "hide": 0,
+            "includeAll": false,
+            "multi": false,
+            "options": [],
+            "refresh": 2,
+            "regex": "",
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+    }, 
+    "template_variable_all" : {
+            "class": "template_variable_single",
+            "allValue": null,
+            "current": {
+                "text": "All",
+                "value": [
+                    "$__all"
+                ]
+            },
+            "datasource": "prometheus",
+            "hide": 0,
+            "includeAll": true,
+            "multi": true,
+            "options": [],
+            "refresh": 2,
+            "regex": "",
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+        }}

--- a/prometheus/node_exporter_servers.yml
+++ b/prometheus/node_exporter_servers.yml
@@ -2,3 +2,11 @@
 
 - targets:
   - '172.17.0.2:9100'
+  labels:
+       cluster: cluster1
+       dc: dc1
+- targets:
+       - 172.17.0.3:9180
+  labels:
+       cluster: cluster1
+       dc: dc2

--- a/prometheus/prometheus.yml.template
+++ b/prometheus/prometheus.yml.template
@@ -20,16 +20,26 @@ alerting:
 
 scrape_configs:
 - job_name: scylla
-  honor_labels: true
+  honor_labels: false
   file_sd_configs:
     - files:
       - /etc/scylla.d/prometheus/scylla_servers.yml
+  metric_relabel_configs:
+    - source_labels: [instance]
+      regex:  '(.*):\d+'
+      target_label: instance
+      replacement: '${1}'
 
 - job_name: node_exporter
-  honor_labels: true
+  honor_labels: false
   file_sd_configs:
     - files:
       - /etc/scylla.d/prometheus/node_exporter_servers.yml
+  metric_relabel_configs:
+    - source_labels: [instance]
+      regex:  '(.*):\d+'
+      target_label: instance
+      replacement: '${1}'
 
 - job_name: scylla_manager
   honor_labels: true

--- a/prometheus/scylla_servers.yml
+++ b/prometheus/scylla_servers.yml
@@ -1,4 +1,13 @@
 # List Scylla end points
 
+# An example with a single cluster and two DC
 - targets:
-  - 172.17.0.2:9180
+       - 172.17.0.2:9180
+  labels:
+       cluster: cluster1
+       dc: dc1
+- targets:
+       - 172.17.0.3:9180
+  labels:
+       cluster: cluster1
+       dc: dc2


### PR DESCRIPTION
This patch extends the dashboard support for multi dc and multi cluster.
Setting which node belongs to which dc/cluster is done on the prometheus level.

We switch to use nodes ip (wihtout port) instead of names so that the node_exporter and scylla metrics would have the same instance name.