### PR TITLE
Cql optimization cleanup

### DIFF
--- a/grafana/build/ver_2019.1/scylla-cql-optimization.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-cql-optimization.2019.1.json
@@ -860,27 +860,6 @@
             ]
         },
         {
-            "class": "plain_text",
-            "content": "<span/>",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 8,
-                "x": 16,
-                "y": 10
-            },
-            "id": 13,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "span": 4,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
             "cacheTimeout": null,
             "class": "gauge_errors_panel",
             "colorBackground": false,
@@ -891,7 +870,7 @@
                 "#d44a3a"
             ],
             "datasource": "prometheus",
-            "description": "All of the requests should be Token Aware\n\nNon Token Aware requests sources:\n* Non-Prepared Stamements\n* Client not using a Token Aware load balancing policy\n\nTokenAware requests are sent to a Scylla node that is also a replica. Token Un-Aware requests require extra hop and additional processing.",
+            "description": "All of the requests should be Token Aware\n\nNon Token Aware requests sources:\n* Non-Prepared Stamements\n* Client not using a Token Aware load balancing policy\n\nTokenAware requests are sent to a Scylla node that is also a replica. Token Un-Aware requests require extra hop and additional processing.\n\nNote that the metric shows incorrect values when batches are used.",
             "editable": true,
             "error": false,
             "format": "percent",
@@ -905,10 +884,10 @@
             "gridPos": {
                 "h": 6,
                 "w": 2,
-                "x": 0,
-                "y": 16
+                "x": 16,
+                "y": 10
             },
-            "id": 14,
+            "id": 13,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -973,7 +952,7 @@
             "bars": false,
             "class": "ops_panel",
             "datasource": "prometheus",
-            "description": "Requests that are not token aware indicates that requests are not routed to the right node, which require extra hop and additional processing",
+            "description": "Requests that are not token aware indicates that requests are not routed to the right node, which require extra hop and additional processing.\n\nNote that the metric shows incorrect values when batches are used.",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -986,10 +965,10 @@
             "gridPos": {
                 "h": 6,
                 "w": 6,
-                "x": 2,
-                "y": 16
+                "x": 18,
+                "y": 10
             },
-            "id": 15,
+            "id": 14,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1064,200 +1043,6 @@
                 "#d44a3a"
             ],
             "datasource": "prometheus",
-            "description": "Scylla uses a shared-nothing model that shards all requests onto individual cores.\n\nScylla runs one application thread-per-core, and depends on explicit message passing, not shared memory between threads. This design avoids slow, unscalable lock primitives and cache bounces.\n\nIdeally, each request to a Scylla node reaches the right core (shard), avoiding internal communication between cores. This is not always the case, for example, when using a non-shard-aware Scylla driver (see more here: https://docs.scylladb.com/getting-started/scylla_drivers/)",
-            "editable": true,
-            "error": false,
-            "format": "percent",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": true,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 8,
-                "y": 16
-            },
-            "id": 16,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "floor(100*sum(irate(scylla_storage_proxy_replica_cross_shard_ops{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s]))/(sum(irate(scylla_storage_proxy_coordinator_reads_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) + sum(irate(scylla_storage_proxy_coordinator_total_write_attempts_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])))) OR vector(0)",
-                    "format": "time_series",
-                    "hide": false,
-                    "intervalFactor": 1,
-                    "legendFormat": "aaa",
-                    "refId": "A"
-                }
-            ],
-            "thresholds": "4,10",
-            "title": "Cross Shard",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "110%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "ops_panel",
-            "datasource": "prometheus",
-            "description": "Requests that are not shard aware",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 10,
-                "y": 16
-            },
-            "id": 17,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(irate(scylla_storage_proxy_replica_cross_shard_ops{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                    "format": "time_series",
-                    "hide": false,
-                    "intervalFactor": 2,
-                    "refId": "A"
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Cross Shard Queries",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "class": "plain_text",
-            "content": "<span/>",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 8,
-                "x": 16,
-                "y": 16
-            },
-            "id": 18,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "span": 4,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "cacheTimeout": null,
-            "class": "gauge_errors_panel",
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "#299c46",
-                "rgba(237, 129, 40, 0.89)",
-                "#d44a3a"
-            ],
-            "datasource": "prometheus",
             "description": "Reversed CQL Reads entail additional processing on server side\n\nSources: CQL Read requests with ORDER BY that is different from the \"CLUSTERING ORDER BY\" of the table\nAlternatives:\n\n* Denormalize your data (use a Materialized View)",
             "editable": true,
             "error": false,
@@ -1273,9 +1058,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 22
+                "y": 16
             },
