### PR TITLE
Version per node

### DIFF
--- a/grafana/build/ver_2019.1/scylla-dash.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-dash.2019.1.json
@@ -384,7 +384,7 @@
             "error": false,
             "gridPos": {
                 "h": 6,
-                "w": 2,
+                "w": 4,
                 "x": 8,
                 "y": 4
             },
@@ -392,11 +392,37 @@
             "isNew": true,
             "links": [],
             "mode": "markdown",
-            "span": 1,
+            "span": 2,
             "style": {},
             "title": "",
             "transparent": true,
             "type": "text"
+        },
+        {
+            "class": "dashlist",
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 6,
+                "w": 4,
+                "x": 12,
+                "y": 4
+            },
+            "headings": false,
+            "id": 7,
+            "isNew": true,
+            "limit": 10,
+            "links": [],
+            "query": "",
+            "recent": false,
+            "search": true,
+            "span": 2,
+            "starred": false,
+            "tags": [
+                "2019.1"
+            ],
+            "title": "Dashboards",
+            "type": "dashlist"
         },
         {
             "aliasColors": {},
@@ -416,11 +442,11 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 10,
-                "x": 10,
+                "w": 8,
+                "x": 16,
                 "y": 4
             },
-            "id": 7,
+            "id": 8,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -447,7 +473,7 @@
                 "col": 0,
                 "desc": true
             },
-            "span": 5,
+            "span": 4,
             "stack": false,
             "steppedLine": false,
             "styles": [
@@ -461,34 +487,29 @@
                     "type": "date"
                 },
                 {
-                    "alias": "",
-                    "colorMode": null,
-                    "colors": [
-                        "rgba(245, 54, 54, 0.9)",
-                        "rgba(237, 129, 40, 0.89)",
-                        "rgba(50, 172, 45, 0.97)"
-                    ],
-                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                    "decimals": 2,
-                    "pattern": "Severity",
-                    "thresholds": [],
-                    "type": "hidden",
-                    "unit": "short"
+                    "class": "hidden_column",
+                    "pattern": "severity",
+                    "type": "hidden"
                 },
                 {
-                    "alias": "",
-                    "colorMode": null,
-                    "colors": [
-                        "rgba(245, 54, 54, 0.9)",
-                        "rgba(237, 129, 40, 0.89)",
-                        "rgba(50, 172, 45, 0.97)"
-                    ],
-                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                    "decimals": 2,
-                    "pattern": "Alertname",
-                    "thresholds": [],
-                    "type": "hidden",
-                    "unit": "short"
+                    "class": "hidden_column",
+                    "pattern": "alertname",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "cluster",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "monitor",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "summary",
+                    "type": "hidden"
                 },
                 {
                     "alias": "Instance",
@@ -566,32 +587,6 @@
             ]
         },
         {
-            "class": "dashlist",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 4,
-                "x": 20,
-                "y": 4
-            },
-            "headings": false,
-            "id": 8,
-            "isNew": true,
-            "limit": 10,
-            "links": [],
-            "query": "",
-            "recent": false,
-            "search": true,
-            "span": 2,
-            "starred": false,
-            "tags": [
-                "2019.1"
-            ],
-            "title": "Dashboards",
-            "type": "dashlist"
-        },
-        {
             "aliasColors": {},
             "bars": false,
             "class": "percent_panel",
@@ -608,7 +603,7 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 10,
+                "w": 8,
                 "x": 0,
                 "y": 10
             },
@@ -634,7 +629,7 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 5,
+            "span": 4,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -694,8 +689,8 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 10,
-                "x": 10,
+                "w": 8,
+                "x": 8,
                 "y": 10
             },
             "id": 10,
@@ -720,7 +715,7 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 5,
+            "span": 4,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -764,6 +759,102 @@
             ]
         },
         {
+            "class": "single_value_table",
+            "columns": [
+                {
+                    "text": "Avg",
+                    "value": "avg"
+                }
+            ],
+            "datasource": "prometheus",
+            "description": "Nodes Information table",
+            "fontSize": "100%",
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 10
+            },
+            "id": 11,
+            "links": [],
+            "pageSize": null,
+            "scroll": true,
+            "showHeader": true,
+            "sort": {
+                "col": 0,
+                "desc": true
+            },
+            "span": 4,
+            "styles": [
+                {
+                    "alias": "",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the detailed node information",
+                    "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_6}",
+                    "mappingType": 1,
+                    "pattern": "instance",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "Time",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "__name__",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "exported_instance",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "job",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "type",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "Value",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "cluster",
+                    "type": "hidden"
+                }
+            ],
+            "targets": [
+                {
+                    "expr": "scylla_scylladb_current_version{cluster=~\"$cluster|$^\", dc=~\"$dc\"}",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 1,
+                    "refId": "A"
+                }
+            ],
+            "title": "Nodes",
+            "transform": "table",
+            "type": "table"
+        },
+        {
             "aliasColors": {},
             "bars": false,
             "class": "us_panel",
@@ -783,7 +874,7 @@
                 "x": 0,
                 "y": 16
             },
