### PR TITLE
genconfig cleaner nodetool implementation and allow specify outfile

### DIFF
--- a/genconfig.py
+++ b/genconfig.py
@@ -4,6 +4,7 @@ import argparse
 import os
 import yaml
 import re
+import sys
 
 def gen_targets(servers, cluster):
     if ':' not in servers:
@@ -13,22 +14,21 @@ def gen_targets(servers, cluster):
     res["targets"] = dcs[1].split(',')
     return res;
 
-def get_servers_from_nodetool_status(filename):
+def get_servers_from_nodetool_status():
     res = []
     dc = None
     ips = []
-    with open(filename, 'r') as status_file:
-        for l in status_file.readlines():
+    for l in sys.stdin:
+        if dc:
+            ip = re.search(r"..  ([\d\.]+)\s", l)
+            if ip:
+                ips.append(ip.group(1))
+        m = re.search(r"Datacenter: ([^\s]+)\s*$", l)
+        if m:
             if dc:
-                ip = re.search(r"..  ([\d\.]+)\s", l)
-                if ip:
-                    ips.append(ip.group(1))
-            m = re.search(r"Datacenter: (.*)$", l)
-            if m:
-                if dc:
-                    res.append(dc + ":" + ",".join(ips))
-                ips = []
-                dc = m.group(1)
+                res.append(dc + ":" + ",".join(ips))
+            ips = []
+            dc = m.group(1)
     if dc:
         res.append(dc + ":" + ",".join(ips))
     return res
@@ -60,17 +60,18 @@ if __name__ == "__main__":
     parser.add_argument('-s', '--scylla', help="Deprecated: Generate scylla_servers.yml file", action='store_true')
     parser.add_argument('-n', '--node', help="Deprecated: Generate node_exporter_servers.yml file", action='store_true')
     parser.add_argument('-c', '--cluster', help="The cluster name", type=str, default="my-cluster")
-    parser.add_argument('-NS', '--nodetool-status', help="A file containing nodetool status", type=str)
+    parser.add_argument('-o', '--output-file', help="The servers output file", type=str, default="scylla_servers.yml")
+    parser.add_argument('-NS', '--nodetool-status', help="Use nodetool status output. Output is read from stdin", action='store_true')
     parser.add_argument('servers', help="list of nodes to configure, separated by space", nargs='*', type=str, metavar='node_ip')
     parser.add_argument('-dc', '--datacenters', action='append', help="list of dc and nodes to configure separated by space. Each dc/node entry is a combination of {dc}:ip1,ip2..ipn")
     arguments = parser.parse_args()
 
     if arguments.nodetool_status:
-        dump_yaml(arguments.directory, 'scylla_servers.yml', get_servers_from_nodetool_status(arguments.nodetool_status), arguments.cluster)
+        dump_yaml(arguments.directory, arguments.output_file, get_servers_from_nodetool_status(), arguments.cluster)
     else:
         if arguments.servers:
-            dump_yaml_no_dc(arguments.directory, 'scylla_servers.yml', arguments.servers)
+            dump_yaml_no_dc(arguments.directory, arguments.output_file, arguments.servers)
         else:
-            dump_yaml(arguments.directory, 'scylla_servers.yml', arguments.datacenters , arguments.cluster)
+            dump_yaml(arguments.directory, arguments.output_file, arguments.datacenters , arguments.cluster)
     if arguments.node:
         dump_yaml_no_dc(arguments.directory, 'node_exporter_servers.yml', arguments.servers)


### PR DESCRIPTION
Fixes #613

This patch makes the following changes:
* instead of specifying a file name for `-NS` it read it from stdin
* ignores trailing whitespaces after a datacenter name
* add an option to specify the scylla_server file