-            "id": 19,
+            "id": 15,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -1356,9 +1141,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 22
+                "y": 16
             },
-            "id": 20,
+            "id": 16,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1448,9 +1233,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 22
+                "y": 16
             },
-            "id": 21,
+            "id": 17,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -1529,9 +1314,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 22
+                "y": 16
             },
-            "id": 22,
+            "id": 18,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1619,9 +1404,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 16,
-                "y": 22
+                "y": 16
             },
-            "id": 23,
+            "id": 19,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -1702,9 +1487,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 22
+                "y": 16
             },
-            "id": 24,
+            "id": 20,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1809,9 +1594,9 @@
                 "h": 6,
                 "w": 4,
                 "x": 0,
-                "y": 28
+                "y": 22
             },
-            "id": 25,
+            "id": 21,
             "interval": null,
             "isNew": true,
             "links": [],

--- a/grafana/build/ver_3.0/scylla-cql-optimization.3.0.json
+++ b/grafana/build/ver_3.0/scylla-cql-optimization.3.0.json
@@ -707,27 +707,6 @@
             ]
         },
         {
-            "class": "plain_text",
-            "content": "<span/>",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 8,
-                "x": 16,
-                "y": 10
-            },
-            "id": 12,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "span": 4,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
             "cacheTimeout": null,
             "class": "gauge_errors_panel",
             "colorBackground": false,
@@ -738,7 +717,7 @@
                 "#d44a3a"
             ],
             "datasource": "prometheus",
-            "description": "All of the requests should be Token Aware\n\nNon Token Aware requests sources:\n* Non-Prepared Stamements\n* Client not using a Token Aware load balancing policy\n\nTokenAware requests are sent to a Scylla node that is also a replica. Token Un-Aware requests require extra hop and additional processing.",
+            "description": "All of the requests should be Token Aware\n\nNon Token Aware requests sources:\n* Non-Prepared Stamements\n* Client not using a Token Aware load balancing policy\n\nTokenAware requests are sent to a Scylla node that is also a replica. Token Un-Aware requests require extra hop and additional processing.\n\nNote that the metric shows incorrect values when batches are used.",
             "editable": true,
             "error": false,
             "format": "percent",
@@ -752,10 +731,10 @@
             "gridPos": {
                 "h": 6,
                 "w": 2,
-                "x": 0,
-                "y": 16
+                "x": 16,
+                "y": 10
             },
-            "id": 13,
+            "id": 12,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -820,7 +799,7 @@
             "bars": false,
             "class": "ops_panel",
             "datasource": "prometheus",
-            "description": "Requests that are not token aware indicates that requests are not routed to the right node, which require extra hop and additional processing",
+            "description": "Requests that are not token aware indicates that requests are not routed to the right node, which require extra hop and additional processing.\n\nNote that the metric shows incorrect values when batches are used.",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -833,10 +812,10 @@
             "gridPos": {
                 "h": 6,
                 "w": 6,
-                "x": 2,
-                "y": 16
+                "x": 18,
+                "y": 10
             },
-            "id": 14,
+            "id": 13,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -911,200 +890,6 @@
                 "#d44a3a"
             ],
             "datasource": "prometheus",
-            "description": "Scylla uses a shared-nothing model that shards all requests onto individual cores.\n\nScylla runs one application thread-per-core, and depends on explicit message passing, not shared memory between threads. This design avoids slow, unscalable lock primitives and cache bounces.\n\nIdeally, each request to a Scylla node reaches the right core (shard), avoiding internal communication between cores. This is not always the case, for example, when using a non-shard-aware Scylla driver (see more here: https://docs.scylladb.com/getting-started/scylla_drivers/)",
-            "editable": true,
-            "error": false,
-            "format": "percent",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": true,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 8,
-                "y": 16
-            },
-            "id": 15,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "floor(100*sum(irate(scylla_storage_proxy_replica_cross_shard_ops{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s]))/(sum(irate(scylla_storage_proxy_coordinator_reads_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) + sum(irate(scylla_storage_proxy_coordinator_total_write_attempts_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])))) OR vector(0)",
-                    "format": "time_series",
-                    "hide": false,
-                    "intervalFactor": 1,
-                    "legendFormat": "aaa",
-                    "refId": "A"
-                }
-            ],
-            "thresholds": "4,10",
-            "title": "Cross Shard",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "110%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "ops_panel",
-            "datasource": "prometheus",
-            "description": "Requests that are not shard aware",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 10,
-                "y": 16
-            },
-            "id": 16,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(irate(scylla_storage_proxy_replica_cross_shard_ops{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                    "format": "time_series",
-                    "hide": false,
-                    "intervalFactor": 2,
-                    "refId": "A"
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Cross Shard Queries",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "class": "plain_text",
-            "content": "<span/>",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 8,
-                "x": 16,
-                "y": 16
-            },
-            "id": 17,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "span": 4,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "cacheTimeout": null,
-            "class": "gauge_errors_panel",
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "#299c46",
-                "rgba(237, 129, 40, 0.89)",
-                "#d44a3a"
-            ],
-            "datasource": "prometheus",
             "description": "Reversed CQL Reads entail additional processing on server side\n\nSources: CQL Read requests with ORDER BY that is different from the \"CLUSTERING ORDER BY\" of the table\nAlternatives:\n\n* Denormalize your data (use a Materialized View)",
             "editable": true,
             "error": false,
@@ -1120,9 +905,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 22
+                "y": 16
             },