-            "id": 11,
+            "id": 12,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -868,7 +959,7 @@
                 "x": 8,
                 "y": 16
             },
-            "id": 12,
+            "id": 13,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -954,7 +1045,7 @@
                 "x": 16,
                 "y": 16
             },
-            "id": 13,
+            "id": 14,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1040,7 +1131,7 @@
                 "x": 0,
                 "y": 22
             },
-            "id": 14,
+            "id": 15,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1125,7 +1216,7 @@
                 "x": 8,
                 "y": 22
             },
-            "id": 15,
+            "id": 16,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1211,7 +1302,7 @@
                 "x": 16,
                 "y": 22
             },
-            "id": 16,
+            "id": 17,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1288,7 +1379,7 @@
                 "x": 0,
                 "y": 28
             },
-            "id": 17,
+            "id": 18,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -1309,7 +1400,7 @@
                 "x": 12,
                 "y": 28
             },
-            "id": 18,
+            "id": 19,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -1340,7 +1431,7 @@
                 "x": 0,
                 "y": 30
             },
-            "id": 19,
+            "id": 20,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1424,7 +1515,7 @@
                 "x": 6,
                 "y": 30
             },
-            "id": 20,
+            "id": 21,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1509,7 +1600,7 @@
                 "x": 12,
                 "y": 30
             },
-            "id": 21,
+            "id": 22,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1592,7 +1683,7 @@
                 "x": 18,
                 "y": 30
             },
-            "id": 22,
+            "id": 23,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1675,7 +1766,7 @@
                 "x": 0,
                 "y": 36
             },
-            "id": 23,
+            "id": 24,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1759,7 +1850,7 @@
                 "x": 6,
                 "y": 36
             },
-            "id": 24,
+            "id": 25,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1843,7 +1934,7 @@
                 "x": 12,
                 "y": 36
             },
-            "id": 25,
+            "id": 26,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1926,7 +2017,7 @@
                 "x": 18,
                 "y": 36
             },
-            "id": 26,
+            "id": 27,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1998,7 +2089,7 @@
                 "x": 0,
                 "y": 42
             },
-            "id": 27,
+            "id": 28,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -2018,7 +2109,7 @@
                 "x": 12,
                 "y": 42
             },
-            "id": 28,
+            "id": 29,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -2049,7 +2140,7 @@
                 "x": 0,
                 "y": 44
             },
-            "id": 29,
+            "id": 30,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2134,7 +2225,7 @@
                 "x": 6,
                 "y": 44
             },
-            "id": 30,
+            "id": 31,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2219,7 +2310,7 @@
                 "x": 12,
                 "y": 44
             },
-            "id": 31,
+            "id": 32,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2301,7 +2392,7 @@
                 "x": 18,
                 "y": 44
             },
-            "id": 32,
+            "id": 33,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2376,7 +2467,7 @@
                 "x": 0,
                 "y": 50
             },
-            "id": 33,
+            "id": 34,
             "isNew": true,
             "links": [],
             "mode": "markdown",
@@ -2406,7 +2497,7 @@
                 "x": 18,
                 "y": 50
             },
-            "id": 34,
+            "id": 35,
             "isNew": true,
             "legend": {
                 "avg": false,

--- a/grafana/build/ver_3.0/scylla-dash.3.0.json
+++ b/grafana/build/ver_3.0/scylla-dash.3.0.json
@@ -210,7 +210,7 @@
             "error": false,
             "gridPos": {
                 "h": 6,
-                "w": 6,
+                "w": 8,
                 "x": 4,
                 "y": 4
             },
@@ -218,11 +218,37 @@
             "isNew": true,
             "links": [],
             "mode": "markdown",
-            "span": 3,
+            "span": 4,
             "style": {},
             "title": "",
             "transparent": true,
             "type": "text"
+        },
+        {
+            "class": "dashlist",
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 6,
+                "w": 4,
+                "x": 12,
+                "y": 4
+            },
+            "headings": false,
+            "id": 5,
+            "isNew": true,
+            "limit": 10,
+            "links": [],
+            "query": "",
+            "recent": false,
+            "search": true,
+            "span": 2,
+            "starred": false,
+            "tags": [
+                "3.0"
+            ],
+            "title": "Dashboards",
+            "type": "dashlist"
         },
         {
             "aliasColors": {},
@@ -242,11 +268,11 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 10,
-                "x": 10,
+                "w": 8,
+                "x": 16,
                 "y": 4
             },
