### PR TITLE
Use files instead of the API

### DIFF
--- a/generate-dashboards.sh
+++ b/generate-dashboards.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+. versions.sh
+VERSIONS=$DEFAULT_VERSION
+
+usage="$(basename "$0") [-h] [-v comma separated versions ]  [-j additional dashboard to load to Grafana, multiple params are supported] [-M scylla-manager version ] -- Generates the grafana dashboards and their load files"
+
+while getopts ':hv:j:M:' option; do
+  case "$option" in
+    h) echo "$usage"
+       exit
+       ;;
+    v) VERSIONS=$OPTARG
+       ;;
+    M) MANAGER_VERSION=$OPTARG
+       ;;
+    j) GRAFANA_DASHBOARD_ARRAY+=("$OPTARG")
+       ;;
+  esac
+done
+
+function set_loader {
+    sed "s/NAME/$1/" grafana/load.yaml | sed "s/FOLDER/$2/" | sed "s/VERSION/$3/" > "grafana/provisioning/dashboards/load.$1.yaml"
+}
+
+mkdir -p grafana/build
+rm -f grafana/build/load.*.yml
+IFS=',' ;for v in $VERSIONS; do
+VERDIR="grafana/build/ver_$v"
+mkdir -p $VERDIR
+set_loader $v $v "ver_$v"
+for f in scylla-dash scylla-dash-per-server scylla-dash-io-per-server scylla-dash-cpu-per-server scylla-dash-per-machine; do
+    if [ -e grafana/$f.$v.template.json ]
+    then
+        if [ ! -f "$VERDIR/$f.$v.json" ] || [ "$VERDIR/$f.$v.json" -ot "grafana/$f.$v.template.json" ]; then
+            ./make_dashboards.py -af $VERDIR -t grafana/types.json -d grafana/$f.$v.template.json
+        fi
+    else
+        if [ -f grafana/$f.$v.json ]
+        then
+            cp grafana/$f.$v.json $VERDIR
+        fi
+    fi
+done
+done
+
+if [ -e grafana/scylla-manager.$MANAGER_VERSION.template.json ]
+then
+    VERDIR="grafana/build/manager_$MANAGER_VERSION"
+    mkdir -p $VERDIR
+    set_loader "manager_$MANAGER_VERSION" "manager_$MANAGER_VERSION" "manager_$MANAGER_VERSION"
+    if [ ! -f "$VERDIR/scylla-manager.$MANAGER_VERSION.json" ] || [ "$VERDIR/scylla-manager.$MANAGER_VERSION.json" -ot "grafana/scylla-manager.$MANAGER_VERSION.template.json" ]; then
+        ./make_dashboards.py -af $VERDIR -t grafana/types.json -d grafana/scylla-manager.$MANAGER_VERSION.template.json
+    fi
+fi
+
+for val in "${GRAFANA_DASHBOARD_ARRAY[@]}"; do
+    VERDIR="grafana/build/default"
+    set_loader "default" "" "default"
+    mkdir -p $VERDIR
+    if [[ $val == *".template.json" ]]; then
+        val1=${val::-14}
+        val1=${val1:8}
+        if [ ! -f $VERDIR/$val1.json ] || [ $VERDIR/$val1.json -ot $val ]; then
+           ./make_dashboards.py -af $VERDIR -t grafana/types.json -d $val
+        fi
+    else
+       cp $val $VERDIR
+    fi
+done
+

--- a/grafana/datasource.yml
+++ b/grafana/datasource.yml
@@ -1,0 +1,26 @@
+# config file version
+apiVersion: 1
+datasources:
+- name: prometheus
+  type: prometheus
+  url: http://DB_ADDRESS
+  access: proxy
+  basicAuth: false
+
+- name: alertmanager
+  type: camptocamp-prometheus-alertmanager-datasource
+  orgId: 1
+  typeLogoUrl: public/img/icn-datasource.svg
+  access: proxy
+  url: http://AM_ADDRESS
+  password: 
+  user: 
+  database: 
+  basicAuth: 
+  isDefault: 
+  jsonData:
+    severity_critical: '4'
+    severity_high: '3'
+    severity_warning: '2'
+    severity_info: '1'
+  

--- a/grafana/load.yaml
+++ b/grafana/load.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+- name: 'NAME'
+  orgId: 1
+  folder: 'FOLDER'
+  type: file
+  disableDeletion: false
+  updateIntervalSeconds: 10 #how often Grafana will scan for changed dashboards
+  options:
+    path: /var/lib/grafana/dashboards/VERSION

--- a/make_dashboards.py
+++ b/make_dashboards.py
@@ -24,6 +24,7 @@ from __future__ import print_function
 import argparse
 import json
 import re
+import os
 
 parser = argparse.ArgumentParser(description='Dashboards creating tool', conflict_handler="resolve")
 parser.add_argument('-t', '--type', action='append', help='Types file')
@@ -32,6 +33,7 @@ parser.add_argument('-r', '--reverse', action='store_true', default=False, help=
 parser.add_argument('-G', '--grafana4', action='store_true', default=False, help='Do not Migrate the dashboard to the grafa 5 format, if not set the script will remove and emulate the rows with a single panels')
 parser.add_argument('-h', '--help', action='store_true', default=False, help='Print help information')
 parser.add_argument('-kt', '--key-tips', action='store_true', default=False, help='Add key tips when there are conflict values between the template and the value')
+parser.add_argument('-af', '--as-file', type=str, default="", help='Make the dashboard ready to be loaded as files and not with http, when not empty, state the directory the file will be written to')
 
 def help(args):
     parser.print_help()
@@ -242,6 +244,10 @@ def make_grafna_5(results, args):
     del results["dashboard"]["rows"]
     results["dashboard"]["panels"] = panels
 
+def write_as_file(name_path, result, dir):
+    name = os.path.basename(name_path)
+    write_json(os.path.join(dir, name), result["dashboard"])
+
 def get_dashboard(name, types, args):
     global id
     id = 1
@@ -250,7 +256,10 @@ def get_dashboard(name, types, args):
     update_object(result, types)
     if not args.grafana4:
         make_grafna_5(result, args)
-    write_json(new_name, result)
+    if args.as_file:
+        write_as_file(new_name, result, args.as_file)
+    else:
+        write_json(new_name, result)
     
 def compact_dashboard(name, type, args):
     new_name = name.replace(".json", ".template.json")


### PR DESCRIPTION
This series changes how grafana load its dashboards, data-sources and plugins.

Instead of using the API, everything will be done from local files.

To do that the generated dashboard will be generated in a file format vs API format.
Using grafana 5 folders, each dashboard will be generated in its own version directory and a load file will be placed in the grafana dashboard directory to load all the files of that versions.

Fixes #222 #452 #48