-            "id": 18,
+            "id": 14,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -1203,9 +988,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 22
+                "y": 16
             },
-            "id": 19,
+            "id": 15,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1295,9 +1080,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 22
+                "y": 16
             },
-            "id": 20,
+            "id": 16,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -1376,9 +1161,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 22
+                "y": 16
             },
-            "id": 21,
+            "id": 17,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1466,9 +1251,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 16,
-                "y": 22
+                "y": 16
             },
-            "id": 22,
+            "id": 18,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -1549,9 +1334,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 22
+                "y": 16
             },
-            "id": 23,
+            "id": 19,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1656,9 +1441,9 @@
                 "h": 6,
                 "w": 4,
                 "x": 0,
-                "y": 28
+                "y": 22
             },
-            "id": 24,
+            "id": 20,
             "interval": null,
             "isNew": true,
             "links": [],

--- a/grafana/build/ver_3.1/scylla-cql-optimization.3.1.json
+++ b/grafana/build/ver_3.1/scylla-cql-optimization.3.1.json
@@ -860,27 +860,6 @@
             ]
         },
         {
-            "class": "plain_text",
-            "content": "<span/>",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 8,
-                "x": 16,
-                "y": 10
-            },
-            "id": 13,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "span": 4,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
             "cacheTimeout": null,
             "class": "gauge_errors_panel",
             "colorBackground": false,
@@ -891,7 +870,7 @@
                 "#d44a3a"
             ],
             "datasource": "prometheus",
-            "description": "All of the requests should be Token Aware\n\nNon Token Aware requests sources:\n* Non-Prepared Stamements\n* Client not using a Token Aware load balancing policy\n\nTokenAware requests are sent to a Scylla node that is also a replica. Token Un-Aware requests require extra hop and additional processing.",
+            "description": "All of the requests should be Token Aware\n\nNon Token Aware requests sources:\n* Non-Prepared Stamements\n* Client not using a Token Aware load balancing policy\n\nTokenAware requests are sent to a Scylla node that is also a replica. Token Un-Aware requests require extra hop and additional processing.\n\nNote that the metric shows incorrect values when batches are used.",
             "editable": true,
             "error": false,
             "format": "percent",
@@ -905,10 +884,10 @@
             "gridPos": {
                 "h": 6,
                 "w": 2,
-                "x": 0,
-                "y": 16
+                "x": 16,
+                "y": 10
             },
-            "id": 14,
+            "id": 13,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -973,7 +952,7 @@
             "bars": false,
             "class": "ops_panel",
             "datasource": "prometheus",
-            "description": "Requests that are not token aware indicates that requests are not routed to the right node, which require extra hop and additional processing",
+            "description": "Requests that are not token aware indicates that requests are not routed to the right node, which require extra hop and additional processing.\n\nNote that the metric shows incorrect values when batches are used.",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -986,10 +965,10 @@
             "gridPos": {
                 "h": 6,
                 "w": 6,
-                "x": 2,
-                "y": 16
+                "x": 18,
+                "y": 10
             },
-            "id": 15,
+            "id": 14,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1064,200 +1043,6 @@
                 "#d44a3a"
             ],
             "datasource": "prometheus",