-            "id": 5,
+            "id": 6,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -273,7 +299,7 @@
                 "col": 0,
                 "desc": true
             },
-            "span": 5,
+            "span": 4,
             "stack": false,
             "steppedLine": false,
             "styles": [
@@ -287,34 +313,29 @@
                     "type": "date"
                 },
                 {
-                    "alias": "",
-                    "colorMode": null,
-                    "colors": [
-                        "rgba(245, 54, 54, 0.9)",
-                        "rgba(237, 129, 40, 0.89)",
-                        "rgba(50, 172, 45, 0.97)"
-                    ],
-                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                    "decimals": 2,
-                    "pattern": "Severity",
-                    "thresholds": [],
-                    "type": "hidden",
-                    "unit": "short"
+                    "class": "hidden_column",
+                    "pattern": "severity",
+                    "type": "hidden"
                 },
                 {
-                    "alias": "",
-                    "colorMode": null,
-                    "colors": [
-                        "rgba(245, 54, 54, 0.9)",
-                        "rgba(237, 129, 40, 0.89)",
-                        "rgba(50, 172, 45, 0.97)"
-                    ],
-                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                    "decimals": 2,
-                    "pattern": "Alertname",
-                    "thresholds": [],
-                    "type": "hidden",
-                    "unit": "short"
+                    "class": "hidden_column",
+                    "pattern": "alertname",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "cluster",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "monitor",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "summary",
+                    "type": "hidden"
                 },
                 {
                     "alias": "Instance",
@@ -392,32 +413,6 @@
             ]
         },
         {
-            "class": "dashlist",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 4,
-                "x": 20,
-                "y": 4
-            },
-            "headings": false,
-            "id": 6,
-            "isNew": true,
-            "limit": 10,
-            "links": [],
-            "query": "",
-            "recent": false,
-            "search": true,
-            "span": 2,
-            "starred": false,
-            "tags": [
-                "3.0"
-            ],
-            "title": "Dashboards",
-            "type": "dashlist"
-        },
-        {
             "aliasColors": {},
             "bars": false,
             "class": "percent_panel",
@@ -434,7 +429,7 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 10,
+                "w": 8,
                 "x": 0,
                 "y": 10
             },
@@ -460,7 +455,7 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 5,
+            "span": 4,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -520,8 +515,8 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 10,
-                "x": 10,
+                "w": 8,
+                "x": 8,
                 "y": 10
             },
             "id": 8,
@@ -546,7 +541,7 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 5,
+            "span": 4,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -590,6 +585,102 @@
             ]
         },
         {
+            "class": "single_value_table",
+            "columns": [
+                {
+                    "text": "Avg",
+                    "value": "avg"
+                }
+            ],
+            "datasource": "prometheus",
+            "description": "Nodes Information table",
+            "fontSize": "100%",
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 10
+            },
+            "id": 9,
+            "links": [],
+            "pageSize": null,
+            "scroll": true,
+            "showHeader": true,
+            "sort": {
+                "col": 0,
+                "desc": true
+            },
+            "span": 4,
+            "styles": [
+                {
+                    "alias": "",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the detailed node information",
+                    "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_6}",
+                    "mappingType": 1,
+                    "pattern": "instance",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "Time",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "__name__",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "exported_instance",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "job",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "type",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "Value",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "cluster",
+                    "type": "hidden"
+                }
+            ],
+            "targets": [
+                {
+                    "expr": "scylla_scylladb_current_version{cluster=~\"$cluster|$^\", dc=~\"$dc\"}",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 1,
+                    "refId": "A"
+                }
+            ],
+            "title": "Nodes",
+            "transform": "table",
+            "type": "table"
+        },
+        {
             "aliasColors": {},
             "bars": false,
             "class": "us_panel",
@@ -609,7 +700,7 @@
                 "x": 0,
                 "y": 16
             },
-            "id": 9,
+            "id": 10,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -694,7 +785,7 @@
                 "x": 8,
                 "y": 16
             },
-            "id": 10,
+            "id": 11,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -780,7 +871,7 @@
                 "x": 16,
                 "y": 16
             },
