### PR TITLE
Prometheus: move the name relabaling to metric_relabel_configs

### DIFF
--- a/prometheus/prometheus.yml.template
+++ b/prometheus/prometheus.yml.template
@@ -44,6 +44,7 @@ scrape_configs:
       regex:  '(.*):\d+'
       target_label: __address__
       replacement: '${1}:9100'
+  metric_relabel_configs:
     - source_labels: [__name__]
       regex:  'node_disk_read_bytes_total'
       target_label: __name__


### PR DESCRIPTION
Prometheus does not replace the metrics name when it also needs to
replace the __address__.

To overcome this, we can move the __name__ relabling to the
metric_relabel_configs section, which is perform after the
relabel_config part.