### PR TITLE
disk usage should be per node

### DIFF
--- a/grafana/scylla-dash-per-machine.2.3.template.json
+++ b/grafana/scylla-dash-per-machine.2.3.template.json
@@ -21,7 +21,7 @@
                         "height": "250px",
                         "targets": [
                             {
-                                "expr": "sum(node_filesystem_avail{mountpoint=\"$mount_point\"})",
+                                "expr": "sum(node_filesystem_avail{mountpoint=\"$mount_point\", instance=~\"$node\"})",
                                 "interval": "",
                                 "intervalFactor": 1,
                                 "legendFormat": "Free",
@@ -30,7 +30,7 @@
                                 "step": 7200
                             },
                             {
-                                "expr": "(sum(node_filesystem_size{mountpoint=\"$mount_point\"})-sum(node_filesystem_avail{mountpoint=\"$mount_point\"}))",
+                                "expr": "(sum(node_filesystem_size{mountpoint=\"$mount_point\", instance=~\"$node\"})-sum(node_filesystem_avail{mountpoint=\"$mount_point\", instance=~\"$node\"}))",
                                 "intervalFactor": 1,
                                 "legendFormat": "Used",
                                 "refId": "B",

--- a/grafana/scylla-dash-per-machine.master.template.json
+++ b/grafana/scylla-dash-per-machine.master.template.json
@@ -21,7 +21,7 @@
                         "height": "250px",
                         "targets": [
                             {
-                                "expr": "sum(node_filesystem_avail{mountpoint=\"$mount_point\"})",
+                                "expr": "sum(node_filesystem_avail{mountpoint=\"$mount_point\", instance=~\"$node\"})",
                                 "interval": "",
                                 "intervalFactor": 1,
                                 "legendFormat": "Free",
@@ -30,7 +30,7 @@
                                 "step": 7200
                             },
                             {
-                                "expr": "(sum(node_filesystem_size{mountpoint=\"$mount_point\"})-sum(node_filesystem_avail{mountpoint=\"$mount_point\"}))",
+                                "expr": "(sum(node_filesystem_size{mountpoint=\"$mount_point\", instance=~\"$node\"})-sum(node_filesystem_avail{mountpoint=\"$mount_point\", instance=~\"$node\"}))",
                                 "intervalFactor": 1,
                                 "legendFormat": "Used",
                                 "refId": "B",


### PR DESCRIPTION
This series set the disk pie-chart usage to be per node, so the repeated
pannel, would show the per server usage.

Signed-off-by: Amnon Heiman <amnon@scylladb.com>