### PR TITLE
point the user to the logs on failur

### DIFF
--- a/start-alertmanager.sh
+++ b/start-alertmanager.sh
@@ -56,11 +56,12 @@ fi
 
 docker run -d $DOCKER_PARAM -i $PORT_MAPPING \
 	 -v $RULE_FILE:/etc/alertmanager/config.yml:z \
-     --name $ALERTMANAGER_NAME prom/alertmanager:$ALERT_MANAGER_VERSION --config.file=/etc/alertmanager/config.yml > /dev/null
+     --name $ALERTMANAGER_NAME prom/alertmanager:$ALERT_MANAGER_VERSION --config.file=/etc/alertmanager/config.yml >& /dev/null
 
 
 if [ $? -ne 0 ]; then
     echo "Error: Alertmanager container failed to start"
+    echo "For more information use: docker logs $ALERTMANAGER_NAME"
     exit 1
 fi
 

--- a/start-all.sh
+++ b/start-all.sh
@@ -111,7 +111,7 @@ if [[ $DOCKER_PARAM = *"--net=host"* ]]; then
     HOST_NETWORK=1
 fi
 
-printf "Wait for alert manager container to start."
+echo "Wait for alert manager container to start"
 
 AM_ADDRESS=`./start-alertmanager.sh $ALERTMANAGER_PORT -D "$DOCKER_PARAM" $ALERT_MANAGER_RULE_CONFIG`
 if [ $? -ne 0 ]; then
@@ -158,7 +158,7 @@ then
          -v $(readlink -m $SCYLLA_TARGET_FILE):/etc/scylla.d/prometheus/scylla_servers.yml:Z \
          -v $(readlink -m $SCYLLA_MANGER_TARGET_FILE):/etc/scylla.d/prometheus/scylla_manager_servers.yml:Z \
          -v $(readlink -m $NODE_TARGET_FILE):/etc/scylla.d/prometheus/node_exporter_servers.yml:Z \
-         $PORT_MAPPING --name $PROMETHEUS_NAME prom/prometheus:$PROMETHEUS_VERSION --config.file=/etc/prometheus/prometheus.yml $PROMETHEUS_COMMAND_LINE_OPTIONS
+         $PORT_MAPPING --name $PROMETHEUS_NAME prom/prometheus:$PROMETHEUS_VERSION --config.file=/etc/prometheus/prometheus.yml $PROMETHEUS_COMMAND_LINE_OPTIONS >& /dev/null
 else
     echo "Loading prometheus data from $DATA_DIR"
     docker run -d $DOCKER_PARAM $USER_PERMISSIONS -v $(readlink -m $DATA_DIR):/prometheus/data:Z \
@@ -167,11 +167,12 @@ else
          -v $(readlink -m $SCYLLA_TARGET_FILE):/etc/scylla.d/prometheus/scylla_servers.yml:Z \
          -v $(readlink -m $SCYLLA_MANGER_TARGET_FILE):/etc/scylla.d/prometheus/scylla_manager_servers.yml:Z \
          -v $(readlink -m $NODE_TARGET_FILE):/etc/scylla.d/prometheus/node_exporter_servers.yml:Z \
-         $PORT_MAPPING --name $PROMETHEUS_NAME prom/prometheus:$PROMETHEUS_VERSION  --config.file=/etc/prometheus/prometheus.yml $PROMETHEUS_COMMAND_LINE_OPTIONS
+         $PORT_MAPPING --name $PROMETHEUS_NAME prom/prometheus:$PROMETHEUS_VERSION  --config.file=/etc/prometheus/prometheus.yml $PROMETHEUS_COMMAND_LINE_OPTIONS >& /dev/null
 fi
 
 if [ $? -ne 0 ]; then
     echo "Error: Prometheus container failed to start"
+    echo "For more information use: docker logs $PROMETHEUS_NAME"
     exit 1
 fi
 if [ "$VERSIONS" = "latest" ]; then
@@ -193,10 +194,12 @@ until $(curl --output /dev/null -f --silent http://localhost:$PROMETHEUS_PORT) |
     ((TRIES=TRIES+1))
     sleep 5
 done
+echo
 
 if [ ! "$(docker ps -q -f name=$PROMETHEUS_NAME)" ]
 then
         echo "Error: Prometheus container failed to start"
+        echo "For more information use: docker logs $PROMETHEUS_NAME"
         exit 1
 fi
 

--- a/start-grafana.sh
+++ b/start-grafana.sh
@@ -120,10 +120,11 @@ docker run -d $DOCKER_PARAM -i $USER_PERMISSIONS $PORT_MAPPING \
      -e "GF_SECURITY_ADMIN_PASSWORD=$GRAFANA_ADMIN_PASSWORD" \
      $GRAFANA_ENV_COMMAND \
      "${proxy_args[@]}" \
-     --name $GRAFANA_NAME grafana/grafana:$GRAFANA_VERSION
+     --name $GRAFANA_NAME grafana/grafana:$GRAFANA_VERSION >& /dev/null
 
 if [ $? -ne 0 ]; then
     echo "Error: Grafana container failed to start"
+    echo "For more information use: docker logs $GRAFANA_NAME"
     exit 1
 fi
 
@@ -136,11 +137,12 @@ until $(curl --output /dev/null -f --silent http://localhost:$GRAFANA_PORT/api/o
     ((TRIES=TRIES+1))
     sleep 5
 done
-
+echo
 if [ ! "$(docker ps -q -f name=$GRAFANA_NAME)" ]
 then
         echo "Error: Grafana container failed to start"
+        echo "For more information use: docker logs $GRAFANA_NAME"
         exit 1
 fi
 
-printf "\nStart completed successfully, check http://localhost:$GRAFANA_PORT\n"
+printf "Start completed successfully, check http://localhost:$GRAFANA_PORT\n"


### PR DESCRIPTION
This patch both make the startup lines cleaner (removing the docker names) and points the users to docker logs on failure.
For example:
```
./start-all.sh -G dir1 -v 3.1 -s scylla_servers.yml 
Wait for alert manager container to start
Wait for Prometheus container to start..
Wait for Grafana container to start........
Error: Grafana container failed to start
For more information use: docker logs agraf
```


Fixes #647