### PR TITLE
Fix chart legend formats

### DIFF
--- a/grafana/scylla-dash-per-server.2.0.json
+++ b/grafana/scylla-dash-per-server.2.0.json
@@ -2329,7 +2329,7 @@
                             {
                                 "expr": "irate(node_disk_writes_completed{device=\"$monitor_disk\"}[30s])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Disk Writes per Server per Second",
+                                "legendFormat": "{{ instance }} / {{ device }}",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 1
@@ -2412,7 +2412,7 @@
                                 "expr": "irate(node_disk_reads_completed{device=\"$monitor_disk\"}[30s])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "Disk Reads per Server per Second",
+                                "legendFormat": "{{ instance }} / {{ device }}",
                                 "step": 1
                             }
                         ],
@@ -2664,7 +2664,7 @@
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "Disk Writes Bps per Server",
+                                "legendFormat": "{{ instance }} / {{ device }}",
                                 "step": 1
                             }
                         ],
@@ -2745,7 +2745,7 @@
                                 "expr": "irate(node_disk_bytes_read{device=\"$monitor_disk\"}[30s])",
                                 "intervalFactor": 1,
                                 "refId": "A",
-                                "legendFormat": "Disk Read Bps per Server",
+                                "legendFormat": "{{ instance }} / {{ device }}",
                                 "step": 1
                             }
                         ],
@@ -3573,7 +3573,7 @@
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "Interface Rx Packets",
+                                "legendFormat": "{{ instance }}",
                                 "step": 1
                             }
                         ],
@@ -3655,7 +3655,7 @@
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "Interface Tx Packets",
+                                "legendFormat": "{{ instance }}",
                                 "step": 1
                             }
                         ],
@@ -3745,7 +3745,7 @@
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "Interface Rx Bps",
+                                "legendFormat": "{{ instance }}",
                                 "step": 1
                             }
                         ],
@@ -3827,7 +3827,7 @@
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "Interface Tx Bps",
+                                "legendFormat": "{{ instance }}",
                                 "step": 1
                             }
                         ],
@@ -4059,7 +4059,7 @@
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "CQL Inserts",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -4141,7 +4141,7 @@
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "CQL Reads",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -4223,7 +4223,7 @@
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "CQL Deletes",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],
@@ -4305,7 +4305,7 @@
                                 "intervalFactor": 1,
                                 "metric": "",
                                 "refId": "A",
-                                "legendFormat": "CQL Updates",
+                                "legendFormat": "",
                                 "step": 1
                             }
                         ],


### PR DESCRIPTION
Having the same static string for many graph series is not
very helpful as you can't tell the source instance when you
spot an anomaly in the graph.

Let's format the legend with instance and device for metrics
that are not dependent on `by` template parameter.

For metrics that change the grouping based on the `by` template
parameter we just use empty legend format since the tags that
generate series in the graph vary. With empty legend format,
Grafana includes all the information needed using its default
format.