### PR TITLE
Add a variable for the datasource

### DIFF
--- a/grafana/scylla-dash-cpu-per-server.2.3.template.json
+++ b/grafana/scylla-dash-cpu-per-server.2.3.template.json
@@ -146,6 +146,13 @@
                     "name": "shard",
                     "query": "label_values(scylla_reactor_utilization,shard)",
                     "sort": 3
+                },
+                {
+                    "label": "Datasource",
+                    "name": "datasource",
+                    "query": "prometheus",
+                    "refresh": 1,
+                    "type": "datasource"
                 }
             ]
         },

--- a/grafana/scylla-dash-cpu-per-server.3.0.template.json
+++ b/grafana/scylla-dash-cpu-per-server.3.0.template.json
@@ -146,6 +146,13 @@
                     "name": "shard",
                     "query": "label_values(scylla_reactor_utilization,shard)",
                     "sort": 3
+                },
+                {
+                    "label": "Datasource",
+                    "name": "datasource",
+                    "query": "prometheus",
+                    "refresh": 1,
+                    "type": "datasource"
                 }
             ]
         },

--- a/grafana/scylla-dash-cpu-per-server.master.template.json
+++ b/grafana/scylla-dash-cpu-per-server.master.template.json
@@ -146,6 +146,13 @@
                     "name": "shard",
                     "query": "label_values(scylla_reactor_utilization,shard)",
                     "sort": 3
+                },
+                {
+                    "label": "Datasource",
+                    "name": "datasource",
+                    "query": "prometheus",
+                    "refresh": 1,
+                    "type": "datasource"
                 }
             ]
         },

--- a/grafana/scylla-dash-io-per-server.2.3.template.json
+++ b/grafana/scylla-dash-io-per-server.2.3.template.json
@@ -495,7 +495,7 @@
             "list": [
                 {
                     "current": {},
-                    "datasource": "prometheus",
+                    "datasource": "$datasource",
                     "hide": 0,
                     "includeAll": false,
                     "multi": false,
@@ -567,7 +567,15 @@
                     "name": "shard",
                     "query": "label_values(scylla_reactor_utilization,shard)",
                     "sort": 3
+                },
+                {
+                    "label": "Datasource",
+                    "name": "datasource",
+                    "query": "prometheus",
+                    "refresh": 1,
+                    "type": "datasource"
                 }
+
             ]
         },
         "title": "Scylla Per-Server Disk I/O 2.3"

--- a/grafana/scylla-dash-io-per-server.3.0.template.json
+++ b/grafana/scylla-dash-io-per-server.3.0.template.json
@@ -495,7 +495,7 @@
             "list": [
                 {
                     "current": {},
-                    "datasource": "prometheus",
+                    "datasource": "$datasource",
                     "hide": 0,
                     "includeAll": false,
                     "multi": false,
@@ -567,6 +567,13 @@
                     "name": "shard",
                     "query": "label_values(scylla_reactor_utilization,shard)",
                     "sort": 3
+                },
+                {
+                    "label": "Datasource",
+                    "name": "datasource",
+                    "query": "prometheus",
+                    "refresh": 1,
+                    "type": "datasource"
                 }
             ]
         },

--- a/grafana/scylla-dash-io-per-server.master.template.json
+++ b/grafana/scylla-dash-io-per-server.master.template.json
@@ -495,7 +495,7 @@
             "list": [
                 {
                     "current": {},
-                    "datasource": "prometheus",
+                    "datasource": "$datasource",
                     "hide": 0,
                     "includeAll": false,
                     "multi": false,
@@ -567,7 +567,15 @@
                     "name": "shard",
                     "query": "label_values(scylla_reactor_utilization,shard)",
                     "sort": 3
+                },
+                {
+                    "label": "Datasource",
+                    "name": "datasource",
+                    "query": "prometheus",
+                    "refresh": 1,
+                    "type": "datasource"
                 }
+
             ]
         },
         "title": "Scylla Per-Server Disk I/O master"

