### PR TITLE
remove legendFormat where it's not needed

### DIFF
--- a/grafana/scylla-dash-io-per-server.master.template.json
+++ b/grafana/scylla-dash-io-per-server.master.template.json
@@ -162,7 +162,7 @@
                             {
                                 "expr": "irate(node_disk_writes_completed{device=\"$monitor_disk\"}[30s])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Disk Writes per Server per Second",
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 20
@@ -177,7 +177,7 @@
                             {
                                 "expr": "irate(node_disk_reads_completed{device=\"$monitor_disk\"}[30s])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Disk Reads per Server per Second",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 20
                             }
@@ -197,7 +197,7 @@
                             {
                                 "expr": "irate(node_disk_bytes_written{device=\"$monitor_disk\"}[30s])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Disk Writes Bps per Server",
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 20
@@ -212,7 +212,7 @@
                             {
                                 "expr": "irate(node_disk_bytes_read{device=\"$monitor_disk\"}[30s])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Disk Read Bps per Server",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 20
                             }

--- a/grafana/scylla-dash-per-machine.master.template.json
+++ b/grafana/scylla-dash-per-machine.master.template.json
@@ -64,7 +64,7 @@
                             {
                                 "expr": "sum(irate(node_disk_writes_completed{instance=~\"[[node]]\", device=\"$monitor_disk\"}[30s])) by (instance)",
                                 "intervalFactor": 1,
-                                "legendFormat": "Disk Writes per Server per Second",
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 1
@@ -79,7 +79,7 @@
                             {
                                 "expr": "sum(irate(node_disk_reads_completed{instance=~\"[[node]]\", device=\"$monitor_disk\"}[30s])) by (instance)",
                                 "intervalFactor": 1,
-                                "legendFormat": "Disk Reads per Server per Second",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 1
                             }
@@ -93,7 +93,7 @@
                             {
                                 "expr": "sum(irate(node_disk_bytes_written{instance=~\"[[node]]\", device=\"$monitor_disk\"}[30s])) by (instance)",
                                 "intervalFactor": 1,
-                                "legendFormat": "Disk Writes Bps per Server",
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 1
@@ -108,7 +108,7 @@
                             {
                                 "expr": "sum(irate(node_disk_bytes_read{instance=~\"[[node]]\", device=\"$monitor_disk\"}[30s])) by (instance)",
                                 "intervalFactor": 1,
-                                "legendFormat": "Disk Read Bps per Server",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 1
                             }
@@ -140,7 +140,7 @@
                             {
                                 "expr": "sum(irate(node_network_receive_packets{instance=~\"[[node]]\", device=\"$monitor_network_interface\"}[30s])) by (instance)",
                                 "intervalFactor": 1,
-                                "legendFormat": "Interface Rx Packets",
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 1
@@ -155,7 +155,7 @@
                             {
                                 "expr": "sum(irate(node_network_transmit_packets{instance=~\"[[node]]\", device=\"$monitor_network_interface\"}[30s])) by (instance)",
                                 "intervalFactor": 1,
-                                "legendFormat": "Interface Tx Packets",
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 1
@@ -176,7 +176,7 @@
                             {
                                 "expr": "sum(irate(node_network_receive_bytes{instance=~\"[[node]]\", device=\"$monitor_network_interface\"}[30s])) by (instance)",
                                 "intervalFactor": 1,
-                                "legendFormat": "Interface Rx Bps",
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 1
@@ -191,7 +191,7 @@
                             {
                                 "expr": "sum(irate(node_network_transmit_bytes{instance=~\"[[node]]\", device=\"$monitor_network_interface\"}[30s])) by (instance)",
                                 "intervalFactor": 1,
-                                "legendFormat": "Interface Tx Bps",
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 1

--- a/grafana/scylla-dash-per-server.master.template.json
+++ b/grafana/scylla-dash-per-server.master.template.json
@@ -481,7 +481,7 @@
                             {
                                 "expr": "irate(node_disk_writes_completed{device=\"$monitor_disk\"}[30s])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Disk Writes per Server per Second",
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 1
@@ -496,7 +496,7 @@
                             {
                                 "expr": "irate(node_disk_reads_completed{device=\"$monitor_disk\"}[30s])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Disk Reads per Server per Second",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 1
                             }
@@ -510,7 +510,7 @@
                             {
                                 "expr": "irate(node_disk_bytes_written{device=\"$monitor_disk\"}[30s])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Disk Writes Bps per Server",
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 1
@@ -525,7 +525,7 @@
                             {
                                 "expr": "irate(node_disk_bytes_read{device=\"$monitor_disk\"}[30s])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Disk Read Bps per Server",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 1
                             }
@@ -894,7 +894,7 @@
                             {
                                 "expr": "irate(node_network_receive_packets{device=\"$monitor_network_interface\"}[30s])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Interface Rx Packets",
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 1
@@ -909,7 +909,7 @@
                             {
                                 "expr": "irate(node_network_transmit_packets{device=\"$monitor_network_interface\"}[30s])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Interface Tx Packets",
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 1
@@ -930,7 +930,7 @@
                             {
                                 "expr": "irate(node_network_receive_bytes{device=\"$monitor_network_interface\"}[30s])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Interface Rx Bps",
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 1
@@ -945,7 +945,7 @@
                             {
                                 "expr": "irate(node_network_transmit_bytes{device=\"$monitor_network_interface\"}[30s])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Interface Tx Bps",
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 1
@@ -1011,7 +1011,7 @@
                             {
                                 "expr": "sum(irate(scylla_cql_inserts{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "CQL Inserts",
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 1
@@ -1026,7 +1026,7 @@
                             {
                                 "expr": "sum(irate(scylla_cql_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "CQL Reads",
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 1
@@ -1041,7 +1041,7 @@
                             {
                                 "expr": "sum(irate(scylla_cql_deletes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "CQL Deletes",
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 1
@@ -1056,7 +1056,7 @@
                             {
                                 "expr": "sum(irate(scylla_cql_updates{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "CQL Updates",
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 1

--- a/grafana/scylla-dash.master.template.json
+++ b/grafana/scylla-dash.master.template.json
@@ -72,7 +72,7 @@
                             {
                                 "expr": "avg(scylla_reactor_utilization{} ) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Load",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 4
                             }
@@ -85,7 +85,7 @@
                             {
                                 "expr": "sum(irate(scylla_transport_requests_served{}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Requests Served",
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 4
@@ -246,7 +246,7 @@
                             {
                                 "expr": "sum(scylla_storage_proxy_coordinator_foreground_writes{}) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Foreground Writes",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -260,7 +260,7 @@
                             {
                                 "expr": "sum(scylla_storage_proxy_coordinator_foreground_reads{}) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Foreground Reads",
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 10
@@ -275,7 +275,7 @@
                             {
                                 "expr": "sum(irate(scylla_storage_proxy_coordinator_write_timeouts{}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Write Timeouts per Second",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -289,7 +289,7 @@
                             {
                                 "expr": "sum(irate(scylla_storage_proxy_coordinator_write_unavailable{}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Write Unavailable per Second",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -310,7 +310,7 @@
                             {
                                 "expr": "sum(scylla_storage_proxy_coordinator_background_writes{}) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Background Writes",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -324,7 +324,7 @@
                             {
                                 "expr": "sum(scylla_storage_proxy_coordinator_background_reads{}) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Background Reads",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -338,7 +338,7 @@
                             {
                                 "expr": "sum(irate(scylla_storage_proxy_coordinator_read_timeouts{}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Read Timeouts per Second",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -352,7 +352,7 @@
                             {
                                 "expr": "sum(irate(scylla_storage_proxy_coordinator_read_unavailable{}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Read Unavailable per Second",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -393,7 +393,7 @@
                             {
                                 "expr": "sum(irate(scylla_cache_row_hits{}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Cache Hits",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -407,7 +407,7 @@
                             {
                                 "expr": "sum(irate(scylla_cache_row_misses{}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Cache Misses",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }


### PR DESCRIPTION
LegendFormat that contains no prameters hides the information of the
graph.
This remove the redundant legendFormat fromt the graphs.

Fixes #354