### PR TITLE
start-all.sh: check that scylla/node target files exist before starting

### DIFF
--- a/start-all.sh
+++ b/start-all.sh
@@ -67,6 +67,16 @@ while getopts ':hled:g:p:v:s:n:a:c:j:b:m:M:D:' option; do
   esac
 done
 
+if [ ! -f $SCYLLA_TARGET_FILE ]; then
+    echo "Scylla target file '${SCYLLA_TARGET_FILE}' does not exist"
+    exit 1
+fi
+
+if [ ! -f $NODE_TARGET_FILE ]; then
+    echo "Node target file '${NODE_TARGET_FILE}' does not exist"
+    exit 1
+fi
+
 if [ ! -z $ALERTMANAGER_PORT ] || [ ! -z $GRAFANA_PORT ] || [ ! -z $PROMETHEUS_PORT ]; then
     if [[ $DOCKER_PARAM = *"--net=host"* ]]; then
         echo "Port mapping is not supported with host network, remove the -l flag from the command line"


### PR DESCRIPTION
Currently `start-all.sh` will silently ignore inexistent or non-file
paths passed to `-s` and `-n`. This leads to an empty dashboard that has
`N/A` available nodes and the user trying to find the error in their
setup when in fact they just had a typo in the `start-all.sh` command
line.
When the paths passed to `-s` or `-n` don't point to a file, refuse to
start and print an error.