### PR TITLE
genconfig: move to python 3 and support dc

### DIFF
--- a/genconfig.py
+++ b/genconfig.py
@@ -35,12 +35,7 @@ def get_servers_from_nodetool_status(filename):
 
 
 def dump_yaml(directory, filename, servers, cluster):
-    try:
-        Path(directory).mkdir(exist_ok=True)
-    except OSError as err:
-        if err.errno != 17:
-            raise
-        pass
+    Path(directory).mkdir(parents=True, exist_ok=True)
     with open(Path(directory).joinpath(Path(filename)), 'w') as yml_file:
         yaml.dump([gen_targets(s, cluster) for s in servers], yml_file, default_flow_style=False)
 

--- a/genconfig.py
+++ b/genconfig.py
@@ -1,42 +1,60 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import argparse
 import os
 import yaml
+import re
 
-scylla_port = 9180
-node_exporter_port = 9100
+def gen_targets(servers, cluster):
+    if ':' not in servers:
+        raise Exception('Server list must contain a dc name')
+    dcs = servers.split(':')
+    res = {"labels": {"cluster": cluster, "dc": dcs[0]}}
+    res["targets"] = dcs[1].split(',')
+    return res;
+
+def get_servers_from_nodetool_status(filename):
+    res = []
+    dc = None
+    ips = []
+    with open(filename, 'r') as status_file:
+        for l in status_file.readlines():
+            if dc:
+                ip = re.search(r"..  ([\d\.]+)\s", l)
+                if ip:
+                    ips.append(ip.group(1))
+            m = re.search(r"Datacenter: (.*)$", l)
+            if m:
+                if dc:
+                    res.append(dc + ":" + ",".join(ips))
+                ips = []
+                dc = m.group(1)
+    if dc:
+        res.append(dc + ":" + ",".join(ips))
+    return res
 
 
-def append_port(ips, port):
-    return ["%s:%s" % (x, port) for x in ips]
-
-
-def gen_targets(servers, port):
-    return {"targets": append_port(servers, port)}
-
-
-def dump_yaml(directory, filename, servers, port):
+def dump_yaml(directory, filename, servers, cluster):
     try:
         os.mkdir(directory)
-    except OSError, err:
+    except OSError as err:
         if err.errno != 17:
             raise
         pass
-    stream = file(os.path.join(directory, filename), 'w')
-    yaml.dump([gen_targets(servers, port)], stream)
+    with open(os.path.join(directory, filename), 'w') as yml_file:
+        yaml.dump([gen_targets(s, cluster) for s in servers], yml_file, default_flow_style=False)
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Generate configuration for prometheus")
     parser.add_argument('-d', '--directory', help="directory where to generate the configuration files", type=str, default="./")
-    parser.add_argument('-s', '--scylla', help="Generate scylla_servers.yml file", action='store_true')
-    parser.add_argument('-n', '--node', help="Generate node_exporter_servers.yml file", action='store_true')
-    parser.add_argument('servers', help="list of nodes to configure, separated by space", nargs='+', type=str, metavar='node_ip')
+    parser.add_argument('-c', '--cluster', help="The cluster name", type=str, default="my-cluster")
+    parser.add_argument('-ns', '--nodetool-status', help="A file containing nodetool status", type=str)
+    parser.add_argument('servers', help="list of dc and nodes to configure separated by space. Each dc/node entry is a combination of {dc}:ip1,ip2..ipn", nargs='*', type=str, metavar='node_ip')
     arguments = parser.parse_args()
 
-    if arguments.scylla:
-        dump_yaml(arguments.directory, 'scylla_servers.yml', arguments.servers, scylla_port)
+    if arguments.nodetool_status:
+        dump_yaml(arguments.directory, 'scylla_servers.yml', get_servers_from_nodetool_status(arguments.nodetool_status), arguments.cluster)
+    else:
+        dump_yaml(arguments.directory, 'scylla_servers.yml', arguments.servers, arguments.cluster)
 
-    if arguments.node:
-        dump_yaml(arguments.directory, 'node_exporter_servers.yml', arguments.servers, node_exporter_port)

--- a/genconfig.py
+++ b/genconfig.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 import argparse
-import os
+from pathlib import Path
 import yaml
 import re
 
@@ -36,12 +36,12 @@ def get_servers_from_nodetool_status(filename):
 
 def dump_yaml(directory, filename, servers, cluster):
     try:
-        os.mkdir(directory)
+        Path(directory).mkdir(exist_ok=True)
     except OSError as err:
         if err.errno != 17:
             raise
         pass
-    with open(os.path.join(directory, filename), 'w') as yml_file:
+    with open(Path(directory).joinpath(Path(filename)), 'w') as yml_file:
         yaml.dump([gen_targets(s, cluster) for s in servers], yml_file, default_flow_style=False)
 
 


### PR DESCRIPTION
This is patch changes the genconfig to use python3 and add datacenter
support.

There are two ways of configure datacenter:
1. from the command line using dc:ip,ip,ip
for example:
genconfig.py dc1:127.0.0.1,127.0.0.2

2. from file using nodetool status output
for example
genconfig.py -ns f.txt

where f.txt holds the nodetool status output

Fixes #513

Signed-off-by: Amnon Heiman <amnon@scylladb.com>