-            "id": 11,
+            "id": 12,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -866,7 +957,7 @@
                 "x": 0,
                 "y": 22
             },
-            "id": 12,
+            "id": 13,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -951,7 +1042,7 @@
                 "x": 8,
                 "y": 22
             },
-            "id": 13,
+            "id": 14,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1037,7 +1128,7 @@
                 "x": 16,
                 "y": 22
             },
-            "id": 14,
+            "id": 15,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1114,7 +1205,7 @@
                 "x": 0,
                 "y": 28
             },
-            "id": 15,
+            "id": 16,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -1135,7 +1226,7 @@
                 "x": 12,
                 "y": 28
             },
-            "id": 16,
+            "id": 17,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -1166,7 +1257,7 @@
                 "x": 0,
                 "y": 30
             },
-            "id": 17,
+            "id": 18,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1250,7 +1341,7 @@
                 "x": 6,
                 "y": 30
             },
-            "id": 18,
+            "id": 19,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1335,7 +1426,7 @@
                 "x": 12,
                 "y": 30
             },
-            "id": 19,
+            "id": 20,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1418,7 +1509,7 @@
                 "x": 18,
                 "y": 30
             },
-            "id": 20,
+            "id": 21,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1501,7 +1592,7 @@
                 "x": 0,
                 "y": 36
             },
-            "id": 21,
+            "id": 22,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1585,7 +1676,7 @@
                 "x": 6,
                 "y": 36
             },
-            "id": 22,
+            "id": 23,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1669,7 +1760,7 @@
                 "x": 12,
                 "y": 36
             },
-            "id": 23,
+            "id": 24,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1752,7 +1843,7 @@
                 "x": 18,
                 "y": 36
             },
-            "id": 24,
+            "id": 25,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1824,7 +1915,7 @@
                 "x": 0,
                 "y": 42
             },
-            "id": 25,
+            "id": 26,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -1844,7 +1935,7 @@
                 "x": 12,
                 "y": 42
             },
-            "id": 26,
+            "id": 27,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -1875,7 +1966,7 @@
                 "x": 0,
                 "y": 44
             },
-            "id": 27,
+            "id": 28,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1960,7 +2051,7 @@
                 "x": 6,
                 "y": 44
             },
-            "id": 28,
+            "id": 29,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2045,7 +2136,7 @@
                 "x": 12,
                 "y": 44
             },
-            "id": 29,
+            "id": 30,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2127,7 +2218,7 @@
                 "x": 18,
                 "y": 44
             },
-            "id": 30,
+            "id": 31,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2202,7 +2293,7 @@
                 "x": 0,
                 "y": 50
             },
-            "id": 31,
+            "id": 32,
             "isNew": true,
             "links": [],
             "mode": "markdown",
@@ -2232,7 +2323,7 @@
                 "x": 18,
                 "y": 50
             },
-            "id": 32,
+            "id": 33,
             "isNew": true,
             "legend": {
                 "avg": false,

--- a/grafana/build/ver_master/scylla-dash.master.json
+++ b/grafana/build/ver_master/scylla-dash.master.json
@@ -384,7 +384,7 @@
             "error": false,
             "gridPos": {
                 "h": 6,
-                "w": 2,
+                "w": 4,
                 "x": 8,
                 "y": 4
             },
@@ -392,11 +392,37 @@
             "isNew": true,
             "links": [],
             "mode": "markdown",
-            "span": 1,
+            "span": 2,
             "style": {},
             "title": "",
             "transparent": true,
             "type": "text"
+        },
+        {
+            "class": "dashlist",
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 6,
+                "w": 4,
+                "x": 12,
+                "y": 4
+            },
+            "headings": false,
+            "id": 7,
+            "isNew": true,
+            "limit": 10,
+            "links": [],
+            "query": "",
+            "recent": false,
+            "search": true,
+            "span": 2,
+            "starred": false,
+            "tags": [
+                "master"
+            ],
+            "title": "Dashboards",
+            "type": "dashlist"
         },
         {
             "aliasColors": {},
@@ -416,11 +442,11 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 10,
-                "x": 10,
+                "w": 8,
+                "x": 16,
                 "y": 4
             },
-            "id": 7,
+            "id": 8,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -447,7 +473,7 @@
                 "col": 0,
                 "desc": true
             },