-            "description": "Scylla uses a shared-nothing model that shards all requests onto individual cores.\n\nScylla runs one application thread-per-core, and depends on explicit message passing, not shared memory between threads. This design avoids slow, unscalable lock primitives and cache bounces.\n\nIdeally, each request to a Scylla node reaches the right core (shard), avoiding internal communication between cores. This is not always the case, for example, when using a non-shard-aware Scylla driver (see more here: https://docs.scylladb.com/getting-started/scylla_drivers/)",
-            "editable": true,
-            "error": false,
-            "format": "percent",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": true,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 8,
-                "y": 16
-            },
-            "id": 16,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "floor(100*sum(irate(scylla_storage_proxy_replica_cross_shard_ops{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s]))/(sum(irate(scylla_storage_proxy_coordinator_reads_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) + sum(irate(scylla_storage_proxy_coordinator_total_write_attempts_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])))) OR vector(0)",
-                    "format": "time_series",
-                    "hide": false,
-                    "intervalFactor": 1,
-                    "legendFormat": "aaa",
-                    "refId": "A"
-                }
-            ],
-            "thresholds": "4,10",
-            "title": "Cross Shard",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "110%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "ops_panel",
-            "datasource": "prometheus",
-            "description": "Requests that are not shard aware",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 10,
-                "y": 16
-            },
-            "id": 17,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(irate(scylla_storage_proxy_replica_cross_shard_ops{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                    "format": "time_series",
-                    "hide": false,
-                    "intervalFactor": 2,
-                    "refId": "A"
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Cross Shard Queries",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "class": "plain_text",
-            "content": "<span/>",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 8,
-                "x": 16,
-                "y": 16
-            },
-            "id": 18,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "span": 4,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "cacheTimeout": null,
-            "class": "gauge_errors_panel",
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "#299c46",
-                "rgba(237, 129, 40, 0.89)",
-                "#d44a3a"
-            ],
-            "datasource": "prometheus",
             "description": "Reversed CQL Reads entail additional processing on server side\n\nSources: CQL Read requests with ORDER BY that is different from the \"CLUSTERING ORDER BY\" of the table\nAlternatives:\n\n* Denormalize your data (use a Materialized View)",
             "editable": true,
             "error": false,
@@ -1273,9 +1058,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 22
+                "y": 16
             },
-            "id": 19,
+            "id": 15,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -1356,9 +1141,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 22
+                "y": 16
             },
-            "id": 20,
+            "id": 16,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1448,9 +1233,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 22
+                "y": 16
             },
-            "id": 21,
+            "id": 17,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -1529,9 +1314,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 22
+                "y": 16
             },
-            "id": 22,
+            "id": 18,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1619,9 +1404,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 16,
-                "y": 22
+                "y": 16
             },
-            "id": 23,
+            "id": 19,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -1702,9 +1487,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 22
+                "y": 16
             },
-            "id": 24,
+            "id": 20,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1809,9 +1594,9 @@
                 "h": 6,
                 "w": 4,
                 "x": 0,
-                "y": 28
+                "y": 22
             },
-            "id": 25,
+            "id": 21,
             "interval": null,
             "isNew": true,
             "links": [],

--- a/grafana/build/ver_master/scylla-cql-optimization.master.json
+++ b/grafana/build/ver_master/scylla-cql-optimization.master.json
@@ -860,27 +860,6 @@
             ]
         },
         {
-            "class": "plain_text",
-            "content": "<span/>",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 8,
-                "x": 16,
-                "y": 10
-            },
-            "id": 13,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "span": 4,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
             "cacheTimeout": null,
             "class": "gauge_errors_panel",
             "colorBackground": false,
@@ -891,7 +870,7 @@
                 "#d44a3a"
             ],
             "datasource": "prometheus",
-            "description": "All of the requests should be Token Aware\n\nNon Token Aware requests sources:\n* Non-Prepared Stamements\n* Client not using a Token Aware load balancing policy\n\nTokenAware requests are sent to a Scylla node that is also a replica. Token Un-Aware requests require extra hop and additional processing.",
+            "description": "All of the requests should be Token Aware\n\nNon Token Aware requests sources:\n* Non-Prepared Stamements\n* Client not using a Token Aware load balancing policy\n\nTokenAware requests are sent to a Scylla node that is also a replica. Token Un-Aware requests require extra hop and additional processing.\n\nNote that the metric shows incorrect values when batches are used.",
             "editable": true,
             "error": false,
             "format": "percent",
@@ -905,10 +884,10 @@
             "gridPos": {
                 "h": 6,
                 "w": 2,
-                "x": 0,
-                "y": 16
+                "x": 16,
+                "y": 10
             },
-            "id": 14,
+            "id": 13,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -973,7 +952,7 @@
             "bars": false,
             "class": "ops_panel",
             "datasource": "prometheus",
