### PR TITLE
prometheus.yml.template: Support config ips without configuring ports

### DIFF
--- a/prometheus/prometheus.yml.template
+++ b/prometheus/prometheus.yml.template
@@ -26,6 +26,11 @@ scrape_configs:
       - /etc/scylla.d/prometheus/scylla_servers.yml
   relabel_configs:
     - source_labels: [__address__]
+      regex:  '([^:]+)'
+      target_label: __address__
+      replacement: '${1}:9180'
+
+    - source_labels: [__address__]
       regex:  '(.*):.+'
       target_label: instance
       replacement: '${1}'
@@ -41,9 +46,14 @@ scrape_configs:
       target_label: instance
       replacement: '${1}'
     - source_labels: [__address__]
-      regex:  '(.*):\d+'
+      regex:  '([^:]+)'
+      target_label: instance
+      replacement: '${1}'
+    - source_labels: [instance]
+      regex:  '(.*)'
       target_label: __address__
       replacement: '${1}:9100'
+
   metric_relabel_configs:
     - source_labels: [__name__]
       regex:  'node_disk_read_bytes_total'


### PR DESCRIPTION
This patch adds to the existing patch that unified scylla and node_exporter files.
It is now possible to set only the IPs without the ports numbers and prometheus will assume Scylla's default port