-            "span": 5,
+            "span": 4,
             "stack": false,
             "steppedLine": false,
             "styles": [
@@ -461,34 +487,29 @@
                     "type": "date"
                 },
                 {
-                    "alias": "",
-                    "colorMode": null,
-                    "colors": [
-                        "rgba(245, 54, 54, 0.9)",
-                        "rgba(237, 129, 40, 0.89)",
-                        "rgba(50, 172, 45, 0.97)"
-                    ],
-                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                    "decimals": 2,
-                    "pattern": "Severity",
-                    "thresholds": [],
-                    "type": "hidden",
-                    "unit": "short"
+                    "class": "hidden_column",
+                    "pattern": "severity",
+                    "type": "hidden"
                 },
                 {
-                    "alias": "",
-                    "colorMode": null,
-                    "colors": [
-                        "rgba(245, 54, 54, 0.9)",
-                        "rgba(237, 129, 40, 0.89)",
-                        "rgba(50, 172, 45, 0.97)"
-                    ],
-                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                    "decimals": 2,
-                    "pattern": "Alertname",
-                    "thresholds": [],
-                    "type": "hidden",
-                    "unit": "short"
+                    "class": "hidden_column",
+                    "pattern": "alertname",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "cluster",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "monitor",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "summary",
+                    "type": "hidden"
                 },
                 {
                     "alias": "Instance",
@@ -566,32 +587,6 @@
             ]
         },
         {
-            "class": "dashlist",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 4,
-                "x": 20,
-                "y": 4
-            },
-            "headings": false,
-            "id": 8,
-            "isNew": true,
-            "limit": 10,
-            "links": [],
-            "query": "",
-            "recent": false,
-            "search": true,
-            "span": 2,
-            "starred": false,
-            "tags": [
-                "master"
-            ],
-            "title": "Dashboards",
-            "type": "dashlist"
-        },
-        {
             "aliasColors": {},
             "bars": false,
             "class": "percent_panel",
@@ -608,7 +603,7 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 10,
+                "w": 8,
                 "x": 0,
                 "y": 10
             },
@@ -634,7 +629,7 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 5,
+            "span": 4,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -694,8 +689,8 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 10,
-                "x": 10,
+                "w": 8,
+                "x": 8,
                 "y": 10
             },
             "id": 10,
@@ -720,7 +715,7 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 5,
+            "span": 4,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -764,6 +759,102 @@
             ]
         },
         {
+            "class": "single_value_table",
+            "columns": [
+                {
+                    "text": "Avg",
+                    "value": "avg"
+                }
+            ],
+            "datasource": "prometheus",
+            "description": "Nodes Information table",
+            "fontSize": "100%",
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 10
+            },
+            "id": 11,
+            "links": [],
+            "pageSize": null,
+            "scroll": true,
+            "showHeader": true,
+            "sort": {
+                "col": 0,
+                "desc": true
+            },
+            "span": 4,
+            "styles": [
+                {
+                    "alias": "",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the detailed node information",
+                    "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_6}",
+                    "mappingType": 1,
+                    "pattern": "instance",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "Time",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "__name__",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "exported_instance",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "job",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "type",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "Value",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "cluster",
+                    "type": "hidden"
+                }
+            ],
+            "targets": [
+                {
+                    "expr": "scylla_scylladb_current_version{cluster=~\"$cluster|$^\", dc=~\"$dc\"}",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 1,
+                    "refId": "A"
+                }
+            ],
+            "title": "Nodes",
+            "transform": "table",
+            "type": "table"
+        },
+        {
             "aliasColors": {},
             "bars": false,
             "class": "us_panel",
@@ -783,7 +874,7 @@
                 "x": 0,
                 "y": 16
             },
-            "id": 11,
+            "id": 12,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -868,7 +959,7 @@
                 "x": 8,
                 "y": 16
             },
-            "id": 12,
+            "id": 13,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -954,7 +1045,7 @@
                 "x": 16,
                 "y": 16
             },
-            "id": 13,
+            "id": 14,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1040,7 +1131,7 @@
                 "x": 0,
                 "y": 22
             },
-            "id": 14,
+            "id": 15,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1125,7 +1216,7 @@
                 "x": 8,
                 "y": 22
             },
-            "id": 15,
+            "id": 16,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1211,7 +1302,7 @@
                 "x": 16,
                 "y": 22
             },
-            "id": 16,
+            "id": 17,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1288,7 +1379,7 @@
                 "x": 0,
                 "y": 28
             },
-            "id": 17,
+            "id": 18,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -1309,7 +1400,7 @@
                 "x": 12,
                 "y": 28
             },
-            "id": 18,
+            "id": 19,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -1340,7 +1431,7 @@
                 "x": 0,
                 "y": 30
             },
