### PR TITLE
start scripts: Fail gracefully when a container exists

### DIFF
--- a/start-alertmanager.sh
+++ b/start-alertmanager.sh
@@ -40,6 +40,12 @@ else
     ALERTMANAGER_NAME=aalert-$ALERTMANAGER_PORT
 fi
 
+docker container inspect $ALERTMANAGER_NAME > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+    printf "\nSome of the monitoring docker instances ($ALERTMANAGER_NAME) are already running. You can kill all of them using kill-all.sh\n"
+    exit 1
+fi
+
 docker run -d $DOCKER_PARAM -i -p $ALERTMANAGER_PORT:9093 \
 	-v $PWD/prometheus/rule_config.yml:/etc/alertmanager/config.yml:Z \
      --name $ALERTMANAGER_NAME prom/alertmanager:$ALERT_MANAGER_VERSION > /dev/null

--- a/start-alertmanager.sh
+++ b/start-alertmanager.sh
@@ -42,7 +42,7 @@ fi
 
 docker container inspect $ALERTMANAGER_NAME > /dev/null 2>&1
 if [ $? -eq 0 ]; then
-    printf "\nSome of the monitoring docker instances ($ALERTMANAGER_NAME) are already running. You can kill all of them using kill-all.sh\n"
+    printf "\nSome of the monitoring docker instances ($ALERTMANAGER_NAME) exist. Make sure all containers are stopped and deleted. You can use kill-all.sh for that\n"
     exit 1
 fi
 

--- a/start-alertmanager.sh
+++ b/start-alertmanager.sh
@@ -42,7 +42,7 @@ fi
 
 docker container inspect $ALERTMANAGER_NAME > /dev/null 2>&1
 if [ $? -eq 0 ]; then
-    printf "\nSome of the monitoring docker instances ($ALERTMANAGER_NAME) exist. Make sure all containers are stopped and deleted. You can use kill-all.sh for that\n"
+    printf "\nSome of the monitoring docker instances ($ALERTMANAGER_NAME) exist. Make sure all containers are killed and removed. You can use kill-all.sh for that\n"
     exit 1
 fi
 

--- a/start-all.sh
+++ b/start-all.sh
@@ -70,12 +70,21 @@ done
 printf "Wait for alert manager container to start."
 
 AM_ADDRESS=`./start-alertmanager.sh $ALERTMANAGER_PORT -D "$DOCKER_PARAM"`
-
+if [ $? -ne 0 ]; then
+    echo "$AM_ADDRESS"
+    exit 1
+fi
 if [ -z $PROMETHEUS_PORT ]; then
     PROMETHEUS_PORT=9090
     PROMETHEUS_NAME=aprom
 else
     PROMETHEUS_NAME=aprom-$PROMETHEUS_PORT
+fi
+
+docker container inspect $PROMETHEUS_NAME > /dev/null
+if [ $? -eq 0 ]; then
+    printf "\nSome of the monitoring docker instances ($PROMETHEUS_NAME) are already running. You can kill all of them using kill-all.sh\n"
+    exit 1
 fi
 
 

--- a/start-all.sh
+++ b/start-all.sh
@@ -83,7 +83,7 @@ fi
 
 docker container inspect $PROMETHEUS_NAME > /dev/null
 if [ $? -eq 0 ]; then
-    printf "\nSome of the monitoring docker instances ($PROMETHEUS_NAME) exist. Make sure all containers are stopped and deleted. You can use kill-all.sh for that\n"
+    printf "\nSome of the monitoring docker instances ($PROMETHEUS_NAME) exist. Make sure all containers are killed and removed. You can use kill-all.sh for that\n"
     exit 1
 fi
 

--- a/start-all.sh
+++ b/start-all.sh
@@ -83,7 +83,7 @@ fi
 
 docker container inspect $PROMETHEUS_NAME > /dev/null
 if [ $? -eq 0 ]; then
-    printf "\nSome of the monitoring docker instances ($PROMETHEUS_NAME) are already running. You can kill all of them using kill-all.sh\n"
+    printf "\nSome of the monitoring docker instances ($PROMETHEUS_NAME) exist. Make sure all containers are stopped and deleted. You can use kill-all.sh for that\n"
     exit 1
 fi
 

--- a/start-grafana.sh
+++ b/start-grafana.sh
@@ -73,7 +73,7 @@ fi
 
 docker container inspect $GRAFANA_NAME > /dev/null 2>&1
 if [ $? -eq 0 ]; then
-    printf "\nSome of the monitoring docker instances ($GRAFANA_NAME) exist. Make sure all containers are stopped and deleted. You can use kill-all.sh for that\n"
+    printf "\nSome of the monitoring docker instances ($GRAFANA_NAME) exist. Make sure all containers are killed and removed. You can use kill-all.sh for that\n"
     exit 1
 fi
 

--- a/start-grafana.sh
+++ b/start-grafana.sh
@@ -71,6 +71,12 @@ if [ -z $GRAFANA_NAME ]; then
     GRAFANA_NAME=agraf-$GRAFANA_PORT
 fi
 
+docker container inspect $GRAFANA_NAME > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+    printf "\nSome of the monitoring docker instances ($GRAFANA_NAME) are already running. You can kill all of them using kill-all.sh\n"
+    exit 1
+fi
+
 proxy_args=()
 if [[ -n "$HTTP_PROXY" ]]; then
     proxy_args=(-e http_proxy="$HTTP_PROXY")

--- a/start-grafana.sh
+++ b/start-grafana.sh
@@ -73,7 +73,7 @@ fi
 
 docker container inspect $GRAFANA_NAME > /dev/null 2>&1
 if [ $? -eq 0 ]; then
-    printf "\nSome of the monitoring docker instances ($GRAFANA_NAME) are already running. You can kill all of them using kill-all.sh\n"
+    printf "\nSome of the monitoring docker instances ($GRAFANA_NAME) exist. Make sure all containers are stopped and deleted. You can use kill-all.sh for that\n"
     exit 1
 fi
 


### PR DESCRIPTION
Check if a container exists before trying to run it and exit with an
error code.

Fixes #316

Signed-off-by: Amnon Heiman <amnon@scylladb.com>