-            "description": "Requests that are not token aware indicates that requests are not routed to the right node, which require extra hop and additional processing",
+            "description": "Requests that are not token aware indicates that requests are not routed to the right node, which require extra hop and additional processing.\n\nNote that the metric shows incorrect values when batches are used.",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -986,10 +965,10 @@
             "gridPos": {
                 "h": 6,
                 "w": 6,
-                "x": 2,
-                "y": 16
+                "x": 18,
+                "y": 10
             },
-            "id": 15,
+            "id": 14,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1064,200 +1043,6 @@
                 "#d44a3a"
             ],
             "datasource": "prometheus",
-            "description": "Scylla uses a shared-nothing model that shards all requests onto individual cores.\n\nScylla runs one application thread-per-core, and depends on explicit message passing, not shared memory between threads. This design avoids slow, unscalable lock primitives and cache bounces.\n\nIdeally, each request to a Scylla node reaches the right core (shard), avoiding internal communication between cores. This is not always the case, for example, when using a non-shard-aware Scylla driver (see more here: https://docs.scylladb.com/getting-started/scylla_drivers/)",
-            "editable": true,
-            "error": false,
-            "format": "percent",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": true,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 8,
-                "y": 16
-            },
-            "id": 16,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "floor(100*sum(irate(scylla_storage_proxy_replica_cross_shard_ops{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s]))/(sum(irate(scylla_storage_proxy_coordinator_reads_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) + sum(irate(scylla_storage_proxy_coordinator_total_write_attempts_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])))) OR vector(0)",
-                    "format": "time_series",
-                    "hide": false,
-                    "intervalFactor": 1,
-                    "legendFormat": "aaa",
-                    "refId": "A"
-                }
-            ],
-            "thresholds": "4,10",
-            "title": "Cross Shard",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "110%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "ops_panel",
-            "datasource": "prometheus",
-            "description": "Requests that are not shard aware",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 10,
-                "y": 16
-            },
-            "id": 17,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(irate(scylla_storage_proxy_replica_cross_shard_ops{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                    "format": "time_series",
-                    "hide": false,
-                    "intervalFactor": 2,
-                    "refId": "A"
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Cross Shard Queries",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "class": "plain_text",
-            "content": "<span/>",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 8,
-                "x": 16,
-                "y": 16
-            },
-            "id": 18,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "span": 4,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "cacheTimeout": null,
-            "class": "gauge_errors_panel",
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "#299c46",
-                "rgba(237, 129, 40, 0.89)",
-                "#d44a3a"
-            ],
-            "datasource": "prometheus",
             "description": "Reversed CQL Reads entail additional processing on server side\n\nSources: CQL Read requests with ORDER BY that is different from the \"CLUSTERING ORDER BY\" of the table\nAlternatives:\n\n* Denormalize your data (use a Materialized View)",
             "editable": true,
             "error": false,
@@ -1273,9 +1058,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 22
+                "y": 16
             },
-            "id": 19,
+            "id": 15,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -1356,9 +1141,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 22
+                "y": 16
             },
-            "id": 20,
+            "id": 16,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1448,9 +1233,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 22
+                "y": 16
             },
-            "id": 21,
+            "id": 17,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -1529,9 +1314,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 22
+                "y": 16
             },
-            "id": 22,
+            "id": 18,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1619,9 +1404,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 16,
-                "y": 22
+                "y": 16
             },
-            "id": 23,
+            "id": 19,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -1702,9 +1487,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 22
+                "y": 16
             },
-            "id": 24,
+            "id": 20,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1809,9 +1594,9 @@
                 "h": 6,
                 "w": 4,
                 "x": 0,
-                "y": 28
+                "y": 22
             },
-            "id": 25,
+            "id": 21,
             "interval": null,
             "isNew": true,
             "links": [],

--- a/grafana/scylla-cql-optimization.2019.1.template.json
+++ b/grafana/scylla-cql-optimization.2019.1.template.json
@@ -165,19 +165,8 @@
                         "title": "Non-Paged CQL Reads"
                     },
                     {
-                      "class":"plain_text",
-                      "content": "<span/>",
-                      "span":4
-                    }
-                    ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
                         "class": "gauge_errors_panel",