-            "id": 19,
+            "id": 20,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1424,7 +1515,7 @@
                 "x": 6,
                 "y": 30
             },
-            "id": 20,
+            "id": 21,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1509,7 +1600,7 @@
                 "x": 12,
                 "y": 30
             },
-            "id": 21,
+            "id": 22,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1592,7 +1683,7 @@
                 "x": 18,
                 "y": 30
             },
-            "id": 22,
+            "id": 23,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1675,7 +1766,7 @@
                 "x": 0,
                 "y": 36
             },
-            "id": 23,
+            "id": 24,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1759,7 +1850,7 @@
                 "x": 6,
                 "y": 36
             },
-            "id": 24,
+            "id": 25,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1843,7 +1934,7 @@
                 "x": 12,
                 "y": 36
             },
-            "id": 25,
+            "id": 26,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1926,7 +2017,7 @@
                 "x": 18,
                 "y": 36
             },
-            "id": 26,
+            "id": 27,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1998,7 +2089,7 @@
                 "x": 0,
                 "y": 42
             },
-            "id": 27,
+            "id": 28,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -2018,7 +2109,7 @@
                 "x": 12,
                 "y": 42
             },
-            "id": 28,
+            "id": 29,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -2049,7 +2140,7 @@
                 "x": 0,
                 "y": 44
             },
-            "id": 29,
+            "id": 30,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2134,7 +2225,7 @@
                 "x": 6,
                 "y": 44
             },
-            "id": 30,
+            "id": 31,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2219,7 +2310,7 @@
                 "x": 12,
                 "y": 44
             },
-            "id": 31,
+            "id": 32,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2301,7 +2392,7 @@
                 "x": 18,
                 "y": 44
             },
-            "id": 32,
+            "id": 33,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2376,7 +2467,7 @@
                 "x": 0,
                 "y": 50
             },
-            "id": 33,
+            "id": 34,
             "isNew": true,
             "links": [],
             "mode": "markdown",
@@ -2406,7 +2497,7 @@
                 "x": 18,
                 "y": 50
             },
-            "id": 34,
+            "id": 35,
             "isNew": true,
             "legend": {
                 "avg": false,

--- a/grafana/scylla-dash.2019.1.template.json
+++ b/grafana/scylla-dash.2019.1.template.json
@@ -72,18 +72,83 @@
                         "class": "text_panel",
                         "content": "##  ",
                         "mode": "markdown",
-                        "span": 1,
+                        "span": 2,
                         "style": {}
-                    },
-                    {
-                        "class": "alert_table",
-                        "title": "Active Alerts"
                     },
                     {
                         "class": "dashlist",
                         "tags": [
-                        	"2019.1"
-		                ]
+                            "2019.1"
+                        ]
+                    },
+                    {
+                        "class": "alert_table",
+                        "span":4,
+                        "styles": [
+                            {
+                                "alias": "Time",
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                                "pattern": "Time",
+                                "link": true,
+                                "linkTooltip": "Jump to the see the node",
+                                "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_4}&from=${__cell_0}",
+                                "type": "date"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "severity"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "alertname"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "cluster"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "monitor"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "summary"
+                            },
+                            {
+                              "alias": "Instance",
+                              "colorMode": null,
+                              "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                              ],
+                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                              "decimals": 2,
+                              "link": true,
+                              "linkTooltip": "Jump to the see the node",
+                              "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_4}",
+                              "mappingType": 1,
+                              "pattern": "instance",
+                              "thresholds": [],
+                              "type": "string",
+                              "unit": "short"
+                            },
+                            {
+                                "alias": "",
+                                "colorMode": null,
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)",
+                                    "rgba(237, 129, 40, 0.89)",
+                                    "rgba(50, 172, 45, 0.97)"
+                                ],
+                                "decimals": 2,
+                                "pattern": "/.*/",
+                                "thresholds": [],
+                                "type": "number",
+                                "unit": "short"
+                            }
+                        ],
+                        "title": "Active Alerts"
                     }
                 ],
                 "title": "New row"
