### PR TITLE
prometheus: Add node_exporter 016 support

### DIFF
--- a/prometheus/prometheus.yml.template
+++ b/prometheus/prometheus.yml.template
@@ -40,6 +40,46 @@ scrape_configs:
       regex:  '(.*):\d+'
       target_label: instance
       replacement: '${1}'
+    - source_labels: [__name__]
+      regex:  'node_disk_read_bytes_total'
+      target_label: __name__
+      replacement: 'node_disk_bytes_read'
+    - source_labels: [__name__]
+      regex:  'node_disk_written_bytes_total'
+      target_label: __name__
+      replacement: 'node_disk_bytes_written'
+    - source_labels: [__name__]
+      regex:  'node_disk_reads_completed_total'
+      target_label: __name__
+      replacement: 'node_disk_reads_completed'
+    - source_labels: [__name__]
+      regex:  'node_disk_writes_completed_total'
+      target_label: __name__
+      replacement: 'node_disk_writes_completed'
+    - source_labels: [__name__]
+      regex:  'node_filesystem_avail_bytes'
+      target_label: __name__
+      replacement: 'node_filesystem_avail'
+    - source_labels: [__name__]
+      regex:  'node_network_receive_bytes_total'
+      target_label: __name__
+      replacement: 'node_network_receive_bytes'
+    - source_labels: [__name__]
+      regex:  'node_network_receive_packets_total'
+      target_label: __name__
+      replacement: 'node_network_receive_packets'
+    - source_labels: [__name__]
+      regex:  'node_network_transmit_bytes_total'
+      target_label: __name__
+      replacement: 'node_network_transmit_bytes'
+    - source_labels: [__name__]
+      regex:  'node_network_transmit_packets_total'
+      target_label: __name__
+      replacement: 'node_network_transmit_packets'
+    - source_labels: [__name__]
+      regex:  'node_filesystem_size_bytes'
+      target_label: __name__
+      replacement: 'node_filesystem_size'
 
 - job_name: scylla_manager
   honor_labels: false


### PR DESCRIPTION
This patch rename node_exporter 0.16/0.17 metrics name to be compatible
with 0.14 version.

All dashboards will continue to work as before

Fixes #427
Fixes #395