### PR TITLE
create external directories if they don't exist

### DIFF
--- a/start-all.sh
+++ b/start-all.sh
@@ -160,7 +160,12 @@ then
          -v $(readlink -m $NODE_TARGET_FILE):/etc/scylla.d/prometheus/node_exporter_servers.yml:Z \
          $PORT_MAPPING --name $PROMETHEUS_NAME prom/prometheus:$PROMETHEUS_VERSION --config.file=/etc/prometheus/prometheus.yml $PROMETHEUS_COMMAND_LINE_OPTIONS >& /dev/null
 else
-    echo "Loading prometheus data from $DATA_DIR"
+    if [ -d $DATA_DIR ]; then
+        echo "Loading prometheus data from $DATA_DIR"
+    else
+        echo "Creating data directory $DATA_DIR"
+        mkdir -p $DATA_DIR
+    fi
     docker run -d $DOCKER_PARAM $USER_PERMISSIONS -v $(readlink -m $DATA_DIR):/prometheus/data:Z \
          -v $PWD/prometheus/build/prometheus.yml:/etc/prometheus/prometheus.yml:Z \
          -v $PROMETHEUS_RULES:/etc/prometheus/prometheus.rules.yml:Z \

--- a/start-grafana.sh
+++ b/start-grafana.sh
@@ -108,6 +108,10 @@ if [[ ! $DOCKER_PARAM = *"--net=host"* ]]; then
     PORT_MAPPING="-p $GRAFANA_PORT:3000"
 fi
 
+if [ ! -d $EXTERNAL_VOLUME ]; then
+    echo "Creating grafana directory directory $EXTERNAL_VOLUME"
+    mkdir -p $EXTERNAL_VOLUME
+fi
 
 docker run -d $DOCKER_PARAM -i $USER_PERMISSIONS $PORT_MAPPING \
      -e "GF_AUTH_BASIC_ENABLED=$GRAFANA_AUTH" \


### PR DESCRIPTION
I verified today that if the prometheus data directory does not exist,
docker itself will try to create it.  However the directory will then be
created with the wrong permissions and as a result prometheus fails to
start if the code is being executed as a user.

Create the directory ourselves to prevent this issue. I am also doing
the same for grafana since it is bound to have the same issue.

Signed-off-by: Glauber Costa <glauber@scylladb.com>