-                        "description": "All of the requests should be Token Aware\n\nNon Token Aware requests sources:\n* Non-Prepared Stamements\n* Client not using a Token Aware load balancing policy\n\nTokenAware requests are sent to a Scylla node that is also a replica. Token Un-Aware requests require extra hop and additional processing.",
+                        "description": "All of the requests should be Token Aware\n\nNon Token Aware requests sources:\n* Non-Prepared Stamements\n* Client not using a Token Aware load balancing policy\n\nTokenAware requests are sent to a Scylla node that is also a replica. Token Un-Aware requests require extra hop and additional processing.\n\nNote that the metric shows incorrect values when batches are used.",
                         "targets": [
                             {
                                 "expr": "100 - floor(100*(sum(irate(scylla_storage_proxy_coordinator_reads_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) +sum(irate(scylla_storage_proxy_coordinator_total_write_attempts_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])))/(sum(irate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s]) + irate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s]) + irate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s]) + irate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])))) OR vector(0)",
@@ -192,7 +181,7 @@
                     },
                     {
                         "class": "ops_panel",
-                        "description": "Requests that are not token aware indicates that requests are not routed to the right node, which require extra hop and additional processing",
+                        "description": "Requests that are not token aware indicates that requests are not routed to the right node, which require extra hop and additional processing.\n\nNote that the metric shows incorrect values when batches are used.",
                         "span": 3,
                         "targets": [
                             {
@@ -204,41 +193,6 @@
                             }
                         ],
                         "title": "Non-Token Aware Queries"
-                    },
-                    {
-                        "class": "gauge_errors_panel",
-                        "description": "Scylla uses a shared-nothing model that shards all requests onto individual cores.\n\nScylla runs one application thread-per-core, and depends on explicit message passing, not shared memory between threads. This design avoids slow, unscalable lock primitives and cache bounces.\n\nIdeally, each request to a Scylla node reaches the right core (shard), avoiding internal communication between cores. This is not always the case, for example, when using a non-shard-aware Scylla driver (see more here: https://docs.scylladb.com/getting-started/scylla_drivers/)",
-                        "targets": [
-                            {
-                                "expr": "floor(100*sum(irate(scylla_storage_proxy_replica_cross_shard_ops{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s]))/(sum(irate(scylla_storage_proxy_coordinator_reads_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) + sum(irate(scylla_storage_proxy_coordinator_total_write_attempts_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])))) OR vector(0)",
-                                "format": "time_series",
-                                "hide": false,
-                                "intervalFactor": 1,
-                                "legendFormat": "aaa",
-                                "refId": "A"
-                            }
-                        ],
-                        "title": "Cross Shard"
-                    },
-                    {
-                        "class": "ops_panel",
-                        "description": "Requests that are not shard aware",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "sum(irate(scylla_storage_proxy_replica_cross_shard_ops{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "format": "time_series",
-                                "hide": false,
-                                "intervalFactor": 2,
-                                "refId": "A"
-                            }
-                        ],
-                        "title": "Cross Shard Queries"
-                    },
-                    {
-                      "class":"plain_text",
-                      "content": "<span/>",
-                      "span":4
                     }
                     ],
                 "title": "New row"

--- a/grafana/scylla-cql-optimization.3.0.template.json
+++ b/grafana/scylla-cql-optimization.3.0.template.json
@@ -140,19 +140,8 @@
                         "title": "Non-Paged CQL Reads"
                     },
                     {
-                      "class":"plain_text",
-                      "content": "<span/>",
-                      "span":4
-                    }
-                    ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
                         "class": "gauge_errors_panel",