--- a/grafana/scylla-dash-per-machine.2.3.template.json
+++ b/grafana/scylla-dash-per-machine.2.3.template.json
@@ -230,7 +230,7 @@
                         "text": "None",
                         "value": ""
                     },
-                    "datasource": "prometheus",
+                    "datasource": "$datasource",
                     "hide": 0,
                     "includeAll": false,
                     "label": null,
@@ -254,7 +254,7 @@
                         "text": "None",
                         "value": ""
                     },
-                    "datasource": "prometheus",
+                    "datasource": "$datasource",
                     "hide": 0,
                     "includeAll": false,
                     "label": null,
@@ -277,7 +277,7 @@
                         "text": "/var/lib/scylla",
                         "value": "/var/lib/scylla"
                     },
-                    "datasource": "prometheus",
+                    "datasource": "$datasource",
                     "hide": 0,
                     "includeAll": false,
                     "label": "Mounnt path",
@@ -293,10 +293,14 @@
                     "tagsQuery": "",
                     "type": "query",
                     "useTags": false
+                },
+                {
+                    "label": "Datasource",
+                    "name": "datasource",
+                    "query": "prometheus",
+                    "refresh": 1,
+                    "type": "datasource"
                 }
-                
-                
-                
             ]
         },
 		"tags": [

--- a/grafana/scylla-dash-per-machine.3.0.template.json
+++ b/grafana/scylla-dash-per-machine.3.0.template.json
@@ -230,7 +230,7 @@
                         "text": "None",
                         "value": ""
                     },
-                    "datasource": "prometheus",
+                    "datasource": "$datasource",
                     "hide": 0,
                     "includeAll": false,
                     "label": null,
@@ -254,7 +254,7 @@
                         "text": "None",
                         "value": ""
                     },
-                    "datasource": "prometheus",
+                    "datasource": "$datasource",
                     "hide": 0,
                     "includeAll": false,
                     "label": null,
@@ -277,7 +277,7 @@
                         "text": "/var/lib/scylla",
                         "value": "/var/lib/scylla"
                     },
-                    "datasource": "prometheus",
+                    "datasource": "$datasource",
                     "hide": 0,
                     "includeAll": false,
                     "label": "Mounnt path",
@@ -293,10 +293,14 @@
                     "tagsQuery": "",
                     "type": "query",
                     "useTags": false
+                },
+                {
+                    "label": "Datasource",
+                    "name": "datasource",
+                    "query": "prometheus",
+                    "refresh": 1,
+                    "type": "datasource"
                 }
-                
-                
-                
             ]
         },
 		"tags": [

--- a/grafana/scylla-dash-per-machine.master.template.json
+++ b/grafana/scylla-dash-per-machine.master.template.json
@@ -230,7 +230,7 @@
                         "text": "None",
                         "value": ""
                     },
-                    "datasource": "prometheus",
+                    "datasource": "$datasource",
                     "hide": 0,
                     "includeAll": false,
                     "label": null,
@@ -254,7 +254,7 @@
                         "text": "None",
                         "value": ""
                     },
-                    "datasource": "prometheus",
+                    "datasource": "$datasource",
                     "hide": 0,
                     "includeAll": false,
                     "label": null,
@@ -277,7 +277,7 @@
                         "text": "/var/lib/scylla",
                         "value": "/var/lib/scylla"
                     },
-                    "datasource": "prometheus",
+                    "datasource": "$datasource",
                     "hide": 0,
                     "includeAll": false,
                     "label": "Mounnt path",
@@ -293,10 +293,14 @@
                     "tagsQuery": "",
                     "type": "query",
                     "useTags": false
+                },
+                {
+                    "label": "Datasource",
+                    "name": "datasource",
+                    "query": "prometheus",
+                    "refresh": 1,
+                    "type": "datasource"
                 }
-                
-                
-                
             ]
         },
 		"tags": [

--- a/grafana/scylla-dash-per-server.2.3.template.json
+++ b/grafana/scylla-dash-per-server.2.3.template.json
@@ -962,6 +962,13 @@
                     "name": "shard",
                     "query": "label_values(scylla_reactor_utilization,shard)",
                     "sort": 3
+                },
+                {
+                    "label": "Datasource",
+                    "name": "datasource",
+                    "query": "prometheus",
+                    "refresh": 1,
+                    "type": "datasource"
                 }
             ]
         },

