### PR TITLE
do not specify any particular group when aggregating violations.

### DIFF
--- a/grafana/scylla-dash-cpu-per-server.2.3.template.json
+++ b/grafana/scylla-dash-cpu-per-server.2.3.template.json
@@ -69,7 +69,7 @@
                         "pointradius": 1,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_scheduler_time_spent_on_task_quota_violations_ns{group=\"main\",instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_scheduler_time_spent_on_task_quota_violations_ns{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",

--- a/grafana/scylla-dash-cpu-per-server.3.0.template.json
+++ b/grafana/scylla-dash-cpu-per-server.3.0.template.json
@@ -69,7 +69,7 @@
                         "pointradius": 1,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_scheduler_time_spent_on_task_quota_violations_ms{group=\"main\",instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_scheduler_time_spent_on_task_quota_violations_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",

--- a/grafana/scylla-dash-cpu-per-server.master.template.json
+++ b/grafana/scylla-dash-cpu-per-server.master.template.json
@@ -63,7 +63,7 @@
                         "pointradius": 1,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_scheduler_time_spent_on_task_quota_violations_ms{group=\"main\",instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_scheduler_time_spent_on_task_quota_violations_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",


### PR DESCRIPTION
We are interested in seeing all violations, not just the ones from the main class.
In particular, the main class tends to be very uninteresting. Most of the violations
come from somewhere else.

Fixes #524

Signed-off-by: Glauber Costa <glauber@scylladb.com>