### PR TITLE
Add instance and node to version 1.0

### DIFF
--- a/grafana/scylla-dash.2.1.template.json
+++ b/grafana/scylla-dash.2.1.template.json
@@ -66,9 +66,9 @@
                         "class": "percent_panel",
                         "targets": [
                             {
-                                "expr": "avg(scylla_reactor_utilization{} ) by ([[by]])",
+                                "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\", shard=~\"[[shard]]\"} ) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Load",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 4
                             }
@@ -81,9 +81,9 @@
                         "pointradius": 1,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_transport_requests_served{}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Requests Served",
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 4
@@ -377,9 +377,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_writes{}) by ([[by]])",
+                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_writes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Foreground Writes",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -413,9 +413,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_reads{}) by ([[by]])",
+                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Foreground Reads",
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 10
@@ -451,9 +451,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_timeouts{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Write Timeouts per Second",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -487,9 +487,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_unavailable{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_unavailable{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Write Unavailable per Second",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -529,9 +529,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_background_writes{}) by ([[by]])",
+                                "expr": "sum(scylla_storage_proxy_coordinator_background_writes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Background Writes",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -565,9 +565,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_background_reads{}) by ([[by]])",
+                                "expr": "sum(scylla_storage_proxy_coordinator_background_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Background Reads",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -602,9 +602,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_timeouts{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Read Timeouts per Second",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -638,9 +638,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_unavailable{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_unavailable{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Read Unavailable per Second",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -701,9 +701,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_row_hits{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cache_row_hits{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Cache Hits",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -740,9 +740,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_row_misses{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cache_row_misses{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Cache Misses",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -853,7 +853,7 @@
                     "multi": true,
                     "name": "node",
                     "options": [],
-                    "query": "label_values(node_filesystem_avail, instance)",
+                    "query": "label_values(scylla_reactor_utilization, instance)",
                     "refresh": 2,
                     "regex": "",
                     "sort": 0,

--- a/grafana/scylla-dash.2.2.template.json
+++ b/grafana/scylla-dash.2.2.template.json
@@ -70,9 +70,9 @@
                         "class": "percent_panel",
                         "targets": [
                             {
-                                "expr": "avg(scylla_reactor_utilization{} ) by ([[by]])",
+                                "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\", shard=~\"[[shard]]\"} ) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Load",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 4
                             }
@@ -83,9 +83,9 @@
                         "class": "ops_panel",
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_transport_requests_served{}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Requests Served",
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 4
@@ -244,9 +244,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_writes{}) by ([[by]])",
+                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_writes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Foreground Writes",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -258,9 +258,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_reads{}) by ([[by]])",
+                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Foreground Reads",
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 10
@@ -273,9 +273,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_timeouts{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Write Timeouts per Second",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -287,9 +287,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_unavailable{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_unavailable{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Write Unavailable per Second",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -308,9 +308,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_background_writes{}) by ([[by]])",
+                                "expr": "sum(scylla_storage_proxy_coordinator_background_writes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Background Writes",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -322,9 +322,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_background_reads{}) by ([[by]])",
+                                "expr": "sum(scylla_storage_proxy_coordinator_background_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Background Reads",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -336,9 +336,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_timeouts{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Read Timeouts per Second",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -350,9 +350,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_unavailable{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_unavailable{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Read Unavailable per Second",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -391,9 +391,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_row_hits{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cache_row_hits{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Cache Hits",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -405,9 +405,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_row_misses{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cache_row_misses{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Cache Misses",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }

--- a/grafana/scylla-dash.2.3.template.json
+++ b/grafana/scylla-dash.2.3.template.json
@@ -70,9 +70,9 @@
                         "class": "percent_panel",
                         "targets": [
                             {
-                                "expr": "avg(scylla_reactor_utilization{} ) by ([[by]])",
+                                "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\", shard=~\"[[shard]]\"} ) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Load",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 4
                             }
@@ -83,9 +83,9 @@
                         "class": "ops_panel",
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_transport_requests_served{}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Requests Served",
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 4
@@ -244,9 +244,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_writes{}) by ([[by]])",
+                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_writes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Foreground Writes",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -258,9 +258,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_reads{}) by ([[by]])",
+                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Foreground Reads",
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 10
@@ -273,9 +273,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_timeouts{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Write Timeouts per Second",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -287,9 +287,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_unavailable{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_unavailable{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Write Unavailable per Second",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -308,9 +308,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_background_writes{}) by ([[by]])",
+                                "expr": "sum(scylla_storage_proxy_coordinator_background_writes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Background Writes",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -322,9 +322,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_background_reads{}) by ([[by]])",
+                                "expr": "sum(scylla_storage_proxy_coordinator_background_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Background Reads",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -336,9 +336,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_timeouts{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Read Timeouts per Second",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -350,9 +350,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_unavailable{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_unavailable{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Read Unavailable per Second",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -391,9 +391,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_row_hits{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cache_row_hits{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Cache Hits",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -405,9 +405,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_row_misses{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cache_row_misses{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Cache Misses",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }

--- a/grafana/scylla-dash.2018.1.template.json
+++ b/grafana/scylla-dash.2018.1.template.json
@@ -70,9 +70,9 @@
                         "class": "percent_panel",
                         "targets": [
                             {
-                                "expr": "avg(scylla_reactor_utilization{} ) by ([[by]])",
+                                "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\", shard=~\"[[shard]]\"} ) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Load",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 4
                             }
@@ -83,9 +83,9 @@
                         "class": "ops_panel",
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_transport_requests_served{}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Requests Served",
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 4
@@ -244,9 +244,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_writes{}) by ([[by]])",
+                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_writes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Foreground Writes",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -258,9 +258,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_reads{}) by ([[by]])",
+                                "expr": "sum(scylla_storage_proxy_coordinator_foreground_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Foreground Reads",
+                                "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 10
@@ -273,9 +273,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_timeouts{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Write Timeouts per Second",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -287,9 +287,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_unavailable{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_write_unavailable{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Write Unavailable per Second",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -308,9 +308,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_background_writes{}) by ([[by]])",
+                                "expr": "sum(scylla_storage_proxy_coordinator_background_writes{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Background Writes",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -322,9 +322,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(scylla_storage_proxy_coordinator_background_reads{}) by ([[by]])",
+                                "expr": "sum(scylla_storage_proxy_coordinator_background_reads{instance=~\"[[node]]\", shard=~\"[[shard]]\"}) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Background Reads",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -336,9 +336,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_timeouts{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Read Timeouts per Second",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -350,9 +350,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_unavailable{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_storage_proxy_coordinator_read_unavailable{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Read Unavailable per Second",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -391,9 +391,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_row_hits{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cache_row_hits{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Cache Hits",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
@@ -405,9 +405,9 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_cache_row_misses{}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cache_row_misses{instance=~\"[[node]]\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Cache Misses",
+                                "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }


### PR DESCRIPTION
This patch addresses two issues: #369 and #354 this patch is 1.0 version specific, as the solution is different in version 2.0
The metrics in the overview dashboard should contain a filter based on the current node and current shard if they are chosen in the pull-down menu see #369 

The legendFormat should be empty in graphs with multiple lines or the information that will be displayed will not contain the node and shard information.