@@ -93,6 +158,7 @@
                 "panels": [
                     {
                         "class": "percent_panel",
+                        "span": 4,
                         "targets": [
                             {
                                 "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
@@ -107,6 +173,7 @@
                     },
                     {
                         "class": "ops_panel",
+                        "span": 4,
                         "targets": [
                             {
                                 "expr": "$func(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + $func(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
@@ -119,6 +186,70 @@
                         ],
                         "title": "Requests Served",
                         "description": "Amount of requests served as the coordinator. Imbalances here represent dispersion at the client-side level or connection balancing level, not your data model."
+                    },
+                    {
+                        "class": "single_value_table",
+                        "span": 4,
+                        "description": "Nodes Information table",
+                        "targets": [
+                            {
+                              "refId": "A",
+                              "expr": "scylla_scylladb_current_version{cluster=~\"$cluster|$^\", dc=~\"$dc\"}",
+                              "intervalFactor": 1,
+                              "format": "table",
+                              "instant": true
+                            }
+                        ],
+                        "styles": [
+                            {
+                              "unit": "short",
+                              "type": "string",
+                              "alias": "",
+                              "decimals": 2,
+                              "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                              ],
+                              "colorMode": null,
+                              "pattern": "instance",
+                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                              "thresholds": [],
+                              "mappingType": 1,
+                              "link": true,
+                              "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_6}",
+                              "linkTooltip": "Jump to the detailed node information"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "Time"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "__name__"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "exported_instance"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "job"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "type"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "Value"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "cluster"
+                            }
+                        ],
+                        "title": "Nodes"
                     }
                 ],
                 "title": "New row"

--- a/grafana/scylla-dash.3.0.template.json
+++ b/grafana/scylla-dash.3.0.template.json
@@ -42,18 +42,83 @@
                         "class": "text_panel",
                         "content": "##  ",
                         "mode": "markdown",
-                        "span": 3,
+                        "span": 4,
                         "style": {}
-                    },
-                    {
-                        "class": "alert_table",
-                        "title": "Active Alerts"
                     },
                     {
                         "class": "dashlist",
                         "tags": [
-                        	"3.0"
-		                ]
+                            "3.0"
+                        ]
+                    },
+                    {
+                        "class": "alert_table",
+                        "span":4,
+                        "styles": [
+                            {
+                                "alias": "Time",
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                                "pattern": "Time",
+                                "link": true,
+                                "linkTooltip": "Jump to the see the node",
+                                "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_4}&from=${__cell_0}",
+                                "type": "date"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "severity"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "alertname"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "cluster"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "monitor"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "summary"
+                            },
+                            {
+                              "alias": "Instance",
+                              "colorMode": null,
+                              "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                              ],
+                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                              "decimals": 2,
+                              "link": true,
+                              "linkTooltip": "Jump to the see the node",
+                              "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_4}",
+                              "mappingType": 1,
+                              "pattern": "instance",
+                              "thresholds": [],
+                              "type": "string",
+                              "unit": "short"
+                            },
+                            {
+                                "alias": "",
+                                "colorMode": null,
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)",
+                                    "rgba(237, 129, 40, 0.89)",
+                                    "rgba(50, 172, 45, 0.97)"
+                                ],
+                                "decimals": 2,
+                                "pattern": "/.*/",
+                                "thresholds": [],
+                                "type": "number",
+                                "unit": "short"
+                            }
+                        ],
+                        "title": "Active Alerts"
                     }
                 ],
                 "title": "New row"
