### PR TITLE
Add status to node table

### DIFF
--- a/grafana/build/ver_2019.1/scylla-dash.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-dash.2019.1.json
@@ -831,9 +831,52 @@
                     "type": "hidden"
                 },
                 {
-                    "class": "hidden_column",
+                    "alias": "Status",
+                    "mappingType": 2,
                     "pattern": "Value",
-                    "type": "hidden"
+                    "rangeMaps": [
+                        {
+                            "from": "1",
+                            "text": "Starting",
+                            "to": "1"
+                        },
+                        {
+                            "from": "2",
+                            "text": "Joining",
+                            "to": "2"
+                        },
+                        {
+                            "from": "3",
+                            "text": "Normal",
+                            "to": "3"
+                        },
+                        {
+                            "from": "4",
+                            "text": "Leaving",
+                            "to": "4"
+                        },
+                        {
+                            "from": "5",
+                            "text": "Decommissioned",
+                            "to": "5"
+                        },
+                        {
+                            "from": "6",
+                            "text": "Draining",
+                            "to": "6"
+                        },
+                        {
+                            "from": "7",
+                            "text": "Drained",
+                            "to": "7"
+                        },
+                        {
+                            "from": "8",
+                            "text": "Moving",
+                            "to": "8"
+                        }
+                    ],
+                    "type": "string"
                 },
                 {
                     "class": "hidden_column",
@@ -843,7 +886,7 @@
             ],
             "targets": [
                 {
-                    "expr": "scylla_scylladb_current_version{cluster=~\"$cluster|$^\", dc=~\"$dc\"}",
+                    "expr": "0*scylla_scylladb_current_version{cluster=~\"$cluster|$^\", dc=~\"$dc\"} + on (instance) group_left() scylla_node_operation_mode",
                     "format": "table",
                     "instant": true,
                     "intervalFactor": 1,

--- a/grafana/build/ver_3.1/scylla-dash.3.1.json
+++ b/grafana/build/ver_3.1/scylla-dash.3.1.json
@@ -831,9 +831,52 @@
                     "type": "hidden"
                 },
                 {
-                    "class": "hidden_column",
+                    "alias": "Status",
+                    "mappingType": 2,
                     "pattern": "Value",
-                    "type": "hidden"
+                    "rangeMaps": [
+                        {
+                            "from": "1",
+                            "text": "Starting",
+                            "to": "1"
+                        },
+                        {
+                            "from": "2",
+                            "text": "Joining",
+                            "to": "2"
+                        },
+                        {
+                            "from": "3",
+                            "text": "Normal",
+                            "to": "3"
+                        },
+                        {
+                            "from": "4",
+                            "text": "Leaving",
+                            "to": "4"
+                        },
+                        {
+                            "from": "5",
+                            "text": "Decommissioned",
+                            "to": "5"
+                        },
+                        {
+                            "from": "6",
+                            "text": "Draining",
+                            "to": "6"
+                        },
+                        {
+                            "from": "7",
+                            "text": "Drained",
+                            "to": "7"
+                        },
+                        {
+                            "from": "8",
+                            "text": "Moving",
+                            "to": "8"
+                        }
+                    ],
+                    "type": "string"
                 },
                 {
                     "class": "hidden_column",
@@ -843,7 +886,7 @@
             ],
             "targets": [
                 {
-                    "expr": "scylla_scylladb_current_version{cluster=~\"$cluster|$^\", dc=~\"$dc\"}",
+                    "expr": "0*scylla_scylladb_current_version{cluster=~\"$cluster|$^\", dc=~\"$dc\"} + on (instance) group_left() scylla_node_operation_mode",
                     "format": "table",
                     "instant": true,
                     "intervalFactor": 1,

--- a/grafana/build/ver_master/scylla-dash.master.json
+++ b/grafana/build/ver_master/scylla-dash.master.json
@@ -831,9 +831,52 @@
                     "type": "hidden"
                 },
                 {
-                    "class": "hidden_column",
+                    "alias": "Status",
+                    "mappingType": 2,
                     "pattern": "Value",
-                    "type": "hidden"
+                    "rangeMaps": [
+                        {
+                            "from": "1",
+                            "text": "Starting",
+                            "to": "1"
+                        },
+                        {
+                            "from": "2",
+                            "text": "Joining",
+                            "to": "2"
+                        },
+                        {
+                            "from": "3",
+                            "text": "Normal",
+                            "to": "3"
+                        },
+                        {
+                            "from": "4",
+                            "text": "Leaving",
+                            "to": "4"
+                        },
+                        {
+                            "from": "5",
+                            "text": "Decommissioned",
+                            "to": "5"
+                        },
+                        {
+                            "from": "6",
+                            "text": "Draining",
+                            "to": "6"
+                        },
+                        {
+                            "from": "7",
+                            "text": "Drained",
+                            "to": "7"
+                        },
+                        {
+                            "from": "8",
+                            "text": "Moving",
+                            "to": "8"
+                        }
+                    ],
+                    "type": "string"
                 },
                 {
                     "class": "hidden_column",
@@ -843,7 +886,7 @@
             ],
             "targets": [
                 {
-                    "expr": "scylla_scylladb_current_version{cluster=~\"$cluster|$^\", dc=~\"$dc\"}",
+                    "expr": "0*scylla_scylladb_current_version{cluster=~\"$cluster|$^\", dc=~\"$dc\"} + on (instance) group_left() scylla_node_operation_mode",
                     "format": "table",
                     "instant": true,
                     "intervalFactor": 1,

--- a/grafana/scylla-dash.2019.1.template.json
+++ b/grafana/scylla-dash.2019.1.template.json
@@ -194,7 +194,7 @@
                         "targets": [
                             {
                               "refId": "A",
-                              "expr": "scylla_scylladb_current_version{cluster=~\"$cluster|$^\", dc=~\"$dc\"}",
+                              "expr": "0*scylla_scylladb_current_version{cluster=~\"$cluster|$^\", dc=~\"$dc\"} + on (instance) group_left() scylla_node_operation_mode",
                               "intervalFactor": 1,
                               "format": "table",
                               "instant": true
@@ -241,8 +241,52 @@
                                 "pattern": "type"
                             },
                             {
-                                "class":"hidden_column",
-                                "pattern": "Value"
+                                "pattern": "Value",
+                                "type": "string",
+                                "alias": "Status",
+                                "mappingType": 2,
+                                "rangeMaps": [
+                                    {
+                                      "from": "1",
+                                      "to": "1",
+                                      "text": "Starting"
+                                    },
+                                    {
+                                      "from": "2",
+                                      "to": "2",
+                                      "text": "Joining"
+                                    },
+                                    {
+                                      "from": "3",
+                                      "to": "3",
+                                      "text": "Normal"
+                                    },
+                                    {
+                                      "from": "4",
+                                      "to": "4",
+                                      "text": "Leaving"
+                                    },
+                                    {
+                                      "from": "5",
+                                      "to": "5",
+                                      "text": "Decommissioned"
+                                    },
+                                    {
+                                      "from": "6",
+                                      "to": "6",
+                                      "text": "Draining"
+                                    },
+                                    {
+                                      "from": "7",
+                                      "to": "7",
+                                      "text": "Drained"
+                                    },
+                                    {
+                                      "from": "8",
+                                      "to": "8",
+                                      "text": "Moving"
+                                    }
+                                 ]
                             },
                             {
                                 "class":"hidden_column",

--- a/grafana/scylla-dash.3.1.template.json
+++ b/grafana/scylla-dash.3.1.template.json
@@ -194,7 +194,7 @@
                         "targets": [
                             {
                               "refId": "A",
-                              "expr": "scylla_scylladb_current_version{cluster=~\"$cluster|$^\", dc=~\"$dc\"}",
+                              "expr": "0*scylla_scylladb_current_version{cluster=~\"$cluster|$^\", dc=~\"$dc\"} + on (instance) group_left() scylla_node_operation_mode",
                               "intervalFactor": 1,
                               "format": "table",
                               "instant": true
@@ -241,8 +241,52 @@
                                 "pattern": "type"
                             },
                             {
-                                "class":"hidden_column",
-                                "pattern": "Value"
+                                "pattern": "Value",
+                                "type": "string",
+                                "alias": "Status",
+                                "mappingType": 2,
+                                "rangeMaps": [
+                                    {
+                                      "from": "1",
+                                      "to": "1",
+                                      "text": "Starting"
+                                    },
+                                    {
+                                      "from": "2",
+                                      "to": "2",
+                                      "text": "Joining"
+                                    },
+                                    {
+                                      "from": "3",
+                                      "to": "3",
+                                      "text": "Normal"
+                                    },
+                                    {
+                                      "from": "4",
+                                      "to": "4",
+                                      "text": "Leaving"
+                                    },
+                                    {
+                                      "from": "5",
+                                      "to": "5",
+                                      "text": "Decommissioned"
+                                    },
+                                    {
+                                      "from": "6",
+                                      "to": "6",
+                                      "text": "Draining"
+                                    },
+                                    {
+                                      "from": "7",
+                                      "to": "7",
+                                      "text": "Drained"
+                                    },
+                                    {
+                                      "from": "8",
+                                      "to": "8",
+                                      "text": "Moving"
+                                    }
+                                 ]
                             },
                             {
                                 "class":"hidden_column",

--- a/grafana/scylla-dash.master.template.json
+++ b/grafana/scylla-dash.master.template.json
@@ -194,7 +194,7 @@
                         "targets": [
                             {
                               "refId": "A",
-                              "expr": "scylla_scylladb_current_version{cluster=~\"$cluster|$^\", dc=~\"$dc\"}",
+                              "expr": "0*scylla_scylladb_current_version{cluster=~\"$cluster|$^\", dc=~\"$dc\"} + on (instance) group_left() scylla_node_operation_mode",
                               "intervalFactor": 1,
                               "format": "table",
                               "instant": true
@@ -241,8 +241,52 @@
                                 "pattern": "type"
                             },
                             {
-                                "class":"hidden_column",
-                                "pattern": "Value"
+                                "pattern": "Value",
+                                "type": "string",
+                                "alias": "Status",
+                                "mappingType": 2,
+                                "rangeMaps": [
+                                    {
+                                      "from": "1",
+                                      "to": "1",
+                                      "text": "Starting"
+                                    },
+                                    {
+                                      "from": "2",
+                                      "to": "2",
+                                      "text": "Joining"
+                                    },
+                                    {
+                                      "from": "3",
+                                      "to": "3",
+                                      "text": "Normal"
+                                    },
+                                    {
+                                      "from": "4",
+                                      "to": "4",
+                                      "text": "Leaving"
+                                    },
+                                    {
+                                      "from": "5",
+                                      "to": "5",
+                                      "text": "Decommissioned"
+                                    },
+                                    {
+                                      "from": "6",
+                                      "to": "6",
+                                      "text": "Draining"
+                                    },
+                                    {
+                                      "from": "7",
+                                      "to": "7",
+                                      "text": "Drained"
+                                    },
+                                    {
+                                      "from": "8",
+                                      "to": "8",
+                                      "text": "Moving"
+                                    }
+                                 ]
                             },
                             {
                                 "class":"hidden_column",


### PR DESCRIPTION
Fixes #629 

This is how it looks like when a node drain:
![image](https://user-images.githubusercontent.com/2118079/59561950-bc168a80-902e-11e9-8990-082b394b3f57.png)
