### PR TITLE
Clickable alerts

### DIFF
--- a/grafana/scylla-dash.2.3.template.json
+++ b/grafana/scylla-dash.2.3.template.json
@@ -478,6 +478,22 @@
                     "name": "shard",
                     "query": "label_values(scylla_reactor_utilization,shard)",
                     "sort": 3
+                },
+                {
+                    "class": "template_variable_custom",
+                    "name": "dash_version",
+                    "options": [
+                      {
+                         "selected": true,
+                         "text": "2-3",
+                         "value": "2-3"
+                      }
+                    ],
+                    "query": "2-3",
+                    "current": {
+                        "text": "2-3",
+                        "value": "2-3"
+                    }
                 }
             ]
         },

--- a/grafana/scylla-dash.2018.1.template.json
+++ b/grafana/scylla-dash.2018.1.template.json
@@ -501,6 +501,22 @@
                     "tagsQuery": "",
                     "type": "query",
                     "useTags": false
+                },
+                {
+                    "class": "template_variable_custom",
+                    "name": "dash_version",
+                    "options": [
+                      {
+                         "selected": true,
+                         "text": "2018-1",
+                         "value": "2018-1"
+                      }
+                    ],
+                    "query": "2018-1",
+                    "current": {
+                        "text": "2018-1",
+                        "value": "2018-1"
+                    }
                 }
             ]
         },

--- a/grafana/scylla-dash.3.0.template.json
+++ b/grafana/scylla-dash.3.0.template.json
@@ -544,6 +544,22 @@
                     "name": "shard",
                     "query": "label_values(scylla_reactor_utilization,shard)",
                     "sort": 3
+                },
+                {
+                    "class": "template_variable_custom",
+                    "name": "dash_version",
+                    "options": [
+                      {
+                         "selected": true,
+                         "text": "3-0",
+                         "value": "3-0"
+                      }
+                    ],
+                    "query": "3-0",
+                    "current": {
+                        "text": "3-0",
+                        "value": "3-0"
+                    }
                 }
             ]
         },

--- a/grafana/scylla-dash.master.template.json
+++ b/grafana/scylla-dash.master.template.json
@@ -568,6 +568,22 @@
                     "name": "shard",
                     "query": "label_values(scylla_reactor_utilization,shard)",
                     "sort": 3
+                },
+                {
+                    "class": "template_variable_custom",
+                    "name": "dash_version",
+                    "options": [
+                      {
+                         "selected": true,
+                         "text": "master",
+                         "value": "master"
+                      }
+                    ],
+                    "query": "master",
+                    "current": {
+                        "text": "master",
+                        "value": "master"
+                    }
                 }
             ]
         },

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -594,7 +594,7 @@
                 "pattern": "Time",
                 "link": true,
                 "linkTooltip": "Jump to the see the node",
-                "linkUrl": "/d/detail/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_4}&from=${__cell_0}",
+                "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_4}&from=${__cell_0}",
                 "type": "date"
             },
             {
@@ -694,7 +694,7 @@
     },
     "template_variable_custom": {
         "allValue": null,
-        "hide": 1,
+        "hide": 2,
         "includeAll": false,
         "label": null,
         "multi": false,

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -592,6 +592,9 @@
                 "alias": "Time",
                 "dateFormat": "YYYY-MM-DD HH:mm:ss",
                 "pattern": "Time",
+                "link": true,
+                "linkTooltip": "Jump to the see the node",
+                "linkUrl": "/d/detail/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_4}&from=${__cell_0}",
                 "type": "date"
             },
             {
@@ -622,6 +625,25 @@
               "pattern": "Alertname",
               "thresholds": [],
               "type": "hidden",
+              "unit": "short"
+            },
+            {
+              "alias": "Instance",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "link": true,
+              "linkTooltip": "Jump to the see the node",
+              "linkUrl": "/d/detail/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_4}",
+              "mappingType": 1,
+              "pattern": "instance",
+              "thresholds": [],
+              "type": "string",
               "unit": "short"
             },
             {
@@ -669,7 +691,16 @@
             "tagsQuery": "",
             "type": "query",
             "useTags": false
-    }, 
+    },
+    "template_variable_custom": {
+        "allValue": null,
+        "hide": 1,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "skipUrlSync": false,
+        "type": "custom"
+      },
     "template_variable_all" : {
             "class": "template_variable_single",
             "allValue": null,

--- a/prometheus/prometheus.yml.template
+++ b/prometheus/prometheus.yml.template
@@ -24,9 +24,9 @@ scrape_configs:
   file_sd_configs:
     - files:
       - /etc/scylla.d/prometheus/scylla_servers.yml
-  metric_relabel_configs:
-    - source_labels: [instance]
-      regex:  '(.*):\d+'
+  relabel_configs:
+    - source_labels: [__address__]
+      regex:  '(.*):.+'
       target_label: instance
       replacement: '${1}'
 
@@ -35,8 +35,8 @@ scrape_configs:
   file_sd_configs:
     - files:
       - /etc/scylla.d/prometheus/node_exporter_servers.yml
-  metric_relabel_configs:
-    - source_labels: [instance]
+  relabel_configs:
+    - source_labels: [__address__]
       regex:  '(.*):\d+'
       target_label: instance
       replacement: '${1}'


### PR DESCRIPTION
Add links to the alerts table, it will now be possible to press the instance or the time/date cell to jump to the per-server dashboard set to the problematic instance.

Using the time/date will set the time to the event time, pressing the instance would use the current time.