--- a/grafana/scylla-dash-per-server.3.0.template.json
+++ b/grafana/scylla-dash-per-server.3.0.template.json
@@ -962,6 +962,13 @@
                     "name": "shard",
                     "query": "label_values(scylla_reactor_utilization,shard)",
                     "sort": 3
+                },
+                {
+                    "label": "Datasource",
+                    "name": "datasource",
+                    "query": "prometheus",
+                    "refresh": 1,
+                    "type": "datasource"
                 }
             ]
         },

--- a/grafana/scylla-dash-per-server.master.template.json
+++ b/grafana/scylla-dash-per-server.master.template.json
@@ -962,6 +962,13 @@
                     "name": "shard",
                     "query": "label_values(scylla_reactor_utilization,shard)",
                     "sort": 3
+                },
+                {
+                    "label": "Datasource",
+                    "name": "datasource",
+                    "query": "prometheus",
+                    "refresh": 1,
+                    "type": "datasource"
                 }
             ]
         },

--- a/grafana/scylla-dash.2.3.template.json
+++ b/grafana/scylla-dash.2.3.template.json
@@ -476,6 +476,13 @@
                     "name": "shard",
                     "query": "label_values(scylla_reactor_utilization,shard)",
                     "sort": 3
+                },
+                {
+                    "label": "Datasource",
+                    "name": "datasource",
+                    "query": "prometheus",
+                    "refresh": 1,
+                    "type": "datasource"
                 }
             ]
         },

--- a/grafana/scylla-dash.3.0.template.json
+++ b/grafana/scylla-dash.3.0.template.json
@@ -476,6 +476,13 @@
                     "name": "shard",
                     "query": "label_values(scylla_reactor_utilization,shard)",
                     "sort": 3
+                },
+                {
+                    "label": "Datasource",
+                    "name": "datasource",
+                    "query": "prometheus",
+                    "refresh": 1,
+                    "type": "datasource"
                 }
             ]
         },

--- a/grafana/scylla-dash.master.template.json
+++ b/grafana/scylla-dash.master.template.json
@@ -476,6 +476,13 @@
                     "name": "shard",
                     "query": "label_values(scylla_reactor_utilization,shard)",
                     "sort": 3
+                },
+                {
+                    "label": "Datasource",
+                    "name": "datasource",
+                    "query": "prometheus",
+                    "refresh": 1,
+                    "type": "datasource"
                 }
             ]
         },

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -34,7 +34,7 @@
 		"height": "250px"
 	},
 	"base_panel": {
-		"datasource": "prometheus",
+		"datasource": "$datasource",
 		"editable": true,
 		"error": false,
 		"id": "auto",
@@ -423,7 +423,7 @@
         "aliasColors": {},
         "cacheTimeout": null,
         "class": "base_panel",
-        "datasource": "prometheus",
+        "datasource": "$datasource",
         "editable": true,
         "error": false,
         "fontSize": "80%",
@@ -638,7 +638,7 @@
             "allValue": null,
             "current": {
             },
-            "datasource": "prometheus",
+            "datasource": "$datasource",
             "hide": 0,
             "includeAll": false,
             "multi": false,
@@ -661,7 +661,7 @@
                     "$__all"
                 ]
             },
-            "datasource": "prometheus",
+            "datasource": "$datasource",
             "hide": 0,
             "includeAll": true,
             "multi": true,


### PR DESCRIPTION
There are situations in complex deployments where we can be monitoring different
clusters that are in different prometheus servers.

What we have been usually doing in situations like that is having many different
stacks, each with its own grafana/prometheus pair. But it would be useful to be
able to have the same entry point for it.

With this patch, the datasource becomes configurable as a grafana variable. We
can then choose which datasource we'll monitor, here called an "organization"
and seamlessly flip between them.

Signed-off-by: Glauber Costa <glauber@scylladb.com>