-                        "description": "All of the requests should be Token Aware\n\nNon Token Aware requests sources:\n* Non-Prepared Stamements\n* Client not using a Token Aware load balancing policy\n\nTokenAware requests are sent to a Scylla node that is also a replica. Token Un-Aware requests require extra hop and additional processing.",
+                        "description": "All of the requests should be Token Aware\n\nNon Token Aware requests sources:\n* Non-Prepared Stamements\n* Client not using a Token Aware load balancing policy\n\nTokenAware requests are sent to a Scylla node that is also a replica. Token Un-Aware requests require extra hop and additional processing.\n\nNote that the metric shows incorrect values when batches are used.",
                         "targets": [
                             {
                                 "expr": "100 - floor(100*(sum(irate(scylla_storage_proxy_coordinator_reads_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) +sum(irate(scylla_storage_proxy_coordinator_total_write_attempts_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])))/(sum(irate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s]) + irate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s]) + irate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s]) + irate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])))) OR vector(0)",
@@ -167,7 +156,7 @@
                     },
                     {
                         "class": "ops_panel",
-                        "description": "Requests that are not token aware indicates that requests are not routed to the right node, which require extra hop and additional processing",
+                        "description": "Requests that are not token aware indicates that requests are not routed to the right node, which require extra hop and additional processing.\n\nNote that the metric shows incorrect values when batches are used.",
                         "span": 3,
                         "targets": [
                             {
@@ -179,41 +168,6 @@
                             }
                         ],
                         "title": "Non-Token Aware Queries"
-                    },
-                    {
-                        "class": "gauge_errors_panel",
-                        "description": "Scylla uses a shared-nothing model that shards all requests onto individual cores.\n\nScylla runs one application thread-per-core, and depends on explicit message passing, not shared memory between threads. This design avoids slow, unscalable lock primitives and cache bounces.\n\nIdeally, each request to a Scylla node reaches the right core (shard), avoiding internal communication between cores. This is not always the case, for example, when using a non-shard-aware Scylla driver (see more here: https://docs.scylladb.com/getting-started/scylla_drivers/)",
-                        "targets": [
-                            {
-                                "expr": "floor(100*sum(irate(scylla_storage_proxy_replica_cross_shard_ops{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s]))/(sum(irate(scylla_storage_proxy_coordinator_reads_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) + sum(irate(scylla_storage_proxy_coordinator_total_write_attempts_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])))) OR vector(0)",
-                                "format": "time_series",
-                                "hide": false,
-                                "intervalFactor": 1,
-                                "legendFormat": "aaa",
-                                "refId": "A"
-                            }
-                        ],
-                        "title": "Cross Shard"
-                    },
-                    {
-                        "class": "ops_panel",
-                        "description": "Requests that are not shard aware",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "sum(irate(scylla_storage_proxy_replica_cross_shard_ops{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "format": "time_series",
-                                "hide": false,
-                                "intervalFactor": 2,
-                                "refId": "A"
-                            }
-                        ],
-                        "title": "Cross Shard Queries"
-                    },
-                    {
-                      "class":"plain_text",
-                      "content": "<span/>",
-                      "span":4
                     }
                     ],
                 "title": "New row"

--- a/grafana/scylla-cql-optimization.3.1.template.json
+++ b/grafana/scylla-cql-optimization.3.1.template.json
@@ -165,19 +165,8 @@
                         "title": "Non-Paged CQL Reads"
                     },
                     {
-                      "class":"plain_text",
-                      "content": "<span/>",
-                      "span":4
-                    }
-                    ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
                         "class": "gauge_errors_panel",
-                        "description": "All of the requests should be Token Aware\n\nNon Token Aware requests sources:\n* Non-Prepared Stamements\n* Client not using a Token Aware load balancing policy\n\nTokenAware requests are sent to a Scylla node that is also a replica. Token Un-Aware requests require extra hop and additional processing.",
+                        "description": "All of the requests should be Token Aware\n\nNon Token Aware requests sources:\n* Non-Prepared Stamements\n* Client not using a Token Aware load balancing policy\n\nTokenAware requests are sent to a Scylla node that is also a replica. Token Un-Aware requests require extra hop and additional processing.\n\nNote that the metric shows incorrect values when batches are used.",
                         "targets": [
                             {
                                 "expr": "100 - floor(100*(sum(irate(scylla_storage_proxy_coordinator_reads_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) +sum(irate(scylla_storage_proxy_coordinator_total_write_attempts_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])))/(sum(irate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s]) + irate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s]) + irate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s]) + irate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])))) OR vector(0)",
@@ -192,7 +181,7 @@
                     },
                     {
                         "class": "ops_panel",
-                        "description": "Requests that are not token aware indicates that requests are not routed to the right node, which require extra hop and additional processing",
+                        "description": "Requests that are not token aware indicates that requests are not routed to the right node, which require extra hop and additional processing.\n\nNote that the metric shows incorrect values when batches are used.",
                         "span": 3,
                         "targets": [
                             {
@@ -204,42 +193,6 @@
                             }
                         ],
                         "title": "Non-Token Aware Queries"
-                    },
-                    {
-                        "class": "gauge_errors_panel",
-                        "description": "Scylla uses a shared-nothing model that shards all requests onto individual cores.\n\nScylla runs one application thread-per-core, and depends on explicit message passing, not shared memory between threads. This design avoids slow, unscalable lock primitives and cache bounces.\n\nIdeally, each request to a Scylla node reaches the right core (shard), avoiding internal communication between cores. This is not always the case, for example, when using a non-shard-aware Scylla driver (see more here: https://docs.scylladb.com/getting-started/scylla_drivers/)",
-                        "targets": [
-                            {
-                                "expr": "floor(100*sum(irate(scylla_storage_proxy_replica_cross_shard_ops{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s]))/(sum(irate(scylla_storage_proxy_coordinator_reads_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) + sum(irate(scylla_storage_proxy_coordinator_total_write_attempts_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])))) OR vector(0)",
-                                "format": "time_series",
-                                "hide": false,
-                                "intervalFactor": 1,
-                                "legendFormat": "aaa",
-                                "refId": "A"
-                            }
-                        ],
-                        "title": "Cross Shard"
-                    },
-                    {
-                        "class": "ops_panel",
-                        "description": "Requests that are not shard aware",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "sum(irate(scylla_storage_proxy_replica_cross_shard_ops{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "format": "time_series",
-                                "hide": false,
-                                "intervalFactor": 2,
-                                "refId": "A"
-                            }
-                        ],
-                        "title": "Cross Shard Queries"
-                    },
-                    
-                    {
-                      "class":"plain_text",
-                      "content": "<span/>",
-                      "span":4
                     }
                     ],
                 "title": "New row"