@@ -63,6 +128,7 @@
                 "panels": [
                     {
                         "class": "percent_panel",
+                        "span": 4,
                         "targets": [
                             {
                                 "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
@@ -77,6 +143,7 @@
                     },
                     {
                         "class": "ops_panel",
+                        "span": 4,
                         "targets": [
                             {
                                 "expr": "$func(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + $func(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
@@ -89,6 +156,70 @@
                         ],
                         "title": "Requests Served",
                         "description": "Amount of requests served as the coordinator. Imbalances here represent dispersion at the client-side level or connection balancing level, not your data model."
+                    },
+                    {
+                        "class": "single_value_table",
+                        "span": 4,
+                        "description": "Nodes Information table",
+                        "targets": [
+                            {
+                              "refId": "A",
+                              "expr": "scylla_scylladb_current_version{cluster=~\"$cluster|$^\", dc=~\"$dc\"}",
+                              "intervalFactor": 1,
+                              "format": "table",
+                              "instant": true
+                            }
+                        ],
+                        "styles": [
+                            {
+                              "unit": "short",
+                              "type": "string",
+                              "alias": "",
+                              "decimals": 2,
+                              "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                              ],
+                              "colorMode": null,
+                              "pattern": "instance",
+                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                              "thresholds": [],
+                              "mappingType": 1,
+                              "link": true,
+                              "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_6}",
+                              "linkTooltip": "Jump to the detailed node information"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "Time"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "__name__"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "exported_instance"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "job"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "type"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "Value"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "cluster"
+                            }
+                        ],
+                        "title": "Nodes"
                     }
                 ],
                 "title": "New row"

--- a/grafana/scylla-dash.master.template.json
+++ b/grafana/scylla-dash.master.template.json
@@ -72,18 +72,83 @@
                         "class": "text_panel",
                         "content": "##  ",
                         "mode": "markdown",
-                        "span": 1,
+                        "span": 2,
                         "style": {}
-                    },
-                    {
-                        "class": "alert_table",
-                        "title": "Active Alerts"
                     },
                     {
                         "class": "dashlist",
                         "tags": [
-                        	"master"
-		                ]
+                            "master"
+                        ]
+                    },
+                    {
+                        "class": "alert_table",
+                        "span":4,
+                        "styles": [
+                            {
+                                "alias": "Time",
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                                "pattern": "Time",
+                                "link": true,
+                                "linkTooltip": "Jump to the see the node",
+                                "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_4}&from=${__cell_0}",
+                                "type": "date"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "severity"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "alertname"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "cluster"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "monitor"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "summary"
+                            },
+                            {
+                              "alias": "Instance",
+                              "colorMode": null,
+                              "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                              ],
+                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                              "decimals": 2,
+                              "link": true,
+                              "linkTooltip": "Jump to the see the node",
+                              "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_4}",
+                              "mappingType": 1,
+                              "pattern": "instance",
+                              "thresholds": [],
+                              "type": "string",
+                              "unit": "short"
+                            },
+                            {
+                                "alias": "",
+                                "colorMode": null,
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)",
+                                    "rgba(237, 129, 40, 0.89)",
+                                    "rgba(50, 172, 45, 0.97)"
+                                ],
+                                "decimals": 2,
+                                "pattern": "/.*/",
+                                "thresholds": [],
+                                "type": "number",
+                                "unit": "short"
+                            }
+                        ],
+                        "title": "Active Alerts"
                     }
                 ],
                 "title": "New row"
@@ -93,6 +158,7 @@
                 "panels": [
                     {
                         "class": "percent_panel",
+                        "span": 4,
                         "targets": [
                             {
                                 "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
@@ -107,6 +173,7 @@
                     },
                     {
                         "class": "ops_panel",
+                        "span": 4,
                         "targets": [
                             {
                                 "expr": "$func(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + $func(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
@@ -119,6 +186,70 @@
                         ],
                         "title": "Requests Served",
                         "description": "Amount of requests served as the coordinator. Imbalances here represent dispersion at the client-side level or connection balancing level, not your data model."
+                    },
+                    {
+                        "class": "single_value_table",
+                        "span": 4,
+                        "description": "Nodes Information table",
+                        "targets": [
+                            {
+                              "refId": "A",
+                              "expr": "scylla_scylladb_current_version{cluster=~\"$cluster|$^\", dc=~\"$dc\"}",
+                              "intervalFactor": 1,
+                              "format": "table",
+                              "instant": true
+                            }
+                        ],
+                        "styles": [
+                            {
+                              "unit": "short",
+                              "type": "string",
+                              "alias": "",
+                              "decimals": 2,
+                              "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                              ],
+                              "colorMode": null,
+                              "pattern": "instance",
+                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                              "thresholds": [],
+                              "mappingType": 1,
+                              "link": true,
+                              "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_6}",
+                              "linkTooltip": "Jump to the detailed node information"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "Time"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "__name__"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "exported_instance"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "job"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "type"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "Value"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "cluster"
+                            }
+                        ],
+                        "title": "Nodes"
                     }
                 ],
                 "title": "New row"

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -724,6 +724,30 @@
         "transform": "table",
         "type": "table"
     },
+    "hidden_column" : {
+      "type": "hidden"
+    },
+    "single_value_table": {
+      "type": "table",
+      "id": "auto",
+      "datasource": "prometheus",
+      "transform": "table",
+      "pageSize": null,
+      "showHeader": true,
+      "columns": [
+        {
+          "text": "Avg",
+          "value": "avg"
+        }
+      ],
+      "scroll": true,
+      "fontSize": "100%",
+      "sort": {
+        "col": 0,
+        "desc": true
+      },
+      "links": []
+    },
     "template_variable_single" : {
             "allValue": null,
             "current": {


### PR DESCRIPTION
Fixes #151

This series adds a single stat panel that shows the number of running versions and a table with version per node.

![image](https://user-images.githubusercontent.com/2118079/58874014-57733b80-86d0-11e9-912e-9b2f3713111e.png)

When this patch will be ok I will add the enterprise and 3.0 dashboard.