--- a/grafana/scylla-cql-optimization.master.template.json
+++ b/grafana/scylla-cql-optimization.master.template.json
@@ -165,19 +165,8 @@
                         "title": "Non-Paged CQL Reads"
                     },
                     {
-                      "class":"plain_text",
-                      "content": "<span/>",
-                      "span":4
-                    }
-                    ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
                         "class": "gauge_errors_panel",
-                        "description": "All of the requests should be Token Aware\n\nNon Token Aware requests sources:\n* Non-Prepared Stamements\n* Client not using a Token Aware load balancing policy\n\nTokenAware requests are sent to a Scylla node that is also a replica. Token Un-Aware requests require extra hop and additional processing.",
+                        "description": "All of the requests should be Token Aware\n\nNon Token Aware requests sources:\n* Non-Prepared Stamements\n* Client not using a Token Aware load balancing policy\n\nTokenAware requests are sent to a Scylla node that is also a replica. Token Un-Aware requests require extra hop and additional processing.\n\nNote that the metric shows incorrect values when batches are used.",
                         "targets": [
                             {
                                 "expr": "100 - floor(100*(sum(irate(scylla_storage_proxy_coordinator_reads_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) +sum(irate(scylla_storage_proxy_coordinator_total_write_attempts_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])))/(sum(irate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s]) + irate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s]) + irate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s]) + irate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])))) OR vector(0)",
@@ -192,7 +181,7 @@
                     },
                     {
                         "class": "ops_panel",
-                        "description": "Requests that are not token aware indicates that requests are not routed to the right node, which require extra hop and additional processing",
+                        "description": "Requests that are not token aware indicates that requests are not routed to the right node, which require extra hop and additional processing.\n\nNote that the metric shows incorrect values when batches are used.",
                         "span": 3,
                         "targets": [
                             {
@@ -204,42 +193,6 @@
                             }
                         ],
                         "title": "Non-Token Aware Queries"
-                    },
-                    {
-                        "class": "gauge_errors_panel",
-                        "description": "Scylla uses a shared-nothing model that shards all requests onto individual cores.\n\nScylla runs one application thread-per-core, and depends on explicit message passing, not shared memory between threads. This design avoids slow, unscalable lock primitives and cache bounces.\n\nIdeally, each request to a Scylla node reaches the right core (shard), avoiding internal communication between cores. This is not always the case, for example, when using a non-shard-aware Scylla driver (see more here: https://docs.scylladb.com/getting-started/scylla_drivers/)",
-                        "targets": [
-                            {
-                                "expr": "floor(100*sum(irate(scylla_storage_proxy_replica_cross_shard_ops{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s]))/(sum(irate(scylla_storage_proxy_coordinator_reads_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) + sum(irate(scylla_storage_proxy_coordinator_total_write_attempts_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])))) OR vector(0)",
-                                "format": "time_series",
-                                "hide": false,
-                                "intervalFactor": 1,
-                                "legendFormat": "aaa",
-                                "refId": "A"
-                            }
-                        ],
-                        "title": "Cross Shard"
-                    },
-                    {
-                        "class": "ops_panel",
-                        "description": "Requests that are not shard aware",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "sum(irate(scylla_storage_proxy_replica_cross_shard_ops{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "format": "time_series",
-                                "hide": false,
-                                "intervalFactor": 2,
-                                "refId": "A"
-                            }
-                        ],
-                        "title": "Cross Shard Queries"
-                    },
-                    
-                    {
-                      "class":"plain_text",
-                      "content": "<span/>",
-                      "span":4
                     }
                     ],
                 "title": "New row"


### PR DESCRIPTION
The cross-shard metric is more confusing than helping, removing it for this version.
Make it clearer that batches will make the token-aware shows wrong value.
Fixes #659 
Fixes #660 