### PR TITLE
Dashboard reform 3 0

### DIFF
--- a/grafana/build/ver_2019.1/scylla-cql-optimization.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-cql-optimization.2019.1.json
@@ -8,7 +8,7 @@
     "hideControls": true,
     "id": null,
     "links": [],
-    "originalTitle": "Scylla CQL Optimization",
+    "originalTitle": "CQL",
     "overwrite": true,
     "panels": [
         {
@@ -32,357 +32,31 @@
             "type": "text"
         },
         {
-            "cacheTimeout": null,
-            "class": "single_stat_panel",
-            "colorBackground": false,
-            "colorValue": false,
-            "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-            ],
-            "datasource": "prometheus",
+            "class": "text_panel",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">CQL - Coordinator</h1>",
             "editable": true,
             "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-            },
             "gridPos": {
-                "h": 6,
-                "w": 2,
+                "h": 2,
+                "w": 24,
                 "x": 0,
                 "y": 4
             },
             "id": 2,
-            "interval": null,
             "isNew": true,
             "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
-                    "intervalFactor": 1,
-                    "legendFormat": "Total Nodes",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "thresholds": "",
-            "title": "Total Nodes",
+            "mode": "html",
+            "span": 12,
+            "style": {},
+            "title": "",
             "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "cacheTimeout": null,
-            "class": "single_stat_panel_fail",
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(250, 113, 0, 0.89)",
-                "rgba(255, 0, 0, 0.9)"
-            ],
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": false
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 2,
-                "y": 4
-            },
-            "id": 3,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Unreachable",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "thresholds": "1,2",
-            "title": "Unreachable",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "cacheTimeout": null,
-            "class": "single_stat_panel_fail",
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(250, 113, 0, 0.89)",
-                "rgba(255, 0, 0, 0.9)"
-            ],
-            "datasource": "prometheus",
-            "description": "Number of nodes that reported their status as Starting or Joining",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": false
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 4,
-                "y": 4
-            },
-            "id": 4,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Joining",
-                    "refId": "A",
-                    "step": 20
-                }
-            ],
-            "thresholds": "1,2",
-            "title": "Joining",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "cacheTimeout": null,
-            "class": "single_stat_panel_fail",
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(250, 113, 0, 0.89)",
-                "rgba(255, 0, 0, 0.9)"
-            ],
-            "datasource": "prometheus",
-            "description": "Number of nodes that reported their status as  Leaving, Decommissioned, Draining or Drained",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": false
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 6,
-                "y": 4
-            },
-            "id": 5,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(scylla_node_operation_mode>3)OR vector(0)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Leaving",
-                    "refId": "A",
-                    "step": 20
-                }
-            ],
-            "thresholds": "1,2",
-            "title": "Leaving",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
+            "type": "text"
         },
         {
             "aliasColors": {},
             "bars": false,
             "class": "ops_panel",
             "datasource": "prometheus",
-            "description": "Total requests graph is the baseline for comparison",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -394,11 +68,11 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 8,
-                "x": 8,
-                "y": 4
+                "w": 6,
+                "x": 0,
+                "y": 6
             },
-            "id": 6,
+            "id": 3,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -420,21 +94,22 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 4,
+            "span": 3,
             "stack": false,
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "expr": "sum(irate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                     "intervalFactor": 1,
-                    "legendFormat": "Total Requests",
+                    "legendFormat": "",
+                    "metric": "",
                     "refId": "A",
                     "step": 1
                 }
             ],
             "timeFrom": null,
             "timeShift": null,
-            "title": "Total Requests",
+            "title": "CQL Insert",
             "tooltip": {
                 "msResolution": false,
                 "shared": true,
@@ -463,51 +138,553 @@
             ]
         },
         {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 6
+            },
+            "id": 4,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CQL Reads",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 6
+            },
+            "id": 5,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CQL Deletes",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 6
+            },
+            "id": 6,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CQL Updates",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "datasource": "prometheus",
+            "description": "amount of CQL connections currently established",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 12
+            },
+            "id": 7,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(scylla_transport_current_connections{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Client CQL connections by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "datasource": "prometheus",
+            "description": "Number of CQL batches command, each batched command is counted once",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 12
+            },
+            "id": 8,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_batches{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CQL Batches by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "datasource": "prometheus",
+            "description": "Number of CQL command batched. Each batch would add the number of commands inside the batch",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 12
+            },
+            "id": 9,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_statements_in_batches{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CQL Coomand In Batches by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
             "class": "plain_text",
             "content": "<span/>",
             "editable": true,
             "error": false,
             "gridPos": {
                 "h": 6,
-                "w": 4,
-                "x": 16,
-                "y": 4
+                "w": 10,
+                "x": 0,
+                "y": 18
             },
-            "id": 7,
+            "id": 10,
             "isNew": true,
             "links": [],
             "mode": "html",
-            "span": 2,
+            "span": 5,
             "style": {},
             "title": "",
             "transparent": true,
             "type": "text"
         },
         {
-            "class": "dashlist",
+            "class": "text_panel",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Optimization</h1>",
             "editable": true,
             "error": false,
             "gridPos": {
-                "h": 6,
-                "w": 4,
-                "x": 20,
-                "y": 4
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 24
             },
-            "headings": false,
-            "id": 8,
+            "id": 11,
             "isNew": true,
-            "limit": 10,
             "links": [],
-            "query": "",
-            "recent": false,
-            "search": true,
-            "span": 2,
-            "starred": false,
-            "tags": [
-                "2019.1"
-            ],
-            "title": "Dashboards",
-            "type": "dashlist"
+            "mode": "html",
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
         },
         {
             "cacheTimeout": null,
@@ -535,9 +712,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 10
+                "y": 26
             },
-            "id": 9,
+            "id": 12,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -618,9 +795,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 10
+                "y": 26
             },
-            "id": 10,
+            "id": 13,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -710,9 +887,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 10
+                "y": 26
             },
-            "id": 11,
+            "id": 14,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -793,9 +970,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 10
+                "y": 26
             },
-            "id": 12,
+            "id": 15,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -885,9 +1062,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 16,
-                "y": 10
+                "y": 26
             },
-            "id": 13,
+            "id": 16,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -966,9 +1143,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 10
+                "y": 26
             },
-            "id": 14,
+            "id": 17,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1058,9 +1235,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 16
+                "y": 32
             },
-            "id": 15,
+            "id": 18,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -1141,9 +1318,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 16
+                "y": 32
             },
-            "id": 16,
+            "id": 19,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1233,9 +1410,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 16
+                "y": 32
             },
-            "id": 17,
+            "id": 20,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -1314,9 +1491,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 16
+                "y": 32
             },
-            "id": 18,
+            "id": 21,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1404,9 +1581,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 16,
-                "y": 16
+                "y": 32
             },
-            "id": 19,
+            "id": 22,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -1487,9 +1664,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 16
+                "y": 32
             },
-            "id": 20,
+            "id": 23,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1594,9 +1771,9 @@
                 "h": 6,
                 "w": 4,
                 "x": 0,
-                "y": 22
+                "y": 38
             },
-            "id": 21,
+            "id": 24,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -1858,7 +2035,7 @@
         ]
     },
     "timezone": "browser",
-    "title": "Scylla CQL Optimization",
-    "uid": "cqlopt-2019-1",
+    "title": "Scylla CQL",
+    "uid": "cql-2019-1",
     "version": 0
 }

--- a/grafana/build/ver_2019.1/scylla-dash-cpu-per-server.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-dash-cpu-per-server.2019.1.json
@@ -117,53 +117,6 @@
             ]
         },
         {
-            "class": "text_panel",
-            "content": "##  ",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 10,
-                "y": 4
-            },
-            "id": 3,
-            "isNew": true,
-            "links": [],
-            "mode": "markdown",
-            "span": 3,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "class": "dashlist",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 4,
-                "x": 16,
-                "y": 4
-            },
-            "headings": false,
-            "id": 4,
-            "isNew": true,
-            "limit": 10,
-            "links": [],
-            "query": "",
-            "recent": false,
-            "search": true,
-            "span": 2,
-            "starred": false,
-            "tags": [
-                "2019.1"
-            ],
-            "title": "Dashboards",
-            "type": "dashlist"
-        },
-        {
             "aliasColors": {},
             "bars": false,
             "class": "percent_panel",
@@ -181,10 +134,10 @@
             "gridPos": {
                 "h": 6,
                 "w": 10,
-                "x": 0,
-                "y": 10
+                "x": 10,
+                "y": 4
             },
-            "id": 5,
+            "id": 3,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -251,6 +204,27 @@
             ]
         },
         {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Task Quota Violation</h1>",
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 10
+            },
+            "id": 4,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
             "aliasColors": {},
             "bars": false,
             "class": "ms_panel",
@@ -267,11 +241,11 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 10,
-                "x": 10,
-                "y": 10
+                "w": 6,
+                "x": 0,
+                "y": 12
             },
-            "id": 6,
+            "id": 5,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -290,13 +264,14 @@
             "pointradius": 1,
             "points": false,
             "renderer": "flot",
+            "repeat": "group",
             "seriesOverrides": [],
-            "span": 5,
+            "span": 3,
             "stack": false,
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(scylla_scheduler_time_spent_on_task_quota_violations_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "expr": "sum(irate(scylla_scheduler_time_spent_on_task_quota_violations_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -306,7 +281,7 @@
             ],
             "timeFrom": null,
             "timeShift": null,
-            "title": "Time spent in task quota violations by [[by]]",
+            "title": "Time spent in task quota violations by [[by]] - $group",
             "tooltip": {
                 "msResolution": false,
                 "shared": true,
@@ -480,6 +455,32 @@
                 "tagsQuery": "",
                 "type": "query",
                 "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "hide": 2,
+                "includeAll": true,
+                "label": "group",
+                "multi": true,
+                "name": "group",
+                "options": [],
+                "query": "label_values(scylla_scheduler_time_spent_on_task_quota_violations_ms,group)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 3,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
             }
         ]
     },
@@ -514,7 +515,7 @@
         ]
     },
     "timezone": "browser",
-    "title": "Scylla CPU Per Server Metrics",
+    "title": "CPU Metrics",
     "uid": "cpu-2019-1",
     "version": 5
 }

--- a/grafana/build/ver_2019.1/scylla-dash-io-per-server.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-dash-io-per-server.2019.1.json
@@ -31,480 +31,6 @@
             "type": "text"
         },
         {
-            "cacheTimeout": null,
-            "class": "single_stat_panel",
-            "colorBackground": false,
-            "colorValue": false,
-            "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-            ],
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 0,
-                "y": 4
-            },
-            "id": 2,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
-                    "intervalFactor": 1,
-                    "legendFormat": "Total Nodes",
-                    "refId": "A",
-                    "step": 240
-                }
-            ],
-            "thresholds": "",
-            "title": "Total Nodes",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "cacheTimeout": null,
-            "class": "single_stat_panel_fail",
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(250, 113, 0, 0.89)",
-                "rgba(255, 0, 0, 0.9)"
-            ],
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": false
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 2,
-                "y": 4
-            },
-            "id": 3,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Unreachable",
-                    "refId": "A",
-                    "step": 120
-                }
-            ],
-            "thresholds": "1,2",
-            "title": "Unreachable",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "class": "text_panel",
-            "content": "##  ",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 4,
-                "y": 4
-            },
-            "id": 4,
-            "isNew": true,
-            "links": [],
-            "mode": "markdown",
-            "span": 3,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "aliasColors": {
-                "{}": "#584477"
-            },
-            "bars": true,
-            "class": "graph_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 10,
-                "y": 4
-            },
-            "id": 5,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": false,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(irate(scylla_transport_requests_served{cluster=~\"$cluster|$^\"}[30s])) + sum(irate(scylla_thrift_served{cluster=~\"$cluster|$^\"}[30s]))",
-                    "intervalFactor": 1,
-                    "legendFormat": "Total Requests",
-                    "refId": "A",
-                    "step": 30
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Total Requests",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "class": "dashlist",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 4,
-                "x": 20,
-                "y": 4
-            },
-            "headings": false,
-            "id": 6,
-            "isNew": true,
-            "limit": 10,
-            "links": [],
-            "query": "",
-            "recent": false,
-            "search": true,
-            "span": 2,
-            "starred": false,
-            "tags": [
-                "2019.1"
-            ],
-            "title": "Dashboards",
-            "type": "dashlist"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "graph_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 0,
-                "y": 10
-            },
-            "id": 7,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 30
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Load per [[by]]",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "graph_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 10,
-                "y": 10
-            },
-            "id": 8,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 1,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 30
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Requests Served per [[by]]",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
             "class": "plain_text",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue</h1>",
             "editable": true,
@@ -513,9 +39,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 16
+                "y": 4
             },
-            "id": 9,
+            "id": 2,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -543,9 +69,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 18
+                "y": 6
             },
-            "id": 10,
+            "id": 3,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -629,9 +155,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 18
+                "y": 6
             },
-            "id": 11,
+            "id": 4,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -712,9 +238,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 18
+                "y": 6
             },
-            "id": 12,
+            "id": 5,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -795,9 +321,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 24
+                "y": 12
             },
-            "id": 13,
+            "id": 6,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -881,9 +407,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 24
+                "y": 12
             },
-            "id": 14,
+            "id": 7,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -964,9 +490,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 24
+                "y": 12
             },
-            "id": 15,
+            "id": 8,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1047,9 +573,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 30
+                "y": 18
             },
-            "id": 16,
+            "id": 9,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1133,9 +659,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 30
+                "y": 18
             },
-            "id": 17,
+            "id": 10,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1216,9 +742,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 30
+                "y": 18
             },
-            "id": 18,
+            "id": 11,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1299,9 +825,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 36
+                "y": 24
             },
-            "id": 19,
+            "id": 12,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1385,9 +911,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 36
+                "y": 24
             },
-            "id": 20,
+            "id": 13,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1468,9 +994,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 36
+                "y": 24
             },
-            "id": 21,
+            "id": 14,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1551,9 +1077,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 42
+                "y": 30
             },
-            "id": 22,
+            "id": 15,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1637,9 +1163,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 42
+                "y": 30
             },
-            "id": 23,
+            "id": 16,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1720,9 +1246,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 42
+                "y": 30
             },
-            "id": 24,
+            "id": 17,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1803,9 +1329,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 48
+                "y": 36
             },
-            "id": 25,
+            "id": 18,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1889,9 +1415,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 48
+                "y": 36
             },
-            "id": 26,
+            "id": 19,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1972,9 +1498,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 48
+                "y": 36
             },
-            "id": 27,
+            "id": 20,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2217,7 +1743,7 @@
         ]
     },
     "timezone": "browser",
-    "title": "Scylla Per-Server I/O",
+    "title": "I/O",
     "uid": "io-2019-1",
     "version": 0
 }

--- a/grafana/build/ver_2019.1/scylla-dash-io-per-server.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-dash-io-per-server.2019.1.json
@@ -506,7 +506,7 @@
         },
         {
             "class": "plain_text",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Disk Activity</h1>",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue</h1>",
             "editable": true,
             "error": false,
             "gridPos": {
@@ -516,357 +516,6 @@
                 "y": 16
             },
             "id": 9,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "span": 12,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "graph_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 12,
-                "x": 0,
-                "y": 18
-            },
-            "id": 10,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 6,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 20
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Disk Writes per Server",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "graph_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 12,
-                "x": 12,
-                "y": 18
-            },
-            "id": 11,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 6,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 20
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Disk Reads per Server",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "bps_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 12,
-                "x": 0,
-                "y": 24
-            },
-            "id": 12,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 6,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 20
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Disk Writes Bps per Server",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "Bps",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "bps_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 12,
-                "x": 12,
-                "y": 24
-            },
-            "id": 13,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 6,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 20
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Disk Read Bps per Server",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "Bps",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "class": "plain_text",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue</h1>",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 2,
-                "w": 24,
-                "x": 0,
-                "y": 30
-            },
-            "id": 14,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -894,9 +543,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 32
+                "y": 18
             },
-            "id": 15,
+            "id": 10,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -980,9 +629,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 32
+                "y": 18
             },
-            "id": 16,
+            "id": 11,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1063,9 +712,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 32
+                "y": 18
             },
-            "id": 17,
+            "id": 12,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1146,9 +795,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 38
+                "y": 24
             },
-            "id": 18,
+            "id": 13,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1232,9 +881,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 38
+                "y": 24
             },
-            "id": 19,
+            "id": 14,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1315,9 +964,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 38
+                "y": 24
             },
-            "id": 20,
+            "id": 15,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1398,9 +1047,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 44
+                "y": 30
             },
-            "id": 21,
+            "id": 16,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1484,9 +1133,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 44
+                "y": 30
             },
-            "id": 22,
+            "id": 17,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1567,9 +1216,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 44
+                "y": 30
             },
-            "id": 23,
+            "id": 18,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1650,9 +1299,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 50
+                "y": 36
             },
-            "id": 24,
+            "id": 19,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1736,9 +1385,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 50
+                "y": 36
             },
-            "id": 25,
+            "id": 20,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1819,9 +1468,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 50
+                "y": 36
             },
-            "id": 26,
+            "id": 21,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1902,9 +1551,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 56
+                "y": 42
             },
-            "id": 27,
+            "id": 22,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1988,9 +1637,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 56
+                "y": 42
             },
-            "id": 28,
+            "id": 23,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2071,9 +1720,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 56
+                "y": 42
             },
-            "id": 29,
+            "id": 24,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2154,9 +1803,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 62
+                "y": 48
             },
-            "id": 30,
+            "id": 25,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2240,9 +1889,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 62
+                "y": 48
             },
-            "id": 31,
+            "id": 26,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2323,9 +1972,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 62
+                "y": 48
             },
-            "id": 32,
+            "id": 27,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2398,43 +2047,6 @@
     ],
     "templating": {
         "list": [
-            {
-                "current": {},
-                "datasource": "prometheus",
-                "hide": 0,
-                "includeAll": false,
-                "multi": false,
-                "name": "monitor_disk",
-                "options": [],
-                "query": "node_disk_read_bytes_total",
-                "refresh": 2,
-                "regex": "/.*device=\"([^\\\"]*)\".*/",
-                "type": "query"
-            },
-            {
-                "allValue": null,
-                "class": "template_variable_single",
-                "current": {
-                    "text": "/var/lib/scylla",
-                    "value": "/var/lib/scylla"
-                },
-                "datasource": "prometheus",
-                "hide": 0,
-                "includeAll": false,
-                "label": "Mounnt path",
-                "multi": false,
-                "name": "mount_point",
-                "options": [],
-                "query": "label_values(scylla_io_queue_delay,mountpoint)",
-                "refresh": 2,
-                "regex": "",
-                "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
-            },
             {
                 "allValue": null,
                 "class": "by_template_var",
@@ -2605,7 +2217,7 @@
         ]
     },
     "timezone": "browser",
-    "title": "Scylla Per-Server Disk I/O",
+    "title": "Scylla Per-Server I/O",
     "uid": "io-2019-1",
     "version": 0
 }

--- a/grafana/build/ver_2019.1/scylla-dash-per-machine.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-dash-per-machine.2019.1.json
@@ -1114,7 +1114,7 @@
         ]
     },
     "timezone": "browser",
-    "title": "Scylla Per Machine Metrics",
-    "uid": "machine-2019-1",
+    "title": "OS Metrics",
+    "uid": "OS-2019-1",
     "version": 5
 }

--- a/grafana/build/ver_2019.1/scylla-dash-per-server.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-dash-per-server.2019.1.json
@@ -31,568 +31,6 @@
             "type": "text"
         },
         {
-            "cacheTimeout": null,
-            "class": "single_stat_panel",
-            "colorBackground": false,
-            "colorValue": false,
-            "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-            ],
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 0,
-                "y": 4
-            },
-            "id": 2,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
-                    "intervalFactor": 1,
-                    "legendFormat": "Total Nodes",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "thresholds": "",
-            "title": "Total Nodes",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "cacheTimeout": null,
-            "class": "single_stat_panel_fail",
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(250, 113, 0, 0.89)",
-                "rgba(255, 0, 0, 0.9)"
-            ],
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": false
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 2,
-                "y": 4
-            },
-            "id": 3,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Unreachable",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "thresholds": "1,2",
-            "title": "Unreachable",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "cacheTimeout": null,
-            "class": "single_stat_panel_fail",
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(250, 113, 0, 0.89)",
-                "rgba(255, 0, 0, 0.9)"
-            ],
-            "datasource": "prometheus",
-            "description": "Number of nodes that reported their status as Starting or Joining",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": false
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 4,
-                "y": 4
-            },
-            "id": 4,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Joining",
-                    "refId": "A",
-                    "step": 20
-                }
-            ],
-            "thresholds": "1,2",
-            "title": "Joining",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "cacheTimeout": null,
-            "class": "single_stat_panel_fail",
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(250, 113, 0, 0.89)",
-                "rgba(255, 0, 0, 0.9)"
-            ],
-            "datasource": "prometheus",
-            "description": "Number of nodes that reported their status as  Leaving, Decommissioned, Draining or Drained",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": false
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 6,
-                "y": 4
-            },
-            "id": 5,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(scylla_node_operation_mode>3)OR vector(0)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Leaving",
-                    "refId": "A",
-                    "step": 20
-                }
-            ],
-            "thresholds": "1,2",
-            "title": "Leaving",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "class": "text_panel",
-            "content": "##  ",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 8,
-                "y": 4
-            },
-            "id": 6,
-            "isNew": true,
-            "links": [],
-            "mode": "markdown",
-            "span": 1,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "aliasColors": {},
-            "bars": true,
-            "class": "ops_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 10,
-                "y": 4
-            },
-            "id": 7,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_transport_requests_served{cluster=~\"$cluster|$^\"}[30s])) + $func(irate(scylla_thrift_served{cluster=~\"$cluster|$^\"}[30s]))",
-                    "intervalFactor": 1,
-                    "legendFormat": "Total Requests",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Total Requests - Coordinator",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "class": "dashlist",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 4,
-                "x": 20,
-                "y": 4
-            },
-            "headings": false,
-            "id": 8,
-            "isNew": true,
-            "limit": 10,
-            "links": [],
-            "query": "",
-            "recent": false,
-            "search": true,
-            "span": 2,
-            "starred": false,
-            "tags": [
-                "2019.1"
-            ],
-            "title": "Dashboards",
-            "type": "dashlist"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "percent_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 0,
-                "y": 10
-            },
-            "id": 9,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Load per [[by]]",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "percent",
-                    "logBase": 1,
-                    "max": 101,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
             "aliasColors": {},
             "bars": false,
             "class": "ops_panel",
@@ -609,11 +47,11 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 10,
-                "x": 10,
-                "y": 10
+                "w": 8,
+                "x": 0,
+                "y": 4
             },
-            "id": 10,
+            "id": 2,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -635,7 +73,7 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 5,
+            "span": 4,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -679,6 +117,171 @@
             ]
         },
         {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 4
+            },
+            "id": 3,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_database_total_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Reads per [[by]] - Replica",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 4
+            },
+            "id": 4,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_database_total_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Writes per [[by]] - Replica",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
             "class": "text_header_panel",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Reads and Writes - Coordinator</h1>",
             "editable": true,
@@ -687,9 +290,9 @@
                 "h": 2,
                 "w": 12,
                 "x": 0,
-                "y": 16
+                "y": 10
             },
-            "id": 11,
+            "id": 5,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -708,9 +311,9 @@
                 "h": 2,
                 "w": 12,
                 "x": 12,
-                "y": 16
+                "y": 10
             },
-            "id": 12,
+            "id": 6,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -738,9 +341,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 18
+                "y": 12
             },
-            "id": 13,
+            "id": 7,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -820,9 +423,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 18
+                "y": 12
             },
-            "id": 14,
+            "id": 8,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -903,9 +506,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 18
+                "y": 12
             },
-            "id": 15,
+            "id": 9,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -985,9 +588,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 18
+                "y": 12
             },
-            "id": 16,
+            "id": 10,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1067,9 +670,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 24
+                "y": 18
             },
-            "id": 17,
+            "id": 11,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1149,9 +752,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 24
+                "y": 18
             },
-            "id": 18,
+            "id": 12,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1231,9 +834,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 24
+                "y": 18
             },
-            "id": 19,
+            "id": 13,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1313,9 +916,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 24
+                "y": 18
             },
-            "id": 20,
+            "id": 14,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1387,9 +990,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 30
+                "y": 24
             },
-            "id": 21,
+            "id": 15,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -1398,171 +1001,6 @@
             "title": "",
             "transparent": true,
             "type": "text"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "rps_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 12,
-                "x": 0,
-                "y": 32
-            },
-            "id": 22,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 6,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_database_total_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Reads",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "rps",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "wps_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 12,
-                "x": 12,
-                "y": 32
-            },
-            "id": 23,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 6,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_database_total_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Writes",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "wps",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
         },
         {
             "aliasColors": {},
@@ -1582,9 +1020,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 38
+                "y": 26
             },
-            "id": 24,
+            "id": 16,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1664,9 +1102,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 38
+                "y": 26
             },
-            "id": 25,
+            "id": 17,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1746,9 +1184,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 38
+                "y": 26
             },
-            "id": 26,
+            "id": 18,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1828,9 +1266,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 38
+                "y": 26
             },
-            "id": 27,
+            "id": 19,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1901,9 +1339,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 44
+                "y": 32
             },
-            "id": 28,
+            "id": 20,
             "isNew": true,
             "links": [],
             "mode": "markdown",
@@ -1930,9 +1368,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 44
+                "y": 32
             },
-            "id": 29,
+            "id": 21,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2012,9 +1450,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 44
+                "y": 32
             },
-            "id": 30,
+            "id": 22,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2094,9 +1532,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 44
+                "y": 32
             },
-            "id": 31,
+            "id": 23,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2167,9 +1605,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 50
+                "y": 38
             },
-            "id": 32,
+            "id": 24,
             "isNew": true,
             "links": [],
             "mode": "markdown",
@@ -2187,9 +1625,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 50
+                "y": 38
             },
-            "id": 33,
+            "id": 25,
             "isNew": true,
             "links": [],
             "mode": "markdown",
@@ -2216,9 +1654,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 50
+                "y": 38
             },
-            "id": 34,
+            "id": 26,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2298,9 +1736,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 50
+                "y": 38
             },
-            "id": 35,
+            "id": 27,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2371,9 +1809,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 56
+                "y": 44
             },
-            "id": 36,
+            "id": 28,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -2401,9 +1839,9 @@
                 "h": 6,
                 "w": 12,
                 "x": 0,
-                "y": 58
+                "y": 46
             },
-            "id": 37,
+            "id": 29,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2483,9 +1921,9 @@
                 "h": 6,
                 "w": 12,
                 "x": 12,
-                "y": 58
+                "y": 46
             },
-            "id": 38,
+            "id": 30,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2565,9 +2003,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 64
+                "y": 52
             },
-            "id": 39,
+            "id": 31,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2647,9 +2085,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 64
+                "y": 52
             },
-            "id": 40,
+            "id": 32,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2729,9 +2167,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 64
+                "y": 52
             },
-            "id": 41,
+            "id": 33,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2811,9 +2249,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 64
+                "y": 52
             },
-            "id": 42,
+            "id": 34,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2893,9 +2331,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 70
+                "y": 58
             },
-            "id": 43,
+            "id": 35,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2975,9 +2413,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 70
+                "y": 58
             },
-            "id": 44,
+            "id": 36,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3057,9 +2495,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 70
+                "y": 58
             },
-            "id": 45,
+            "id": 37,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3141,9 +2579,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 70
+                "y": 58
             },
-            "id": 46,
+            "id": 38,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3225,9 +2663,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 76
+                "y": 64
             },
-            "id": 47,
+            "id": 39,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3309,9 +2747,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 76
+                "y": 64
             },
-            "id": 48,
+            "id": 40,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3393,9 +2831,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 76
+                "y": 64
             },
-            "id": 49,
+            "id": 41,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3477,9 +2915,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 76
+                "y": 64
             },
-            "id": 50,
+            "id": 42,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3561,9 +2999,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 82
+                "y": 70
             },
-            "id": 51,
+            "id": 43,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3643,9 +3081,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 82
+                "y": 70
             },
-            "id": 52,
+            "id": 44,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3725,9 +3163,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 82
+                "y": 70
             },
-            "id": 53,
+            "id": 45,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3806,9 +3244,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 82
+                "y": 70
             },
-            "id": 54,
+            "id": 46,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3871,16 +3309,16 @@
         },
         {
             "class": "text_panel",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Memory - Replica</h1>",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Materialized Views - Replica</h1>",
             "editable": true,
             "error": false,
             "gridPos": {
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 88
+                "y": 76
             },
-            "id": 55,
+            "id": 47,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -3908,9 +3346,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 90
+                "y": 78
             },
-            "id": 56,
+            "id": 48,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3989,9 +3427,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 90
+                "y": 78
             },
-            "id": 57,
+            "id": 49,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -4071,9 +3509,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 90
+                "y": 78
             },
-            "id": 58,
+            "id": 50,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -4140,6 +3578,189 @@
         },
         {
             "class": "text_panel",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Memory - Replica</h1>",
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 84
+            },
+            "id": 51,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bytes_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 0,
+                "y": 86
+            },
+            "id": 52,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(scylla_lsa_total_space_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "LSA total memory",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "bytes",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bytes_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 12,
+                "y": 86
+            },
+            "id": 53,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(scylla_lsa_non_lsa_used_space_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Non-LSA used memory",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "bytes",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "class": "text_panel",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Compaction - Replica</h1>",
             "editable": true,
             "error": false,
@@ -4147,9 +3768,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 96
+                "y": 92
             },
-            "id": 59,
+            "id": 54,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -4177,9 +3798,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 98
+                "y": 94
             },
-            "id": 60,
+            "id": 55,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -4261,9 +3882,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 98
+                "y": 94
             },
-            "id": 61,
+            "id": 56,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -4348,9 +3969,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 98
+                "y": 94
             },
-            "id": 62,
+            "id": 57,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -4412,451 +4033,6 @@
             ]
         },
         {
-            "class": "text_panel",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">CQL - Coordinator</h1>",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 2,
-                "w": 24,
-                "x": 0,
-                "y": 104
-            },
-            "id": 63,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "span": 12,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "ops_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 0,
-                "y": 106
-            },
-            "id": 64,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "CQL Insert",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "ops_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 6,
-                "y": 106
-            },
-            "id": 65,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "CQL Reads",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "ops_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 12,
-                "y": 106
-            },
-            "id": 66,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "CQL Deletes",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "ops_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 18,
-                "y": 106
-            },
-            "id": 67,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "CQL Updates",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "graph_panel",
-            "datasource": "prometheus",
-            "description": "amount of CQL connections currently established",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 0,
-                "y": 112
-            },
-            "id": 68,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 1,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(scylla_transport_current_connections{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 30
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Client CQL connections by [[by]]",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
             "class": "plain_text",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Your Panels</h1>",
             "editable": true,
@@ -4865,9 +4041,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 118
+                "y": 100
             },
-            "id": 69,
+            "id": 58,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -4896,9 +4072,9 @@
                 "h": 6,
                 "w": 12,
                 "x": 0,
-                "y": 120
+                "y": 102
             },
-            "id": 70,
+            "id": 59,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -4972,9 +4148,9 @@
                 "h": 6,
                 "w": 12,
                 "x": 12,
-                "y": 120
+                "y": 102
             },
-            "id": 71,
+            "id": 60,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -5258,7 +4434,7 @@
         ]
     },
     "timezone": "browser",
-    "title": "Scylla Per Server Metrics",
-    "uid": "detail-2019-1",
+    "title": "Detailed",
+    "uid": "detailed-2019-1",
     "version": 5
 }

--- a/grafana/build/ver_2019.1/scylla-dash.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-dash.2019.1.json
@@ -378,215 +378,6 @@
             "valueName": "current"
         },
         {
-            "class": "text_panel",
-            "content": "##  ",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 4,
-                "x": 8,
-                "y": 4
-            },
-            "id": 6,
-            "isNew": true,
-            "links": [],
-            "mode": "markdown",
-            "span": 2,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "class": "dashlist",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 4,
-                "x": 12,
-                "y": 4
-            },
-            "headings": false,
-            "id": 7,
-            "isNew": true,
-            "limit": 10,
-            "links": [],
-            "query": "",
-            "recent": false,
-            "search": true,
-            "span": 2,
-            "starred": false,
-            "tags": [
-                "2019.1"
-            ],
-            "title": "Dashboards",
-            "type": "dashlist"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "alert_table",
-            "columns": [],
-            "datasource": "alertmanager",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "fontSize": "100%",
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 8,
-                "x": 16,
-                "y": 4
-            },
-            "id": 8,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "pageSize": null,
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "scroll": true,
-            "seriesOverrides": [],
-            "showHeader": true,
-            "sort": {
-                "col": 0,
-                "desc": true
-            },
-            "span": 4,
-            "stack": false,
-            "steppedLine": false,
-            "styles": [
-                {
-                    "alias": "Time",
-                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                    "link": true,
-                    "linkTooltip": "Jump to the see the node",
-                    "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_4}&from=${__cell_0}",
-                    "pattern": "Time",
-                    "type": "date"
-                },
-                {
-                    "class": "hidden_column",
-                    "pattern": "severity",
-                    "type": "hidden"
-                },
-                {
-                    "class": "hidden_column",
-                    "pattern": "alertname",
-                    "type": "hidden"
-                },
-                {
-                    "class": "hidden_column",
-                    "pattern": "cluster",
-                    "type": "hidden"
-                },
-                {
-                    "class": "hidden_column",
-                    "pattern": "monitor",
-                    "type": "hidden"
-                },
-                {
-                    "class": "hidden_column",
-                    "pattern": "summary",
-                    "type": "hidden"
-                },
-                {
-                    "alias": "Instance",
-                    "colorMode": null,
-                    "colors": [
-                        "rgba(245, 54, 54, 0.9)",
-                        "rgba(237, 129, 40, 0.89)",
-                        "rgba(50, 172, 45, 0.97)"
-                    ],
-                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                    "decimals": 2,
-                    "link": true,
-                    "linkTooltip": "Jump to the see the node",
-                    "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_4}",
-                    "mappingType": 1,
-                    "pattern": "instance",
-                    "thresholds": [],
-                    "type": "string",
-                    "unit": "short"
-                },
-                {
-                    "alias": "",
-                    "colorMode": null,
-                    "colors": [
-                        "rgba(245, 54, 54, 0.9)",
-                        "rgba(237, 129, 40, 0.89)",
-                        "rgba(50, 172, 45, 0.97)"
-                    ],
-                    "decimals": 2,
-                    "pattern": "/.*/",
-                    "thresholds": [],
-                    "type": "number",
-                    "unit": "short"
-                }
-            ],
-            "targets": [
-                {
-                    "annotations": true,
-                    "expr": "job!=\"scylla_manager\"",
-                    "legendFormat": "{{description}}",
-                    "refId": "A",
-                    "target": "Query",
-                    "type": "table"
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Active Alerts",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "transform": "table",
-            "type": "table",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
             "aliasColors": {},
             "bars": false,
             "class": "percent_panel",
@@ -604,10 +395,10 @@
             "gridPos": {
                 "h": 6,
                 "w": 8,
-                "x": 0,
-                "y": 10
+                "x": 8,
+                "y": 4
             },
-            "id": 9,
+            "id": 6,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -673,92 +464,6 @@
             ]
         },
         {
-            "aliasColors": {},
-            "bars": false,
-            "class": "ops_panel",
-            "datasource": "prometheus",
-            "description": "Amount of requests served as the coordinator. Imbalances here represent dispersion at the client-side level or connection balancing level, not your data model.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 8,
-                "x": 8,
-                "y": 10
-            },
-            "id": 10,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 4,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + $func(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 4
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Requests Served - Coordinator",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
             "class": "single_value_table",
             "columns": [
                 {
@@ -773,9 +478,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 10
+                "y": 4
             },
-            "id": 11,
+            "id": 7,
             "links": [],
             "pageSize": null,
             "scroll": true,
@@ -798,7 +503,7 @@
                     "decimals": 2,
                     "link": true,
                     "linkTooltip": "Jump to the detailed node information",
-                    "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_6}",
+                    "linkUrl": "/d/detailed-[[dash_version]]/Detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__cell}",
                     "mappingType": 1,
                     "pattern": "instance",
                     "thresholds": [],
@@ -829,6 +534,128 @@
                     "class": "hidden_column",
                     "pattern": "type",
                     "type": "hidden"
+                },
+                {
+                    "alias": "OS",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the OS node information",
+                    "linkUrl": "/d/OS-[[dash_version]]/OS-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                    "mappingType": 1,
+                    "pattern": "OS",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "OS",
+                            "value": "os"
+                        }
+                    ]
+                },
+                {
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the CQL information",
+                    "linkUrl": "/d/cql-[[dash_version]]/scylla-cql?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                    "mappingType": 1,
+                    "pattern": "CQL",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "CQL",
+                            "value": "cql"
+                        }
+                    ]
+                },
+                {
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the Errors metrics information",
+                    "linkUrl": "/d/error-[[dash_version]]/scylla-errors?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                    "mappingType": 1,
+                    "pattern": "Errors",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "Errors",
+                            "value": "errors"
+                        }
+                    ]
+                },
+                {
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the Errors metrics information",
+                    "linkUrl": "/d/io-[[dash_version]]/i-o?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                    "mappingType": 1,
+                    "pattern": "IO",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "IO",
+                            "value": "io"
+                        }
+                    ]
+                },
+                {
+                    "alias": "CPU",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the node CPU information",
+                    "linkUrl": "/d/cpu-[[dash_version]]/CPU-Metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                    "mappingType": 1,
+                    "pattern": "CPU",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "CPU",
+                            "value": "cpu"
+                        }
+                    ]
                 },
                 {
                     "alias": "Status",
@@ -898,6 +725,336 @@
             "type": "table"
         },
         {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bytes_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 10
+            },
+            "id": 8,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(node_filesystem_size_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])-sum(node_filesystem_avail_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Disk Size by $by",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "bytes",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "datasource": "prometheus",
+            "description": "Amount of requests served as the coordinator. Imbalances here represent dispersion at the client-side level or connection balancing level, not your data model.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 10
+            },
+            "id": 9,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + $func(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 4
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Requests Served - Coordinator",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "alert_table",
+            "columns": [],
+            "datasource": "alertmanager",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fontSize": "100%",
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 10
+            },
+            "id": 10,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "pageSize": null,
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "scroll": true,
+            "seriesOverrides": [],
+            "showHeader": true,
+            "sort": {
+                "col": 0,
+                "desc": true
+            },
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "styles": [
+                {
+                    "alias": "Time",
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "link": true,
+                    "linkTooltip": "Jump to the see the node",
+                    "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}&from=${__cell_0}",
+                    "pattern": "Time",
+                    "type": "date"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "severity",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "alertname",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "cluster",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "monitor",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "summary",
+                    "type": "hidden"
+                },
+                {
+                    "alias": "Instance",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the see the node",
+                    "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                    "mappingType": 1,
+                    "pattern": "instance",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short"
+                },
+                {
+                    "alias": "",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "decimals": 2,
+                    "pattern": "/.*/",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "short"
+                }
+            ],
+            "targets": [
+                {
+                    "annotations": true,
+                    "expr": "job!=\"scylla_manager\"",
+                    "legendFormat": "{{description}}",
+                    "refId": "A",
+                    "target": "Query",
+                    "type": "table"
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Active Alerts",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "transform": "table",
+            "type": "table",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
             "class": "plain_text",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Latencies - Coordinator</h1>",
             "editable": true,
@@ -908,7 +1065,7 @@
                 "x": 0,
                 "y": 16
             },
-            "id": 12,
+            "id": 11,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -917,6 +1074,90 @@
             "title": "",
             "transparent": true,
             "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 18
+            },
+            "id": 12,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Writes",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
         },
         {
             "aliasColors": {},
@@ -934,8 +1175,8 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 8,
-                "x": 0,
+                "w": 6,
+                "x": 6,
                 "y": 18
             },
             "id": 13,
@@ -960,7 +1201,7 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 4,
+            "span": 3,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -1019,8 +1260,8 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 8,
-                "x": 8,
+                "w": 6,
+                "x": 12,
                 "y": 18
             },
             "id": 14,
@@ -1045,7 +1286,7 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 4,
+            "span": 3,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -1105,8 +1346,8 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 8,
-                "x": 16,
+                "w": 6,
+                "x": 18,
                 "y": 18
             },
             "id": 15,
@@ -1131,7 +1372,7 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 4,
+            "span": 3,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -1178,7 +1419,7 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "us_panel",
+            "class": "ops_panel",
             "datasource": "prometheus",
             "editable": true,
             "error": false,
@@ -1191,7 +1432,7 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 8,
+                "w": 6,
                 "x": 0,
                 "y": 24
             },
@@ -1217,7 +1458,91 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 4,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Reads",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 24
+            },
+            "id": 17,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "span": 3,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -1276,11 +1601,11 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 8,
-                "x": 8,
+                "w": 6,
+                "x": 12,
                 "y": 24
             },
-            "id": 17,
+            "id": 18,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1302,7 +1627,7 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 4,
+            "span": 3,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -1362,11 +1687,11 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 8,
-                "x": 16,
+                "w": 6,
+                "x": 18,
                 "y": 24
             },
-            "id": 18,
+            "id": 19,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1388,7 +1713,7 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 4,
+            "span": 3,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -1433,35 +1758,13 @@
             ]
         },
         {
-            "class": "text_header_panel",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Reads and Writes - Coordinator</h1>",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Cache - Replica</h1>",
             "editable": true,
             "error": false,
             "gridPos": {
                 "h": 2,
                 "w": 12,
                 "x": 0,
-                "y": 30
-            },
-            "id": 19,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "span": 6,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "class": "text_header_panel",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Timeouts and Errors - Coordinator</h1>",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 2,
-                "w": 12,
-                "x": 12,
                 "y": 30
             },
             "id": 20,
@@ -1475,705 +1778,16 @@
             "type": "text"
         },
         {
-            "aliasColors": {},
-            "bars": false,
-            "class": "queue_lenght_panel",
-            "datasource": "prometheus",
-            "description": "Foreground writes are writes that weren't acknowledged yet to the application. For instance, if a single replica responded and two are needed due to the consistency level. This metric represents a queue size, not a rate. High values here correlate with increased write latencies.",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Timeouts</h1>",
             "editable": true,
             "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
             "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 0,
-                "y": 32
+                "h": 2,
+                "w": 12,
+                "x": 12,
+                "y": 30
             },
             "id": 21,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(scylla_storage_proxy_coordinator_foreground_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 10
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Foreground Writes",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "label": "Queue Length",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "queue_lenght_panel",
-            "datasource": "prometheus",
-            "description": "Foreground reads are reads that weren't acknowledged yet to the application. For instance, if a single replica responded and two are needed due to the consistency level. This metric represents a queue size, not a rate. High values here correlate with increased read latencies.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 6,
-                "y": 32
-            },
-            "id": 22,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(scylla_storage_proxy_coordinator_foreground_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 10
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Foreground Reads",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "label": "Queue Length",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "wps_panel",
-            "datasource": "prometheus",
-            "description": "Requests that Scylla tried to write but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 12,
-                "y": 32
-            },
-            "id": 23,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 10
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Write Timeouts",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "wps",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "wps_panel",
-            "datasource": "prometheus",
-            "description": "Requests that Scylla did not even try to write because replicas that were needed to execute this write were unavailable. Unavailable writes are counted in the node that received the request (the coordinator), not at the replicas.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 18,
-                "y": 32
-            },
-            "id": 24,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_storage_proxy_coordinator_write_unavailable{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 10
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Write Unavailable",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "wps",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "queue_lenght_panel",
-            "datasource": "prometheus",
-            "description": "Background writes are writes that are already acknowledged to the application but have additional work to be done. For instance, if a replica responded and only one is needed, this request is still listed as a background request until all replicas respond. This metric represents a queue size, not a rate. High values here correlate with increased write latencies.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 0,
-                "y": 38
-            },
-            "id": 25,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(scylla_storage_proxy_coordinator_background_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 10
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Background Writes",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "label": "Queue Length",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "queue_lenght_panel",
-            "datasource": "prometheus",
-            "description": "Background reads are reads that are already acknowledged to the application but have additional work to be done. For instance, if a replica responded and only one is needed, this request is still listed as a background request until all replicas respond. This metric represents a queue size, not a rate. High values here correlate with increased read latencies.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 6,
-                "y": 38
-            },
-            "id": 26,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(scylla_storage_proxy_coordinator_background_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 10
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Background Reads",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "label": "Queue Length",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "rps_panel",
-            "datasource": "prometheus",
-            "description": "Requests that Scylla tried to read but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 12,
-                "y": 38
-            },
-            "id": 27,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 10
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Read Timeouts",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "rps",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "rps_panel",
-            "datasource": "prometheus",
-            "description": "Requests that Scylla did not even try to read because replicas that were needed to execute this write were unavailable. Unavailable reads are counted in the node that received the request (the coordinator), not at the replicas.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 18,
-                "y": 38
-            },
-            "id": 28,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_storage_proxy_coordinator_read_unavailable{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 10
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Read Unavailable",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "rps",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Cache - Replica</h1>",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 2,
-                "w": 12,
-                "x": 0,
-                "y": 44
-            },
-            "id": 29,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "span": 6,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Materialized Views - Replica</h1>",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 2,
-                "w": 12,
-                "x": 12,
-                "y": 44
-            },
-            "id": 30,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -2202,9 +1816,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 46
+                "y": 32
             },
-            "id": 31,
+            "id": 22,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2287,9 +1901,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 46
+                "y": 32
             },
-            "id": 32,
+            "id": 23,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2356,9 +1970,9 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "bytes_panel",
+            "class": "wps_panel",
             "datasource": "prometheus",
-            "description": "Size in bytes of the view update backlog at each base replica.",
+            "description": "Requests that Scylla tried to write but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas.",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -2372,9 +1986,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 46
+                "y": 32
             },
-            "id": 33,
+            "id": 24,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2399,7 +2013,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(scylla_database_view_update_backlog{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
+                    "expr": "$func(irate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -2408,194 +2022,7 @@
             ],
             "timeFrom": null,
             "timeShift": null,
-            "title": "View Update Backlog",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "bytes",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "ops_panel",
-            "datasource": "prometheus",
-            "description": "Number of dropped view updates due to an excessive view update backlog.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 18,
-                "y": 46
-            },
-            "id": 34,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_database_dropped_view_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 10
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Dropped View Updates",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "class": "text_panel",
-            "content": "",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 18,
-                "x": 0,
-                "y": 52
-            },
-            "id": 35,
-            "isNew": true,
-            "links": [],
-            "mode": "markdown",
-            "span": 9,
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "wps_panel",
-            "datasource": "prometheus",
-            "description": "Currently throttled base writes, as a consequence of the respective view update backlog.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 18,
-                "y": 52
-            },
-            "id": 36,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(scylla_storage_proxy_coordinator_current_throttled_base_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"})  by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 10
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Throttled Base Writes",
+            "title": "Write Timeouts",
             "tooltip": {
                 "msResolution": false,
                 "shared": true,
@@ -2624,6 +2051,89 @@
             ]
         },
         {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "datasource": "prometheus",
+            "description": "Requests that Scylla tried to read but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 32
+            },
+            "id": 25,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Read Timeouts",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
             "class": "plain_text",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Your Panels</h1>",
             "editable": true,
@@ -2632,9 +2142,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 58
+                "y": 38
             },
-            "id": 37,
+            "id": 26,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -2663,9 +2173,9 @@
                 "h": 6,
                 "w": 12,
                 "x": 0,
-                "y": 60
+                "y": 40
             },
-            "id": 38,
+            "id": 27,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2739,9 +2249,9 @@
                 "h": 6,
                 "w": 12,
                 "x": 12,
-                "y": 60
+                "y": 40
             },
-            "id": 39,
+            "id": 28,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2945,6 +2455,29 @@
             },
             {
                 "allValue": null,
+                "current": {
+                    "text": "/var/lib/scylla",
+                    "value": "/var/lib/scylla"
+                },
+                "datasource": "prometheus",
+                "hide": 0,
+                "includeAll": false,
+                "label": "Mounnt path",
+                "multi": false,
+                "name": "mount_point",
+                "options": [],
+                "query": "node_filesystem_avail_bytes",
+                "refresh": 2,
+                "regex": "/mountpoint=\"([^\"]*)\".*/",
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
                 "class": "aggregation_function",
                 "current": {
                     "tags": [],
@@ -2996,8 +2529,8 @@
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {
-                    "text": "2019.1",
-                    "value": "2019.1"
+                    "text": "2019-1",
+                    "value": "2019-1"
                 },
                 "hide": 2,
                 "includeAll": false,
@@ -3007,11 +2540,11 @@
                 "options": [
                     {
                         "selected": true,
-                        "text": "2019.1",
-                        "value": "2019.1"
+                        "text": "2019-1",
+                        "value": "2019-1"
                     }
                 ],
-                "query": "2019.1",
+                "query": "2019-1",
                 "skipUrlSync": false,
                 "type": "custom"
             }
@@ -3048,7 +2581,7 @@
         ]
     },
     "timezone": "browser",
-    "title": "Scylla Overview Metrics",
+    "title": "Overview",
     "uid": "overview-2019-1",
     "version": 3
 }

--- a/grafana/build/ver_3.0/scylla-cql-optimization.3.0.json
+++ b/grafana/build/ver_3.0/scylla-cql-optimization.3.0.json
@@ -8,7 +8,7 @@
     "hideControls": true,
     "id": null,
     "links": [],
-    "originalTitle": "Scylla CQL Optimization",
+    "originalTitle": "CQL",
     "overwrite": true,
     "panels": [
         {
@@ -32,193 +32,21 @@
             "type": "text"
         },
         {
-            "cacheTimeout": null,
-            "class": "single_stat_panel",
-            "colorBackground": false,
-            "colorValue": false,
-            "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-            ],
-            "datasource": "prometheus",
+            "class": "text_panel",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">CQL - Coordinator</h1>",
             "editable": true,
             "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-            },
             "gridPos": {
-                "h": 6,
-                "w": 2,
+                "h": 2,
+                "w": 24,
                 "x": 0,
                 "y": 4
             },
             "id": 2,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
-                    "intervalFactor": 1,
-                    "legendFormat": "Total Nodes",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "thresholds": "",
-            "title": "Total Nodes",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "cacheTimeout": null,
-            "class": "single_stat_panel_fail",
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(250, 113, 0, 0.89)",
-                "rgba(255, 0, 0, 0.9)"
-            ],
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": false
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 2,
-                "y": 4
-            },
-            "id": 3,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Unreachable",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "thresholds": "1,2",
-            "title": "Unreachable",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "class": "plain_text",
-            "content": "<span/>",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 4,
-                "x": 4,
-                "y": 4
-            },
-            "id": 4,
             "isNew": true,
             "links": [],
             "mode": "html",
-            "span": 2,
+            "span": 12,
             "style": {},
             "title": "",
             "transparent": true,
@@ -229,7 +57,6 @@
             "bars": false,
             "class": "ops_panel",
             "datasource": "prometheus",
-            "description": "Total requests graph is the baseline for comparison",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -241,11 +68,11 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 8,
-                "x": 8,
-                "y": 4
+                "w": 6,
+                "x": 0,
+                "y": 6
             },
-            "id": 5,
+            "id": 3,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -267,21 +94,22 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 4,
+            "span": 3,
             "stack": false,
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "expr": "sum(irate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                     "intervalFactor": 1,
-                    "legendFormat": "Total Requests",
+                    "legendFormat": "",
+                    "metric": "",
                     "refId": "A",
                     "step": 1
                 }
             ],
             "timeFrom": null,
             "timeShift": null,
-            "title": "Total Requests",
+            "title": "CQL Insert",
             "tooltip": {
                 "msResolution": false,
                 "shared": true,
@@ -310,51 +138,553 @@
             ]
         },
         {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 6
+            },
+            "id": 4,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CQL Reads",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 6
+            },
+            "id": 5,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CQL Deletes",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 6
+            },
+            "id": 6,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CQL Updates",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "datasource": "prometheus",
+            "description": "amount of CQL connections currently established",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 12
+            },
+            "id": 7,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(scylla_transport_current_connections{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Client CQL connections by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "datasource": "prometheus",
+            "description": "Number of CQL batches command, each batched command is counted once",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 12
+            },
+            "id": 8,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_batches{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CQL Batches by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "datasource": "prometheus",
+            "description": "Number of CQL command batched. Each batch would add the number of commands inside the batch",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 12
+            },
+            "id": 9,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_statements_in_batches{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CQL Coomand In Batches by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
             "class": "plain_text",
             "content": "<span/>",
             "editable": true,
             "error": false,
             "gridPos": {
                 "h": 6,
-                "w": 4,
-                "x": 16,
-                "y": 4
+                "w": 6,
+                "x": 18,
+                "y": 12
             },
-            "id": 6,
+            "id": 10,
             "isNew": true,
             "links": [],
             "mode": "html",
-            "span": 2,
+            "span": 3,
             "style": {},
             "title": "",
             "transparent": true,
             "type": "text"
         },
         {
-            "class": "dashlist",
+            "class": "text_panel",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Optimization</h1>",
             "editable": true,
             "error": false,
             "gridPos": {
-                "h": 6,
-                "w": 4,
-                "x": 20,
-                "y": 4
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 18
             },
-            "headings": false,
-            "id": 7,
+            "id": 11,
             "isNew": true,
-            "limit": 10,
             "links": [],
-            "query": "",
-            "recent": false,
-            "search": true,
-            "span": 2,
-            "starred": false,
-            "tags": [
-                "3.0"
-            ],
-            "title": "Dashboards",
-            "type": "dashlist"
+            "mode": "html",
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
         },
         {
             "cacheTimeout": null,
@@ -382,9 +712,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 10
+                "y": 20
             },
-            "id": 8,
+            "id": 12,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -465,9 +795,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 10
+                "y": 20
             },
-            "id": 9,
+            "id": 13,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -557,9 +887,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 10
+                "y": 20
             },
-            "id": 10,
+            "id": 14,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -640,9 +970,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 10
+                "y": 20
             },
-            "id": 11,
+            "id": 15,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -732,9 +1062,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 16,
-                "y": 10
+                "y": 20
             },
-            "id": 12,
+            "id": 16,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -813,9 +1143,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 10
+                "y": 20
             },
-            "id": 13,
+            "id": 17,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -905,9 +1235,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 16
+                "y": 26
             },
-            "id": 14,
+            "id": 18,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -988,9 +1318,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 16
+                "y": 26
             },
-            "id": 15,
+            "id": 19,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1080,9 +1410,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 16
+                "y": 26
             },
-            "id": 16,
+            "id": 20,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -1161,9 +1491,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 16
+                "y": 26
             },
-            "id": 17,
+            "id": 21,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1251,9 +1581,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 16,
-                "y": 16
+                "y": 26
             },
-            "id": 18,
+            "id": 22,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -1334,9 +1664,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 16
+                "y": 26
             },
-            "id": 19,
+            "id": 23,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1441,9 +1771,9 @@
                 "h": 6,
                 "w": 4,
                 "x": 0,
-                "y": 22
+                "y": 32
             },
-            "id": 20,
+            "id": 24,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -1648,29 +1978,6 @@
                 "tagsQuery": "",
                 "type": "query",
                 "useTags": false
-            },
-            {
-                "allValue": null,
-                "class": "template_variable_custom",
-                "current": {
-                    "text": "3.0",
-                    "value": "3.0"
-                },
-                "hide": 2,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
-                "name": "dash_version",
-                "options": [
-                    {
-                        "selected": true,
-                        "text": "3.0",
-                        "value": "3.0"
-                    }
-                ],
-                "query": "master",
-                "skipUrlSync": false,
-                "type": "custom"
             }
         ]
     },
@@ -1705,7 +2012,7 @@
         ]
     },
     "timezone": "browser",
-    "title": "Scylla CQL Optimization",
-    "uid": "cqlopt-3-0",
+    "title": "Scylla CQL",
+    "uid": "cql-3-0",
     "version": 0
 }

--- a/grafana/build/ver_3.0/scylla-dash-cpu-per-server.3.0.json
+++ b/grafana/build/ver_3.0/scylla-dash-cpu-per-server.3.0.json
@@ -117,53 +117,6 @@
             ]
         },
         {
-            "class": "text_panel",
-            "content": "##  ",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 10,
-                "y": 4
-            },
-            "id": 3,
-            "isNew": true,
-            "links": [],
-            "mode": "markdown",
-            "span": 3,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "class": "dashlist",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 4,
-                "x": 16,
-                "y": 4
-            },
-            "headings": false,
-            "id": 4,
-            "isNew": true,
-            "limit": 10,
-            "links": [],
-            "query": "",
-            "recent": false,
-            "search": true,
-            "span": 2,
-            "starred": false,
-            "tags": [
-                "3.0"
-            ],
-            "title": "Dashboards",
-            "type": "dashlist"
-        },
-        {
             "aliasColors": {},
             "bars": false,
             "class": "percent_panel",
@@ -181,10 +134,10 @@
             "gridPos": {
                 "h": 6,
                 "w": 10,
-                "x": 0,
-                "y": 10
+                "x": 10,
+                "y": 4
             },
-            "id": 5,
+            "id": 3,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -251,6 +204,27 @@
             ]
         },
         {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Task Quota Violation</h1>",
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 10
+            },
+            "id": 4,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
             "aliasColors": {},
             "bars": false,
             "class": "ms_panel",
@@ -267,11 +241,11 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 10,
-                "x": 10,
-                "y": 10
+                "w": 6,
+                "x": 0,
+                "y": 12
             },
-            "id": 6,
+            "id": 5,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -290,13 +264,14 @@
             "pointradius": 1,
             "points": false,
             "renderer": "flot",
+            "repeat": "group",
             "seriesOverrides": [],
-            "span": 5,
+            "span": 3,
             "stack": false,
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(scylla_scheduler_time_spent_on_task_quota_violations_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "expr": "sum(irate(scylla_scheduler_time_spent_on_task_quota_violations_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -306,7 +281,7 @@
             ],
             "timeFrom": null,
             "timeShift": null,
-            "title": "Time spent in task quota violations by [[by]]",
+            "title": "Time spent in task quota violations by [[by]] - $group",
             "tooltip": {
                 "msResolution": false,
                 "shared": true,
@@ -480,6 +455,32 @@
                 "tagsQuery": "",
                 "type": "query",
                 "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "hide": 2,
+                "includeAll": true,
+                "label": "group",
+                "multi": true,
+                "name": "group",
+                "options": [],
+                "query": "label_values(scylla_scheduler_time_spent_on_task_quota_violations_ms,group)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 3,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
             }
         ]
     },
@@ -514,7 +515,7 @@
         ]
     },
     "timezone": "browser",
-    "title": "Scylla CPU Per Server Metrics",
+    "title": "CPU Metrics",
     "uid": "cpu-3-0",
     "version": 5
 }

--- a/grafana/build/ver_3.0/scylla-dash-io-per-server.3.0.json
+++ b/grafana/build/ver_3.0/scylla-dash-io-per-server.3.0.json
@@ -506,7 +506,7 @@
         },
         {
             "class": "plain_text",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Disk Activity</h1>",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue</h1>",
             "editable": true,
             "error": false,
             "gridPos": {
@@ -516,357 +516,6 @@
                 "y": 16
             },
             "id": 9,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "span": 12,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "graph_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 12,
-                "x": 0,
-                "y": 18
-            },
-            "id": 10,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 6,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 20
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Disk Writes per Server",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "graph_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 12,
-                "x": 12,
-                "y": 18
-            },
-            "id": 11,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 6,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 20
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Disk Reads per Server",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "bps_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 12,
-                "x": 0,
-                "y": 24
-            },
-            "id": 12,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 6,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 20
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Disk Writes Bps per Server",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "Bps",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "bps_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 12,
-                "x": 12,
-                "y": 24
-            },
-            "id": 13,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 6,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 20
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Disk Read Bps per Server",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "Bps",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "class": "plain_text",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue</h1>",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 2,
-                "w": 24,
-                "x": 0,
-                "y": 30
-            },
-            "id": 14,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -894,9 +543,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 32
+                "y": 18
             },
-            "id": 15,
+            "id": 10,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -980,9 +629,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 32
+                "y": 18
             },
-            "id": 16,
+            "id": 11,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1063,9 +712,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 32
+                "y": 18
             },
-            "id": 17,
+            "id": 12,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1146,9 +795,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 38
+                "y": 24
             },
-            "id": 18,
+            "id": 13,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1232,9 +881,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 38
+                "y": 24
             },
-            "id": 19,
+            "id": 14,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1315,9 +964,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 38
+                "y": 24
             },
-            "id": 20,
+            "id": 15,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1398,9 +1047,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 44
+                "y": 30
             },
-            "id": 21,
+            "id": 16,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1484,9 +1133,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 44
+                "y": 30
             },
-            "id": 22,
+            "id": 17,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1567,9 +1216,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 44
+                "y": 30
             },
-            "id": 23,
+            "id": 18,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1650,9 +1299,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 50
+                "y": 36
             },
-            "id": 24,
+            "id": 19,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1736,9 +1385,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 50
+                "y": 36
             },
-            "id": 25,
+            "id": 20,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1819,9 +1468,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 50
+                "y": 36
             },
-            "id": 26,
+            "id": 21,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1902,9 +1551,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 56
+                "y": 42
             },
-            "id": 27,
+            "id": 22,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1988,9 +1637,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 56
+                "y": 42
             },
-            "id": 28,
+            "id": 23,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2071,9 +1720,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 56
+                "y": 42
             },
-            "id": 29,
+            "id": 24,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2154,9 +1803,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 62
+                "y": 48
             },
-            "id": 30,
+            "id": 25,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2240,9 +1889,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 62
+                "y": 48
             },
-            "id": 31,
+            "id": 26,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2323,9 +1972,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 62
+                "y": 48
             },
-            "id": 32,
+            "id": 27,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2399,19 +2048,6 @@
     "templating": {
         "list": [
             {
-                "current": {},
-                "datasource": "prometheus",
-                "hide": 0,
-                "includeAll": false,
-                "multi": false,
-                "name": "monitor_disk",
-                "options": [],
-                "query": "node_disk_read_bytes_total",
-                "refresh": 2,
-                "regex": "/.*device=\"([^\\\"]*)\".*/",
-                "type": "query"
-            },
-            {
                 "allValue": null,
                 "class": "by_template_var",
                 "current": {
@@ -2448,30 +2084,6 @@
                 ],
                 "query": "Cluster,DC,Instance,Shard",
                 "type": "custom"
-            },
-            {
-                "allValue": null,
-                "class": "template_variable_single",
-                "current": {
-                    "text": "/var/lib/scylla",
-                    "value": "/var/lib/scylla"
-                },
-                "datasource": "prometheus",
-                "hide": 0,
-                "includeAll": false,
-                "label": "Mounnt path",
-                "multi": false,
-                "name": "mount_point",
-                "options": [],
-                "query": "label_values(scylla_io_queue_delay,mountpoint)",
-                "refresh": 2,
-                "regex": "",
-                "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
             },
             {
                 "allValue": null,
@@ -2605,7 +2217,7 @@
         ]
     },
     "timezone": "browser",
-    "title": "Scylla Per-Server Disk I/O",
+    "title": "Scylla Per-Server I/O",
     "uid": "io-3-0",
     "version": 0
 }

--- a/grafana/build/ver_3.0/scylla-dash-io-per-server.3.0.json
+++ b/grafana/build/ver_3.0/scylla-dash-io-per-server.3.0.json
@@ -31,480 +31,6 @@
             "type": "text"
         },
         {
-            "cacheTimeout": null,
-            "class": "single_stat_panel",
-            "colorBackground": false,
-            "colorValue": false,
-            "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-            ],
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 0,
-                "y": 4
-            },
-            "id": 2,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
-                    "intervalFactor": 1,
-                    "legendFormat": "Total Nodes",
-                    "refId": "A",
-                    "step": 240
-                }
-            ],
-            "thresholds": "",
-            "title": "Total Nodes",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "cacheTimeout": null,
-            "class": "single_stat_panel_fail",
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(250, 113, 0, 0.89)",
-                "rgba(255, 0, 0, 0.9)"
-            ],
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": false
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 2,
-                "y": 4
-            },
-            "id": 3,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Unreachable",
-                    "refId": "A",
-                    "step": 120
-                }
-            ],
-            "thresholds": "1,2",
-            "title": "Unreachable",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "class": "text_panel",
-            "content": "##  ",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 4,
-                "y": 4
-            },
-            "id": 4,
-            "isNew": true,
-            "links": [],
-            "mode": "markdown",
-            "span": 3,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "aliasColors": {
-                "{}": "#584477"
-            },
-            "bars": true,
-            "class": "graph_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 10,
-                "y": 4
-            },
-            "id": 5,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": false,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(irate(scylla_transport_requests_served{cluster=~\"$cluster|$^\"}[30s])) + sum(irate(scylla_thrift_served{cluster=~\"$cluster|$^\"}[30s]))",
-                    "intervalFactor": 1,
-                    "legendFormat": "Total Requests",
-                    "refId": "A",
-                    "step": 30
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Total Requests",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "class": "dashlist",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 4,
-                "x": 20,
-                "y": 4
-            },
-            "headings": false,
-            "id": 6,
-            "isNew": true,
-            "limit": 10,
-            "links": [],
-            "query": "",
-            "recent": false,
-            "search": true,
-            "span": 2,
-            "starred": false,
-            "tags": [
-                "3.0"
-            ],
-            "title": "Dashboards",
-            "type": "dashlist"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "graph_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 0,
-                "y": 10
-            },
-            "id": 7,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 30
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Load per [[by]]",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "graph_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 10,
-                "y": 10
-            },
-            "id": 8,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 1,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 30
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Requests Served per [[by]]",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
             "class": "plain_text",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue</h1>",
             "editable": true,
@@ -513,9 +39,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 16
+                "y": 4
             },
-            "id": 9,
+            "id": 2,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -543,9 +69,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 18
+                "y": 6
             },
-            "id": 10,
+            "id": 3,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -629,9 +155,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 18
+                "y": 6
             },
-            "id": 11,
+            "id": 4,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -712,9 +238,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 18
+                "y": 6
             },
-            "id": 12,
+            "id": 5,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -795,9 +321,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 24
+                "y": 12
             },
-            "id": 13,
+            "id": 6,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -881,9 +407,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 24
+                "y": 12
             },
-            "id": 14,
+            "id": 7,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -964,9 +490,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 24
+                "y": 12
             },
-            "id": 15,
+            "id": 8,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1047,9 +573,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 30
+                "y": 18
             },
-            "id": 16,
+            "id": 9,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1133,9 +659,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 30
+                "y": 18
             },
-            "id": 17,
+            "id": 10,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1216,9 +742,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 30
+                "y": 18
             },
-            "id": 18,
+            "id": 11,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1299,9 +825,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 36
+                "y": 24
             },
-            "id": 19,
+            "id": 12,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1385,9 +911,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 36
+                "y": 24
             },
-            "id": 20,
+            "id": 13,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1468,9 +994,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 36
+                "y": 24
             },
-            "id": 21,
+            "id": 14,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1551,9 +1077,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 42
+                "y": 30
             },
-            "id": 22,
+            "id": 15,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1637,9 +1163,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 42
+                "y": 30
             },
-            "id": 23,
+            "id": 16,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1720,9 +1246,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 42
+                "y": 30
             },
-            "id": 24,
+            "id": 17,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1803,9 +1329,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 48
+                "y": 36
             },
-            "id": 25,
+            "id": 18,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1889,9 +1415,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 48
+                "y": 36
             },
-            "id": 26,
+            "id": 19,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1972,9 +1498,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 48
+                "y": 36
             },
-            "id": 27,
+            "id": 20,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2217,7 +1743,7 @@
         ]
     },
     "timezone": "browser",
-    "title": "Scylla Per-Server I/O",
+    "title": "I/O",
     "uid": "io-3-0",
     "version": 0
 }

--- a/grafana/build/ver_3.0/scylla-dash-per-machine.3.0.json
+++ b/grafana/build/ver_3.0/scylla-dash-per-machine.3.0.json
@@ -1114,7 +1114,7 @@
         ]
     },
     "timezone": "browser",
-    "title": "Scylla Per Machine Metrics",
-    "uid": "machine-3-0",
+    "title": "OS Metrics",
+    "uid": "OS-3-0",
     "version": 5
 }

--- a/grafana/build/ver_3.0/scylla-dash-per-server.3.0.json
+++ b/grafana/build/ver_3.0/scylla-dash-per-server.3.0.json
@@ -31,394 +31,6 @@
             "type": "text"
         },
         {
-            "cacheTimeout": null,
-            "class": "single_stat_panel",
-            "colorBackground": false,
-            "colorValue": false,
-            "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-            ],
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 0,
-                "y": 4
-            },
-            "id": 2,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
-                    "intervalFactor": 1,
-                    "legendFormat": "Total Nodes",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "thresholds": "",
-            "title": "Total Nodes",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "cacheTimeout": null,
-            "class": "single_stat_panel_fail",
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(250, 113, 0, 0.89)",
-                "rgba(255, 0, 0, 0.9)"
-            ],
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": false
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 2,
-                "y": 4
-            },
-            "id": 3,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Unreachable",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "thresholds": "1,2",
-            "title": "Unreachable",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "class": "text_panel",
-            "content": "##  ",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 4,
-                "y": 4
-            },
-            "id": 4,
-            "isNew": true,
-            "links": [],
-            "mode": "markdown",
-            "span": 3,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "aliasColors": {},
-            "bars": true,
-            "class": "ops_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 10,
-                "y": 4
-            },
-            "id": 5,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_transport_requests_served{cluster=~\"$cluster|$^\"}[30s])) + $func(irate(scylla_thrift_served{cluster=~\"$cluster|$^\"}[30s]))",
-                    "intervalFactor": 1,
-                    "legendFormat": "Total Requests",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Total Requests - Coordinator",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "class": "dashlist",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 4,
-                "x": 20,
-                "y": 4
-            },
-            "headings": false,
-            "id": 6,
-            "isNew": true,
-            "limit": 10,
-            "links": [],
-            "query": "",
-            "recent": false,
-            "search": true,
-            "span": 2,
-            "starred": false,
-            "tags": [
-                "3.0"
-            ],
-            "title": "Dashboards",
-            "type": "dashlist"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "percent_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 0,
-                "y": 10
-            },
-            "id": 7,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Load per [[by]]",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "percent",
-                    "logBase": 1,
-                    "max": 101,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
             "aliasColors": {},
             "bars": false,
             "class": "ops_panel",
@@ -435,11 +47,11 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 10,
-                "x": 10,
-                "y": 10
+                "w": 8,
+                "x": 0,
+                "y": 4
             },
-            "id": 8,
+            "id": 2,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -461,7 +73,7 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 5,
+            "span": 4,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -505,6 +117,171 @@
             ]
         },
         {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 4
+            },
+            "id": 3,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_database_total_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Reads per [[by]] - Replica",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 4
+            },
+            "id": 4,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_database_total_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Writes per [[by]] - Replica",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
             "class": "text_header_panel",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Reads and Writes - Coordinator</h1>",
             "editable": true,
@@ -513,9 +290,9 @@
                 "h": 2,
                 "w": 12,
                 "x": 0,
-                "y": 16
+                "y": 10
             },
-            "id": 9,
+            "id": 5,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -534,9 +311,9 @@
                 "h": 2,
                 "w": 12,
                 "x": 12,
-                "y": 16
+                "y": 10
             },
-            "id": 10,
+            "id": 6,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -564,9 +341,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 18
+                "y": 12
             },
-            "id": 11,
+            "id": 7,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -646,9 +423,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 18
+                "y": 12
             },
-            "id": 12,
+            "id": 8,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -729,9 +506,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 18
+                "y": 12
             },
-            "id": 13,
+            "id": 9,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -811,9 +588,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 18
+                "y": 12
             },
-            "id": 14,
+            "id": 10,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -893,9 +670,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 24
+                "y": 18
             },
-            "id": 15,
+            "id": 11,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -975,9 +752,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 24
+                "y": 18
             },
-            "id": 16,
+            "id": 12,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1057,9 +834,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 24
+                "y": 18
             },
-            "id": 17,
+            "id": 13,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1139,9 +916,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 24
+                "y": 18
             },
-            "id": 18,
+            "id": 14,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1213,9 +990,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 30
+                "y": 24
             },
-            "id": 19,
+            "id": 15,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -1224,171 +1001,6 @@
             "title": "",
             "transparent": true,
             "type": "text"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "rps_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 12,
-                "x": 0,
-                "y": 32
-            },
-            "id": 20,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 6,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_database_total_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Reads",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "rps",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "wps_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 12,
-                "x": 12,
-                "y": 32
-            },
-            "id": 21,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 6,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_database_total_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Writes",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "wps",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
         },
         {
             "aliasColors": {},
@@ -1408,9 +1020,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 38
+                "y": 26
             },
-            "id": 22,
+            "id": 16,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1490,9 +1102,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 38
+                "y": 26
             },
-            "id": 23,
+            "id": 17,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1572,9 +1184,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 38
+                "y": 26
             },
-            "id": 24,
+            "id": 18,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1654,9 +1266,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 38
+                "y": 26
             },
-            "id": 25,
+            "id": 19,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1727,9 +1339,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 44
+                "y": 32
             },
-            "id": 26,
+            "id": 20,
             "isNew": true,
             "links": [],
             "mode": "markdown",
@@ -1756,9 +1368,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 44
+                "y": 32
             },
-            "id": 27,
+            "id": 21,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1838,9 +1450,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 44
+                "y": 32
             },
-            "id": 28,
+            "id": 22,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1920,9 +1532,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 44
+                "y": 32
             },
-            "id": 29,
+            "id": 23,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1993,9 +1605,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 50
+                "y": 38
             },
-            "id": 30,
+            "id": 24,
             "isNew": true,
             "links": [],
             "mode": "markdown",
@@ -2013,9 +1625,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 50
+                "y": 38
             },
-            "id": 31,
+            "id": 25,
             "isNew": true,
             "links": [],
             "mode": "markdown",
@@ -2042,9 +1654,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 50
+                "y": 38
             },
-            "id": 32,
+            "id": 26,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2124,9 +1736,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 50
+                "y": 38
             },
-            "id": 33,
+            "id": 27,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2197,9 +1809,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 56
+                "y": 44
             },
-            "id": 34,
+            "id": 28,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -2227,9 +1839,9 @@
                 "h": 6,
                 "w": 12,
                 "x": 0,
-                "y": 58
+                "y": 46
             },
-            "id": 35,
+            "id": 29,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2309,9 +1921,9 @@
                 "h": 6,
                 "w": 12,
                 "x": 12,
-                "y": 58
+                "y": 46
             },
-            "id": 36,
+            "id": 30,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2391,9 +2003,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 64
+                "y": 52
             },
-            "id": 37,
+            "id": 31,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2473,9 +2085,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 64
+                "y": 52
             },
-            "id": 38,
+            "id": 32,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2555,9 +2167,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 64
+                "y": 52
             },
-            "id": 39,
+            "id": 33,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2637,9 +2249,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 64
+                "y": 52
             },
-            "id": 40,
+            "id": 34,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2719,9 +2331,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 70
+                "y": 58
             },
-            "id": 41,
+            "id": 35,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2801,9 +2413,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 70
+                "y": 58
             },
-            "id": 42,
+            "id": 36,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2883,9 +2495,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 70
+                "y": 58
             },
-            "id": 43,
+            "id": 37,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2967,9 +2579,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 70
+                "y": 58
             },
-            "id": 44,
+            "id": 38,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3051,9 +2663,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 76
+                "y": 64
             },
-            "id": 45,
+            "id": 39,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3135,9 +2747,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 76
+                "y": 64
             },
-            "id": 46,
+            "id": 40,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3219,9 +2831,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 76
+                "y": 64
             },
-            "id": 47,
+            "id": 41,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3303,9 +2915,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 76
+                "y": 64
             },
-            "id": 48,
+            "id": 42,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3387,9 +2999,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 82
+                "y": 70
             },
-            "id": 49,
+            "id": 43,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3469,9 +3081,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 82
+                "y": 70
             },
-            "id": 50,
+            "id": 44,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3551,9 +3163,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 82
+                "y": 70
             },
-            "id": 51,
+            "id": 45,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3632,9 +3244,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 82
+                "y": 70
             },
-            "id": 52,
+            "id": 46,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3697,6 +3309,277 @@
         },
         {
             "class": "text_panel",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Materialized Views - Replica</h1>",
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 76
+            },
+            "id": 47,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bytes_panel",
+            "datasource": "prometheus",
+            "description": "Size in bytes of the view update backlog at each base replica.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 78
+            },
+            "id": 48,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(scylla_database_view_update_backlog{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "View Update Backlog",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "bytes",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "datasource": "prometheus",
+            "description": "Number of dropped view updates due to an excessive view update backlog.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 78
+            },
+            "id": 49,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_database_dropped_view_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Dropped View Updates",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "datasource": "prometheus",
+            "description": "Currently throttled base writes, as a consequence of the respective view update backlog.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 78
+            },
+            "id": 50,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(scylla_storage_proxy_coordinator_current_throttled_base_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"})  by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Throttled Base Writes",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "class": "text_panel",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Memory - Replica</h1>",
             "editable": true,
             "error": false,
@@ -3704,9 +3587,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 88
+                "y": 84
             },
-            "id": 53,
+            "id": 51,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -3734,9 +3617,9 @@
                 "h": 6,
                 "w": 12,
                 "x": 0,
-                "y": 90
+                "y": 86
             },
-            "id": 54,
+            "id": 52,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3815,9 +3698,9 @@
                 "h": 6,
                 "w": 12,
                 "x": 12,
-                "y": 90
+                "y": 86
             },
-            "id": 55,
+            "id": 53,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3887,9 +3770,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 96
+                "y": 92
             },
-            "id": 56,
+            "id": 54,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -3917,9 +3800,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 98
+                "y": 94
             },
-            "id": 57,
+            "id": 55,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -4001,9 +3884,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 98
+                "y": 94
             },
-            "id": 58,
+            "id": 56,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -4088,9 +3971,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 98
+                "y": 94
             },
-            "id": 59,
+            "id": 57,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -4152,451 +4035,6 @@
             ]
         },
         {
-            "class": "text_panel",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">CQL - Coordinator</h1>",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 2,
-                "w": 24,
-                "x": 0,
-                "y": 104
-            },
-            "id": 60,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "span": 12,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "ops_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 0,
-                "y": 106
-            },
-            "id": 61,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "CQL Insert",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "ops_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 6,
-                "y": 106
-            },
-            "id": 62,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "CQL Reads",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "ops_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 12,
-                "y": 106
-            },
-            "id": 63,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "CQL Deletes",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "ops_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 18,
-                "y": 106
-            },
-            "id": 64,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "CQL Updates",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "graph_panel",
-            "datasource": "prometheus",
-            "description": "amount of CQL connections currently established",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 0,
-                "y": 112
-            },
-            "id": 65,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 1,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(scylla_transport_current_connections{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 30
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Client CQL connections by [[by]]",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
             "class": "plain_text",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Your Panels</h1>",
             "editable": true,
@@ -4605,9 +4043,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 118
+                "y": 100
             },
-            "id": 66,
+            "id": 58,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -4636,9 +4074,9 @@
                 "h": 6,
                 "w": 12,
                 "x": 0,
-                "y": 120
+                "y": 102
             },
-            "id": 67,
+            "id": 59,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -4712,9 +4150,9 @@
                 "h": 6,
                 "w": 12,
                 "x": 12,
-                "y": 120
+                "y": 102
             },
-            "id": 68,
+            "id": 60,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -4998,7 +4436,7 @@
         ]
     },
     "timezone": "browser",
-    "title": "Scylla Per Server Metrics",
-    "uid": "detail-3-0",
+    "title": "Detailed",
+    "uid": "detailed-3-0",
     "version": 5
 }

--- a/grafana/build/ver_3.0/scylla-dash.3.0.json
+++ b/grafana/build/ver_3.0/scylla-dash.3.0.json
@@ -210,7 +210,7 @@
             "error": false,
             "gridPos": {
                 "h": 6,
-                "w": 8,
+                "w": 4,
                 "x": 4,
                 "y": 4
             },
@@ -218,37 +218,483 @@
             "isNew": true,
             "links": [],
             "mode": "markdown",
-            "span": 4,
+            "span": 2,
             "style": {},
             "title": "",
             "transparent": true,
             "type": "text"
         },
         {
-            "class": "dashlist",
+            "aliasColors": {},
+            "bars": false,
+            "class": "percent_panel",
+            "datasource": "prometheus",
+            "description": "The percentage of the time during which Scylla utilized the CPU. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high.",
             "editable": true,
             "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
             "gridPos": {
                 "h": 6,
-                "w": 4,
-                "x": 12,
+                "w": 8,
+                "x": 8,
                 "y": 4
             },
-            "headings": false,
             "id": 5,
             "isNew": true,
-            "limit": 10,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
             "links": [],
-            "query": "",
-            "recent": false,
-            "search": true,
-            "span": 2,
-            "starred": false,
-            "tags": [
-                "3.0"
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
             ],
-            "title": "Dashboards",
-            "type": "dashlist"
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 4
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Load",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "percent",
+                    "logBase": 1,
+                    "max": 101,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "class": "single_value_table",
+            "columns": [
+                {
+                    "text": "Avg",
+                    "value": "avg"
+                }
+            ],
+            "datasource": "prometheus",
+            "description": "Nodes Information table",
+            "fontSize": "100%",
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 4
+            },
+            "id": 6,
+            "links": [],
+            "pageSize": null,
+            "scroll": true,
+            "showHeader": true,
+            "sort": {
+                "col": 0,
+                "desc": true
+            },
+            "span": 4,
+            "styles": [
+                {
+                    "alias": "",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the detailed node information",
+                    "linkUrl": "/d/detailed-[[dash_version]]/Detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__cell}",
+                    "mappingType": 1,
+                    "pattern": "instance",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "Time",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "__name__",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "exported_instance",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "job",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "type",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "Value",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "cluster",
+                    "type": "hidden"
+                },
+                {
+                    "alias": "OS",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the OS node information",
+                    "linkUrl": "/d/OS-[[dash_version]]/OS-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                    "mappingType": 1,
+                    "pattern": "OS",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "OS",
+                            "value": "os"
+                        }
+                    ]
+                },
+                {
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the CQL information",
+                    "linkUrl": "/d/cql-[[dash_version]]/scylla-cql?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                    "mappingType": 1,
+                    "pattern": "CQL",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "CQL",
+                            "value": "cql"
+                        }
+                    ]
+                },
+                {
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the Errors metrics information",
+                    "linkUrl": "/d/error-[[dash_version]]/scylla-errors?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                    "mappingType": 1,
+                    "pattern": "Errors",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "Errors",
+                            "value": "errors"
+                        }
+                    ]
+                },
+                {
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the Errors metrics information",
+                    "linkUrl": "/d/io-[[dash_version]]/i-o?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                    "mappingType": 1,
+                    "pattern": "IO",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "IO",
+                            "value": "io"
+                        }
+                    ]
+                },
+                {
+                    "alias": "CPU",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the node CPU information",
+                    "linkUrl": "/d/cpu-[[dash_version]]/CPU-Metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                    "mappingType": 1,
+                    "pattern": "CPU",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "CPU",
+                            "value": "cpu"
+                        }
+                    ]
+                }
+            ],
+            "targets": [
+                {
+                    "expr": "scylla_scylladb_current_version{cluster=~\"$cluster|$^\", dc=~\"$dc\"}",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 1,
+                    "refId": "A"
+                }
+            ],
+            "title": "Nodes",
+            "transform": "table",
+            "type": "table"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bytes_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 10
+            },
+            "id": 7,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(node_filesystem_size_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])-sum(node_filesystem_avail_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Disk Size by $by",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "bytes",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "datasource": "prometheus",
+            "description": "Amount of requests served as the coordinator. Imbalances here represent dispersion at the client-side level or connection balancing level, not your data model.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 10
+            },
+            "id": 8,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + $func(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 4
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Requests Served - Coordinator",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
         },
         {
             "aliasColors": {},
@@ -270,9 +716,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 4
+                "y": 10
             },
-            "id": 6,
+            "id": 9,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -413,272 +859,25 @@
             ]
         },
         {
-            "aliasColors": {},
-            "bars": false,
-            "class": "percent_panel",
-            "datasource": "prometheus",
-            "description": "The percentage of the time during which Scylla utilized the CPU. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high.",
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Latencies - Coordinator</h1>",
             "editable": true,
             "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
             "gridPos": {
-                "h": 6,
-                "w": 8,
+                "h": 2,
+                "w": 24,
                 "x": 0,
-                "y": 10
+                "y": 16
             },
-            "id": 7,
+            "id": 10,
             "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
             "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 4,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 4
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Load",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "percent",
-                    "logBase": 1,
-                    "max": 101,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "ops_panel",
-            "datasource": "prometheus",
-            "description": "Amount of requests served as the coordinator. Imbalances here represent dispersion at the client-side level or connection balancing level, not your data model.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 8,
-                "x": 8,
-                "y": 10
-            },
-            "id": 8,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 4,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + $func(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 4
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Requests Served - Coordinator",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "class": "single_value_table",
-            "columns": [
-                {
-                    "text": "Avg",
-                    "value": "avg"
-                }
-            ],
-            "datasource": "prometheus",
-            "description": "Nodes Information table",
-            "fontSize": "100%",
-            "gridPos": {
-                "h": 6,
-                "w": 8,
-                "x": 16,
-                "y": 10
-            },
-            "id": 9,
-            "links": [],
-            "pageSize": null,
-            "scroll": true,
-            "showHeader": true,
-            "sort": {
-                "col": 0,
-                "desc": true
-            },
-            "span": 4,
-            "styles": [
-                {
-                    "alias": "",
-                    "colorMode": null,
-                    "colors": [
-                        "rgba(245, 54, 54, 0.9)",
-                        "rgba(237, 129, 40, 0.89)",
-                        "rgba(50, 172, 45, 0.97)"
-                    ],
-                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                    "decimals": 2,
-                    "link": true,
-                    "linkTooltip": "Jump to the detailed node information",
-                    "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_6}",
-                    "mappingType": 1,
-                    "pattern": "instance",
-                    "thresholds": [],
-                    "type": "string",
-                    "unit": "short"
-                },
-                {
-                    "class": "hidden_column",
-                    "pattern": "Time",
-                    "type": "hidden"
-                },
-                {
-                    "class": "hidden_column",
-                    "pattern": "__name__",
-                    "type": "hidden"
-                },
-                {
-                    "class": "hidden_column",
-                    "pattern": "exported_instance",
-                    "type": "hidden"
-                },
-                {
-                    "class": "hidden_column",
-                    "pattern": "job",
-                    "type": "hidden"
-                },
-                {
-                    "class": "hidden_column",
-                    "pattern": "type",
-                    "type": "hidden"
-                },
-                {
-                    "class": "hidden_column",
-                    "pattern": "Value",
-                    "type": "hidden"
-                },
-                {
-                    "class": "hidden_column",
-                    "pattern": "cluster",
-                    "type": "hidden"
-                }
-            ],
-            "targets": [
-                {
-                    "expr": "scylla_scylladb_current_version{cluster=~\"$cluster|$^\", dc=~\"$dc\"}",
-                    "format": "table",
-                    "instant": true,
-                    "intervalFactor": 1,
-                    "refId": "A"
-                }
-            ],
-            "title": "Nodes",
-            "transform": "table",
-            "type": "table"
+            "mode": "html",
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
         },
         {
             "aliasColors": {},
@@ -698,9 +897,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 16
+                "y": 18
             },
-            "id": 10,
+            "id": 11,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -783,9 +982,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 16
+                "y": 18
             },
-            "id": 11,
+            "id": 12,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -869,9 +1068,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 16
+                "y": 18
             },
-            "id": 12,
+            "id": 13,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -936,27 +1135,6 @@
                     "show": true
                 }
             ]
-        },
-        {
-            "class": "plain_text",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Latencies - Coordinator</h1>",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 2,
-                "w": 24,
-                "x": 0,
-                "y": 22
-            },
-            "id": 13,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "span": 12,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
         },
         {
             "aliasColors": {},
@@ -1947,7 +2125,7 @@
             "type": "text"
         },
         {
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Materialized Views - Replica</h1>",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Timeouts</h1>",
             "editable": true,
             "error": false,
             "gridPos": {
@@ -2139,9 +2317,9 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "bytes_panel",
+            "class": "wps_panel",
             "datasource": "prometheus",
-            "description": "Size in bytes of the view update backlog at each base replica.",
+            "description": "Requests that Scylla tried to write but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas.",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -2182,7 +2360,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(scylla_database_view_update_backlog{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
+                    "expr": "$func(irate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -2191,10 +2369,11 @@
             ],
             "timeFrom": null,
             "timeShift": null,
-            "title": "View Update Backlog",
+            "title": "Write Timeouts",
             "tooltip": {
                 "msResolution": false,
                 "shared": true,
+                "sort": 0,
                 "value_type": "cumulative"
             },
             "type": "graph",
@@ -2203,7 +2382,7 @@
             },
             "yaxes": [
                 {
-                    "format": "bytes",
+                    "format": "wps",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2221,9 +2400,9 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "ops_panel",
+            "class": "rps_panel",
             "datasource": "prometheus",
-            "description": "Number of dropped view updates due to an excessive view update backlog.",
+            "description": "Requests that Scylla tried to read but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas.",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -2258,118 +2437,13 @@
             "pointradius": 5,
             "points": false,
             "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_database_dropped_view_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 10
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Dropped View Updates",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "class": "text_panel",
-            "content": "",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 18,
-                "x": 0,
-                "y": 52
-            },
-            "id": 33,
-            "isNew": true,
-            "links": [],
-            "mode": "markdown",
-            "span": 9,
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "wps_panel",
-            "datasource": "prometheus",
-            "description": "Currently throttled base writes, as a consequence of the respective view update backlog.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 18,
-                "y": 52
-            },
-            "id": 34,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
             "seriesOverrides": [],
             "span": 3,
             "stack": false,
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(scylla_storage_proxy_coordinator_current_throttled_base_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"})  by ([[by]])",
+                    "expr": "$func(irate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -2378,7 +2452,7 @@
             ],
             "timeFrom": null,
             "timeShift": null,
-            "title": "Throttled Base Writes",
+            "title": "Read Timeouts",
             "tooltip": {
                 "msResolution": false,
                 "shared": true,
@@ -2391,7 +2465,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "rps",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2415,9 +2489,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 58
+                "y": 52
             },
-            "id": 35,
+            "id": 33,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -2446,9 +2520,9 @@
                 "h": 6,
                 "w": 12,
                 "x": 0,
-                "y": 60
+                "y": 54
             },
-            "id": 36,
+            "id": 34,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2522,9 +2596,9 @@
                 "h": 6,
                 "w": 12,
                 "x": 12,
-                "y": 60
+                "y": 54
             },
-            "id": 37,
+            "id": 35,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2728,6 +2802,52 @@
             },
             {
                 "allValue": null,
+                "current": {
+                    "text": "/var/lib/scylla",
+                    "value": "/var/lib/scylla"
+                },
+                "datasource": "prometheus",
+                "hide": 0,
+                "includeAll": false,
+                "label": "Mounnt path",
+                "multi": false,
+                "name": "mount_point",
+                "options": [],
+                "query": "node_filesystem_avail_bytes",
+                "refresh": 2,
+                "regex": "/mountpoint=\"([^\"]*)\".*/",
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "current": {
+                    "text": "/var/lib/scylla",
+                    "value": "/var/lib/scylla"
+                },
+                "datasource": "prometheus",
+                "hide": 0,
+                "includeAll": false,
+                "label": "Mounnt path",
+                "multi": false,
+                "name": "mount_point",
+                "options": [],
+                "query": "node_filesystem_avail_bytes",
+                "refresh": 2,
+                "regex": "/mountpoint=\"([^\"]*)\".*/",
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
                 "class": "aggregation_function",
                 "current": {
                     "tags": [],
@@ -2831,7 +2951,7 @@
         ]
     },
     "timezone": "browser",
-    "title": "Scylla Overview Metrics",
+    "title": "Overview",
     "uid": "overview-3-0",
     "version": 3
 }

--- a/grafana/build/ver_3.1/scylla-cql-optimization.3.1.json
+++ b/grafana/build/ver_3.1/scylla-cql-optimization.3.1.json
@@ -8,7 +8,7 @@
     "hideControls": true,
     "id": null,
     "links": [],
-    "originalTitle": "Scylla CQL Optimization",
+    "originalTitle": "CQL",
     "overwrite": true,
     "panels": [
         {
@@ -32,357 +32,31 @@
             "type": "text"
         },
         {
-            "cacheTimeout": null,
-            "class": "single_stat_panel",
-            "colorBackground": false,
-            "colorValue": false,
-            "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-            ],
-            "datasource": "prometheus",
+            "class": "text_panel",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">CQL - Coordinator</h1>",
             "editable": true,
             "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-            },
             "gridPos": {
-                "h": 6,
-                "w": 2,
+                "h": 2,
+                "w": 24,
                 "x": 0,
                 "y": 4
             },
             "id": 2,
-            "interval": null,
             "isNew": true,
             "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
-                    "intervalFactor": 1,
-                    "legendFormat": "Total Nodes",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "thresholds": "",
-            "title": "Total Nodes",
+            "mode": "html",
+            "span": 12,
+            "style": {},
+            "title": "",
             "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "cacheTimeout": null,
-            "class": "single_stat_panel_fail",
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(250, 113, 0, 0.89)",
-                "rgba(255, 0, 0, 0.9)"
-            ],
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": false
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 2,
-                "y": 4
-            },
-            "id": 3,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Unreachable",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "thresholds": "1,2",
-            "title": "Unreachable",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "cacheTimeout": null,
-            "class": "single_stat_panel_fail",
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(250, 113, 0, 0.89)",
-                "rgba(255, 0, 0, 0.9)"
-            ],
-            "datasource": "prometheus",
-            "description": "Number of nodes that reported their status as Starting or Joining",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": false
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 4,
-                "y": 4
-            },
-            "id": 4,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Joining",
-                    "refId": "A",
-                    "step": 20
-                }
-            ],
-            "thresholds": "1,2",
-            "title": "Joining",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "cacheTimeout": null,
-            "class": "single_stat_panel_fail",
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(250, 113, 0, 0.89)",
-                "rgba(255, 0, 0, 0.9)"
-            ],
-            "datasource": "prometheus",
-            "description": "Number of nodes that reported their status as  Leaving, Decommissioned, Draining or Drained",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": false
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 6,
-                "y": 4
-            },
-            "id": 5,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(scylla_node_operation_mode>3)OR vector(0)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Leaving",
-                    "refId": "A",
-                    "step": 20
-                }
-            ],
-            "thresholds": "1,2",
-            "title": "Leaving",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
+            "type": "text"
         },
         {
             "aliasColors": {},
             "bars": false,
             "class": "ops_panel",
             "datasource": "prometheus",
-            "description": "Total requests graph is the baseline for comparison",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -394,11 +68,11 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 8,
-                "x": 8,
-                "y": 4
+                "w": 6,
+                "x": 0,
+                "y": 6
             },
-            "id": 6,
+            "id": 3,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -420,21 +94,22 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 4,
+            "span": 3,
             "stack": false,
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "expr": "sum(irate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                     "intervalFactor": 1,
-                    "legendFormat": "Total Requests",
+                    "legendFormat": "",
+                    "metric": "",
                     "refId": "A",
                     "step": 1
                 }
             ],
             "timeFrom": null,
             "timeShift": null,
-            "title": "Total Requests",
+            "title": "CQL Insert",
             "tooltip": {
                 "msResolution": false,
                 "shared": true,
@@ -463,51 +138,553 @@
             ]
         },
         {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 6
+            },
+            "id": 4,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CQL Reads",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 6
+            },
+            "id": 5,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CQL Deletes",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 6
+            },
+            "id": 6,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CQL Updates",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "datasource": "prometheus",
+            "description": "amount of CQL connections currently established",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 12
+            },
+            "id": 7,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(scylla_transport_current_connections{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Client CQL connections by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "datasource": "prometheus",
+            "description": "Number of CQL batches command, each batched command is counted once",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 12
+            },
+            "id": 8,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_batches{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CQL Batches by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "datasource": "prometheus",
+            "description": "Number of CQL command batched. Each batch would add the number of commands inside the batch",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 12
+            },
+            "id": 9,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_statements_in_batches{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CQL Coomand In Batches by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
             "class": "plain_text",
             "content": "<span/>",
             "editable": true,
             "error": false,
             "gridPos": {
                 "h": 6,
-                "w": 4,
-                "x": 16,
-                "y": 4
+                "w": 10,
+                "x": 0,
+                "y": 18
             },
-            "id": 7,
+            "id": 10,
             "isNew": true,
             "links": [],
             "mode": "html",
-            "span": 2,
+            "span": 5,
             "style": {},
             "title": "",
             "transparent": true,
             "type": "text"
         },
         {
-            "class": "dashlist",
+            "class": "text_panel",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Optimization</h1>",
             "editable": true,
             "error": false,
             "gridPos": {
-                "h": 6,
-                "w": 4,
-                "x": 20,
-                "y": 4
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 24
             },
-            "headings": false,
-            "id": 8,
+            "id": 11,
             "isNew": true,
-            "limit": 10,
             "links": [],
-            "query": "",
-            "recent": false,
-            "search": true,
-            "span": 2,
-            "starred": false,
-            "tags": [
-                "3.1"
-            ],
-            "title": "Dashboards",
-            "type": "dashlist"
+            "mode": "html",
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
         },
         {
             "cacheTimeout": null,
@@ -535,9 +712,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 10
+                "y": 26
             },
-            "id": 9,
+            "id": 12,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -618,9 +795,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 10
+                "y": 26
             },
-            "id": 10,
+            "id": 13,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -710,9 +887,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 10
+                "y": 26
             },
-            "id": 11,
+            "id": 14,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -793,9 +970,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 10
+                "y": 26
             },
-            "id": 12,
+            "id": 15,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -885,9 +1062,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 16,
-                "y": 10
+                "y": 26
             },
-            "id": 13,
+            "id": 16,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -966,9 +1143,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 10
+                "y": 26
             },
-            "id": 14,
+            "id": 17,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1058,9 +1235,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 16
+                "y": 32
             },
-            "id": 15,
+            "id": 18,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -1141,9 +1318,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 16
+                "y": 32
             },
-            "id": 16,
+            "id": 19,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1233,9 +1410,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 16
+                "y": 32
             },
-            "id": 17,
+            "id": 20,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -1314,9 +1491,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 16
+                "y": 32
             },
-            "id": 18,
+            "id": 21,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1404,9 +1581,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 16,
-                "y": 16
+                "y": 32
             },
-            "id": 19,
+            "id": 22,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -1487,9 +1664,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 16
+                "y": 32
             },
-            "id": 20,
+            "id": 23,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1594,9 +1771,9 @@
                 "h": 6,
                 "w": 4,
                 "x": 0,
-                "y": 22
+                "y": 38
             },
-            "id": 21,
+            "id": 24,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -1858,7 +2035,7 @@
         ]
     },
     "timezone": "browser",
-    "title": "Scylla CQL Optimization",
-    "uid": "cqlopt-3-1",
+    "title": "Scylla CQL",
+    "uid": "cql-3-1",
     "version": 0
 }

--- a/grafana/build/ver_3.1/scylla-dash-cpu-per-server.3.1.json
+++ b/grafana/build/ver_3.1/scylla-dash-cpu-per-server.3.1.json
@@ -117,53 +117,6 @@
             ]
         },
         {
-            "class": "text_panel",
-            "content": "##  ",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 10,
-                "y": 4
-            },
-            "id": 3,
-            "isNew": true,
-            "links": [],
-            "mode": "markdown",
-            "span": 3,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "class": "dashlist",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 4,
-                "x": 16,
-                "y": 4
-            },
-            "headings": false,
-            "id": 4,
-            "isNew": true,
-            "limit": 10,
-            "links": [],
-            "query": "",
-            "recent": false,
-            "search": true,
-            "span": 2,
-            "starred": false,
-            "tags": [
-                "3.1"
-            ],
-            "title": "Dashboards",
-            "type": "dashlist"
-        },
-        {
             "aliasColors": {},
             "bars": false,
             "class": "percent_panel",
@@ -181,10 +134,10 @@
             "gridPos": {
                 "h": 6,
                 "w": 10,
-                "x": 0,
-                "y": 10
+                "x": 10,
+                "y": 4
             },
-            "id": 5,
+            "id": 3,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -251,6 +204,27 @@
             ]
         },
         {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Task Quota Violation</h1>",
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 10
+            },
+            "id": 4,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
             "aliasColors": {},
             "bars": false,
             "class": "ms_panel",
@@ -267,11 +241,11 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 10,
-                "x": 10,
-                "y": 10
+                "w": 6,
+                "x": 0,
+                "y": 12
             },
-            "id": 6,
+            "id": 5,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -290,13 +264,14 @@
             "pointradius": 1,
             "points": false,
             "renderer": "flot",
+            "repeat": "group",
             "seriesOverrides": [],
-            "span": 5,
+            "span": 3,
             "stack": false,
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(scylla_scheduler_time_spent_on_task_quota_violations_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "expr": "sum(irate(scylla_scheduler_time_spent_on_task_quota_violations_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -306,7 +281,7 @@
             ],
             "timeFrom": null,
             "timeShift": null,
-            "title": "Time spent in task quota violations by [[by]]",
+            "title": "Time spent in task quota violations by [[by]] - $group",
             "tooltip": {
                 "msResolution": false,
                 "shared": true,
@@ -480,6 +455,32 @@
                 "tagsQuery": "",
                 "type": "query",
                 "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "hide": 2,
+                "includeAll": true,
+                "label": "group",
+                "multi": true,
+                "name": "group",
+                "options": [],
+                "query": "label_values(scylla_scheduler_time_spent_on_task_quota_violations_ms,group)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 3,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
             }
         ]
     },
@@ -514,7 +515,7 @@
         ]
     },
     "timezone": "browser",
-    "title": "Scylla CPU Per Server Metrics",
+    "title": "CPU Metrics",
     "uid": "cpu-3-1",
     "version": 5
 }

--- a/grafana/build/ver_3.1/scylla-dash-io-per-server.3.1.json
+++ b/grafana/build/ver_3.1/scylla-dash-io-per-server.3.1.json
@@ -31,480 +31,6 @@
             "type": "text"
         },
         {
-            "cacheTimeout": null,
-            "class": "single_stat_panel",
-            "colorBackground": false,
-            "colorValue": false,
-            "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-            ],
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 0,
-                "y": 4
-            },
-            "id": 2,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
-                    "intervalFactor": 1,
-                    "legendFormat": "Total Nodes",
-                    "refId": "A",
-                    "step": 240
-                }
-            ],
-            "thresholds": "",
-            "title": "Total Nodes",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "cacheTimeout": null,
-            "class": "single_stat_panel_fail",
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(250, 113, 0, 0.89)",
-                "rgba(255, 0, 0, 0.9)"
-            ],
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": false
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 2,
-                "y": 4
-            },
-            "id": 3,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Unreachable",
-                    "refId": "A",
-                    "step": 120
-                }
-            ],
-            "thresholds": "1,2",
-            "title": "Unreachable",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "class": "text_panel",
-            "content": "##  ",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 4,
-                "y": 4
-            },
-            "id": 4,
-            "isNew": true,
-            "links": [],
-            "mode": "markdown",
-            "span": 3,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "aliasColors": {
-                "{}": "#584477"
-            },
-            "bars": true,
-            "class": "graph_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 10,
-                "y": 4
-            },
-            "id": 5,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": false,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(irate(scylla_transport_requests_served{cluster=~\"$cluster|$^\"}[30s])) + sum(irate(scylla_thrift_served{cluster=~\"$cluster|$^\"}[30s]))",
-                    "intervalFactor": 1,
-                    "legendFormat": "Total Requests",
-                    "refId": "A",
-                    "step": 30
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Total Requests",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "class": "dashlist",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 4,
-                "x": 20,
-                "y": 4
-            },
-            "headings": false,
-            "id": 6,
-            "isNew": true,
-            "limit": 10,
-            "links": [],
-            "query": "",
-            "recent": false,
-            "search": true,
-            "span": 2,
-            "starred": false,
-            "tags": [
-                "3.1"
-            ],
-            "title": "Dashboards",
-            "type": "dashlist"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "graph_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 0,
-                "y": 10
-            },
-            "id": 7,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 30
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Load per [[by]]",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "graph_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 10,
-                "y": 10
-            },
-            "id": 8,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 1,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 30
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Requests Served per [[by]]",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
             "class": "plain_text",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue</h1>",
             "editable": true,
@@ -513,9 +39,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 16
+                "y": 4
             },
-            "id": 9,
+            "id": 2,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -543,9 +69,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 18
+                "y": 6
             },
-            "id": 10,
+            "id": 3,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -629,9 +155,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 18
+                "y": 6
             },
-            "id": 11,
+            "id": 4,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -712,9 +238,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 18
+                "y": 6
             },
-            "id": 12,
+            "id": 5,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -795,9 +321,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 24
+                "y": 12
             },
-            "id": 13,
+            "id": 6,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -881,9 +407,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 24
+                "y": 12
             },
-            "id": 14,
+            "id": 7,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -964,9 +490,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 24
+                "y": 12
             },
-            "id": 15,
+            "id": 8,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1047,9 +573,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 30
+                "y": 18
             },
-            "id": 16,
+            "id": 9,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1133,9 +659,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 30
+                "y": 18
             },
-            "id": 17,
+            "id": 10,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1216,9 +742,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 30
+                "y": 18
             },
-            "id": 18,
+            "id": 11,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1299,9 +825,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 36
+                "y": 24
             },
-            "id": 19,
+            "id": 12,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1385,9 +911,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 36
+                "y": 24
             },
-            "id": 20,
+            "id": 13,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1468,9 +994,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 36
+                "y": 24
             },
-            "id": 21,
+            "id": 14,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1551,9 +1077,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 42
+                "y": 30
             },
-            "id": 22,
+            "id": 15,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1637,9 +1163,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 42
+                "y": 30
             },
-            "id": 23,
+            "id": 16,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1720,9 +1246,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 42
+                "y": 30
             },
-            "id": 24,
+            "id": 17,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1803,9 +1329,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 48
+                "y": 36
             },
-            "id": 25,
+            "id": 18,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1889,9 +1415,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 48
+                "y": 36
             },
-            "id": 26,
+            "id": 19,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1972,9 +1498,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 48
+                "y": 36
             },
-            "id": 27,
+            "id": 20,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2217,7 +1743,7 @@
         ]
     },
     "timezone": "browser",
-    "title": "Scylla Per-Server I/O",
+    "title": "I/O",
     "uid": "io-3-1",
     "version": 0
 }

--- a/grafana/build/ver_3.1/scylla-dash-io-per-server.3.1.json
+++ b/grafana/build/ver_3.1/scylla-dash-io-per-server.3.1.json
@@ -506,7 +506,7 @@
         },
         {
             "class": "plain_text",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Disk Activity</h1>",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue</h1>",
             "editable": true,
             "error": false,
             "gridPos": {
@@ -516,357 +516,6 @@
                 "y": 16
             },
             "id": 9,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "span": 12,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "graph_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 12,
-                "x": 0,
-                "y": 18
-            },
-            "id": 10,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 6,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 20
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Disk Writes per Server",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "graph_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 12,
-                "x": 12,
-                "y": 18
-            },
-            "id": 11,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 6,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 20
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Disk Reads per Server",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "bps_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 12,
-                "x": 0,
-                "y": 24
-            },
-            "id": 12,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 6,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 20
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Disk Writes Bps per Server",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "Bps",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "bps_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 12,
-                "x": 12,
-                "y": 24
-            },
-            "id": 13,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 6,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 20
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Disk Read Bps per Server",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "Bps",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "class": "plain_text",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue</h1>",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 2,
-                "w": 24,
-                "x": 0,
-                "y": 30
-            },
-            "id": 14,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -894,9 +543,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 32
+                "y": 18
             },
-            "id": 15,
+            "id": 10,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -980,9 +629,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 32
+                "y": 18
             },
-            "id": 16,
+            "id": 11,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1063,9 +712,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 32
+                "y": 18
             },
-            "id": 17,
+            "id": 12,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1146,9 +795,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 38
+                "y": 24
             },
-            "id": 18,
+            "id": 13,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1232,9 +881,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 38
+                "y": 24
             },
-            "id": 19,
+            "id": 14,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1315,9 +964,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 38
+                "y": 24
             },
-            "id": 20,
+            "id": 15,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1398,9 +1047,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 44
+                "y": 30
             },
-            "id": 21,
+            "id": 16,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1484,9 +1133,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 44
+                "y": 30
             },
-            "id": 22,
+            "id": 17,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1567,9 +1216,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 44
+                "y": 30
             },
-            "id": 23,
+            "id": 18,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1650,9 +1299,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 50
+                "y": 36
             },
-            "id": 24,
+            "id": 19,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1736,9 +1385,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 50
+                "y": 36
             },
-            "id": 25,
+            "id": 20,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1819,9 +1468,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 50
+                "y": 36
             },
-            "id": 26,
+            "id": 21,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1902,9 +1551,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 56
+                "y": 42
             },
-            "id": 27,
+            "id": 22,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1988,9 +1637,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 56
+                "y": 42
             },
-            "id": 28,
+            "id": 23,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2071,9 +1720,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 56
+                "y": 42
             },
-            "id": 29,
+            "id": 24,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2154,9 +1803,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 62
+                "y": 48
             },
-            "id": 30,
+            "id": 25,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2240,9 +1889,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 62
+                "y": 48
             },
-            "id": 31,
+            "id": 26,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2323,9 +1972,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 62
+                "y": 48
             },
-            "id": 32,
+            "id": 27,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2398,43 +2047,6 @@
     ],
     "templating": {
         "list": [
-            {
-                "current": {},
-                "datasource": "prometheus",
-                "hide": 0,
-                "includeAll": false,
-                "multi": false,
-                "name": "monitor_disk",
-                "options": [],
-                "query": "node_disk_read_bytes_total",
-                "refresh": 2,
-                "regex": "/.*device=\"([^\\\"]*)\".*/",
-                "type": "query"
-            },
-            {
-                "allValue": null,
-                "class": "template_variable_single",
-                "current": {
-                    "text": "/var/lib/scylla",
-                    "value": "/var/lib/scylla"
-                },
-                "datasource": "prometheus",
-                "hide": 0,
-                "includeAll": false,
-                "label": "Mounnt path",
-                "multi": false,
-                "name": "mount_point",
-                "options": [],
-                "query": "label_values(scylla_io_queue_delay,mountpoint)",
-                "refresh": 2,
-                "regex": "",
-                "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
-            },
             {
                 "allValue": null,
                 "class": "by_template_var",
@@ -2605,7 +2217,7 @@
         ]
     },
     "timezone": "browser",
-    "title": "Scylla Per-Server Disk I/O",
+    "title": "Scylla Per-Server I/O",
     "uid": "io-3-1",
     "version": 0
 }

--- a/grafana/build/ver_3.1/scylla-dash-per-machine.3.1.json
+++ b/grafana/build/ver_3.1/scylla-dash-per-machine.3.1.json
@@ -1114,7 +1114,7 @@
         ]
     },
     "timezone": "browser",
-    "title": "Scylla Per Machine Metrics",
-    "uid": "machine-3-1",
+    "title": "OS Metrics",
+    "uid": "OS-3-1",
     "version": 5
 }

--- a/grafana/build/ver_3.1/scylla-dash-per-server.3.1.json
+++ b/grafana/build/ver_3.1/scylla-dash-per-server.3.1.json
@@ -31,568 +31,6 @@
             "type": "text"
         },
         {
-            "cacheTimeout": null,
-            "class": "single_stat_panel",
-            "colorBackground": false,
-            "colorValue": false,
-            "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-            ],
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 0,
-                "y": 4
-            },
-            "id": 2,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
-                    "intervalFactor": 1,
-                    "legendFormat": "Total Nodes",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "thresholds": "",
-            "title": "Total Nodes",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "cacheTimeout": null,
-            "class": "single_stat_panel_fail",
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(250, 113, 0, 0.89)",
-                "rgba(255, 0, 0, 0.9)"
-            ],
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": false
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 2,
-                "y": 4
-            },
-            "id": 3,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Unreachable",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "thresholds": "1,2",
-            "title": "Unreachable",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "cacheTimeout": null,
-            "class": "single_stat_panel_fail",
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(250, 113, 0, 0.89)",
-                "rgba(255, 0, 0, 0.9)"
-            ],
-            "datasource": "prometheus",
-            "description": "Number of nodes that reported their status as Starting or Joining",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": false
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 4,
-                "y": 4
-            },
-            "id": 4,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Joining",
-                    "refId": "A",
-                    "step": 20
-                }
-            ],
-            "thresholds": "1,2",
-            "title": "Joining",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "cacheTimeout": null,
-            "class": "single_stat_panel_fail",
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(250, 113, 0, 0.89)",
-                "rgba(255, 0, 0, 0.9)"
-            ],
-            "datasource": "prometheus",
-            "description": "Number of nodes that reported their status as  Leaving, Decommissioned, Draining or Drained",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": false
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 6,
-                "y": 4
-            },
-            "id": 5,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(scylla_node_operation_mode>3)OR vector(0)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Leaving",
-                    "refId": "A",
-                    "step": 20
-                }
-            ],
-            "thresholds": "1,2",
-            "title": "Leaving",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "class": "text_panel",
-            "content": "##  ",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 8,
-                "y": 4
-            },
-            "id": 6,
-            "isNew": true,
-            "links": [],
-            "mode": "markdown",
-            "span": 1,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "aliasColors": {},
-            "bars": true,
-            "class": "ops_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 10,
-                "y": 4
-            },
-            "id": 7,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_transport_requests_served{cluster=~\"$cluster|$^\"}[30s])) + $func(irate(scylla_thrift_served{cluster=~\"$cluster|$^\"}[30s]))",
-                    "intervalFactor": 1,
-                    "legendFormat": "Total Requests",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Total Requests - Coordinator",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "class": "dashlist",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 4,
-                "x": 20,
-                "y": 4
-            },
-            "headings": false,
-            "id": 8,
-            "isNew": true,
-            "limit": 10,
-            "links": [],
-            "query": "",
-            "recent": false,
-            "search": true,
-            "span": 2,
-            "starred": false,
-            "tags": [
-                "3.1"
-            ],
-            "title": "Dashboards",
-            "type": "dashlist"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "percent_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 0,
-                "y": 10
-            },
-            "id": 9,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Load per [[by]]",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "percent",
-                    "logBase": 1,
-                    "max": 101,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
             "aliasColors": {},
             "bars": false,
             "class": "ops_panel",
@@ -609,11 +47,11 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 10,
-                "x": 10,
-                "y": 10
+                "w": 8,
+                "x": 0,
+                "y": 4
             },
-            "id": 10,
+            "id": 2,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -635,7 +73,7 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 5,
+            "span": 4,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -679,6 +117,171 @@
             ]
         },
         {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 4
+            },
+            "id": 3,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_database_total_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Reads per [[by]] - Replica",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 4
+            },
+            "id": 4,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_database_total_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Writes per [[by]] - Replica",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
             "class": "text_header_panel",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Reads and Writes - Coordinator</h1>",
             "editable": true,
@@ -687,9 +290,9 @@
                 "h": 2,
                 "w": 12,
                 "x": 0,
-                "y": 16
+                "y": 10
             },
-            "id": 11,
+            "id": 5,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -708,9 +311,9 @@
                 "h": 2,
                 "w": 12,
                 "x": 12,
-                "y": 16
+                "y": 10
             },
-            "id": 12,
+            "id": 6,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -738,9 +341,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 18
+                "y": 12
             },
-            "id": 13,
+            "id": 7,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -820,9 +423,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 18
+                "y": 12
             },
-            "id": 14,
+            "id": 8,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -903,9 +506,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 18
+                "y": 12
             },
-            "id": 15,
+            "id": 9,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -985,9 +588,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 18
+                "y": 12
             },
-            "id": 16,
+            "id": 10,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1067,9 +670,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 24
+                "y": 18
             },
-            "id": 17,
+            "id": 11,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1149,9 +752,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 24
+                "y": 18
             },
-            "id": 18,
+            "id": 12,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1231,9 +834,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 24
+                "y": 18
             },
-            "id": 19,
+            "id": 13,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1313,9 +916,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 24
+                "y": 18
             },
-            "id": 20,
+            "id": 14,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1387,9 +990,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 30
+                "y": 24
             },
-            "id": 21,
+            "id": 15,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -1398,171 +1001,6 @@
             "title": "",
             "transparent": true,
             "type": "text"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "rps_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 12,
-                "x": 0,
-                "y": 32
-            },
-            "id": 22,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 6,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_database_total_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Reads",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "rps",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "wps_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 12,
-                "x": 12,
-                "y": 32
-            },
-            "id": 23,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 6,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_database_total_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Writes",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "wps",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
         },
         {
             "aliasColors": {},
@@ -1582,9 +1020,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 38
+                "y": 26
             },
-            "id": 24,
+            "id": 16,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1664,9 +1102,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 38
+                "y": 26
             },
-            "id": 25,
+            "id": 17,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1746,9 +1184,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 38
+                "y": 26
             },
-            "id": 26,
+            "id": 18,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1828,9 +1266,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 38
+                "y": 26
             },
-            "id": 27,
+            "id": 19,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1901,9 +1339,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 44
+                "y": 32
             },
-            "id": 28,
+            "id": 20,
             "isNew": true,
             "links": [],
             "mode": "markdown",
@@ -1930,9 +1368,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 44
+                "y": 32
             },
-            "id": 29,
+            "id": 21,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2012,9 +1450,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 44
+                "y": 32
             },
-            "id": 30,
+            "id": 22,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2094,9 +1532,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 44
+                "y": 32
             },
-            "id": 31,
+            "id": 23,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2167,9 +1605,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 50
+                "y": 38
             },
-            "id": 32,
+            "id": 24,
             "isNew": true,
             "links": [],
             "mode": "markdown",
@@ -2187,9 +1625,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 50
+                "y": 38
             },
-            "id": 33,
+            "id": 25,
             "isNew": true,
             "links": [],
             "mode": "markdown",
@@ -2216,9 +1654,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 50
+                "y": 38
             },
-            "id": 34,
+            "id": 26,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2298,9 +1736,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 50
+                "y": 38
             },
-            "id": 35,
+            "id": 27,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2371,9 +1809,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 56
+                "y": 44
             },
-            "id": 36,
+            "id": 28,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -2401,9 +1839,9 @@
                 "h": 6,
                 "w": 12,
                 "x": 0,
-                "y": 58
+                "y": 46
             },
-            "id": 37,
+            "id": 29,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2483,9 +1921,9 @@
                 "h": 6,
                 "w": 12,
                 "x": 12,
-                "y": 58
+                "y": 46
             },
-            "id": 38,
+            "id": 30,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2565,9 +2003,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 64
+                "y": 52
             },
-            "id": 39,
+            "id": 31,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2647,9 +2085,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 64
+                "y": 52
             },
-            "id": 40,
+            "id": 32,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2729,9 +2167,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 64
+                "y": 52
             },
-            "id": 41,
+            "id": 33,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2811,9 +2249,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 64
+                "y": 52
             },
-            "id": 42,
+            "id": 34,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2893,9 +2331,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 70
+                "y": 58
             },
-            "id": 43,
+            "id": 35,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2975,9 +2413,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 70
+                "y": 58
             },
-            "id": 44,
+            "id": 36,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3057,9 +2495,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 70
+                "y": 58
             },
-            "id": 45,
+            "id": 37,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3141,9 +2579,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 70
+                "y": 58
             },
-            "id": 46,
+            "id": 38,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3225,9 +2663,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 76
+                "y": 64
             },
-            "id": 47,
+            "id": 39,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3309,9 +2747,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 76
+                "y": 64
             },
-            "id": 48,
+            "id": 40,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3393,9 +2831,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 76
+                "y": 64
             },
-            "id": 49,
+            "id": 41,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3477,9 +2915,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 76
+                "y": 64
             },
-            "id": 50,
+            "id": 42,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3561,9 +2999,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 82
+                "y": 70
             },
-            "id": 51,
+            "id": 43,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3643,9 +3081,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 82
+                "y": 70
             },
-            "id": 52,
+            "id": 44,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3725,9 +3163,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 82
+                "y": 70
             },
-            "id": 53,
+            "id": 45,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3806,9 +3244,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 82
+                "y": 70
             },
-            "id": 54,
+            "id": 46,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3871,6 +3309,277 @@
         },
         {
             "class": "text_panel",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Materialized Views - Replica</h1>",
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 76
+            },
+            "id": 47,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bytes_panel",
+            "datasource": "prometheus",
+            "description": "Size in bytes of the view update backlog at each base replica.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 78
+            },
+            "id": 48,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(scylla_database_view_update_backlog{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "View Update Backlog",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "bytes",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "datasource": "prometheus",
+            "description": "Number of dropped view updates due to an excessive view update backlog.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 78
+            },
+            "id": 49,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_database_dropped_view_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Dropped View Updates",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "datasource": "prometheus",
+            "description": "Currently throttled base writes, as a consequence of the respective view update backlog.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 78
+            },
+            "id": 50,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(scylla_storage_proxy_coordinator_current_throttled_base_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"})  by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Throttled Base Writes",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "class": "text_panel",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Memory - Replica</h1>",
             "editable": true,
             "error": false,
@@ -3878,9 +3587,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 88
+                "y": 84
             },
-            "id": 55,
+            "id": 51,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -3908,9 +3617,9 @@
                 "h": 6,
                 "w": 12,
                 "x": 0,
-                "y": 90
+                "y": 86
             },
-            "id": 56,
+            "id": 52,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3989,9 +3698,9 @@
                 "h": 6,
                 "w": 12,
                 "x": 12,
-                "y": 90
+                "y": 86
             },
-            "id": 57,
+            "id": 53,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -4061,9 +3770,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 96
+                "y": 92
             },
-            "id": 58,
+            "id": 54,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -4091,9 +3800,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 98
+                "y": 94
             },
-            "id": 59,
+            "id": 55,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -4175,9 +3884,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 98
+                "y": 94
             },
-            "id": 60,
+            "id": 56,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -4262,9 +3971,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 98
+                "y": 94
             },
-            "id": 61,
+            "id": 57,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -4326,451 +4035,6 @@
             ]
         },
         {
-            "class": "text_panel",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">CQL - Coordinator</h1>",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 2,
-                "w": 24,
-                "x": 0,
-                "y": 104
-            },
-            "id": 62,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "span": 12,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "ops_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 0,
-                "y": 106
-            },
-            "id": 63,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "CQL Insert",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "ops_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 6,
-                "y": 106
-            },
-            "id": 64,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "CQL Reads",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "ops_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 12,
-                "y": 106
-            },
-            "id": 65,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "CQL Deletes",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "ops_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 18,
-                "y": 106
-            },
-            "id": 66,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "CQL Updates",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "graph_panel",
-            "datasource": "prometheus",
-            "description": "amount of CQL connections currently established",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 0,
-                "y": 112
-            },
-            "id": 67,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 1,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(scylla_transport_current_connections{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 30
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Client CQL connections by [[by]]",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
             "class": "plain_text",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Your Panels</h1>",
             "editable": true,
@@ -4779,9 +4043,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 118
+                "y": 100
             },
-            "id": 68,
+            "id": 58,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -4810,9 +4074,9 @@
                 "h": 6,
                 "w": 12,
                 "x": 0,
-                "y": 120
+                "y": 102
             },
-            "id": 69,
+            "id": 59,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -4886,9 +4150,9 @@
                 "h": 6,
                 "w": 12,
                 "x": 12,
-                "y": 120
+                "y": 102
             },
-            "id": 70,
+            "id": 60,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -5172,7 +4436,7 @@
         ]
     },
     "timezone": "browser",
-    "title": "Scylla Per Server Metrics",
-    "uid": "detail-3-1",
+    "title": "Detailed",
+    "uid": "detailed-3-1",
     "version": 5
 }

--- a/grafana/build/ver_3.1/scylla-dash.3.1.json
+++ b/grafana/build/ver_3.1/scylla-dash.3.1.json
@@ -378,215 +378,6 @@
             "valueName": "current"
         },
         {
-            "class": "text_panel",
-            "content": "##  ",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 4,
-                "x": 8,
-                "y": 4
-            },
-            "id": 6,
-            "isNew": true,
-            "links": [],
-            "mode": "markdown",
-            "span": 2,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "class": "dashlist",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 4,
-                "x": 12,
-                "y": 4
-            },
-            "headings": false,
-            "id": 7,
-            "isNew": true,
-            "limit": 10,
-            "links": [],
-            "query": "",
-            "recent": false,
-            "search": true,
-            "span": 2,
-            "starred": false,
-            "tags": [
-                "3.1"
-            ],
-            "title": "Dashboards",
-            "type": "dashlist"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "alert_table",
-            "columns": [],
-            "datasource": "alertmanager",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "fontSize": "100%",
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 8,
-                "x": 16,
-                "y": 4
-            },
-            "id": 8,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "pageSize": null,
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "scroll": true,
-            "seriesOverrides": [],
-            "showHeader": true,
-            "sort": {
-                "col": 0,
-                "desc": true
-            },
-            "span": 4,
-            "stack": false,
-            "steppedLine": false,
-            "styles": [
-                {
-                    "alias": "Time",
-                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                    "link": true,
-                    "linkTooltip": "Jump to the see the node",
-                    "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_4}&from=${__cell_0}",
-                    "pattern": "Time",
-                    "type": "date"
-                },
-                {
-                    "class": "hidden_column",
-                    "pattern": "severity",
-                    "type": "hidden"
-                },
-                {
-                    "class": "hidden_column",
-                    "pattern": "alertname",
-                    "type": "hidden"
-                },
-                {
-                    "class": "hidden_column",
-                    "pattern": "cluster",
-                    "type": "hidden"
-                },
-                {
-                    "class": "hidden_column",
-                    "pattern": "monitor",
-                    "type": "hidden"
-                },
-                {
-                    "class": "hidden_column",
-                    "pattern": "summary",
-                    "type": "hidden"
-                },
-                {
-                    "alias": "Instance",
-                    "colorMode": null,
-                    "colors": [
-                        "rgba(245, 54, 54, 0.9)",
-                        "rgba(237, 129, 40, 0.89)",
-                        "rgba(50, 172, 45, 0.97)"
-                    ],
-                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                    "decimals": 2,
-                    "link": true,
-                    "linkTooltip": "Jump to the see the node",
-                    "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_4}",
-                    "mappingType": 1,
-                    "pattern": "instance",
-                    "thresholds": [],
-                    "type": "string",
-                    "unit": "short"
-                },
-                {
-                    "alias": "",
-                    "colorMode": null,
-                    "colors": [
-                        "rgba(245, 54, 54, 0.9)",
-                        "rgba(237, 129, 40, 0.89)",
-                        "rgba(50, 172, 45, 0.97)"
-                    ],
-                    "decimals": 2,
-                    "pattern": "/.*/",
-                    "thresholds": [],
-                    "type": "number",
-                    "unit": "short"
-                }
-            ],
-            "targets": [
-                {
-                    "annotations": true,
-                    "expr": "job!=\"scylla_manager\"",
-                    "legendFormat": "{{description}}",
-                    "refId": "A",
-                    "target": "Query",
-                    "type": "table"
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Active Alerts",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "transform": "table",
-            "type": "table",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
             "aliasColors": {},
             "bars": false,
             "class": "percent_panel",
@@ -604,10 +395,10 @@
             "gridPos": {
                 "h": 6,
                 "w": 8,
-                "x": 0,
-                "y": 10
+                "x": 8,
+                "y": 4
             },
-            "id": 9,
+            "id": 6,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -673,92 +464,6 @@
             ]
         },
         {
-            "aliasColors": {},
-            "bars": false,
-            "class": "ops_panel",
-            "datasource": "prometheus",
-            "description": "Amount of requests served as the coordinator. Imbalances here represent dispersion at the client-side level or connection balancing level, not your data model.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 8,
-                "x": 8,
-                "y": 10
-            },
-            "id": 10,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 4,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + $func(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 4
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Requests Served - Coordinator",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
             "class": "single_value_table",
             "columns": [
                 {
@@ -773,9 +478,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 10
+                "y": 4
             },
-            "id": 11,
+            "id": 7,
             "links": [],
             "pageSize": null,
             "scroll": true,
@@ -798,7 +503,7 @@
                     "decimals": 2,
                     "link": true,
                     "linkTooltip": "Jump to the detailed node information",
-                    "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_6}",
+                    "linkUrl": "/d/detailed-[[dash_version]]/Detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__cell}",
                     "mappingType": 1,
                     "pattern": "instance",
                     "thresholds": [],
@@ -829,6 +534,128 @@
                     "class": "hidden_column",
                     "pattern": "type",
                     "type": "hidden"
+                },
+                {
+                    "alias": "OS",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the OS node information",
+                    "linkUrl": "/d/OS-[[dash_version]]/OS-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                    "mappingType": 1,
+                    "pattern": "OS",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "OS",
+                            "value": "os"
+                        }
+                    ]
+                },
+                {
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the CQL information",
+                    "linkUrl": "/d/cql-[[dash_version]]/scylla-cql?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                    "mappingType": 1,
+                    "pattern": "CQL",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "CQL",
+                            "value": "cql"
+                        }
+                    ]
+                },
+                {
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the Errors metrics information",
+                    "linkUrl": "/d/error-[[dash_version]]/scylla-errors?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                    "mappingType": 1,
+                    "pattern": "Errors",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "Errors",
+                            "value": "errors"
+                        }
+                    ]
+                },
+                {
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the Errors metrics information",
+                    "linkUrl": "/d/io-[[dash_version]]/i-o?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                    "mappingType": 1,
+                    "pattern": "IO",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "IO",
+                            "value": "io"
+                        }
+                    ]
+                },
+                {
+                    "alias": "CPU",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the node CPU information",
+                    "linkUrl": "/d/cpu-[[dash_version]]/CPU-Metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                    "mappingType": 1,
+                    "pattern": "CPU",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "CPU",
+                            "value": "cpu"
+                        }
+                    ]
                 },
                 {
                     "alias": "Status",
@@ -898,6 +725,336 @@
             "type": "table"
         },
         {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bytes_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 10
+            },
+            "id": 8,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(node_filesystem_size_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])-sum(node_filesystem_avail_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Disk Size by $by",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "bytes",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "datasource": "prometheus",
+            "description": "Amount of requests served as the coordinator. Imbalances here represent dispersion at the client-side level or connection balancing level, not your data model.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 10
+            },
+            "id": 9,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + $func(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 4
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Requests Served - Coordinator",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "alert_table",
+            "columns": [],
+            "datasource": "alertmanager",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fontSize": "100%",
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 10
+            },
+            "id": 10,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "pageSize": null,
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "scroll": true,
+            "seriesOverrides": [],
+            "showHeader": true,
+            "sort": {
+                "col": 0,
+                "desc": true
+            },
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "styles": [
+                {
+                    "alias": "Time",
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "link": true,
+                    "linkTooltip": "Jump to the see the node",
+                    "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}&from=${__cell_0}",
+                    "pattern": "Time",
+                    "type": "date"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "severity",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "alertname",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "cluster",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "monitor",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "summary",
+                    "type": "hidden"
+                },
+                {
+                    "alias": "Instance",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the see the node",
+                    "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                    "mappingType": 1,
+                    "pattern": "instance",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short"
+                },
+                {
+                    "alias": "",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "decimals": 2,
+                    "pattern": "/.*/",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "short"
+                }
+            ],
+            "targets": [
+                {
+                    "annotations": true,
+                    "expr": "job!=\"scylla_manager\"",
+                    "legendFormat": "{{description}}",
+                    "refId": "A",
+                    "target": "Query",
+                    "type": "table"
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Active Alerts",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "transform": "table",
+            "type": "table",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
             "class": "plain_text",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Latencies - Coordinator</h1>",
             "editable": true,
@@ -908,7 +1065,7 @@
                 "x": 0,
                 "y": 16
             },
-            "id": 12,
+            "id": 11,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -917,6 +1074,90 @@
             "title": "",
             "transparent": true,
             "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 18
+            },
+            "id": 12,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Writes",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
         },
         {
             "aliasColors": {},
@@ -934,8 +1175,8 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 8,
-                "x": 0,
+                "w": 6,
+                "x": 6,
                 "y": 18
             },
             "id": 13,
@@ -960,7 +1201,7 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 4,
+            "span": 3,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -1019,8 +1260,8 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 8,
-                "x": 8,
+                "w": 6,
+                "x": 12,
                 "y": 18
             },
             "id": 14,
@@ -1045,7 +1286,7 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 4,
+            "span": 3,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -1105,8 +1346,8 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 8,
-                "x": 16,
+                "w": 6,
+                "x": 18,
                 "y": 18
             },
             "id": 15,
@@ -1131,7 +1372,7 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 4,
+            "span": 3,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -1178,7 +1419,7 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "us_panel",
+            "class": "ops_panel",
             "datasource": "prometheus",
             "editable": true,
             "error": false,
@@ -1191,7 +1432,7 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 8,
+                "w": 6,
                 "x": 0,
                 "y": 24
             },
@@ -1217,7 +1458,91 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 4,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Reads",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 24
+            },
+            "id": 17,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "span": 3,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -1276,11 +1601,11 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 8,
-                "x": 8,
+                "w": 6,
+                "x": 12,
                 "y": 24
             },
-            "id": 17,
+            "id": 18,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1302,7 +1627,7 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 4,
+            "span": 3,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -1362,11 +1687,11 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 8,
-                "x": 16,
+                "w": 6,
+                "x": 18,
                 "y": 24
             },
-            "id": 18,
+            "id": 19,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1388,7 +1713,7 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 4,
+            "span": 3,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -1433,35 +1758,13 @@
             ]
         },
         {
-            "class": "text_header_panel",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Reads and Writes - Coordinator</h1>",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Cache - Replica</h1>",
             "editable": true,
             "error": false,
             "gridPos": {
                 "h": 2,
                 "w": 12,
                 "x": 0,
-                "y": 30
-            },
-            "id": 19,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "span": 6,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "class": "text_header_panel",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Timeouts and Errors - Coordinator</h1>",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 2,
-                "w": 12,
-                "x": 12,
                 "y": 30
             },
             "id": 20,
@@ -1475,705 +1778,16 @@
             "type": "text"
         },
         {
-            "aliasColors": {},
-            "bars": false,
-            "class": "queue_lenght_panel",
-            "datasource": "prometheus",
-            "description": "Foreground writes are writes that weren't acknowledged yet to the application. For instance, if a single replica responded and two are needed due to the consistency level. This metric represents a queue size, not a rate. High values here correlate with increased write latencies.",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Timeouts</h1>",
             "editable": true,
             "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
             "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 0,
-                "y": 32
+                "h": 2,
+                "w": 12,
+                "x": 12,
+                "y": 30
             },
             "id": 21,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(scylla_storage_proxy_coordinator_foreground_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 10
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Foreground Writes",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "label": "Queue Length",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "queue_lenght_panel",
-            "datasource": "prometheus",
-            "description": "Foreground reads are reads that weren't acknowledged yet to the application. For instance, if a single replica responded and two are needed due to the consistency level. This metric represents a queue size, not a rate. High values here correlate with increased read latencies.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 6,
-                "y": 32
-            },
-            "id": 22,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(scylla_storage_proxy_coordinator_foreground_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 10
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Foreground Reads",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "label": "Queue Length",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "wps_panel",
-            "datasource": "prometheus",
-            "description": "Requests that Scylla tried to write but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 12,
-                "y": 32
-            },
-            "id": 23,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 10
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Write Timeouts",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "wps",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "wps_panel",
-            "datasource": "prometheus",
-            "description": "Requests that Scylla did not even try to write because replicas that were needed to execute this write were unavailable. Unavailable writes are counted in the node that received the request (the coordinator), not at the replicas.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 18,
-                "y": 32
-            },
-            "id": 24,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_storage_proxy_coordinator_write_unavailable{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 10
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Write Unavailable",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "wps",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "queue_lenght_panel",
-            "datasource": "prometheus",
-            "description": "Background writes are writes that are already acknowledged to the application but have additional work to be done. For instance, if a replica responded and only one is needed, this request is still listed as a background request until all replicas respond. This metric represents a queue size, not a rate. High values here correlate with increased write latencies.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 0,
-                "y": 38
-            },
-            "id": 25,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(scylla_storage_proxy_coordinator_background_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 10
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Background Writes",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "label": "Queue Length",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "queue_lenght_panel",
-            "datasource": "prometheus",
-            "description": "Background reads are reads that are already acknowledged to the application but have additional work to be done. For instance, if a replica responded and only one is needed, this request is still listed as a background request until all replicas respond. This metric represents a queue size, not a rate. High values here correlate with increased read latencies.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 6,
-                "y": 38
-            },
-            "id": 26,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(scylla_storage_proxy_coordinator_background_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 10
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Background Reads",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "label": "Queue Length",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "rps_panel",
-            "datasource": "prometheus",
-            "description": "Requests that Scylla tried to read but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 12,
-                "y": 38
-            },
-            "id": 27,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 10
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Read Timeouts",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "rps",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "rps_panel",
-            "datasource": "prometheus",
-            "description": "Requests that Scylla did not even try to read because replicas that were needed to execute this write were unavailable. Unavailable reads are counted in the node that received the request (the coordinator), not at the replicas.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 18,
-                "y": 38
-            },
-            "id": 28,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_storage_proxy_coordinator_read_unavailable{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 10
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Read Unavailable",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "rps",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Cache - Replica</h1>",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 2,
-                "w": 12,
-                "x": 0,
-                "y": 44
-            },
-            "id": 29,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "span": 6,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Materialized Views - Replica</h1>",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 2,
-                "w": 12,
-                "x": 12,
-                "y": 44
-            },
-            "id": 30,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -2202,9 +1816,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 46
+                "y": 32
             },
-            "id": 31,
+            "id": 22,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2287,9 +1901,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 46
+                "y": 32
             },
-            "id": 32,
+            "id": 23,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2356,9 +1970,9 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "bytes_panel",
+            "class": "wps_panel",
             "datasource": "prometheus",
-            "description": "Size in bytes of the view update backlog at each base replica.",
+            "description": "Requests that Scylla tried to write but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas.",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -2372,9 +1986,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 46
+                "y": 32
             },
-            "id": 33,
+            "id": 24,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2399,7 +2013,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(scylla_database_view_update_backlog{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
+                    "expr": "$func(irate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -2408,194 +2022,7 @@
             ],
             "timeFrom": null,
             "timeShift": null,
-            "title": "View Update Backlog",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "bytes",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "ops_panel",
-            "datasource": "prometheus",
-            "description": "Number of dropped view updates due to an excessive view update backlog.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 18,
-                "y": 46
-            },
-            "id": 34,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_database_dropped_view_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 10
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Dropped View Updates",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "class": "text_panel",
-            "content": "",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 18,
-                "x": 0,
-                "y": 52
-            },
-            "id": 35,
-            "isNew": true,
-            "links": [],
-            "mode": "markdown",
-            "span": 9,
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "wps_panel",
-            "datasource": "prometheus",
-            "description": "Currently throttled base writes, as a consequence of the respective view update backlog.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 18,
-                "y": 52
-            },
-            "id": 36,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(scylla_storage_proxy_coordinator_current_throttled_base_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"})  by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 10
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Throttled Base Writes",
+            "title": "Write Timeouts",
             "tooltip": {
                 "msResolution": false,
                 "shared": true,
@@ -2624,6 +2051,89 @@
             ]
         },
         {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "datasource": "prometheus",
+            "description": "Requests that Scylla tried to read but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 32
+            },
+            "id": 25,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Read Timeouts",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
             "class": "plain_text",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Your Panels</h1>",
             "editable": true,
@@ -2632,9 +2142,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 58
+                "y": 38
             },
-            "id": 37,
+            "id": 26,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -2663,9 +2173,9 @@
                 "h": 6,
                 "w": 12,
                 "x": 0,
-                "y": 60
+                "y": 40
             },
-            "id": 38,
+            "id": 27,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2739,9 +2249,9 @@
                 "h": 6,
                 "w": 12,
                 "x": 12,
-                "y": 60
+                "y": 40
             },
-            "id": 39,
+            "id": 28,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2945,6 +2455,29 @@
             },
             {
                 "allValue": null,
+                "current": {
+                    "text": "/var/lib/scylla",
+                    "value": "/var/lib/scylla"
+                },
+                "datasource": "prometheus",
+                "hide": 0,
+                "includeAll": false,
+                "label": "Mounnt path",
+                "multi": false,
+                "name": "mount_point",
+                "options": [],
+                "query": "node_filesystem_avail_bytes",
+                "refresh": 2,
+                "regex": "/mountpoint=\"([^\"]*)\".*/",
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
                 "class": "aggregation_function",
                 "current": {
                     "tags": [],
@@ -2996,8 +2529,8 @@
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {
-                    "text": "3.1",
-                    "value": "3.1"
+                    "text": "3-1",
+                    "value": "3-1"
                 },
                 "hide": 2,
                 "includeAll": false,
@@ -3007,11 +2540,11 @@
                 "options": [
                     {
                         "selected": true,
-                        "text": "3.1",
-                        "value": "3.1"
+                        "text": "3-1",
+                        "value": "3-1"
                     }
                 ],
-                "query": "3.1",
+                "query": "3-1",
                 "skipUrlSync": false,
                 "type": "custom"
             }
@@ -3048,7 +2581,7 @@
         ]
     },
     "timezone": "browser",
-    "title": "Scylla Overview Metrics",
+    "title": "Overview",
     "uid": "overview-3-1",
     "version": 3
 }

--- a/grafana/build/ver_master/scylla-cql-optimization.master.json
+++ b/grafana/build/ver_master/scylla-cql-optimization.master.json
@@ -8,7 +8,7 @@
     "hideControls": true,
     "id": null,
     "links": [],
-    "originalTitle": "Scylla CQL Optimization",
+    "originalTitle": "CQL",
     "overwrite": true,
     "panels": [
         {
@@ -32,357 +32,31 @@
             "type": "text"
         },
         {
-            "cacheTimeout": null,
-            "class": "single_stat_panel",
-            "colorBackground": false,
-            "colorValue": false,
-            "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-            ],
-            "datasource": "prometheus",
+            "class": "text_panel",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">CQL - Coordinator</h1>",
             "editable": true,
             "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-            },
             "gridPos": {
-                "h": 6,
-                "w": 2,
+                "h": 2,
+                "w": 24,
                 "x": 0,
                 "y": 4
             },
             "id": 2,
-            "interval": null,
             "isNew": true,
             "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
-                    "intervalFactor": 1,
-                    "legendFormat": "Total Nodes",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "thresholds": "",
-            "title": "Total Nodes",
+            "mode": "html",
+            "span": 12,
+            "style": {},
+            "title": "",
             "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "cacheTimeout": null,
-            "class": "single_stat_panel_fail",
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(250, 113, 0, 0.89)",
-                "rgba(255, 0, 0, 0.9)"
-            ],
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": false
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 2,
-                "y": 4
-            },
-            "id": 3,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Unreachable",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "thresholds": "1,2",
-            "title": "Unreachable",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "cacheTimeout": null,
-            "class": "single_stat_panel_fail",
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(250, 113, 0, 0.89)",
-                "rgba(255, 0, 0, 0.9)"
-            ],
-            "datasource": "prometheus",
-            "description": "Number of nodes that reported their status as Starting or Joining",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": false
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 4,
-                "y": 4
-            },
-            "id": 4,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Joining",
-                    "refId": "A",
-                    "step": 20
-                }
-            ],
-            "thresholds": "1,2",
-            "title": "Joining",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "cacheTimeout": null,
-            "class": "single_stat_panel_fail",
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(250, 113, 0, 0.89)",
-                "rgba(255, 0, 0, 0.9)"
-            ],
-            "datasource": "prometheus",
-            "description": "Number of nodes that reported their status as  Leaving, Decommissioned, Draining or Drained",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": false
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 6,
-                "y": 4
-            },
-            "id": 5,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(scylla_node_operation_mode>3)OR vector(0)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Leaving",
-                    "refId": "A",
-                    "step": 20
-                }
-            ],
-            "thresholds": "1,2",
-            "title": "Leaving",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
+            "type": "text"
         },
         {
             "aliasColors": {},
             "bars": false,
             "class": "ops_panel",
             "datasource": "prometheus",
-            "description": "Total requests graph is the baseline for comparison",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -394,11 +68,11 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 8,
-                "x": 8,
-                "y": 4
+                "w": 6,
+                "x": 0,
+                "y": 6
             },
-            "id": 6,
+            "id": 3,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -420,21 +94,22 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 4,
+            "span": 3,
             "stack": false,
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "expr": "sum(irate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                     "intervalFactor": 1,
-                    "legendFormat": "Total Requests",
+                    "legendFormat": "",
+                    "metric": "",
                     "refId": "A",
                     "step": 1
                 }
             ],
             "timeFrom": null,
             "timeShift": null,
-            "title": "Total Requests",
+            "title": "CQL Insert",
             "tooltip": {
                 "msResolution": false,
                 "shared": true,
@@ -463,51 +138,553 @@
             ]
         },
         {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 6
+            },
+            "id": 4,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CQL Reads",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 6
+            },
+            "id": 5,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CQL Deletes",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 6
+            },
+            "id": 6,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CQL Updates",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "datasource": "prometheus",
+            "description": "amount of CQL connections currently established",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 12
+            },
+            "id": 7,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(scylla_transport_current_connections{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Client CQL connections by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "datasource": "prometheus",
+            "description": "Number of CQL batches command, each batched command is counted once",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 12
+            },
+            "id": 8,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_batches{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CQL Batches by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "datasource": "prometheus",
+            "description": "Number of CQL command batched. Each batch would add the number of commands inside the batch",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 12
+            },
+            "id": 9,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_statements_in_batches{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CQL Coomand In Batches by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
             "class": "plain_text",
             "content": "<span/>",
             "editable": true,
             "error": false,
             "gridPos": {
                 "h": 6,
-                "w": 4,
-                "x": 16,
-                "y": 4
+                "w": 10,
+                "x": 0,
+                "y": 18
             },
-            "id": 7,
+            "id": 10,
             "isNew": true,
             "links": [],
             "mode": "html",
-            "span": 2,
+            "span": 5,
             "style": {},
             "title": "",
             "transparent": true,
             "type": "text"
         },
         {
-            "class": "dashlist",
+            "class": "text_panel",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Optimization</h1>",
             "editable": true,
             "error": false,
             "gridPos": {
-                "h": 6,
-                "w": 4,
-                "x": 20,
-                "y": 4
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 24
             },
-            "headings": false,
-            "id": 8,
+            "id": 11,
             "isNew": true,
-            "limit": 10,
             "links": [],
-            "query": "",
-            "recent": false,
-            "search": true,
-            "span": 2,
-            "starred": false,
-            "tags": [
-                "master"
-            ],
-            "title": "Dashboards",
-            "type": "dashlist"
+            "mode": "html",
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
         },
         {
             "cacheTimeout": null,
@@ -535,9 +712,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 10
+                "y": 26
             },
-            "id": 9,
+            "id": 12,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -618,9 +795,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 10
+                "y": 26
             },
-            "id": 10,
+            "id": 13,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -710,9 +887,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 10
+                "y": 26
             },
-            "id": 11,
+            "id": 14,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -793,9 +970,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 10
+                "y": 26
             },
-            "id": 12,
+            "id": 15,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -885,9 +1062,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 16,
-                "y": 10
+                "y": 26
             },
-            "id": 13,
+            "id": 16,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -966,9 +1143,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 10
+                "y": 26
             },
-            "id": 14,
+            "id": 17,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1058,9 +1235,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 16
+                "y": 32
             },
-            "id": 15,
+            "id": 18,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -1141,9 +1318,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 16
+                "y": 32
             },
-            "id": 16,
+            "id": 19,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1233,9 +1410,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 16
+                "y": 32
             },
-            "id": 17,
+            "id": 20,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -1314,9 +1491,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 16
+                "y": 32
             },
-            "id": 18,
+            "id": 21,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1404,9 +1581,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 16,
-                "y": 16
+                "y": 32
             },
-            "id": 19,
+            "id": 22,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -1487,9 +1664,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 16
+                "y": 32
             },
-            "id": 20,
+            "id": 23,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1594,9 +1771,9 @@
                 "h": 6,
                 "w": 4,
                 "x": 0,
-                "y": 22
+                "y": 38
             },
-            "id": 21,
+            "id": 24,
             "interval": null,
             "isNew": true,
             "links": [],
@@ -1858,7 +2035,7 @@
         ]
     },
     "timezone": "browser",
-    "title": "Scylla CQL Optimization",
-    "uid": "cqlopt-master",
+    "title": "Scylla CQL",
+    "uid": "cql-master",
     "version": 0
 }

--- a/grafana/build/ver_master/scylla-dash-cpu-per-server.master.json
+++ b/grafana/build/ver_master/scylla-dash-cpu-per-server.master.json
@@ -117,53 +117,6 @@
             ]
         },
         {
-            "class": "text_panel",
-            "content": "##  ",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 10,
-                "y": 4
-            },
-            "id": 3,
-            "isNew": true,
-            "links": [],
-            "mode": "markdown",
-            "span": 3,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "class": "dashlist",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 4,
-                "x": 16,
-                "y": 4
-            },
-            "headings": false,
-            "id": 4,
-            "isNew": true,
-            "limit": 10,
-            "links": [],
-            "query": "",
-            "recent": false,
-            "search": true,
-            "span": 2,
-            "starred": false,
-            "tags": [
-                "master"
-            ],
-            "title": "Dashboards",
-            "type": "dashlist"
-        },
-        {
             "aliasColors": {},
             "bars": false,
             "class": "percent_panel",
@@ -181,10 +134,10 @@
             "gridPos": {
                 "h": 6,
                 "w": 10,
-                "x": 0,
-                "y": 10
+                "x": 10,
+                "y": 4
             },
-            "id": 5,
+            "id": 3,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -251,6 +204,27 @@
             ]
         },
         {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Task Quota Violation</h1>",
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 10
+            },
+            "id": 4,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
             "aliasColors": {},
             "bars": false,
             "class": "ms_panel",
@@ -267,11 +241,11 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 10,
-                "x": 10,
-                "y": 10
+                "w": 6,
+                "x": 0,
+                "y": 12
             },
-            "id": 6,
+            "id": 5,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -290,13 +264,14 @@
             "pointradius": 1,
             "points": false,
             "renderer": "flot",
+            "repeat": "group",
             "seriesOverrides": [],
-            "span": 5,
+            "span": 3,
             "stack": false,
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(scylla_scheduler_time_spent_on_task_quota_violations_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "expr": "sum(irate(scylla_scheduler_time_spent_on_task_quota_violations_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -306,7 +281,7 @@
             ],
             "timeFrom": null,
             "timeShift": null,
-            "title": "Time spent in task quota violations by [[by]]",
+            "title": "Time spent in task quota violations by [[by]] - $group",
             "tooltip": {
                 "msResolution": false,
                 "shared": true,
@@ -480,6 +455,32 @@
                 "tagsQuery": "",
                 "type": "query",
                 "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "hide": 2,
+                "includeAll": true,
+                "label": "group",
+                "multi": true,
+                "name": "group",
+                "options": [],
+                "query": "label_values(scylla_scheduler_time_spent_on_task_quota_violations_ms,group)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 3,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
             }
         ]
     },
@@ -514,7 +515,7 @@
         ]
     },
     "timezone": "browser",
-    "title": "Scylla CPU Per Server Metrics",
+    "title": "CPU Metrics",
     "uid": "cpu-master",
     "version": 5
 }

--- a/grafana/build/ver_master/scylla-dash-io-per-server.master.json
+++ b/grafana/build/ver_master/scylla-dash-io-per-server.master.json
@@ -506,7 +506,7 @@
         },
         {
             "class": "plain_text",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Disk Activity</h1>",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue</h1>",
             "editable": true,
             "error": false,
             "gridPos": {
@@ -516,357 +516,6 @@
                 "y": 16
             },
             "id": 9,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "span": 12,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "graph_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 12,
-                "x": 0,
-                "y": 18
-            },
-            "id": 10,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 6,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 20
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Disk Writes per Server",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "graph_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 12,
-                "x": 12,
-                "y": 18
-            },
-            "id": 11,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 6,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 20
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Disk Reads per Server",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "bps_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 12,
-                "x": 0,
-                "y": 24
-            },
-            "id": 12,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 6,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 20
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Disk Writes Bps per Server",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "Bps",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "bps_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 12,
-                "x": 12,
-                "y": 24
-            },
-            "id": 13,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 6,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 20
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Disk Read Bps per Server",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "Bps",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "class": "plain_text",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue</h1>",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 2,
-                "w": 24,
-                "x": 0,
-                "y": 30
-            },
-            "id": 14,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -894,9 +543,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 32
+                "y": 18
             },
-            "id": 15,
+            "id": 10,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -980,9 +629,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 32
+                "y": 18
             },
-            "id": 16,
+            "id": 11,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1063,9 +712,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 32
+                "y": 18
             },
-            "id": 17,
+            "id": 12,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1146,9 +795,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 38
+                "y": 24
             },
-            "id": 18,
+            "id": 13,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1232,9 +881,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 38
+                "y": 24
             },
-            "id": 19,
+            "id": 14,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1315,9 +964,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 38
+                "y": 24
             },
-            "id": 20,
+            "id": 15,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1398,9 +1047,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 44
+                "y": 30
             },
-            "id": 21,
+            "id": 16,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1484,9 +1133,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 44
+                "y": 30
             },
-            "id": 22,
+            "id": 17,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1567,9 +1216,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 44
+                "y": 30
             },
-            "id": 23,
+            "id": 18,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1650,9 +1299,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 50
+                "y": 36
             },
-            "id": 24,
+            "id": 19,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1736,9 +1385,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 50
+                "y": 36
             },
-            "id": 25,
+            "id": 20,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1819,9 +1468,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 50
+                "y": 36
             },
-            "id": 26,
+            "id": 21,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1902,9 +1551,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 56
+                "y": 42
             },
-            "id": 27,
+            "id": 22,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1988,9 +1637,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 56
+                "y": 42
             },
-            "id": 28,
+            "id": 23,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2071,9 +1720,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 56
+                "y": 42
             },
-            "id": 29,
+            "id": 24,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2154,9 +1803,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 62
+                "y": 48
             },
-            "id": 30,
+            "id": 25,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2240,9 +1889,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 62
+                "y": 48
             },
-            "id": 31,
+            "id": 26,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2323,9 +1972,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 62
+                "y": 48
             },
-            "id": 32,
+            "id": 27,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2398,43 +2047,6 @@
     ],
     "templating": {
         "list": [
-            {
-                "current": {},
-                "datasource": "prometheus",
-                "hide": 0,
-                "includeAll": false,
-                "multi": false,
-                "name": "monitor_disk",
-                "options": [],
-                "query": "node_disk_read_bytes_total",
-                "refresh": 2,
-                "regex": "/.*device=\"([^\\\"]*)\".*/",
-                "type": "query"
-            },
-            {
-                "allValue": null,
-                "class": "template_variable_single",
-                "current": {
-                    "text": "/var/lib/scylla",
-                    "value": "/var/lib/scylla"
-                },
-                "datasource": "prometheus",
-                "hide": 0,
-                "includeAll": false,
-                "label": "Mounnt path",
-                "multi": false,
-                "name": "mount_point",
-                "options": [],
-                "query": "label_values(scylla_io_queue_delay,mountpoint)",
-                "refresh": 2,
-                "regex": "",
-                "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
-            },
             {
                 "allValue": null,
                 "class": "by_template_var",
@@ -2605,7 +2217,7 @@
         ]
     },
     "timezone": "browser",
-    "title": "Scylla Per-Server Disk I/O",
+    "title": "Scylla Per-Server I/O",
     "uid": "io-master",
     "version": 0
 }

--- a/grafana/build/ver_master/scylla-dash-io-per-server.master.json
+++ b/grafana/build/ver_master/scylla-dash-io-per-server.master.json
@@ -31,480 +31,6 @@
             "type": "text"
         },
         {
-            "cacheTimeout": null,
-            "class": "single_stat_panel",
-            "colorBackground": false,
-            "colorValue": false,
-            "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-            ],
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 0,
-                "y": 4
-            },
-            "id": 2,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
-                    "intervalFactor": 1,
-                    "legendFormat": "Total Nodes",
-                    "refId": "A",
-                    "step": 240
-                }
-            ],
-            "thresholds": "",
-            "title": "Total Nodes",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "cacheTimeout": null,
-            "class": "single_stat_panel_fail",
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(250, 113, 0, 0.89)",
-                "rgba(255, 0, 0, 0.9)"
-            ],
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": false
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 2,
-                "y": 4
-            },
-            "id": 3,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Unreachable",
-                    "refId": "A",
-                    "step": 120
-                }
-            ],
-            "thresholds": "1,2",
-            "title": "Unreachable",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "class": "text_panel",
-            "content": "##  ",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 4,
-                "y": 4
-            },
-            "id": 4,
-            "isNew": true,
-            "links": [],
-            "mode": "markdown",
-            "span": 3,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "aliasColors": {
-                "{}": "#584477"
-            },
-            "bars": true,
-            "class": "graph_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 10,
-                "y": 4
-            },
-            "id": 5,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": false,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(irate(scylla_transport_requests_served{cluster=~\"$cluster|$^\"}[30s])) + sum(irate(scylla_thrift_served{cluster=~\"$cluster|$^\"}[30s]))",
-                    "intervalFactor": 1,
-                    "legendFormat": "Total Requests",
-                    "refId": "A",
-                    "step": 30
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Total Requests",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "class": "dashlist",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 4,
-                "x": 20,
-                "y": 4
-            },
-            "headings": false,
-            "id": 6,
-            "isNew": true,
-            "limit": 10,
-            "links": [],
-            "query": "",
-            "recent": false,
-            "search": true,
-            "span": 2,
-            "starred": false,
-            "tags": [
-                "master"
-            ],
-            "title": "Dashboards",
-            "type": "dashlist"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "graph_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 0,
-                "y": 10
-            },
-            "id": 7,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 30
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Load per [[by]]",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "graph_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 10,
-                "y": 10
-            },
-            "id": 8,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 1,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 30
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Requests Served per [[by]]",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
             "class": "plain_text",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue</h1>",
             "editable": true,
@@ -513,9 +39,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 16
+                "y": 4
             },
-            "id": 9,
+            "id": 2,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -543,9 +69,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 18
+                "y": 6
             },
-            "id": 10,
+            "id": 3,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -629,9 +155,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 18
+                "y": 6
             },
-            "id": 11,
+            "id": 4,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -712,9 +238,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 18
+                "y": 6
             },
-            "id": 12,
+            "id": 5,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -795,9 +321,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 24
+                "y": 12
             },
-            "id": 13,
+            "id": 6,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -881,9 +407,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 24
+                "y": 12
             },
-            "id": 14,
+            "id": 7,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -964,9 +490,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 24
+                "y": 12
             },
-            "id": 15,
+            "id": 8,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1047,9 +573,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 30
+                "y": 18
             },
-            "id": 16,
+            "id": 9,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1133,9 +659,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 30
+                "y": 18
             },
-            "id": 17,
+            "id": 10,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1216,9 +742,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 30
+                "y": 18
             },
-            "id": 18,
+            "id": 11,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1299,9 +825,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 36
+                "y": 24
             },
-            "id": 19,
+            "id": 12,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1385,9 +911,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 36
+                "y": 24
             },
-            "id": 20,
+            "id": 13,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1468,9 +994,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 36
+                "y": 24
             },
-            "id": 21,
+            "id": 14,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1551,9 +1077,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 42
+                "y": 30
             },
-            "id": 22,
+            "id": 15,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1637,9 +1163,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 42
+                "y": 30
             },
-            "id": 23,
+            "id": 16,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1720,9 +1246,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 42
+                "y": 30
             },
-            "id": 24,
+            "id": 17,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1803,9 +1329,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 48
+                "y": 36
             },
-            "id": 25,
+            "id": 18,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1889,9 +1415,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 48
+                "y": 36
             },
-            "id": 26,
+            "id": 19,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1972,9 +1498,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 48
+                "y": 36
             },
-            "id": 27,
+            "id": 20,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2217,7 +1743,7 @@
         ]
     },
     "timezone": "browser",
-    "title": "Scylla Per-Server I/O",
+    "title": "I/O",
     "uid": "io-master",
     "version": 0
 }

--- a/grafana/build/ver_master/scylla-dash-per-machine.master.json
+++ b/grafana/build/ver_master/scylla-dash-per-machine.master.json
@@ -1114,7 +1114,7 @@
         ]
     },
     "timezone": "browser",
-    "title": "Scylla Per Machine Metrics",
-    "uid": "machine-master",
+    "title": "OS Metrics",
+    "uid": "OS-master",
     "version": 5
 }

--- a/grafana/build/ver_master/scylla-dash-per-server.master.json
+++ b/grafana/build/ver_master/scylla-dash-per-server.master.json
@@ -31,568 +31,6 @@
             "type": "text"
         },
         {
-            "cacheTimeout": null,
-            "class": "single_stat_panel",
-            "colorBackground": false,
-            "colorValue": false,
-            "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-            ],
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 0,
-                "y": 4
-            },
-            "id": 2,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
-                    "intervalFactor": 1,
-                    "legendFormat": "Total Nodes",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "thresholds": "",
-            "title": "Total Nodes",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "cacheTimeout": null,
-            "class": "single_stat_panel_fail",
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(250, 113, 0, 0.89)",
-                "rgba(255, 0, 0, 0.9)"
-            ],
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": false
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 2,
-                "y": 4
-            },
-            "id": 3,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Unreachable",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "thresholds": "1,2",
-            "title": "Unreachable",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "cacheTimeout": null,
-            "class": "single_stat_panel_fail",
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(250, 113, 0, 0.89)",
-                "rgba(255, 0, 0, 0.9)"
-            ],
-            "datasource": "prometheus",
-            "description": "Number of nodes that reported their status as Starting or Joining",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": false
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 4,
-                "y": 4
-            },
-            "id": 4,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Joining",
-                    "refId": "A",
-                    "step": 20
-                }
-            ],
-            "thresholds": "1,2",
-            "title": "Joining",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "cacheTimeout": null,
-            "class": "single_stat_panel_fail",
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(250, 113, 0, 0.89)",
-                "rgba(255, 0, 0, 0.9)"
-            ],
-            "datasource": "prometheus",
-            "description": "Number of nodes that reported their status as  Leaving, Decommissioned, Draining or Drained",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": false
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 6,
-                "y": 4
-            },
-            "id": 5,
-            "interval": null,
-            "isNew": true,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
-                },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "targets": [
-                {
-                    "expr": "count(scylla_node_operation_mode>3)OR vector(0)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Leaving",
-                    "refId": "A",
-                    "step": 20
-                }
-            ],
-            "thresholds": "1,2",
-            "title": "Leaving",
-            "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
-        },
-        {
-            "class": "text_panel",
-            "content": "##  ",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 2,
-                "x": 8,
-                "y": 4
-            },
-            "id": 6,
-            "isNew": true,
-            "links": [],
-            "mode": "markdown",
-            "span": 1,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "aliasColors": {},
-            "bars": true,
-            "class": "ops_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 10,
-                "y": 4
-            },
-            "id": 7,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_transport_requests_served{cluster=~\"$cluster|$^\"}[30s])) + $func(irate(scylla_thrift_served{cluster=~\"$cluster|$^\"}[30s]))",
-                    "intervalFactor": 1,
-                    "legendFormat": "Total Requests",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Total Requests - Coordinator",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "class": "dashlist",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 4,
-                "x": 20,
-                "y": 4
-            },
-            "headings": false,
-            "id": 8,
-            "isNew": true,
-            "limit": 10,
-            "links": [],
-            "query": "",
-            "recent": false,
-            "search": true,
-            "span": 2,
-            "starred": false,
-            "tags": [
-                "master"
-            ],
-            "title": "Dashboards",
-            "type": "dashlist"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "percent_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 0,
-                "y": 10
-            },
-            "id": 9,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Load per [[by]]",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "percent",
-                    "logBase": 1,
-                    "max": 101,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
             "aliasColors": {},
             "bars": false,
             "class": "ops_panel",
@@ -609,11 +47,11 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 10,
-                "x": 10,
-                "y": 10
+                "w": 8,
+                "x": 0,
+                "y": 4
             },
-            "id": 10,
+            "id": 2,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -635,7 +73,7 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 5,
+            "span": 4,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -679,6 +117,171 @@
             ]
         },
         {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 4
+            },
+            "id": 3,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_database_total_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Reads per [[by]] - Replica",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 4
+            },
+            "id": 4,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_database_total_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Writes per [[by]] - Replica",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
             "class": "text_header_panel",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Reads and Writes - Coordinator</h1>",
             "editable": true,
@@ -687,9 +290,9 @@
                 "h": 2,
                 "w": 12,
                 "x": 0,
-                "y": 16
+                "y": 10
             },
-            "id": 11,
+            "id": 5,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -708,9 +311,9 @@
                 "h": 2,
                 "w": 12,
                 "x": 12,
-                "y": 16
+                "y": 10
             },
-            "id": 12,
+            "id": 6,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -738,9 +341,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 18
+                "y": 12
             },
-            "id": 13,
+            "id": 7,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -820,9 +423,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 18
+                "y": 12
             },
-            "id": 14,
+            "id": 8,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -903,9 +506,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 18
+                "y": 12
             },
-            "id": 15,
+            "id": 9,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -985,9 +588,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 18
+                "y": 12
             },
-            "id": 16,
+            "id": 10,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1067,9 +670,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 24
+                "y": 18
             },
-            "id": 17,
+            "id": 11,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1149,9 +752,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 24
+                "y": 18
             },
-            "id": 18,
+            "id": 12,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1231,9 +834,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 24
+                "y": 18
             },
-            "id": 19,
+            "id": 13,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1313,9 +916,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 24
+                "y": 18
             },
-            "id": 20,
+            "id": 14,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1387,9 +990,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 30
+                "y": 24
             },
-            "id": 21,
+            "id": 15,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -1398,171 +1001,6 @@
             "title": "",
             "transparent": true,
             "type": "text"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "rps_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 12,
-                "x": 0,
-                "y": 32
-            },
-            "id": 22,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 6,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_database_total_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Reads",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "rps",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "wps_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 12,
-                "x": 12,
-                "y": 32
-            },
-            "id": 23,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 6,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_database_total_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Writes",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "wps",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
         },
         {
             "aliasColors": {},
@@ -1582,9 +1020,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 38
+                "y": 26
             },
-            "id": 24,
+            "id": 16,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1664,9 +1102,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 38
+                "y": 26
             },
-            "id": 25,
+            "id": 17,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1746,9 +1184,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 38
+                "y": 26
             },
-            "id": 26,
+            "id": 18,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1828,9 +1266,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 38
+                "y": 26
             },
-            "id": 27,
+            "id": 19,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1901,9 +1339,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 44
+                "y": 32
             },
-            "id": 28,
+            "id": 20,
             "isNew": true,
             "links": [],
             "mode": "markdown",
@@ -1930,9 +1368,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 44
+                "y": 32
             },
-            "id": 29,
+            "id": 21,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2012,9 +1450,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 44
+                "y": 32
             },
-            "id": 30,
+            "id": 22,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2094,9 +1532,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 44
+                "y": 32
             },
-            "id": 31,
+            "id": 23,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2167,9 +1605,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 50
+                "y": 38
             },
-            "id": 32,
+            "id": 24,
             "isNew": true,
             "links": [],
             "mode": "markdown",
@@ -2187,9 +1625,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 50
+                "y": 38
             },
-            "id": 33,
+            "id": 25,
             "isNew": true,
             "links": [],
             "mode": "markdown",
@@ -2216,9 +1654,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 50
+                "y": 38
             },
-            "id": 34,
+            "id": 26,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2298,9 +1736,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 50
+                "y": 38
             },
-            "id": 35,
+            "id": 27,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2371,9 +1809,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 56
+                "y": 44
             },
-            "id": 36,
+            "id": 28,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -2401,9 +1839,9 @@
                 "h": 6,
                 "w": 12,
                 "x": 0,
-                "y": 58
+                "y": 46
             },
-            "id": 37,
+            "id": 29,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2483,9 +1921,9 @@
                 "h": 6,
                 "w": 12,
                 "x": 12,
-                "y": 58
+                "y": 46
             },
-            "id": 38,
+            "id": 30,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2565,9 +2003,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 64
+                "y": 52
             },
-            "id": 39,
+            "id": 31,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2647,9 +2085,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 64
+                "y": 52
             },
-            "id": 40,
+            "id": 32,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2729,9 +2167,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 64
+                "y": 52
             },
-            "id": 41,
+            "id": 33,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2811,9 +2249,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 64
+                "y": 52
             },
-            "id": 42,
+            "id": 34,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2893,9 +2331,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 70
+                "y": 58
             },
-            "id": 43,
+            "id": 35,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2975,9 +2413,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 70
+                "y": 58
             },
-            "id": 44,
+            "id": 36,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3057,9 +2495,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 70
+                "y": 58
             },
-            "id": 45,
+            "id": 37,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3141,9 +2579,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 70
+                "y": 58
             },
-            "id": 46,
+            "id": 38,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3225,9 +2663,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 76
+                "y": 64
             },
-            "id": 47,
+            "id": 39,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3309,9 +2747,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 76
+                "y": 64
             },
-            "id": 48,
+            "id": 40,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3393,9 +2831,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 76
+                "y": 64
             },
-            "id": 49,
+            "id": 41,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3477,9 +2915,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 76
+                "y": 64
             },
-            "id": 50,
+            "id": 42,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3561,9 +2999,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 82
+                "y": 70
             },
-            "id": 51,
+            "id": 43,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3643,9 +3081,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 82
+                "y": 70
             },
-            "id": 52,
+            "id": 44,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3725,9 +3163,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 82
+                "y": 70
             },
-            "id": 53,
+            "id": 45,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3806,9 +3244,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 82
+                "y": 70
             },
-            "id": 54,
+            "id": 46,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3871,6 +3309,277 @@
         },
         {
             "class": "text_panel",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Materialized Views - Replica</h1>",
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 76
+            },
+            "id": 47,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bytes_panel",
+            "datasource": "prometheus",
+            "description": "Size in bytes of the view update backlog at each base replica.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 78
+            },
+            "id": 48,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(scylla_database_view_update_backlog{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "View Update Backlog",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "bytes",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "datasource": "prometheus",
+            "description": "Number of dropped view updates due to an excessive view update backlog.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 78
+            },
+            "id": 49,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_database_dropped_view_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Dropped View Updates",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "datasource": "prometheus",
+            "description": "Currently throttled base writes, as a consequence of the respective view update backlog.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 78
+            },
+            "id": 50,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(scylla_storage_proxy_coordinator_current_throttled_base_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"})  by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Throttled Base Writes",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "class": "text_panel",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Memory - Replica</h1>",
             "editable": true,
             "error": false,
@@ -3878,9 +3587,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 88
+                "y": 84
             },
-            "id": 55,
+            "id": 51,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -3908,9 +3617,9 @@
                 "h": 6,
                 "w": 12,
                 "x": 0,
-                "y": 90
+                "y": 86
             },
-            "id": 56,
+            "id": 52,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3989,9 +3698,9 @@
                 "h": 6,
                 "w": 12,
                 "x": 12,
-                "y": 90
+                "y": 86
             },
-            "id": 57,
+            "id": 53,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -4061,9 +3770,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 96
+                "y": 92
             },
-            "id": 58,
+            "id": 54,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -4091,9 +3800,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 98
+                "y": 94
             },
-            "id": 59,
+            "id": 55,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -4175,9 +3884,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 98
+                "y": 94
             },
-            "id": 60,
+            "id": 56,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -4262,9 +3971,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 98
+                "y": 94
             },
-            "id": 61,
+            "id": 57,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -4326,451 +4035,6 @@
             ]
         },
         {
-            "class": "text_panel",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">CQL - Coordinator</h1>",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 2,
-                "w": 24,
-                "x": 0,
-                "y": 104
-            },
-            "id": 62,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "span": 12,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "ops_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 0,
-                "y": 106
-            },
-            "id": 63,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "CQL Insert",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "ops_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 6,
-                "y": 106
-            },
-            "id": 64,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "CQL Reads",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "ops_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 12,
-                "y": 106
-            },
-            "id": 65,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "CQL Deletes",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "ops_panel",
-            "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 18,
-                "y": 106
-            },
-            "id": 66,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "CQL Updates",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "graph_panel",
-            "datasource": "prometheus",
-            "description": "amount of CQL connections currently established",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 0,
-                "y": 112
-            },
-            "id": 67,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 1,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(scylla_transport_current_connections{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 30
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Client CQL connections by [[by]]",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
             "class": "plain_text",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Your Panels</h1>",
             "editable": true,
@@ -4779,9 +4043,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 118
+                "y": 100
             },
-            "id": 68,
+            "id": 58,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -4810,9 +4074,9 @@
                 "h": 6,
                 "w": 12,
                 "x": 0,
-                "y": 120
+                "y": 102
             },
-            "id": 69,
+            "id": 59,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -4886,9 +4150,9 @@
                 "h": 6,
                 "w": 12,
                 "x": 12,
-                "y": 120
+                "y": 102
             },
-            "id": 70,
+            "id": 60,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -5172,7 +4436,7 @@
         ]
     },
     "timezone": "browser",
-    "title": "Scylla Per Server Metrics",
-    "uid": "detail-master",
+    "title": "Detailed",
+    "uid": "detailed-master",
     "version": 5
 }

--- a/grafana/build/ver_master/scylla-dash.master.json
+++ b/grafana/build/ver_master/scylla-dash.master.json
@@ -378,215 +378,6 @@
             "valueName": "current"
         },
         {
-            "class": "text_panel",
-            "content": "##  ",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 4,
-                "x": 8,
-                "y": 4
-            },
-            "id": 6,
-            "isNew": true,
-            "links": [],
-            "mode": "markdown",
-            "span": 2,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "class": "dashlist",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 4,
-                "x": 12,
-                "y": 4
-            },
-            "headings": false,
-            "id": 7,
-            "isNew": true,
-            "limit": 10,
-            "links": [],
-            "query": "",
-            "recent": false,
-            "search": true,
-            "span": 2,
-            "starred": false,
-            "tags": [
-                "master"
-            ],
-            "title": "Dashboards",
-            "type": "dashlist"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "alert_table",
-            "columns": [],
-            "datasource": "alertmanager",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "fontSize": "100%",
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 8,
-                "x": 16,
-                "y": 4
-            },
-            "id": 8,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "pageSize": null,
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "scroll": true,
-            "seriesOverrides": [],
-            "showHeader": true,
-            "sort": {
-                "col": 0,
-                "desc": true
-            },
-            "span": 4,
-            "stack": false,
-            "steppedLine": false,
-            "styles": [
-                {
-                    "alias": "Time",
-                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                    "link": true,
-                    "linkTooltip": "Jump to the see the node",
-                    "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_4}&from=${__cell_0}",
-                    "pattern": "Time",
-                    "type": "date"
-                },
-                {
-                    "class": "hidden_column",
-                    "pattern": "severity",
-                    "type": "hidden"
-                },
-                {
-                    "class": "hidden_column",
-                    "pattern": "alertname",
-                    "type": "hidden"
-                },
-                {
-                    "class": "hidden_column",
-                    "pattern": "cluster",
-                    "type": "hidden"
-                },
-                {
-                    "class": "hidden_column",
-                    "pattern": "monitor",
-                    "type": "hidden"
-                },
-                {
-                    "class": "hidden_column",
-                    "pattern": "summary",
-                    "type": "hidden"
-                },
-                {
-                    "alias": "Instance",
-                    "colorMode": null,
-                    "colors": [
-                        "rgba(245, 54, 54, 0.9)",
-                        "rgba(237, 129, 40, 0.89)",
-                        "rgba(50, 172, 45, 0.97)"
-                    ],
-                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                    "decimals": 2,
-                    "link": true,
-                    "linkTooltip": "Jump to the see the node",
-                    "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_4}",
-                    "mappingType": 1,
-                    "pattern": "instance",
-                    "thresholds": [],
-                    "type": "string",
-                    "unit": "short"
-                },
-                {
-                    "alias": "",
-                    "colorMode": null,
-                    "colors": [
-                        "rgba(245, 54, 54, 0.9)",
-                        "rgba(237, 129, 40, 0.89)",
-                        "rgba(50, 172, 45, 0.97)"
-                    ],
-                    "decimals": 2,
-                    "pattern": "/.*/",
-                    "thresholds": [],
-                    "type": "number",
-                    "unit": "short"
-                }
-            ],
-            "targets": [
-                {
-                    "annotations": true,
-                    "expr": "job!=\"scylla_manager\"",
-                    "legendFormat": "{{description}}",
-                    "refId": "A",
-                    "target": "Query",
-                    "type": "table"
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Active Alerts",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "transform": "table",
-            "type": "table",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
             "aliasColors": {},
             "bars": false,
             "class": "percent_panel",
@@ -604,10 +395,10 @@
             "gridPos": {
                 "h": 6,
                 "w": 8,
-                "x": 0,
-                "y": 10
+                "x": 8,
+                "y": 4
             },
-            "id": 9,
+            "id": 6,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -673,92 +464,6 @@
             ]
         },
         {
-            "aliasColors": {},
-            "bars": false,
-            "class": "ops_panel",
-            "datasource": "prometheus",
-            "description": "Amount of requests served as the coordinator. Imbalances here represent dispersion at the client-side level or connection balancing level, not your data model.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 8,
-                "x": 8,
-                "y": 10
-            },
-            "id": 10,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 4,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + $func(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 4
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Requests Served - Coordinator",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
             "class": "single_value_table",
             "columns": [
                 {
@@ -773,9 +478,9 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 10
+                "y": 4
             },
-            "id": 11,
+            "id": 7,
             "links": [],
             "pageSize": null,
             "scroll": true,
@@ -798,7 +503,7 @@
                     "decimals": 2,
                     "link": true,
                     "linkTooltip": "Jump to the detailed node information",
-                    "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_6}",
+                    "linkUrl": "/d/detailed-[[dash_version]]/Detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__cell}",
                     "mappingType": 1,
                     "pattern": "instance",
                     "thresholds": [],
@@ -829,6 +534,128 @@
                     "class": "hidden_column",
                     "pattern": "type",
                     "type": "hidden"
+                },
+                {
+                    "alias": "OS",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the OS node information",
+                    "linkUrl": "/d/OS-[[dash_version]]/OS-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                    "mappingType": 1,
+                    "pattern": "OS",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "OS",
+                            "value": "os"
+                        }
+                    ]
+                },
+                {
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the CQL information",
+                    "linkUrl": "/d/cql-[[dash_version]]/scylla-cql?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                    "mappingType": 1,
+                    "pattern": "CQL",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "CQL",
+                            "value": "cql"
+                        }
+                    ]
+                },
+                {
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the Errors metrics information",
+                    "linkUrl": "/d/error-[[dash_version]]/scylla-errors?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                    "mappingType": 1,
+                    "pattern": "Errors",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "Errors",
+                            "value": "errors"
+                        }
+                    ]
+                },
+                {
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the Errors metrics information",
+                    "linkUrl": "/d/io-[[dash_version]]/i-o?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                    "mappingType": 1,
+                    "pattern": "IO",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "IO",
+                            "value": "io"
+                        }
+                    ]
+                },
+                {
+                    "alias": "CPU",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the node CPU information",
+                    "linkUrl": "/d/cpu-[[dash_version]]/CPU-Metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                    "mappingType": 1,
+                    "pattern": "CPU",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "CPU",
+                            "value": "cpu"
+                        }
+                    ]
                 },
                 {
                     "alias": "Status",
@@ -898,6 +725,336 @@
             "type": "table"
         },
         {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bytes_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 10
+            },
+            "id": 8,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(node_filesystem_size_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])-sum(node_filesystem_avail_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Disk Size by $by",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "bytes",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "datasource": "prometheus",
+            "description": "Amount of requests served as the coordinator. Imbalances here represent dispersion at the client-side level or connection balancing level, not your data model.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 10
+            },
+            "id": 9,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + $func(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 4
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Requests Served - Coordinator",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "alert_table",
+            "columns": [],
+            "datasource": "alertmanager",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fontSize": "100%",
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 10
+            },
+            "id": 10,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "pageSize": null,
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "scroll": true,
+            "seriesOverrides": [],
+            "showHeader": true,
+            "sort": {
+                "col": 0,
+                "desc": true
+            },
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "styles": [
+                {
+                    "alias": "Time",
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "link": true,
+                    "linkTooltip": "Jump to the see the node",
+                    "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}&from=${__cell_0}",
+                    "pattern": "Time",
+                    "type": "date"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "severity",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "alertname",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "cluster",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "monitor",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "summary",
+                    "type": "hidden"
+                },
+                {
+                    "alias": "Instance",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the see the node",
+                    "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                    "mappingType": 1,
+                    "pattern": "instance",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short"
+                },
+                {
+                    "alias": "",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "decimals": 2,
+                    "pattern": "/.*/",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "short"
+                }
+            ],
+            "targets": [
+                {
+                    "annotations": true,
+                    "expr": "job!=\"scylla_manager\"",
+                    "legendFormat": "{{description}}",
+                    "refId": "A",
+                    "target": "Query",
+                    "type": "table"
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Active Alerts",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "transform": "table",
+            "type": "table",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
             "class": "plain_text",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Latencies - Coordinator</h1>",
             "editable": true,
@@ -908,7 +1065,7 @@
                 "x": 0,
                 "y": 16
             },
-            "id": 12,
+            "id": 11,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -917,6 +1074,90 @@
             "title": "",
             "transparent": true,
             "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 18
+            },
+            "id": 12,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Writes",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
         },
         {
             "aliasColors": {},
@@ -934,8 +1175,8 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 8,
-                "x": 0,
+                "w": 6,
+                "x": 6,
                 "y": 18
             },
             "id": 13,
@@ -960,7 +1201,7 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 4,
+            "span": 3,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -1019,8 +1260,8 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 8,
-                "x": 8,
+                "w": 6,
+                "x": 12,
                 "y": 18
             },
             "id": 14,
@@ -1045,7 +1286,7 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 4,
+            "span": 3,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -1105,8 +1346,8 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 8,
-                "x": 16,
+                "w": 6,
+                "x": 18,
                 "y": 18
             },
             "id": 15,
@@ -1131,7 +1372,7 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 4,
+            "span": 3,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -1178,7 +1419,7 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "us_panel",
+            "class": "ops_panel",
             "datasource": "prometheus",
             "editable": true,
             "error": false,
@@ -1191,7 +1432,7 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 8,
+                "w": 6,
                 "x": 0,
                 "y": 24
             },
@@ -1217,7 +1458,91 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 4,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Reads",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 24
+            },
+            "id": 17,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "span": 3,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -1276,11 +1601,11 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 8,
-                "x": 8,
+                "w": 6,
+                "x": 12,
                 "y": 24
             },
-            "id": 17,
+            "id": 18,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1302,7 +1627,7 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 4,
+            "span": 3,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -1362,11 +1687,11 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 8,
-                "x": 16,
+                "w": 6,
+                "x": 18,
                 "y": 24
             },
-            "id": 18,
+            "id": 19,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1388,7 +1713,7 @@
             "seriesOverrides": [
                 {}
             ],
-            "span": 4,
+            "span": 3,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -1433,35 +1758,13 @@
             ]
         },
         {
-            "class": "text_header_panel",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Reads and Writes - Coordinator</h1>",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Cache - Replica</h1>",
             "editable": true,
             "error": false,
             "gridPos": {
                 "h": 2,
                 "w": 12,
                 "x": 0,
-                "y": 30
-            },
-            "id": 19,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "span": 6,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "class": "text_header_panel",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Timeouts and Errors - Coordinator</h1>",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 2,
-                "w": 12,
-                "x": 12,
                 "y": 30
             },
             "id": 20,
@@ -1475,705 +1778,16 @@
             "type": "text"
         },
         {
-            "aliasColors": {},
-            "bars": false,
-            "class": "queue_lenght_panel",
-            "datasource": "prometheus",
-            "description": "Foreground writes are writes that weren't acknowledged yet to the application. For instance, if a single replica responded and two are needed due to the consistency level. This metric represents a queue size, not a rate. High values here correlate with increased write latencies.",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Timeouts</h1>",
             "editable": true,
             "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
             "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 0,
-                "y": 32
+                "h": 2,
+                "w": 12,
+                "x": 12,
+                "y": 30
             },
             "id": 21,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(scylla_storage_proxy_coordinator_foreground_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 10
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Foreground Writes",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "label": "Queue Length",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "queue_lenght_panel",
-            "datasource": "prometheus",
-            "description": "Foreground reads are reads that weren't acknowledged yet to the application. For instance, if a single replica responded and two are needed due to the consistency level. This metric represents a queue size, not a rate. High values here correlate with increased read latencies.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 6,
-                "y": 32
-            },
-            "id": 22,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(scylla_storage_proxy_coordinator_foreground_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 10
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Foreground Reads",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "label": "Queue Length",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "wps_panel",
-            "datasource": "prometheus",
-            "description": "Requests that Scylla tried to write but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 12,
-                "y": 32
-            },
-            "id": 23,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 10
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Write Timeouts",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "wps",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "wps_panel",
-            "datasource": "prometheus",
-            "description": "Requests that Scylla did not even try to write because replicas that were needed to execute this write were unavailable. Unavailable writes are counted in the node that received the request (the coordinator), not at the replicas.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 18,
-                "y": 32
-            },
-            "id": 24,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_storage_proxy_coordinator_write_unavailable{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 10
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Write Unavailable",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "wps",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "queue_lenght_panel",
-            "datasource": "prometheus",
-            "description": "Background writes are writes that are already acknowledged to the application but have additional work to be done. For instance, if a replica responded and only one is needed, this request is still listed as a background request until all replicas respond. This metric represents a queue size, not a rate. High values here correlate with increased write latencies.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 0,
-                "y": 38
-            },
-            "id": 25,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(scylla_storage_proxy_coordinator_background_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 10
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Background Writes",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "label": "Queue Length",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "queue_lenght_panel",
-            "datasource": "prometheus",
-            "description": "Background reads are reads that are already acknowledged to the application but have additional work to be done. For instance, if a replica responded and only one is needed, this request is still listed as a background request until all replicas respond. This metric represents a queue size, not a rate. High values here correlate with increased read latencies.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 6,
-                "y": 38
-            },
-            "id": 26,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(scylla_storage_proxy_coordinator_background_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 10
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Background Reads",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "short",
-                    "label": "Queue Length",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "rps_panel",
-            "datasource": "prometheus",
-            "description": "Requests that Scylla tried to read but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 12,
-                "y": 38
-            },
-            "id": 27,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 10
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Read Timeouts",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "rps",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "rps_panel",
-            "datasource": "prometheus",
-            "description": "Requests that Scylla did not even try to read because replicas that were needed to execute this write were unavailable. Unavailable reads are counted in the node that received the request (the coordinator), not at the replicas.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 18,
-                "y": 38
-            },
-            "id": 28,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_storage_proxy_coordinator_read_unavailable{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 10
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Read Unavailable",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "rps",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Cache - Replica</h1>",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 2,
-                "w": 12,
-                "x": 0,
-                "y": 44
-            },
-            "id": 29,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "span": 6,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Materialized Views - Replica</h1>",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 2,
-                "w": 12,
-                "x": 12,
-                "y": 44
-            },
-            "id": 30,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -2202,9 +1816,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 46
+                "y": 32
             },
-            "id": 31,
+            "id": 22,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2287,9 +1901,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 46
+                "y": 32
             },
-            "id": 32,
+            "id": 23,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2356,9 +1970,9 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "bytes_panel",
+            "class": "wps_panel",
             "datasource": "prometheus",
-            "description": "Size in bytes of the view update backlog at each base replica.",
+            "description": "Requests that Scylla tried to write but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas.",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -2372,9 +1986,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 46
+                "y": 32
             },
-            "id": 33,
+            "id": 24,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2399,7 +2013,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(scylla_database_view_update_backlog{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
+                    "expr": "$func(irate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -2408,194 +2022,7 @@
             ],
             "timeFrom": null,
             "timeShift": null,
-            "title": "View Update Backlog",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "bytes",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "ops_panel",
-            "datasource": "prometheus",
-            "description": "Number of dropped view updates due to an excessive view update backlog.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 18,
-                "y": 46
-            },
-            "id": 34,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(irate(scylla_database_dropped_view_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 10
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Dropped View Updates",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "show": true
-            },
-            "yaxes": [
-                {
-                    "format": "ops",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ]
-        },
-        {
-            "class": "text_panel",
-            "content": "",
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 6,
-                "w": 18,
-                "x": 0,
-                "y": 52
-            },
-            "id": 35,
-            "isNew": true,
-            "links": [],
-            "mode": "markdown",
-            "span": 9,
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "wps_panel",
-            "datasource": "prometheus",
-            "description": "Currently throttled base writes, as a consequence of the respective view update backlog.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "grid": {
-                "threshold1": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2": null,
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 18,
-                "y": 52
-            },
-            "id": 36,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "$func(scylla_storage_proxy_coordinator_current_throttled_base_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"})  by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 10
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Throttled Base Writes",
+            "title": "Write Timeouts",
             "tooltip": {
                 "msResolution": false,
                 "shared": true,
@@ -2624,6 +2051,89 @@
             ]
         },
         {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "datasource": "prometheus",
+            "description": "Requests that Scylla tried to read but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {
+                "threshold1": null,
+                "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                "threshold2": null,
+                "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 32
+            },
+            "id": 25,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Read Timeouts",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "show": true
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ]
+        },
+        {
             "class": "plain_text",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Your Panels</h1>",
             "editable": true,
@@ -2632,9 +2142,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 58
+                "y": 38
             },
-            "id": 37,
+            "id": 26,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -2663,9 +2173,9 @@
                 "h": 6,
                 "w": 12,
                 "x": 0,
-                "y": 60
+                "y": 40
             },
-            "id": 38,
+            "id": 27,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2739,9 +2249,9 @@
                 "h": 6,
                 "w": 12,
                 "x": 12,
-                "y": 60
+                "y": 40
             },
-            "id": 39,
+            "id": 28,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2945,6 +2455,29 @@
             },
             {
                 "allValue": null,
+                "current": {
+                    "text": "/var/lib/scylla",
+                    "value": "/var/lib/scylla"
+                },
+                "datasource": "prometheus",
+                "hide": 0,
+                "includeAll": false,
+                "label": "Mounnt path",
+                "multi": false,
+                "name": "mount_point",
+                "options": [],
+                "query": "node_filesystem_avail_bytes",
+                "refresh": 2,
+                "regex": "/mountpoint=\"([^\"]*)\".*/",
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
                 "class": "aggregation_function",
                 "current": {
                     "tags": [],
@@ -3048,7 +2581,7 @@
         ]
     },
     "timezone": "browser",
-    "title": "Scylla Overview Metrics",
+    "title": "Overview",
     "uid": "overview-master",
     "version": 3
 }

--- a/grafana/scylla-cql-optimization.2019.1.template.json
+++ b/grafana/scylla-cql-optimization.2019.1.template.json
@@ -1,101 +1,161 @@
 {
     "dashboard": {
         "class": "dashboard",
-        "uid": "cqlopt-2019-1",
-        "originalTitle": "Scylla CQL Optimization",
+        "uid": "cql-2019-1",
+        "originalTitle": "CQL",
         "rows": [
             {
                 "class": "logo_row"
             },
             {
                 "class": "row",
+                "height": "25px",
+                "gridPos": {"h": 2},
                 "panels": [
                     {
-                        "class": "single_stat_panel",
+                        "class": "text_panel",
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">CQL - Coordinator</h1>",
+                        "style": {}
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "ops_panel",
+                        "span": 3,
                         "targets": [
                             {
-                                "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
+                                "expr": "sum(irate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Total Nodes",
+                                "legendFormat": "",
+                                "metric": "",
                                 "refId": "A",
                                 "step": 1
                             }
                         ],
-                        "title": "Total Nodes"
-                    },
-                    {
-                        "class": "single_stat_panel_fail",
-                        "targets": [
-                            {
-                                "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Unreachable",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "thresholds": "1,2",
-                        "title": "Unreachable"
-                    },
-                    {
-                        "class": "single_stat_panel_fail",
-                        "description": "Number of nodes that reported their status as Starting or Joining",
-                        "targets": [
-                            {
-                                "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Joining",
-                                "refId": "A",
-                                "step": 20
-                            }
-                        ],
-                        "thresholds": "1,2",
-                        "title": "Joining"
-                    },
-                    {
-                        "class": "single_stat_panel_fail",
-                        "description": "Number of nodes that reported their status as  Leaving, Decommissioned, Draining or Drained",
-                        "targets": [
-                            {
-                                "expr": "count(scylla_node_operation_mode>3)OR vector(0)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Leaving",
-                                "refId": "A",
-                                "step": 20
-                            }
-                        ],
-                        "thresholds": "1,2",
-                        "title": "Leaving"
+                        "title": "CQL Insert"
                     },
                     {
                         "class": "ops_panel",
-                        "description": "Total requests graph is the baseline for comparison",
-                        "span": 4,
+                        "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Total Requests",
+                                "legendFormat": "",
+                                "metric": "",
                                 "refId": "A",
                                 "step": 1
                             }
                         ],
-                        "title": "Total Requests"
+                        "title": "CQL Reads"
+                    },
+                    {
+                        "class": "ops_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "CQL Deletes"
+                    },
+                    {
+                        "class": "ops_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "CQL Updates"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span": 3,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "sum(scylla_transport_current_connections{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "Client CQL connections by [[by]]",
+                        "description": "amount of CQL connections currently established"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span": 3,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(scylla_cql_batches{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "CQL Batches by [[by]]",
+                        "description": "Number of CQL batches command, each batched command is counted once"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span": 3,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(scylla_cql_statements_in_batches{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "CQL Coomand In Batches by [[by]]",
+                        "description": "Number of CQL command batched. Each batch would add the number of commands inside the batch"
                     },
                     {
                       "class":"plain_text",
                       "content": "<span/>",
-                      "span":2
-                    },
-                    {
-                        "class": "dashlist",
-                        "tags": [
-                            "2019.1"
-                        ]
+                      "span":5
                     }
                 ],
-                "title": "Node status"
+                "title": "New row"
             },
+            {
+                "class": "row",
+                "height": "25px",
+                "gridPos": {"h": 2},
+                "panels": [
+                    {
+                        "class": "text_panel",
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Optimization</h1>",
+                        "style": {}
+                    }
+                ],
+                "title": "New row"
+            },
+
             {
                 "class": "row",
                 "panels": [
@@ -391,6 +451,6 @@
             "to": "now"
         },
         "overwrite": true,
-        "title": "Scylla CQL Optimization"
+        "title": "Scylla CQL"
     }
 }

--- a/grafana/scylla-cql-optimization.3.0.template.json
+++ b/grafana/scylla-cql-optimization.3.0.template.json
@@ -1,76 +1,161 @@
 {
     "dashboard": {
         "class": "dashboard",
-        "uid": "cqlopt-3-0",
-        "originalTitle": "Scylla CQL Optimization",
+        "uid": "cql-3-0",
+        "originalTitle": "CQL",
         "rows": [
             {
                 "class": "logo_row"
             },
             {
                 "class": "row",
+                "height": "25px",
+                "gridPos": {"h": 2},
                 "panels": [
                     {
-                        "class": "single_stat_panel",
+                        "class": "text_panel",
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">CQL - Coordinator</h1>",
+                        "style": {}
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "ops_panel",
+                        "span": 3,
                         "targets": [
                             {
-                                "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
+                                "expr": "sum(irate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Total Nodes",
+                                "legendFormat": "",
+                                "metric": "",
                                 "refId": "A",
                                 "step": 1
                             }
                         ],
-                        "title": "Total Nodes"
-                    },
-                    {
-                        "class": "single_stat_panel_fail",
-                        "targets": [
-                            {
-                                "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Unreachable",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "thresholds": "1,2",
-                        "title": "Unreachable"
-                    },
-                    {
-                      "class":"plain_text",
-                      "content": "<span/>",
-                      "span":2
+                        "title": "CQL Insert"
                     },
                     {
                         "class": "ops_panel",
-                        "description": "Total requests graph is the baseline for comparison",
-                        "span": 4,
+                        "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Total Requests",
+                                "legendFormat": "",
+                                "metric": "",
                                 "refId": "A",
                                 "step": 1
                             }
                         ],
-                        "title": "Total Requests"
+                        "title": "CQL Reads"
+                    },
+                    {
+                        "class": "ops_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "CQL Deletes"
+                    },
+                    {
+                        "class": "ops_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "CQL Updates"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span": 3,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "sum(scylla_transport_current_connections{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "Client CQL connections by [[by]]",
+                        "description": "amount of CQL connections currently established"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span": 3,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(scylla_cql_batches{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "CQL Batches by [[by]]",
+                        "description": "Number of CQL batches command, each batched command is counted once"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span": 3,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(scylla_cql_statements_in_batches{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "CQL Coomand In Batches by [[by]]",
+                        "description": "Number of CQL command batched. Each batch would add the number of commands inside the batch"
                     },
                     {
                       "class":"plain_text",
                       "content": "<span/>",
-                      "span":2
-                    },
-                    {
-                        "class": "dashlist",
-                        "tags": [
-                            "3.0"
-                        ]
+                      "span":3
                     }
                 ],
-                "title": "Node status"
+                "title": "New row"
             },
+            {
+                "class": "row",
+                "height": "25px",
+                "gridPos": {"h": 2},
+                "panels": [
+                    {
+                        "class": "text_panel",
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Optimization</h1>",
+                        "style": {}
+                    }
+                ],
+                "title": "New row"
+            },
+
             {
                 "class": "row",
                 "panels": [
@@ -342,22 +427,6 @@
                     "name": "shard",
                     "query": "label_values(scylla_reactor_utilization,shard)",
                     "sort": 3
-                },
-                {
-                    "class": "template_variable_custom",
-                    "current": {
-                        "text": "3.0",
-                        "value": "3.0"
-                    },
-                    "name": "dash_version",
-                    "options": [
-                        {
-                            "selected": true,
-                            "text": "3.0",
-                            "value": "3.0"
-                        }
-                    ],
-                    "query": "master"
                 }
             ]
         },
@@ -366,6 +435,6 @@
             "to": "now"
         },
         "overwrite": true,
-        "title": "Scylla CQL Optimization"
+        "title": "Scylla CQL"
     }
 }

--- a/grafana/scylla-cql-optimization.3.1.template.json
+++ b/grafana/scylla-cql-optimization.3.1.template.json
@@ -1,101 +1,161 @@
 {
     "dashboard": {
         "class": "dashboard",
-        "uid": "cqlopt-3-1",
-        "originalTitle": "Scylla CQL Optimization",
+        "uid": "cql-3-1",
+        "originalTitle": "CQL",
         "rows": [
             {
                 "class": "logo_row"
             },
             {
                 "class": "row",
+                "height": "25px",
+                "gridPos": {"h": 2},
                 "panels": [
                     {
-                        "class": "single_stat_panel",
+                        "class": "text_panel",
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">CQL - Coordinator</h1>",
+                        "style": {}
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "ops_panel",
+                        "span": 3,
                         "targets": [
                             {
-                                "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
+                                "expr": "sum(irate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Total Nodes",
+                                "legendFormat": "",
+                                "metric": "",
                                 "refId": "A",
                                 "step": 1
                             }
                         ],
-                        "title": "Total Nodes"
-                    },
-                    {
-                        "class": "single_stat_panel_fail",
-                        "targets": [
-                            {
-                                "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Unreachable",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "thresholds": "1,2",
-                        "title": "Unreachable"
-                    },
-                    {
-                        "class": "single_stat_panel_fail",
-                        "description": "Number of nodes that reported their status as Starting or Joining",
-                        "targets": [
-                            {
-                                "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Joining",
-                                "refId": "A",
-                                "step": 20
-                            }
-                        ],
-                        "thresholds": "1,2",
-                        "title": "Joining"
-                    },
-                    {
-                        "class": "single_stat_panel_fail",
-                        "description": "Number of nodes that reported their status as  Leaving, Decommissioned, Draining or Drained",
-                        "targets": [
-                            {
-                                "expr": "count(scylla_node_operation_mode>3)OR vector(0)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Leaving",
-                                "refId": "A",
-                                "step": 20
-                            }
-                        ],
-                        "thresholds": "1,2",
-                        "title": "Leaving"
+                        "title": "CQL Insert"
                     },
                     {
                         "class": "ops_panel",
-                        "description": "Total requests graph is the baseline for comparison",
-                        "span": 4,
+                        "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Total Requests",
+                                "legendFormat": "",
+                                "metric": "",
                                 "refId": "A",
                                 "step": 1
                             }
                         ],
-                        "title": "Total Requests"
+                        "title": "CQL Reads"
+                    },
+                    {
+                        "class": "ops_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "CQL Deletes"
+                    },
+                    {
+                        "class": "ops_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "CQL Updates"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span": 3,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "sum(scylla_transport_current_connections{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "Client CQL connections by [[by]]",
+                        "description": "amount of CQL connections currently established"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span": 3,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(scylla_cql_batches{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "CQL Batches by [[by]]",
+                        "description": "Number of CQL batches command, each batched command is counted once"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span": 3,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(scylla_cql_statements_in_batches{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "CQL Coomand In Batches by [[by]]",
+                        "description": "Number of CQL command batched. Each batch would add the number of commands inside the batch"
                     },
                     {
                       "class":"plain_text",
                       "content": "<span/>",
-                      "span":2
-                    },
-                    {
-                        "class": "dashlist",
-                        "tags": [
-                            "3.1"
-                        ]
+                      "span":5
                     }
                 ],
-                "title": "Node status"
+                "title": "New row"
             },
+            {
+                "class": "row",
+                "height": "25px",
+                "gridPos": {"h": 2},
+                "panels": [
+                    {
+                        "class": "text_panel",
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Optimization</h1>",
+                        "style": {}
+                    }
+                ],
+                "title": "New row"
+            },
+
             {
                 "class": "row",
                 "panels": [
@@ -391,6 +451,6 @@
             "to": "now"
         },
         "overwrite": true,
-        "title": "Scylla CQL Optimization"
+        "title": "Scylla CQL"
     }
 }

--- a/grafana/scylla-cql-optimization.master.template.json
+++ b/grafana/scylla-cql-optimization.master.template.json
@@ -1,101 +1,161 @@
 {
     "dashboard": {
         "class": "dashboard",
-        "uid": "cqlopt-master",
-        "originalTitle": "Scylla CQL Optimization",
+        "uid": "cql-master",
+        "originalTitle": "CQL",
         "rows": [
             {
                 "class": "logo_row"
             },
             {
                 "class": "row",
+                "height": "25px",
+                "gridPos": {"h": 2},
                 "panels": [
                     {
-                        "class": "single_stat_panel",
+                        "class": "text_panel",
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">CQL - Coordinator</h1>",
+                        "style": {}
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "ops_panel",
+                        "span": 3,
                         "targets": [
                             {
-                                "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
+                                "expr": "sum(irate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Total Nodes",
+                                "legendFormat": "",
+                                "metric": "",
                                 "refId": "A",
                                 "step": 1
                             }
                         ],
-                        "title": "Total Nodes"
-                    },
-                    {
-                        "class": "single_stat_panel_fail",
-                        "targets": [
-                            {
-                                "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Unreachable",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "thresholds": "1,2",
-                        "title": "Unreachable"
-                    },
-                    {
-                        "class": "single_stat_panel_fail",
-                        "description": "Number of nodes that reported their status as Starting or Joining",
-                        "targets": [
-                            {
-                                "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Joining",
-                                "refId": "A",
-                                "step": 20
-                            }
-                        ],
-                        "thresholds": "1,2",
-                        "title": "Joining"
-                    },
-                    {
-                        "class": "single_stat_panel_fail",
-                        "description": "Number of nodes that reported their status as  Leaving, Decommissioned, Draining or Drained",
-                        "targets": [
-                            {
-                                "expr": "count(scylla_node_operation_mode>3)OR vector(0)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Leaving",
-                                "refId": "A",
-                                "step": 20
-                            }
-                        ],
-                        "thresholds": "1,2",
-                        "title": "Leaving"
+                        "title": "CQL Insert"
                     },
                     {
                         "class": "ops_panel",
-                        "description": "Total requests graph is the baseline for comparison",
-                        "span": 4,
+                        "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Total Requests",
+                                "legendFormat": "",
+                                "metric": "",
                                 "refId": "A",
                                 "step": 1
                             }
                         ],
-                        "title": "Total Requests"
+                        "title": "CQL Reads"
+                    },
+                    {
+                        "class": "ops_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "CQL Deletes"
+                    },
+                    {
+                        "class": "ops_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "CQL Updates"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span": 3,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "sum(scylla_transport_current_connections{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "Client CQL connections by [[by]]",
+                        "description": "amount of CQL connections currently established"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span": 3,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(scylla_cql_batches{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "CQL Batches by [[by]]",
+                        "description": "Number of CQL batches command, each batched command is counted once"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span": 3,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(scylla_cql_statements_in_batches{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "CQL Coomand In Batches by [[by]]",
+                        "description": "Number of CQL command batched. Each batch would add the number of commands inside the batch"
                     },
                     {
                       "class":"plain_text",
                       "content": "<span/>",
-                      "span":2
-                    },
-                    {
-                        "class": "dashlist",
-                        "tags": [
-                            "master"
-                        ]
+                      "span":5
                     }
                 ],
-                "title": "Node status"
+                "title": "New row"
             },
+            {
+                "class": "row",
+                "height": "25px",
+                "gridPos": {"h": 2},
+                "panels": [
+                    {
+                        "class": "text_panel",
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Optimization</h1>",
+                        "style": {}
+                    }
+                ],
+                "title": "New row"
+            },
+
             {
                 "class": "row",
                 "panels": [
@@ -391,6 +451,6 @@
             "to": "now"
         },
         "overwrite": true,
-        "title": "Scylla CQL Optimization"
+        "title": "Scylla CQL"
     }
 }

--- a/grafana/scylla-dash-cpu-per-server.2019.1.template.json
+++ b/grafana/scylla-dash-cpu-per-server.2019.1.template.json
@@ -24,25 +24,6 @@
                         "description" : "the percentage of the time during which the CPU is utilized by Scylla. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high"
                     },
                     {
-                        "class": "text_panel",
-                        "content": "##  ",
-                        "mode": "markdown",
-                        "span": 3,
-                        "style": {}
-                    },
-                    {
-                        "class": "dashlist",
-                        "tags": [
-                        	"2019.1"
-		                ]
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
                         "class": "percent_panel",
                         "pointradius": 1,
                         "targets": [
@@ -57,13 +38,33 @@
                         ],
                         "title": "Foreground CPU Utilization by [[by]]",
                         "description": "Time spent handling foreground requests (like reads, writes, and some system tasks). The remaining time is either idle, or used by background load like compactions and repairs. Background load in Scylla is opportunistic: background requests will try to use all resources available to complete as fast as possible and rely on the schedulers to provide isolation. This graph is better understood in conjunction with the main CPU load graph. For example, if there are spikes in CPU load that are not present in this graph, that indicates that the foreground load itself is stable."
-                    },
+                    }
+                ]
+            },
+            {
+                "class": "row",
+                "height": "25px",
+                "gridPos": {"h": 2},
+                "panels": [
+                    {
+                        "class": "plain_text",
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Task Quota Violation</h1>"
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "class": "row",
+                "panels": [
+
                     {
                         "class": "ms_panel",
+                        "repeat": "group",
+                        "span":3,
                         "pointradius": 1,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_scheduler_time_spent_on_task_quota_violations_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_scheduler_time_spent_on_task_quota_violations_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -71,7 +72,7 @@
                                 "step": 30
                             }
                         ],
-                        "title": "Time spent in task quota violations by [[by]]",
+                        "title": "Time spent in task quota violations by [[by]] - $group",
                         "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. The maximum amount of time during which a task group can run is called the \"task quota\". Some task groups may disrespect that and run for longer. This may cause latency issues"
                     }
                 ],
@@ -108,6 +109,15 @@
                     "query": "label_values(scylla_reactor_utilization,shard)",
                     "sort": 3
                 }
+                ,
+                {
+                    "class": "template_variable_all",
+                    "label": "group",
+                    "name": "group",
+                    "hide": 2,
+                    "query": "label_values(scylla_scheduler_time_spent_on_task_quota_violations_ms,group)",
+                    "sort": 3
+                }
             ]
         },
 		"tags": [
@@ -117,7 +127,7 @@
             "from": "now-30m",
             "to": "now"
         },
-        "title": "Scylla CPU Per Server Metrics",
+        "title": "CPU Metrics",
         "overwrite": true,
         "version": 5
     }

--- a/grafana/scylla-dash-cpu-per-server.3.0.template.json
+++ b/grafana/scylla-dash-cpu-per-server.3.0.template.json
@@ -24,25 +24,6 @@
                         "description" : "the percentage of the time during which the CPU is utilized by Scylla. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high"
                     },
                     {
-                        "class": "text_panel",
-                        "content": "##  ",
-                        "mode": "markdown",
-                        "span": 3,
-                        "style": {}
-                    },
-                    {
-                        "class": "dashlist",
-                        "tags": [
-                        	"3.0"
-		                ]
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
                         "class": "percent_panel",
                         "pointradius": 1,
                         "targets": [
@@ -57,13 +38,32 @@
                         ],
                         "title": "Foreground CPU Utilization by [[by]]",
                         "description": "Time spent handling foreground requests (like reads, writes, and some system tasks). The remaining time is either idle, or used by background load like compactions and repairs. Background load in Scylla is opportunistic: background requests will try to use all resources available to complete as fast as possible and rely on the schedulers to provide isolation. This graph is better understood in conjunction with the main CPU load graph. For example, if there are spikes in CPU load that are not present in this graph, that indicates that the foreground load itself is stable."
-                    },
+                    }
+                ]
+            },
+            {
+                "class": "row",
+                "height": "25px",
+                "gridPos": {"h": 2},
+                "panels": [
+                    {
+                        "class": "plain_text",
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Task Quota Violation</h1>"
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "class": "row",
+                "panels": [
                     {
                         "class": "ms_panel",
+                        "repeat": "group",
+                        "span":3,
                         "pointradius": 1,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_scheduler_time_spent_on_task_quota_violations_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_scheduler_time_spent_on_task_quota_violations_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -71,7 +71,7 @@
                                 "step": 30
                             }
                         ],
-                        "title": "Time spent in task quota violations by [[by]]",
+                        "title": "Time spent in task quota violations by [[by]] - $group",
                         "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. The maximum amount of time during which a task group can run is called the \"task quota\". Some task groups may disrespect that and run for longer. This may cause latency issues"
                     }
                 ],
@@ -108,6 +108,15 @@
                     "query": "label_values(scylla_reactor_utilization,shard)",
                     "sort": 3
                 }
+                ,
+                {
+                    "class": "template_variable_all",
+                    "label": "group",
+                    "name": "group",
+                    "hide": 2,
+                    "query": "label_values(scylla_scheduler_time_spent_on_task_quota_violations_ms,group)",
+                    "sort": 3
+                }
             ]
         },
 		"tags": [
@@ -117,7 +126,7 @@
             "from": "now-30m",
             "to": "now"
         },
-        "title": "Scylla CPU Per Server Metrics",
+        "title": "CPU Metrics",
         "overwrite": true,
         "version": 5
     }

--- a/grafana/scylla-dash-cpu-per-server.3.1.template.json
+++ b/grafana/scylla-dash-cpu-per-server.3.1.template.json
@@ -24,25 +24,6 @@
                         "description" : "the percentage of the time during which the CPU is utilized by Scylla. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high"
                     },
                     {
-                        "class": "text_panel",
-                        "content": "##  ",
-                        "mode": "markdown",
-                        "span": 3,
-                        "style": {}
-                    },
-                    {
-                        "class": "dashlist",
-                        "tags": [
-                        	"3.1"
-		                ]
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
                         "class": "percent_panel",
                         "pointradius": 1,
                         "targets": [
@@ -57,13 +38,32 @@
                         ],
                         "title": "Foreground CPU Utilization by [[by]]",
                         "description": "Time spent handling foreground requests (like reads, writes, and some system tasks). The remaining time is either idle, or used by background load like compactions and repairs. Background load in Scylla is opportunistic: background requests will try to use all resources available to complete as fast as possible and rely on the schedulers to provide isolation. This graph is better understood in conjunction with the main CPU load graph. For example, if there are spikes in CPU load that are not present in this graph, that indicates that the foreground load itself is stable."
-                    },
+                    }
+                ]
+            },
+            {
+                "class": "row",
+                "height": "25px",
+                "gridPos": {"h": 2},
+                "panels": [
+                    {
+                        "class": "plain_text",
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Task Quota Violation</h1>"
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "class": "row",
+                "panels": [
                     {
                         "class": "ms_panel",
+                        "repeat": "group",
+                        "span":3,
                         "pointradius": 1,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_scheduler_time_spent_on_task_quota_violations_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_scheduler_time_spent_on_task_quota_violations_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -71,7 +71,7 @@
                                 "step": 30
                             }
                         ],
-                        "title": "Time spent in task quota violations by [[by]]",
+                        "title": "Time spent in task quota violations by [[by]] - $group",
                         "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. The maximum amount of time during which a task group can run is called the \"task quota\". Some task groups may disrespect that and run for longer. This may cause latency issues"
                     }
                 ],
@@ -108,6 +108,15 @@
                     "query": "label_values(scylla_reactor_utilization,shard)",
                     "sort": 3
                 }
+                ,
+                {
+                    "class": "template_variable_all",
+                    "label": "group",
+                    "name": "group",
+                    "hide": 2,
+                    "query": "label_values(scylla_scheduler_time_spent_on_task_quota_violations_ms,group)",
+                    "sort": 3
+                }
             ]
         },
 		"tags": [
@@ -117,7 +126,7 @@
             "from": "now-30m",
             "to": "now"
         },
-        "title": "Scylla CPU Per Server Metrics",
+        "title": "CPU Metrics",
         "overwrite": true,
         "version": 5
     }

--- a/grafana/scylla-dash-cpu-per-server.master.template.json
+++ b/grafana/scylla-dash-cpu-per-server.master.template.json
@@ -24,25 +24,6 @@
                         "description" : "the percentage of the time during which the CPU is utilized by Scylla. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high"
                     },
                     {
-                        "class": "text_panel",
-                        "content": "##  ",
-                        "mode": "markdown",
-                        "span": 3,
-                        "style": {}
-                    },
-                    {
-                        "class": "dashlist",
-                        "tags": [
-                        	"master"
-		                ]
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
                         "class": "percent_panel",
                         "pointradius": 1,
                         "targets": [
@@ -57,13 +38,32 @@
                         ],
                         "title": "Foreground CPU Utilization by [[by]]",
                         "description": "Time spent handling foreground requests (like reads, writes, and some system tasks). The remaining time is either idle, or used by background load like compactions and repairs. Background load in Scylla is opportunistic: background requests will try to use all resources available to complete as fast as possible and rely on the schedulers to provide isolation. This graph is better understood in conjunction with the main CPU load graph. For example, if there are spikes in CPU load that are not present in this graph, that indicates that the foreground load itself is stable."
-                    },
+                    }
+                ]
+            },
+            {
+                "class": "row",
+                "height": "25px",
+                "gridPos": {"h": 2},
+                "panels": [
+                    {
+                        "class": "plain_text",
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Task Quota Violation</h1>"
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "class": "row",
+                "panels": [
                     {
                         "class": "ms_panel",
+                        "repeat": "group",
+                        "span":3,
                         "pointradius": 1,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_scheduler_time_spent_on_task_quota_violations_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_scheduler_time_spent_on_task_quota_violations_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -71,7 +71,7 @@
                                 "step": 30
                             }
                         ],
-                        "title": "Time spent in task quota violations by [[by]]",
+                        "title": "Time spent in task quota violations by [[by]] - $group",
                         "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. The maximum amount of time during which a task group can run is called the \"task quota\". Some task groups may disrespect that and run for longer. This may cause latency issues"
                     }
                 ],
@@ -108,6 +108,15 @@
                     "query": "label_values(scylla_reactor_utilization,shard)",
                     "sort": 3
                 }
+                ,
+                {
+                    "class": "template_variable_all",
+                    "label": "group",
+                    "name": "group",
+                    "hide": 2,
+                    "query": "label_values(scylla_scheduler_time_spent_on_task_quota_violations_ms,group)",
+                    "sort": 3
+                }
             ]
         },
 		"tags": [
@@ -117,7 +126,7 @@
             "from": "now-30m",
             "to": "now"
         },
-        "title": "Scylla CPU Per Server Metrics",
+        "title": "CPU Metrics",
         "overwrite": true,
         "version": 5
     }

--- a/grafana/scylla-dash-io-per-server.2019.1.template.json
+++ b/grafana/scylla-dash-io-per-server.2019.1.template.json
@@ -8,113 +8,6 @@
             },
             {
                 "class": "row",
-                "height": "150px",
-                "panels": [
-                    {
-                        "class": "single_stat_panel",
-                        "targets": [
-                            {
-                                "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
-                                "intervalFactor": 1,
-                                "legendFormat": "Total Nodes",
-                                "refId": "A",
-                                "step": 240
-                            }
-                        ],
-                        "title": "Total Nodes"
-                    },
-                    {
-                        "class": "single_stat_panel_fail",
-                        "targets": [
-                            {
-                                "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Unreachable",
-                                "refId": "A",
-                                "step": 120
-                            }
-                        ],
-                        "thresholds": "1,2",
-                        "title": "Unreachable"
-                    },
-                    {
-                        "class": "text_panel",
-                        "content": "##  ",
-                        "mode": "markdown",
-                        "span": 3,
-                        "style": {}
-                    },
-                    {
-                        "aliasColors": {
-                            "{}": "#584477"
-                        },
-                        "bars": true,
-                        "class": "graph_panel",
-                        "lines": false,
-                        "seriesOverrides": [
-                            {}
-                        ],
-                        "targets": [
-                            {
-                                "expr": "sum(irate(scylla_transport_requests_served{cluster=~\"$cluster|$^\"}[30s])) + sum(irate(scylla_thrift_served{cluster=~\"$cluster|$^\"}[30s]))",
-                                "intervalFactor": 1,
-                                "legendFormat": "Total Requests",
-                                "refId": "A",
-                                "step": 30
-                            }
-                        ],
-                        "title": "Total Requests",
-                        "transparent": false
-                    },
-                    {
-                        "class": "dashlist",
-                        "tags": [
-                        	"2019.1"
-		                ]
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
-                        "class": "graph_panel",
-                        "seriesOverrides": [
-                            {}
-                        ],
-                        "targets": [
-                            {
-                                "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 30
-                            }
-                        ],
-                        "title": "Load per [[by]]",
-                        "transparent": false
-                    },
-                    {
-                        "class": "graph_panel",
-                        "pointradius": 1,
-                        "targets": [
-                            {
-                                "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 30
-                            }
-                        ],
-                        "title": "Requests Served per [[by]]"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
                 "height": "25px",
                 "gridPos": {"h": 2},
                 "panels": [
@@ -438,6 +331,6 @@
             ]
         },
         "overwrite": true,
-        "title": "Scylla Per-Server I/O"
+        "title": "I/O"
     }
 }

--- a/grafana/scylla-dash-io-per-server.2019.1.template.json
+++ b/grafana/scylla-dash-io-per-server.2019.1.template.json
@@ -120,88 +120,6 @@
                 "panels": [
                     {
                         "class": "plain_text",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Disk Activity</h1>"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
-                        "class": "graph_panel",
-                        "span": 6,
-                        "targets": [
-                            {
-                                "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 20
-                            }
-                        ],
-                        "title": "Disk Writes per Server"
-                    },
-                    {
-                        "class": "graph_panel",
-                        "span": 6,
-                        "targets": [
-                            {
-                                "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 20
-                            }
-                        ],
-                        "title": "Disk Reads per Server"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
-                        "class": "bps_panel",
-                        "span": 6,
-                        "targets": [
-                            {
-                                "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 20
-                            }
-                        ],
-                        "title": "Disk Writes Bps per Server"
-                    },
-                    {
-                        "class": "bps_panel",
-                        "span": 6,
-                        "targets": [
-                            {
-                                "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 20
-                            }
-                        ],
-                        "title": "Disk Read Bps per Server"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "height": "25px",
-                "gridPos": {"h": 2},
-                "panels": [
-                    {
-                        "class": "plain_text",
                         "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue</h1>"
                     }
                 ],
@@ -490,30 +408,6 @@
         "templating": {
             "list": [
                 {
-                    "current": {},
-                    "datasource": "prometheus",
-                    "hide": 0,
-                    "includeAll": false,
-                    "multi": false,
-                    "name": "monitor_disk",
-                    "options": [],
-                    "query": "node_disk_read_bytes_total",
-                    "refresh": 2,
-                    "regex": "/.*device=\"([^\\\"]*)\".*/",
-                    "type": "query"
-                },
-                {
-                    "class": "template_variable_single",
-                    "current": {
-                        "text": "/var/lib/scylla",
-                        "value": "/var/lib/scylla"
-                    },
-                    "datasource": "prometheus",
-                    "label": "Mounnt path",
-                    "name": "mount_point",
-                    "query": "label_values(scylla_io_queue_delay,mountpoint)"
-                },
-                {
                     "class":"by_template_var"
                 },
                 {
@@ -544,6 +438,6 @@
             ]
         },
         "overwrite": true,
-        "title": "Scylla Per-Server Disk I/O"
+        "title": "Scylla Per-Server I/O"
     }
 }

--- a/grafana/scylla-dash-io-per-server.3.0.template.json
+++ b/grafana/scylla-dash-io-per-server.3.0.template.json
@@ -120,88 +120,6 @@
                 "panels": [
                     {
                         "class": "plain_text",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Disk Activity</h1>"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
-                        "class": "graph_panel",
-                        "span": 6,
-                        "targets": [
-                            {
-                                "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 20
-                            }
-                        ],
-                        "title": "Disk Writes per Server"
-                    },
-                    {
-                        "class": "graph_panel",
-                        "span": 6,
-                        "targets": [
-                            {
-                                "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 20
-                            }
-                        ],
-                        "title": "Disk Reads per Server"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
-                        "class": "bps_panel",
-                        "span": 6,
-                        "targets": [
-                            {
-                                "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 20
-                            }
-                        ],
-                        "title": "Disk Writes Bps per Server"
-                    },
-                    {
-                        "class": "bps_panel",
-                        "span": 6,
-                        "targets": [
-                            {
-                                "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 20
-                            }
-                        ],
-                        "title": "Disk Read Bps per Server"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "height": "25px",
-                "gridPos": {"h": 2},
-                "panels": [
-                    {
-                        "class": "plain_text",
                         "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue</h1>"
                     }
                 ],
@@ -490,31 +408,7 @@
         "templating": {
             "list": [
                 {
-                    "current": {},
-                    "datasource": "prometheus",
-                    "hide": 0,
-                    "includeAll": false,
-                    "multi": false,
-                    "name": "monitor_disk",
-                    "options": [],
-                    "query": "node_disk_read_bytes_total",
-                    "refresh": 2,
-                    "regex": "/.*device=\"([^\\\"]*)\".*/",
-                    "type": "query"
-                },
-		{
                     "class":"by_template_var"
-                },
-                {
-                    "class": "template_variable_single",
-                    "current": {
-                        "text": "/var/lib/scylla",
-                        "value": "/var/lib/scylla"
-                    },
-                    "datasource": "prometheus",
-                    "label": "Mounnt path",
-                    "name": "mount_point",
-                    "query": "label_values(scylla_io_queue_delay,mountpoint)"
                 },
                 {
                     "class": "template_variable_single",
@@ -544,7 +438,7 @@
             ]
         },
         "overwrite": true,
-        "title": "Scylla Per-Server Disk I/O"
+        "title": "Scylla Per-Server I/O"
     }
 }
 

--- a/grafana/scylla-dash-io-per-server.3.0.template.json
+++ b/grafana/scylla-dash-io-per-server.3.0.template.json
@@ -8,113 +8,6 @@
             },
             {
                 "class": "row",
-                "height": "150px",
-                "panels": [
-                    {
-                        "class": "single_stat_panel",
-                        "targets": [
-                            {
-                                "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
-                                "intervalFactor": 1,
-                                "legendFormat": "Total Nodes",
-                                "refId": "A",
-                                "step": 240
-                            }
-                        ],
-                        "title": "Total Nodes"
-                    },
-                    {
-                        "class": "single_stat_panel_fail",
-                        "targets": [
-                            {
-                                "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Unreachable",
-                                "refId": "A",
-                                "step": 120
-                            }
-                        ],
-                        "thresholds": "1,2",
-                        "title": "Unreachable"
-                    },
-                    {
-                        "class": "text_panel",
-                        "content": "##  ",
-                        "mode": "markdown",
-                        "span": 3,
-                        "style": {}
-                    },
-                    {
-                        "aliasColors": {
-                            "{}": "#584477"
-                        },
-                        "bars": true,
-                        "class": "graph_panel",
-                        "lines": false,
-                        "seriesOverrides": [
-                            {}
-                        ],
-                        "targets": [
-                            {
-                                "expr": "sum(irate(scylla_transport_requests_served{cluster=~\"$cluster|$^\"}[30s])) + sum(irate(scylla_thrift_served{cluster=~\"$cluster|$^\"}[30s]))",
-                                "intervalFactor": 1,
-                                "legendFormat": "Total Requests",
-                                "refId": "A",
-                                "step": 30
-                            }
-                        ],
-                        "title": "Total Requests",
-                        "transparent": false
-                    },
-                    {
-                        "class": "dashlist",
-                        "tags": [
-                        	"3.0"
-		                ]
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
-                        "class": "graph_panel",
-                        "seriesOverrides": [
-                            {}
-                        ],
-                        "targets": [
-                            {
-                                "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 30
-                            }
-                        ],
-                        "title": "Load per [[by]]",
-                        "transparent": false
-                    },
-                    {
-                        "class": "graph_panel",
-                        "pointradius": 1,
-                        "targets": [
-                            {
-                                "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 30
-                            }
-                        ],
-                        "title": "Requests Served per [[by]]"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
                 "height": "25px",
                 "gridPos": {"h": 2},
                 "panels": [
@@ -438,7 +331,6 @@
             ]
         },
         "overwrite": true,
-        "title": "Scylla Per-Server I/O"
+        "title": "I/O"
     }
 }
-

--- a/grafana/scylla-dash-io-per-server.3.1.template.json
+++ b/grafana/scylla-dash-io-per-server.3.1.template.json
@@ -8,113 +8,6 @@
             },
             {
                 "class": "row",
-                "height": "150px",
-                "panels": [
-                    {
-                        "class": "single_stat_panel",
-                        "targets": [
-                            {
-                                "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
-                                "intervalFactor": 1,
-                                "legendFormat": "Total Nodes",
-                                "refId": "A",
-                                "step": 240
-                            }
-                        ],
-                        "title": "Total Nodes"
-                    },
-                    {
-                        "class": "single_stat_panel_fail",
-                        "targets": [
-                            {
-                                "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Unreachable",
-                                "refId": "A",
-                                "step": 120
-                            }
-                        ],
-                        "thresholds": "1,2",
-                        "title": "Unreachable"
-                    },
-                    {
-                        "class": "text_panel",
-                        "content": "##  ",
-                        "mode": "markdown",
-                        "span": 3,
-                        "style": {}
-                    },
-                    {
-                        "aliasColors": {
-                            "{}": "#584477"
-                        },
-                        "bars": true,
-                        "class": "graph_panel",
-                        "lines": false,
-                        "seriesOverrides": [
-                            {}
-                        ],
-                        "targets": [
-                            {
-                                "expr": "sum(irate(scylla_transport_requests_served{cluster=~\"$cluster|$^\"}[30s])) + sum(irate(scylla_thrift_served{cluster=~\"$cluster|$^\"}[30s]))",
-                                "intervalFactor": 1,
-                                "legendFormat": "Total Requests",
-                                "refId": "A",
-                                "step": 30
-                            }
-                        ],
-                        "title": "Total Requests",
-                        "transparent": false
-                    },
-                    {
-                        "class": "dashlist",
-                        "tags": [
-                        	"3.1"
-		                ]
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
-                        "class": "graph_panel",
-                        "seriesOverrides": [
-                            {}
-                        ],
-                        "targets": [
-                            {
-                                "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 30
-                            }
-                        ],
-                        "title": "Load per [[by]]",
-                        "transparent": false
-                    },
-                    {
-                        "class": "graph_panel",
-                        "pointradius": 1,
-                        "targets": [
-                            {
-                                "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 30
-                            }
-                        ],
-                        "title": "Requests Served per [[by]]"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
                 "height": "25px",
                 "gridPos": {"h": 2},
                 "panels": [
@@ -438,6 +331,6 @@
             ]
         },
         "overwrite": true,
-        "title": "Scylla Per-Server I/O"
+        "title": "I/O"
     }
 }

--- a/grafana/scylla-dash-io-per-server.3.1.template.json
+++ b/grafana/scylla-dash-io-per-server.3.1.template.json
@@ -120,88 +120,6 @@
                 "panels": [
                     {
                         "class": "plain_text",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Disk Activity</h1>"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
-                        "class": "graph_panel",
-                        "span": 6,
-                        "targets": [
-                            {
-                                "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 20
-                            }
-                        ],
-                        "title": "Disk Writes per Server"
-                    },
-                    {
-                        "class": "graph_panel",
-                        "span": 6,
-                        "targets": [
-                            {
-                                "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 20
-                            }
-                        ],
-                        "title": "Disk Reads per Server"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
-                        "class": "bps_panel",
-                        "span": 6,
-                        "targets": [
-                            {
-                                "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 20
-                            }
-                        ],
-                        "title": "Disk Writes Bps per Server"
-                    },
-                    {
-                        "class": "bps_panel",
-                        "span": 6,
-                        "targets": [
-                            {
-                                "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 20
-                            }
-                        ],
-                        "title": "Disk Read Bps per Server"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "height": "25px",
-                "gridPos": {"h": 2},
-                "panels": [
-                    {
-                        "class": "plain_text",
                         "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue</h1>"
                     }
                 ],
@@ -490,30 +408,6 @@
         "templating": {
             "list": [
                 {
-                    "current": {},
-                    "datasource": "prometheus",
-                    "hide": 0,
-                    "includeAll": false,
-                    "multi": false,
-                    "name": "monitor_disk",
-                    "options": [],
-                    "query": "node_disk_read_bytes_total",
-                    "refresh": 2,
-                    "regex": "/.*device=\"([^\\\"]*)\".*/",
-                    "type": "query"
-                },
-                {
-                    "class": "template_variable_single",
-                    "current": {
-                        "text": "/var/lib/scylla",
-                        "value": "/var/lib/scylla"
-                    },
-                    "datasource": "prometheus",
-                    "label": "Mounnt path",
-                    "name": "mount_point",
-                    "query": "label_values(scylla_io_queue_delay,mountpoint)"
-                },
-                {
                     "class":"by_template_var"
                 },
                 {
@@ -544,6 +438,6 @@
             ]
         },
         "overwrite": true,
-        "title": "Scylla Per-Server Disk I/O"
+        "title": "Scylla Per-Server I/O"
     }
 }

--- a/grafana/scylla-dash-io-per-server.master.template.json
+++ b/grafana/scylla-dash-io-per-server.master.template.json
@@ -8,113 +8,6 @@
             },
             {
                 "class": "row",
-                "height": "150px",
-                "panels": [
-                    {
-                        "class": "single_stat_panel",
-                        "targets": [
-                            {
-                                "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
-                                "intervalFactor": 1,
-                                "legendFormat": "Total Nodes",
-                                "refId": "A",
-                                "step": 240
-                            }
-                        ],
-                        "title": "Total Nodes"
-                    },
-                    {
-                        "class": "single_stat_panel_fail",
-                        "targets": [
-                            {
-                                "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Unreachable",
-                                "refId": "A",
-                                "step": 120
-                            }
-                        ],
-                        "thresholds": "1,2",
-                        "title": "Unreachable"
-                    },
-                    {
-                        "class": "text_panel",
-                        "content": "##  ",
-                        "mode": "markdown",
-                        "span": 3,
-                        "style": {}
-                    },
-                    {
-                        "aliasColors": {
-                            "{}": "#584477"
-                        },
-                        "bars": true,
-                        "class": "graph_panel",
-                        "lines": false,
-                        "seriesOverrides": [
-                            {}
-                        ],
-                        "targets": [
-                            {
-                                "expr": "sum(irate(scylla_transport_requests_served{cluster=~\"$cluster|$^\"}[30s])) + sum(irate(scylla_thrift_served{cluster=~\"$cluster|$^\"}[30s]))",
-                                "intervalFactor": 1,
-                                "legendFormat": "Total Requests",
-                                "refId": "A",
-                                "step": 30
-                            }
-                        ],
-                        "title": "Total Requests",
-                        "transparent": false
-                    },
-                    {
-                        "class": "dashlist",
-                        "tags": [
-                        	"master"
-		                ]
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
-                        "class": "graph_panel",
-                        "seriesOverrides": [
-                            {}
-                        ],
-                        "targets": [
-                            {
-                                "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 30
-                            }
-                        ],
-                        "title": "Load per [[by]]",
-                        "transparent": false
-                    },
-                    {
-                        "class": "graph_panel",
-                        "pointradius": 1,
-                        "targets": [
-                            {
-                                "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + sum(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 30
-                            }
-                        ],
-                        "title": "Requests Served per [[by]]"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
                 "height": "25px",
                 "gridPos": {"h": 2},
                 "panels": [
@@ -438,6 +331,6 @@
             ]
         },
         "overwrite": true,
-        "title": "Scylla Per-Server I/O"
+        "title": "I/O"
     }
 }

--- a/grafana/scylla-dash-io-per-server.master.template.json
+++ b/grafana/scylla-dash-io-per-server.master.template.json
@@ -120,88 +120,6 @@
                 "panels": [
                     {
                         "class": "plain_text",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Disk Activity</h1>"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
-                        "class": "graph_panel",
-                        "span": 6,
-                        "targets": [
-                            {
-                                "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 20
-                            }
-                        ],
-                        "title": "Disk Writes per Server"
-                    },
-                    {
-                        "class": "graph_panel",
-                        "span": 6,
-                        "targets": [
-                            {
-                                "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 20
-                            }
-                        ],
-                        "title": "Disk Reads per Server"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
-                        "class": "bps_panel",
-                        "span": 6,
-                        "targets": [
-                            {
-                                "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 20
-                            }
-                        ],
-                        "title": "Disk Writes Bps per Server"
-                    },
-                    {
-                        "class": "bps_panel",
-                        "span": 6,
-                        "targets": [
-                            {
-                                "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 20
-                            }
-                        ],
-                        "title": "Disk Read Bps per Server"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "height": "25px",
-                "gridPos": {"h": 2},
-                "panels": [
-                    {
-                        "class": "plain_text",
                         "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue</h1>"
                     }
                 ],
@@ -490,30 +408,6 @@
         "templating": {
             "list": [
                 {
-                    "current": {},
-                    "datasource": "prometheus",
-                    "hide": 0,
-                    "includeAll": false,
-                    "multi": false,
-                    "name": "monitor_disk",
-                    "options": [],
-                    "query": "node_disk_read_bytes_total",
-                    "refresh": 2,
-                    "regex": "/.*device=\"([^\\\"]*)\".*/",
-                    "type": "query"
-                },
-                {
-                    "class": "template_variable_single",
-                    "current": {
-                        "text": "/var/lib/scylla",
-                        "value": "/var/lib/scylla"
-                    },
-                    "datasource": "prometheus",
-                    "label": "Mounnt path",
-                    "name": "mount_point",
-                    "query": "label_values(scylla_io_queue_delay,mountpoint)"
-                },
-                {
                     "class":"by_template_var"
                 },
                 {
@@ -544,6 +438,6 @@
             ]
         },
         "overwrite": true,
-        "title": "Scylla Per-Server Disk I/O"
+        "title": "Scylla Per-Server I/O"
     }
 }

--- a/grafana/scylla-dash-per-machine.2019.1.template.json
+++ b/grafana/scylla-dash-per-machine.2019.1.template.json
@@ -1,7 +1,7 @@
 {
     "dashboard": {
         "class": "dashboard",
-        "uid": "machine-2019-1",
+        "uid": "OS-2019-1",
         "rows": [
             {
                 "class": "logo_row"
@@ -349,9 +349,6 @@
                     "type": "query",
                     "useTags": false
                 }
-                
-                
-                
             ]
         },
 		"tags": [
@@ -361,7 +358,7 @@
             "from": "now-30m",
             "to": "now"
         },
-        "title": "Scylla Per Machine Metrics",
+        "title": "OS Metrics",
         "overwrite": true,
         "version": 5
     }

--- a/grafana/scylla-dash-per-machine.3.0.template.json
+++ b/grafana/scylla-dash-per-machine.3.0.template.json
@@ -1,7 +1,7 @@
 {
     "dashboard": {
         "class": "dashboard",
-        "uid": "machine-3-0",
+        "uid": "OS-3-0",
         "rows": [
             {
                 "class": "logo_row"
@@ -349,9 +349,6 @@
                     "type": "query",
                     "useTags": false
                 }
-                
-                
-                
             ]
         },
 		"tags": [
@@ -361,7 +358,7 @@
             "from": "now-30m",
             "to": "now"
         },
-        "title": "Scylla Per Machine Metrics",
+        "title": "OS Metrics",
         "overwrite": true,
         "version": 5
     }

--- a/grafana/scylla-dash-per-machine.3.1.template.json
+++ b/grafana/scylla-dash-per-machine.3.1.template.json
@@ -1,7 +1,7 @@
 {
     "dashboard": {
         "class": "dashboard",
-        "uid": "machine-3-1",
+        "uid": "OS-3-1",
         "rows": [
             {
                 "class": "logo_row"
@@ -349,9 +349,6 @@
                     "type": "query",
                     "useTags": false
                 }
-                
-                
-                
             ]
         },
 		"tags": [
@@ -361,7 +358,7 @@
             "from": "now-30m",
             "to": "now"
         },
-        "title": "Scylla Per Machine Metrics",
+        "title": "OS Metrics",
         "overwrite": true,
         "version": 5
     }

--- a/grafana/scylla-dash-per-machine.master.template.json
+++ b/grafana/scylla-dash-per-machine.master.template.json
@@ -1,7 +1,7 @@
 {
     "dashboard": {
         "class": "dashboard",
-        "uid": "machine-master",
+        "uid": "OS-master",
         "rows": [
             {
                 "class": "logo_row"
@@ -349,9 +349,6 @@
                     "type": "query",
                     "useTags": false
                 }
-                
-                
-                
             ]
         },
 		"tags": [
@@ -361,7 +358,7 @@
             "from": "now-30m",
             "to": "now"
         },
-        "title": "Scylla Per Machine Metrics",
+        "title": "OS Metrics",
         "overwrite": true,
         "version": 5
     }

--- a/grafana/scylla-dash-per-server.2019.1.template.json
+++ b/grafana/scylla-dash-per-server.2019.1.template.json
@@ -1,7 +1,7 @@
 {
     "dashboard": {
         "class": "dashboard",
-        "uid": "detail-2019-1",
+        "uid": "detailed-2019-1",
         "rows": [
             {
                 "class": "logo_row"
@@ -10,110 +10,8 @@
                 "class": "row",
                 "panels": [
                     {
-                        "class": "single_stat_panel",
-                        "targets": [
-                            {
-                                "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
-                                "intervalFactor": 1,
-                                "legendFormat": "Total Nodes",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "Total Nodes"
-                    },
-                    {
-                        "class": "single_stat_panel_fail",
-                        "targets": [
-                            {
-                                "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Unreachable",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "thresholds": "1,2",
-                        "title": "Unreachable"
-                    },
-                    {
-                        "class": "single_stat_panel_fail",
-                        "description": "Number of nodes that reported their status as Starting or Joining",
-                        "targets": [
-                            {
-                                "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Joining",
-                                "refId": "A",
-                                "step": 20
-                            }
-                        ],
-                        "thresholds": "1,2",
-                        "title": "Joining"
-                    },
-                    {
-                        "class": "single_stat_panel_fail",
-                        "description": "Number of nodes that reported their status as  Leaving, Decommissioned, Draining or Drained",
-                        "targets": [
-                            {
-                                "expr": "count(scylla_node_operation_mode>3)OR vector(0)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Leaving",
-                                "refId": "A",
-                                "step": 20
-                            }
-                        ],
-                        "thresholds": "1,2",
-                        "title": "Leaving"
-                    },
-                    {
-                        "class": "text_panel",
-                        "content": "##  ",
-                        "mode": "markdown",
-                        "span": 1,
-                        "style": {}
-                    },
-                    {
                         "class": "ops_panel",
-                        "bars": true,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_transport_requests_served{cluster=~\"$cluster|$^\"}[30s])) + $func(irate(scylla_thrift_served{cluster=~\"$cluster|$^\"}[30s]))",
-                                "intervalFactor": 1,
-                                "legendFormat": "Total Requests",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "Total Requests - Coordinator"
-                    },
-                    {
-                        "class": "dashlist",
-                        "tags": [
-                        	"2019.1"
-		                ]
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
-                        "class": "percent_panel",
-                        "targets": [
-                            {
-                                "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "Load per [[by]]"
-                    },
-                    {
-                        "class": "ops_panel",
+                        "span": 4,
                         "targets": [
                             {
                                 "expr": "$func(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + $func(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
@@ -126,6 +24,35 @@
                         ],
                         "description": "Amount of requests served as the coordinator. Imbalances here represent dispersion at the connection level, not your data model.",
                         "title": "Requests Served per [[by]] - Coordinator"
+                    },
+                    {
+                        "class": "rps_panel",
+                        "span": 4,
+                        "targets": [
+                            {
+                                "expr": "$func(irate(scylla_database_total_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Reads per [[by]] - Replica"
+                    },
+                    {
+                        "class": "wps_panel",
+                        "span": 4,
+                        "targets": [
+                            {
+                                "expr": "$func(irate(scylla_database_total_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Writes per [[by]] - Replica"
                     }
                 ],
                 "title": "New row"
@@ -288,35 +215,6 @@
                 "class": "row",
                 "height": "auto",
                 "panels": [
-                    {
-                        "class": "rps_panel",
-                        "span": 6,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_database_total_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "Reads"
-                    },
-                    {
-                        "class": "wps_panel",
-                        "span": 6,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_database_total_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "Writes"
-                    },
                     {
                         "class": "graph_panel",
                         "span": 3,
@@ -763,7 +661,7 @@
                 "panels": [
                     {
                         "class": "text_panel",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Memory - Replica</h1>",
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Materialized Views - Replica</h1>",
                         "style": {}
                     }
                 ],
@@ -814,6 +712,53 @@
                         ],
                         "description": "This panel indicates how full the in memory is. Check the documentation to learn more about in memory storage",
                         "title": "In-memory storage usage"
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "class": "row",
+                "height": "25px",
+                "gridPos": {"h": 2},
+                "panels": [
+                    {
+                        "class": "text_panel",
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Memory - Replica</h1>",
+                        "style": {}
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "bytes_panel",
+                        "span": 6,
+                        "targets": [
+                            {
+                                "expr": "$func(scylla_lsa_total_space_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "LSA total memory"
+                    },
+                    {
+                        "class": "bytes_panel",
+                        "span": 6,
+                        "targets": [
+                            {
+                                "expr": "$func(scylla_lsa_non_lsa_used_space_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Non-LSA used memory"
                     }
                 ],
                 "title": "New row"
@@ -884,102 +829,6 @@
                 "title": "New row"
             },
             {
-                "class": "row",
-                "height": "25px",
-                "gridPos": {"h": 2},
-                "panels": [
-                    {
-                        "class": "text_panel",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">CQL - Coordinator</h1>",
-                        "style": {}
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
-                        "class": "ops_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "CQL Insert"
-                    },
-                    {
-                        "class": "ops_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "CQL Reads"
-                    },
-                    {
-                        "class": "ops_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "CQL Deletes"
-                    },
-                    {
-                        "class": "ops_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "CQL Updates"
-                    },
-                    {
-                        "class": "graph_panel",
-                        "span": 3,
-                        "pointradius": 1,
-                        "targets": [
-                            {
-                                "expr": "$func(scylla_transport_current_connections{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 30
-                            }
-                        ],
-                        "title": "Client CQL connections by [[by]]",
-                        "description": "amount of CQL connections currently established"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
                 "class": "user_panel_row_header"
             },
             {
@@ -1028,7 +877,7 @@
             "from": "now-30m",
             "to": "now"
         },
-        "title": "Scylla Per Server Metrics",
+        "title": "Detailed",
         "overwrite": true,
         "version": 5
     }

--- a/grafana/scylla-dash-per-server.3.0.template.json
+++ b/grafana/scylla-dash-per-server.3.0.template.json
@@ -1,7 +1,7 @@
 {
     "dashboard": {
         "class": "dashboard",
-        "uid": "detail-3-0",
+        "uid": "detailed-3-0",
         "rows": [
             {
                 "class": "logo_row"
@@ -10,80 +10,8 @@
                 "class": "row",
                 "panels": [
                     {
-                        "class": "single_stat_panel",
-                        "targets": [
-                            {
-                                "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
-                                "intervalFactor": 1,
-                                "legendFormat": "Total Nodes",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "Total Nodes"
-                    },
-                    {
-                        "class": "single_stat_panel_fail",
-                        "targets": [
-                            {
-                                "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Unreachable",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "thresholds": "1,2",
-                        "title": "Unreachable"
-                    },
-                    {
-                        "class": "text_panel",
-                        "content": "##  ",
-                        "mode": "markdown",
-                        "span": 3,
-                        "style": {}
-                    },
-                    {
                         "class": "ops_panel",
-                        "bars": true,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_transport_requests_served{cluster=~\"$cluster|$^\"}[30s])) + $func(irate(scylla_thrift_served{cluster=~\"$cluster|$^\"}[30s]))",
-                                "intervalFactor": 1,
-                                "legendFormat": "Total Requests",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "Total Requests - Coordinator"
-                    },
-                    {
-                        "class": "dashlist",
-                        "tags": [
-                        	"3.0"
-		                ]
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
-                        "class": "percent_panel",
-                        "targets": [
-                            {
-                                "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "Load per [[by]]"
-                    },
-                    {
-                        "class": "ops_panel",
+                        "span": 4,
                         "targets": [
                             {
                                 "expr": "$func(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + $func(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
@@ -96,6 +24,35 @@
                         ],
                         "description": "Amount of requests served as the coordinator. Imbalances here represent dispersion at the connection level, not your data model.",
                         "title": "Requests Served per [[by]] - Coordinator"
+                    },
+                    {
+                        "class": "rps_panel",
+                        "span": 4,
+                        "targets": [
+                            {
+                                "expr": "$func(irate(scylla_database_total_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Reads per [[by]] - Replica"
+                    },
+                    {
+                        "class": "wps_panel",
+                        "span": 4,
+                        "targets": [
+                            {
+                                "expr": "$func(irate(scylla_database_total_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Writes per [[by]] - Replica"
                     }
                 ],
                 "title": "New row"
@@ -258,35 +215,6 @@
                 "class": "row",
                 "height": "auto",
                 "panels": [
-                    {
-                        "class": "rps_panel",
-                        "span": 6,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_database_total_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "Reads"
-                    },
-                    {
-                        "class": "wps_panel",
-                        "span": 6,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_database_total_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "Writes"
-                    },
                     {
                         "class": "graph_panel",
                         "span": 3,
@@ -733,6 +661,69 @@
                 "panels": [
                     {
                         "class": "text_panel",
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Materialized Views - Replica</h1>",
+                        "style": {}
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "bytes_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$func(scylla_database_view_update_backlog{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "View Update Backlog",
+                        "description" : "Size in bytes of the view update backlog at each base replica."
+                    },
+                    {
+                        "class": "ops_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$func(irate(scylla_database_dropped_view_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Dropped View Updates",
+                        "description" : "Number of dropped view updates due to an excessive view update backlog."
+                    },
+                    {
+                        "class": "wps_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$func(scylla_storage_proxy_coordinator_current_throttled_base_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"})  by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Throttled Base Writes",
+                        "description" : "Currently throttled base writes, as a consequence of the respective view update backlog."
+                    }
+                ]
+            },
+            {
+                "class": "row",
+                "height": "25px",
+                "gridPos": {"h": 2},
+                "panels": [
+                    {
+                        "class": "text_panel",
                         "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Memory - Replica</h1>",
                         "style": {}
                     }
@@ -839,102 +830,6 @@
                 "title": "New row"
             },
             {
-                "class": "row",
-                "height": "25px",
-                "gridPos": {"h": 2},
-                "panels": [
-                    {
-                        "class": "text_panel",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">CQL - Coordinator</h1>",
-                        "style": {}
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
-                        "class": "ops_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "CQL Insert"
-                    },
-                    {
-                        "class": "ops_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "CQL Reads"
-                    },
-                    {
-                        "class": "ops_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "CQL Deletes"
-                    },
-                    {
-                        "class": "ops_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "CQL Updates"
-                    },
-                    {
-                        "class": "graph_panel",
-                        "span": 3,
-                        "pointradius": 1,
-                        "targets": [
-                            {
-                                "expr": "$func(scylla_transport_current_connections{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 30
-                            }
-                        ],
-                        "title": "Client CQL connections by [[by]]",
-                        "description": "amount of CQL connections currently established"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
                 "class": "user_panel_row_header"
             },
             {
@@ -983,7 +878,7 @@
             "from": "now-30m",
             "to": "now"
         },
-        "title": "Scylla Per Server Metrics",
+        "title": "Detailed",
         "overwrite": true,
         "version": 5
     }

--- a/grafana/scylla-dash-per-server.3.1.template.json
+++ b/grafana/scylla-dash-per-server.3.1.template.json
@@ -1,7 +1,7 @@
 {
     "dashboard": {
         "class": "dashboard",
-        "uid": "detail-3-1",
+        "uid": "detailed-3-1",
         "rows": [
             {
                 "class": "logo_row"
@@ -10,110 +10,8 @@
                 "class": "row",
                 "panels": [
                     {
-                        "class": "single_stat_panel",
-                        "targets": [
-                            {
-                                "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
-                                "intervalFactor": 1,
-                                "legendFormat": "Total Nodes",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "Total Nodes"
-                    },
-                    {
-                        "class": "single_stat_panel_fail",
-                        "targets": [
-                            {
-                                "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Unreachable",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "thresholds": "1,2",
-                        "title": "Unreachable"
-                    },
-                    {
-                        "class": "single_stat_panel_fail",
-                        "description": "Number of nodes that reported their status as Starting or Joining",
-                        "targets": [
-                            {
-                                "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Joining",
-                                "refId": "A",
-                                "step": 20
-                            }
-                        ],
-                        "thresholds": "1,2",
-                        "title": "Joining"
-                    },
-                    {
-                        "class": "single_stat_panel_fail",
-                        "description": "Number of nodes that reported their status as  Leaving, Decommissioned, Draining or Drained",
-                        "targets": [
-                            {
-                                "expr": "count(scylla_node_operation_mode>3)OR vector(0)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Leaving",
-                                "refId": "A",
-                                "step": 20
-                            }
-                        ],
-                        "thresholds": "1,2",
-                        "title": "Leaving"
-                    },
-                    {
-                        "class": "text_panel",
-                        "content": "##  ",
-                        "mode": "markdown",
-                        "span": 1,
-                        "style": {}
-                    },
-                    {
                         "class": "ops_panel",
-                        "bars": true,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_transport_requests_served{cluster=~\"$cluster|$^\"}[30s])) + $func(irate(scylla_thrift_served{cluster=~\"$cluster|$^\"}[30s]))",
-                                "intervalFactor": 1,
-                                "legendFormat": "Total Requests",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "Total Requests - Coordinator"
-                    },
-                    {
-                        "class": "dashlist",
-                        "tags": [
-                        	"3.1"
-		                ]
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
-                        "class": "percent_panel",
-                        "targets": [
-                            {
-                                "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "Load per [[by]]"
-                    },
-                    {
-                        "class": "ops_panel",
+                        "span": 4,
                         "targets": [
                             {
                                 "expr": "$func(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + $func(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
@@ -126,6 +24,35 @@
                         ],
                         "description": "Amount of requests served as the coordinator. Imbalances here represent dispersion at the connection level, not your data model.",
                         "title": "Requests Served per [[by]] - Coordinator"
+                    },
+                    {
+                        "class": "rps_panel",
+                        "span": 4,
+                        "targets": [
+                            {
+                                "expr": "$func(irate(scylla_database_total_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Reads per [[by]] - Replica"
+                    },
+                    {
+                        "class": "wps_panel",
+                        "span": 4,
+                        "targets": [
+                            {
+                                "expr": "$func(irate(scylla_database_total_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Writes per [[by]] - Replica"
                     }
                 ],
                 "title": "New row"
@@ -288,35 +215,6 @@
                 "class": "row",
                 "height": "auto",
                 "panels": [
-                    {
-                        "class": "rps_panel",
-                        "span": 6,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_database_total_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "Reads"
-                    },
-                    {
-                        "class": "wps_panel",
-                        "span": 6,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_database_total_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "Writes"
-                    },
                     {
                         "class": "graph_panel",
                         "span": 3,
@@ -763,6 +661,69 @@
                 "panels": [
                     {
                         "class": "text_panel",
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Materialized Views - Replica</h1>",
+                        "style": {}
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "bytes_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$func(scylla_database_view_update_backlog{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "View Update Backlog",
+                        "description" : "Size in bytes of the view update backlog at each base replica."
+                    },
+                    {
+                        "class": "ops_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$func(irate(scylla_database_dropped_view_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Dropped View Updates",
+                        "description" : "Number of dropped view updates due to an excessive view update backlog."
+                    },
+                    {
+                        "class": "wps_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$func(scylla_storage_proxy_coordinator_current_throttled_base_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"})  by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Throttled Base Writes",
+                        "description" : "Currently throttled base writes, as a consequence of the respective view update backlog."
+                    }
+                ]
+            },
+            {
+                "class": "row",
+                "height": "25px",
+                "gridPos": {"h": 2},
+                "panels": [
+                    {
+                        "class": "text_panel",
                         "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Memory - Replica</h1>",
                         "style": {}
                     }
@@ -869,102 +830,6 @@
                 "title": "New row"
             },
             {
-                "class": "row",
-                "height": "25px",
-                "gridPos": {"h": 2},
-                "panels": [
-                    {
-                        "class": "text_panel",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">CQL - Coordinator</h1>",
-                        "style": {}
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
-                        "class": "ops_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "CQL Insert"
-                    },
-                    {
-                        "class": "ops_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "CQL Reads"
-                    },
-                    {
-                        "class": "ops_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "CQL Deletes"
-                    },
-                    {
-                        "class": "ops_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "CQL Updates"
-                    },
-                    {
-                        "class": "graph_panel",
-                        "span": 3,
-                        "pointradius": 1,
-                        "targets": [
-                            {
-                                "expr": "$func(scylla_transport_current_connections{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 30
-                            }
-                        ],
-                        "title": "Client CQL connections by [[by]]",
-                        "description": "amount of CQL connections currently established"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
                 "class": "user_panel_row_header"
             },
             {
@@ -1013,7 +878,7 @@
             "from": "now-30m",
             "to": "now"
         },
-        "title": "Scylla Per Server Metrics",
+        "title": "Detailed",
         "overwrite": true,
         "version": 5
     }

--- a/grafana/scylla-dash-per-server.master.template.json
+++ b/grafana/scylla-dash-per-server.master.template.json
@@ -1,7 +1,7 @@
 {
     "dashboard": {
         "class": "dashboard",
-        "uid": "detail-master",
+        "uid": "detailed-master",
         "rows": [
             {
                 "class": "logo_row"
@@ -10,110 +10,8 @@
                 "class": "row",
                 "panels": [
                     {
-                        "class": "single_stat_panel",
-                        "targets": [
-                            {
-                                "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
-                                "intervalFactor": 1,
-                                "legendFormat": "Total Nodes",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "Total Nodes"
-                    },
-                    {
-                        "class": "single_stat_panel_fail",
-                        "targets": [
-                            {
-                                "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Unreachable",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "thresholds": "1,2",
-                        "title": "Unreachable"
-                    },
-                    {
-                        "class": "single_stat_panel_fail",
-                        "description": "Number of nodes that reported their status as Starting or Joining",
-                        "targets": [
-                            {
-                                "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Joining",
-                                "refId": "A",
-                                "step": 20
-                            }
-                        ],
-                        "thresholds": "1,2",
-                        "title": "Joining"
-                    },
-                    {
-                        "class": "single_stat_panel_fail",
-                        "description": "Number of nodes that reported their status as  Leaving, Decommissioned, Draining or Drained",
-                        "targets": [
-                            {
-                                "expr": "count(scylla_node_operation_mode>3)OR vector(0)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Leaving",
-                                "refId": "A",
-                                "step": 20
-                            }
-                        ],
-                        "thresholds": "1,2",
-                        "title": "Leaving"
-                    },
-                    {
-                        "class": "text_panel",
-                        "content": "##  ",
-                        "mode": "markdown",
-                        "span": 1,
-                        "style": {}
-                    },
-                    {
                         "class": "ops_panel",
-                        "bars": true,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_transport_requests_served{cluster=~\"$cluster|$^\"}[30s])) + $func(irate(scylla_thrift_served{cluster=~\"$cluster|$^\"}[30s]))",
-                                "intervalFactor": 1,
-                                "legendFormat": "Total Requests",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "Total Requests - Coordinator"
-                    },
-                    {
-                        "class": "dashlist",
-                        "tags": [
-                        	"master"
-		                ]
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
-                        "class": "percent_panel",
-                        "targets": [
-                            {
-                                "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "Load per [[by]]"
-                    },
-                    {
-                        "class": "ops_panel",
+                        "span": 4,
                         "targets": [
                             {
                                 "expr": "$func(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + $func(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
@@ -126,6 +24,35 @@
                         ],
                         "description": "Amount of requests served as the coordinator. Imbalances here represent dispersion at the connection level, not your data model.",
                         "title": "Requests Served per [[by]] - Coordinator"
+                    },
+                    {
+                        "class": "rps_panel",
+                        "span": 4,
+                        "targets": [
+                            {
+                                "expr": "$func(irate(scylla_database_total_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Reads per [[by]] - Replica"
+                    },
+                    {
+                        "class": "wps_panel",
+                        "span": 4,
+                        "targets": [
+                            {
+                                "expr": "$func(irate(scylla_database_total_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Writes per [[by]] - Replica"
                     }
                 ],
                 "title": "New row"
@@ -288,35 +215,6 @@
                 "class": "row",
                 "height": "auto",
                 "panels": [
-                    {
-                        "class": "rps_panel",
-                        "span": 6,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_database_total_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "Reads"
-                    },
-                    {
-                        "class": "wps_panel",
-                        "span": 6,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_database_total_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "Writes"
-                    },
                     {
                         "class": "graph_panel",
                         "span": 3,
@@ -763,6 +661,69 @@
                 "panels": [
                     {
                         "class": "text_panel",
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Materialized Views - Replica</h1>",
+                        "style": {}
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "bytes_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$func(scylla_database_view_update_backlog{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "View Update Backlog",
+                        "description" : "Size in bytes of the view update backlog at each base replica."
+                    },
+                    {
+                        "class": "ops_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$func(irate(scylla_database_dropped_view_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Dropped View Updates",
+                        "description" : "Number of dropped view updates due to an excessive view update backlog."
+                    },
+                    {
+                        "class": "wps_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$func(scylla_storage_proxy_coordinator_current_throttled_base_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"})  by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Throttled Base Writes",
+                        "description" : "Currently throttled base writes, as a consequence of the respective view update backlog."
+                    }
+                ]
+            },
+            {
+                "class": "row",
+                "height": "25px",
+                "gridPos": {"h": 2},
+                "panels": [
+                    {
+                        "class": "text_panel",
                         "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Memory - Replica</h1>",
                         "style": {}
                     }
@@ -869,102 +830,6 @@
                 "title": "New row"
             },
             {
-                "class": "row",
-                "height": "25px",
-                "gridPos": {"h": 2},
-                "panels": [
-                    {
-                        "class": "text_panel",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">CQL - Coordinator</h1>",
-                        "style": {}
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
-                        "class": "ops_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "CQL Insert"
-                    },
-                    {
-                        "class": "ops_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "CQL Reads"
-                    },
-                    {
-                        "class": "ops_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "CQL Deletes"
-                    },
-                    {
-                        "class": "ops_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "CQL Updates"
-                    },
-                    {
-                        "class": "graph_panel",
-                        "span": 3,
-                        "pointradius": 1,
-                        "targets": [
-                            {
-                                "expr": "$func(scylla_transport_current_connections{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 30
-                            }
-                        ],
-                        "title": "Client CQL connections by [[by]]",
-                        "description": "amount of CQL connections currently established"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
                 "class": "user_panel_row_header"
             },
             {
@@ -1013,7 +878,7 @@
             "from": "now-30m",
             "to": "now"
         },
-        "title": "Scylla Per Server Metrics",
+        "title": "Detailed",
         "overwrite": true,
         "version": 5
     }

--- a/grafana/scylla-dash.2019.1.template.json
+++ b/grafana/scylla-dash.2019.1.template.json
@@ -69,94 +69,6 @@
                         "title": "Leaving"
                     },
                     {
-                        "class": "text_panel",
-                        "content": "##  ",
-                        "mode": "markdown",
-                        "span": 2,
-                        "style": {}
-                    },
-                    {
-                        "class": "dashlist",
-                        "tags": [
-                            "2019.1"
-                        ]
-                    },
-                    {
-                        "class": "alert_table",
-                        "span":4,
-                        "styles": [
-                            {
-                                "alias": "Time",
-                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                                "pattern": "Time",
-                                "link": true,
-                                "linkTooltip": "Jump to the see the node",
-                                "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_4}&from=${__cell_0}",
-                                "type": "date"
-                            },
-                            {
-                                "class":"hidden_column",
-                                "pattern": "severity"
-                            },
-                            {
-                                "class":"hidden_column",
-                                "pattern": "alertname"
-                            },
-                            {
-                                "class":"hidden_column",
-                                "pattern": "cluster"
-                            },
-                            {
-                                "class":"hidden_column",
-                                "pattern": "monitor"
-                            },
-                            {
-                                "class":"hidden_column",
-                                "pattern": "summary"
-                            },
-                            {
-                              "alias": "Instance",
-                              "colorMode": null,
-                              "colors": [
-                                "rgba(245, 54, 54, 0.9)",
-                                "rgba(237, 129, 40, 0.89)",
-                                "rgba(50, 172, 45, 0.97)"
-                              ],
-                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                              "decimals": 2,
-                              "link": true,
-                              "linkTooltip": "Jump to the see the node",
-                              "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_4}",
-                              "mappingType": 1,
-                              "pattern": "instance",
-                              "thresholds": [],
-                              "type": "string",
-                              "unit": "short"
-                            },
-                            {
-                                "alias": "",
-                                "colorMode": null,
-                                "colors": [
-                                    "rgba(245, 54, 54, 0.9)",
-                                    "rgba(237, 129, 40, 0.89)",
-                                    "rgba(50, 172, 45, 0.97)"
-                                ],
-                                "decimals": 2,
-                                "pattern": "/.*/",
-                                "thresholds": [],
-                                "type": "number",
-                                "unit": "short"
-                            }
-                        ],
-                        "title": "Active Alerts"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
                         "class": "percent_panel",
                         "span": 4,
                         "targets": [
@@ -170,22 +82,6 @@
                         ],
                         "title": "Load",
                         "description": "The percentage of the time during which Scylla utilized the CPU. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high."
-                    },
-                    {
-                        "class": "ops_panel",
-                        "span": 4,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + $func(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 4
-                            }
-                        ],
-                        "title": "Requests Served - Coordinator",
-                        "description": "Amount of requests served as the coordinator. Imbalances here represent dispersion at the client-side level or connection balancing level, not your data model."
                     },
                     {
                         "class": "single_value_table",
@@ -217,7 +113,7 @@
                               "thresholds": [],
                               "mappingType": 1,
                               "link": true,
-                              "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_6}",
+                              "linkUrl": "/d/detailed-[[dash_version]]/Detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__cell}",
                               "linkTooltip": "Jump to the detailed node information"
                             },
                             {
@@ -239,6 +135,128 @@
                             {
                                 "class":"hidden_column",
                                 "pattern": "type"
+                            },
+                            {
+                              "alias": "OS",
+                              "unit": "short",
+                              "type": "string",
+                              "decimals": 2,
+                              "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                              ],
+                              "colorMode": null,
+                              "pattern": "OS",
+                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                              "thresholds": [],
+                              "mappingType": 1,
+                              "link": true,
+                              "linkUrl": "/d/OS-[[dash_version]]/OS-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                              "linkTooltip": "Jump to the OS node information",
+                              "valueMaps": [
+                                    {
+                                      "value": "os",
+                                      "text": "OS"
+                                    }
+                                ]
+                            },
+                            {
+                              "unit": "short",
+                              "type": "string",
+                              "decimals": 2,
+                              "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                              ],
+                              "colorMode": null,
+                              "pattern": "CQL",
+                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                              "thresholds": [],
+                              "mappingType": 1,
+                              "link": true,
+                              "linkUrl": "/d/cql-[[dash_version]]/scylla-cql?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                              "linkTooltip": "Jump to the CQL information",
+                              "valueMaps": [
+                                    {
+                                      "value": "cql",
+                                      "text": "CQL"
+                                    }
+                                ]
+                            },
+                            {
+                              "unit": "short",
+                              "type": "string",
+                              "decimals": 2,
+                              "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                              ],
+                              "colorMode": null,
+                              "pattern": "Errors",
+                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                              "thresholds": [],
+                              "mappingType": 1,
+                              "link": true,
+                              "linkUrl": "/d/error-[[dash_version]]/scylla-errors?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                              "linkTooltip": "Jump to the Errors metrics information",
+                              "valueMaps": [
+                                    {
+                                      "value": "errors",
+                                      "text": "Errors"
+                                    }
+                                ]
+                            },
+                            {
+                              "unit": "short",
+                              "type": "string",
+                              "decimals": 2,
+                              "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                              ],
+                              "colorMode": null,
+                              "pattern": "IO",
+                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                              "thresholds": [],
+                              "mappingType": 1,
+                              "link": true,
+                              "linkUrl": "/d/io-[[dash_version]]/i-o?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                              "linkTooltip": "Jump to the Errors metrics information",
+                              "valueMaps": [
+                                    {
+                                      "value": "io",
+                                      "text": "IO"
+                                    }
+                                ]
+                            },
+                            {
+                              "alias": "CPU",
+                              "unit": "short",
+                              "type": "string",
+                              "decimals": 2,
+                              "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                              ],
+                              "colorMode": null,
+                              "pattern": "CPU",
+                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                              "thresholds": [],
+                              "mappingType": 1,
+                              "link": true,
+                              "linkUrl": "/d/cpu-[[dash_version]]/CPU-Metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                              "linkTooltip": "Jump to the node CPU information",
+                              "valueMaps": [
+                                    {
+                                      "value": "cpu",
+                                      "text": "CPU"
+                                    }
+                                ]
                             },
                             {
                                 "pattern": "Value",
@@ -299,6 +317,112 @@
                 "title": "New row"
             },
             {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "bytes_panel",
+                        "span": 4,
+                        "targets": [
+                            {
+                                "expr": "sum(node_filesystem_size_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])-sum(node_filesystem_avail_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Disk Size by $by"
+                    },
+                    {
+                        "class": "ops_panel",
+                        "span": 4,
+                        "targets": [
+                            {
+                                "expr": "$func(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + $func(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 4
+                            }
+                        ],
+                        "title": "Requests Served - Coordinator",
+                        "description": "Amount of requests served as the coordinator. Imbalances here represent dispersion at the client-side level or connection balancing level, not your data model."
+                    },
+                    {
+                        "class": "alert_table",
+                        "span":4,
+                        "styles": [
+                            {
+                                "alias": "Time",
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                                "pattern": "Time",
+                                "link": true,
+                                "linkTooltip": "Jump to the see the node",
+                                "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}&from=${__cell_0}",
+                                "type": "date"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "severity"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "alertname"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "cluster"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "monitor"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "summary"
+                            },
+                            {
+                              "alias": "Instance",
+                              "colorMode": null,
+                              "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                              ],
+                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                              "decimals": 2,
+                              "link": true,
+                              "linkTooltip": "Jump to the see the node",
+                              "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                              "mappingType": 1,
+                              "pattern": "instance",
+                              "thresholds": [],
+                              "type": "string",
+                              "unit": "short"
+                            },
+                            {
+                                "alias": "",
+                                "colorMode": null,
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)",
+                                    "rgba(237, 129, 40, 0.89)",
+                                    "rgba(50, 172, 45, 0.97)"
+                                ],
+                                "decimals": 2,
+                                "pattern": "/.*/",
+                                "thresholds": [],
+                                "type": "number",
+                                "unit": "short"
+                            }
+                        ],
+                        "title": "Active Alerts"
+                    }
+                ],
+                "title": "New row"
+            },
+            {
                 "class":"header_row",
                 "panels": [
                     {
@@ -311,8 +435,22 @@
                 "class": "row",
                 "panels": [
                     {
+                        "class": "ops_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$func(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Writes"
+                    },
+                    {
                         "class": "us_panel",
-                        "span": 4,
+                        "span": 3,
                         "targets": [
                             {
                                 "expr": "$func(rate(scylla_storage_proxy_coordinator_write_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])/($func(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]]) + 1)",
@@ -326,7 +464,7 @@
                     },
                     {
                         "class": "us_panel",
-                        "span": 4,
+                        "span": 3,
                         "targets": [
                             {
                                 "expr": "histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]], le))",
@@ -341,7 +479,7 @@
                     },
                     {
                         "class": "us_panel",
-                        "span": 4,
+                        "span": 3,
                         "targets": [
                             {
                                 "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]], le))",
@@ -359,10 +497,25 @@
             },
             {
                 "class": "row",
+
                 "panels": [
                     {
+                        "class": "ops_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$func(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Reads"
+                    },
+                    {
                         "class": "us_panel",
-                        "span": 4,
+                        "span": 3,
                         "targets": [
                             {
                                 "expr": "$func(rate(scylla_storage_proxy_coordinator_read_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])/($func(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]]) + 1)",
@@ -376,7 +529,7 @@
                     },
                     {
                         "class": "us_panel",
-                        "span": 4,
+                        "span": 3,
                         "targets": [
                             {
                                 "expr": "histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]], le))",
@@ -391,7 +544,7 @@
                     },
                     {
                         "class": "us_panel",
-                        "span": 4,
+                        "span": 3,
                         "targets": [
                             {
                                 "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]], le))",
@@ -403,158 +556,6 @@
                             }
                         ],
                         "title": "99th percentile read latency by [[by]]"
-                    }
-                ],
-                "title": "New row"
-            },
-
-            {
-                "class": "row",
-                "height": "25px",
-                "gridPos": {"h": 2},
-                "panels": [
-                    {
-                        "class": "text_header_panel",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Reads and Writes - Coordinator</h1>"
-                    },
-                    {
-                        "class": "text_header_panel",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Timeouts and Errors - Coordinator</h1>"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "height": "200px",
-                "panels": [
-                    {
-                        "class": "queue_lenght_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(scylla_storage_proxy_coordinator_foreground_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "Foreground Writes",
-                        "description": "Foreground writes are writes that weren't acknowledged yet to the application. For instance, if a single replica responded and two are needed due to the consistency level. This metric represents a queue size, not a rate. High values here correlate with increased write latencies."
-                    },
-                    {
-                        "class": "queue_lenght_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(scylla_storage_proxy_coordinator_foreground_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "Foreground Reads",
-                        "description": "Foreground reads are reads that weren't acknowledged yet to the application. For instance, if a single replica responded and two are needed due to the consistency level. This metric represents a queue size, not a rate. High values here correlate with increased read latencies."
-                    },
-                    {
-                        "class": "wps_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "Write Timeouts",
-                        "description": "Requests that Scylla tried to write but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas."
-                    },
-                    {
-                        "class": "wps_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_storage_proxy_coordinator_write_unavailable{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "Write Unavailable",
-                        "description": "Requests that Scylla did not even try to write because replicas that were needed to execute this write were unavailable. Unavailable writes are counted in the node that received the request (the coordinator), not at the replicas."
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "height": "200px",
-                "panels": [
-                    {
-                        "class": "queue_lenght_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(scylla_storage_proxy_coordinator_background_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "Background Writes",
-                        "description": "Background writes are writes that are already acknowledged to the application but have additional work to be done. For instance, if a replica responded and only one is needed, this request is still listed as a background request until all replicas respond. This metric represents a queue size, not a rate. High values here correlate with increased write latencies."
-                    },
-                    {
-                        "class": "queue_lenght_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(scylla_storage_proxy_coordinator_background_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "Background Reads",
-                        "description": "Background reads are reads that are already acknowledged to the application but have additional work to be done. For instance, if a replica responded and only one is needed, this request is still listed as a background request until all replicas respond. This metric represents a queue size, not a rate. High values here correlate with increased read latencies."
-                    },
-                    {
-                        "class": "rps_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "Read Timeouts",
-                        "description": "Requests that Scylla tried to read but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas."
-                    },
-                    {
-                        "class": "rps_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_storage_proxy_coordinator_read_unavailable{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "Read Unavailable",
-                        "description": "Requests that Scylla did not even try to read because replicas that were needed to execute this write were unavailable. Unavailable reads are counted in the node that received the request (the coordinator), not at the replicas."
                     }
                 ],
                 "title": "New row"
@@ -579,7 +580,7 @@
                         "type": "text"
                     },
                     {
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Materialized Views - Replica</h1>",
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Timeouts</h1>",
                         "editable": true,
                         "error": false,
                         "id": "auto",
@@ -629,56 +630,36 @@
                         "title": "Cache Misses",
                         "description" : "Number of rows that were not present in the cache, and had to be fetched from storage."
                     },
-                    {
-                        "class": "bytes_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(scylla_database_view_update_backlog{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "View Update Backlog",
-                        "description" : "Size in bytes of the view update backlog at each base replica."
-                    },
-                    {
-                        "class": "ops_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_database_dropped_view_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "Dropped View Updates",
-                        "description" : "Number of dropped view updates due to an excessive view update backlog."
-                    },
-                    {
-                        "class": "text_panel",
-                        "content": "",
-                        "mode": "markdown",
-                        "span": 9
-                    },
-                    {
+
+                     {
                         "class": "wps_panel",
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$func(scylla_storage_proxy_coordinator_current_throttled_base_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"})  by ([[by]])",
+                                "expr": "$func(irate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
                         ],
-                        "title": "Throttled Base Writes",
-                        "description" : "Currently throttled base writes, as a consequence of the respective view update backlog."
+                        "title": "Write Timeouts",
+                        "description": "Requests that Scylla tried to write but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas."
+                    },
+                    {
+                        "class": "rps_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$func(irate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Read Timeouts",
+                        "description": "Requests that Scylla tried to read but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas."
                     }
                 ],
                 "title": "New row"
@@ -721,6 +702,29 @@
                     "sort": 3
                 },
                 {
+                    "allValue": null,
+                    "current": {
+                        "text": "/var/lib/scylla",
+                        "value": "/var/lib/scylla"
+                    },
+                    "datasource": "prometheus",
+                    "hide": 0,
+                    "includeAll": false,
+                    "label": "Mounnt path",
+                    "multi": false,
+                    "name": "mount_point",
+                    "options": [],
+                    "query": "node_filesystem_avail_bytes",
+                    "refresh": 2,
+                    "regex": "/mountpoint=\"([^\"]*)\".*/",
+                    "sort": 0,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                },
+                {
                     "class": "aggregation_function"
                 },
                 {
@@ -729,14 +733,14 @@
                     "options": [
                       {
                          "selected": true,
-                         "text": "2019.1",
-                         "value": "2019.1"
+                         "text": "2019-1",
+                         "value": "2019-1"
                       }
                     ],
-                    "query": "2019.1",
+                    "query": "2019-1",
                     "current": {
-                        "text": "2019.1",
-                        "value": "2019.1"
+                        "text": "2019-1",
+                        "value": "2019-1"
                     }
                 }
             ]
@@ -748,7 +752,7 @@
             "from": "now-30m",
             "to": "now"
         },
-        "title": "Scylla Overview Metrics",
+        "title": "Overview",
         "overwrite": true,
         "version": 3
     }

--- a/grafana/scylla-dash.3.0.template.json
+++ b/grafana/scylla-dash.3.0.template.json
@@ -42,14 +42,246 @@
                         "class": "text_panel",
                         "content": "##  ",
                         "mode": "markdown",
-                        "span": 4,
+                        "span": 2,
                         "style": {}
                     },
                     {
-                        "class": "dashlist",
-                        "tags": [
-                            "3.0"
-                        ]
+                        "class": "percent_panel",
+                        "span": 4,
+                        "targets": [
+                            {
+                                "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 4
+                            }
+                        ],
+                        "title": "Load",
+                        "description": "The percentage of the time during which Scylla utilized the CPU. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high."
+                    },
+                    {
+                        "class": "single_value_table",
+                        "span": 4,
+                        "description": "Nodes Information table",
+                        "targets": [
+                            {
+                              "refId": "A",
+                              "expr": "scylla_scylladb_current_version{cluster=~\"$cluster|$^\", dc=~\"$dc\"}",
+                              "intervalFactor": 1,
+                              "format": "table",
+                              "instant": true
+                            }
+                        ],
+                        "styles": [
+                            {
+                              "unit": "short",
+                              "type": "string",
+                              "alias": "",
+                              "decimals": 2,
+                              "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                              ],
+                              "colorMode": null,
+                              "pattern": "instance",
+                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                              "thresholds": [],
+                              "mappingType": 1,
+                              "link": true,
+                              "linkUrl": "/d/detailed-[[dash_version]]/Detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__cell}",
+                              "linkTooltip": "Jump to the detailed node information"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "Time"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "__name__"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "exported_instance"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "job"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "type"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "Value"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "cluster"
+                            },
+                            {
+                              "alias": "OS",
+                              "unit": "short",
+                              "type": "string",
+                              "decimals": 2,
+                              "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                              ],
+                              "colorMode": null,
+                              "pattern": "OS",
+                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                              "thresholds": [],
+                              "mappingType": 1,
+                              "link": true,
+                              "linkUrl": "/d/OS-[[dash_version]]/OS-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                              "linkTooltip": "Jump to the OS node information",
+                              "valueMaps": [
+                                    {
+                                      "value": "os",
+                                      "text": "OS"
+                                    }
+                                ]
+                            },
+                            {
+                              "unit": "short",
+                              "type": "string",
+                              "decimals": 2,
+                              "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                              ],
+                              "colorMode": null,
+                              "pattern": "CQL",
+                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                              "thresholds": [],
+                              "mappingType": 1,
+                              "link": true,
+                              "linkUrl": "/d/cql-[[dash_version]]/scylla-cql?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                              "linkTooltip": "Jump to the CQL information",
+                              "valueMaps": [
+                                    {
+                                      "value": "cql",
+                                      "text": "CQL"
+                                    }
+                                ]
+                            },
+                            {
+                              "unit": "short",
+                              "type": "string",
+                              "decimals": 2,
+                              "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                              ],
+                              "colorMode": null,
+                              "pattern": "Errors",
+                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                              "thresholds": [],
+                              "mappingType": 1,
+                              "link": true,
+                              "linkUrl": "/d/error-[[dash_version]]/scylla-errors?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                              "linkTooltip": "Jump to the Errors metrics information",
+                              "valueMaps": [
+                                    {
+                                      "value": "errors",
+                                      "text": "Errors"
+                                    }
+                                ]
+                            },
+                            {
+                              "unit": "short",
+                              "type": "string",
+                              "decimals": 2,
+                              "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                              ],
+                              "colorMode": null,
+                              "pattern": "IO",
+                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                              "thresholds": [],
+                              "mappingType": 1,
+                              "link": true,
+                              "linkUrl": "/d/io-[[dash_version]]/i-o?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                              "linkTooltip": "Jump to the Errors metrics information",
+                              "valueMaps": [
+                                    {
+                                      "value": "io",
+                                      "text": "IO"
+                                    }
+                                ]
+                            },
+                            {
+                              "alias": "CPU",
+                              "unit": "short",
+                              "type": "string",
+                              "decimals": 2,
+                              "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                              ],
+                              "colorMode": null,
+                              "pattern": "CPU",
+                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                              "thresholds": [],
+                              "mappingType": 1,
+                              "link": true,
+                              "linkUrl": "/d/cpu-[[dash_version]]/CPU-Metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                              "linkTooltip": "Jump to the node CPU information",
+                              "valueMaps": [
+                                    {
+                                      "value": "cpu",
+                                      "text": "CPU"
+                                    }
+                                ]
+                            }
+                        ],
+                        "title": "Nodes"
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "class": "row",
+                "panels": [
+                  {
+                        "class": "bytes_panel",
+                        "span": 4,
+                        "targets": [
+                            {
+                                "expr": "sum(node_filesystem_size_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])-sum(node_filesystem_avail_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Disk Size by $by"
+                    },
+                  {
+                        "class": "ops_panel",
+                        "span": 4,
+                        "targets": [
+                            {
+                                "expr": "$func(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + $func(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 4
+                            }
+                        ],
+                        "title": "Requests Served - Coordinator",
+                        "description": "Amount of requests served as the coordinator. Imbalances here represent dispersion at the client-side level or connection balancing level, not your data model."
                     },
                     {
                         "class": "alert_table",
@@ -124,105 +356,13 @@
                 "title": "New row"
             },
             {
-                "class": "row",
+                "class":"header_row",
                 "panels": [
                     {
-                        "class": "percent_panel",
-                        "span": 4,
-                        "targets": [
-                            {
-                                "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 4
-                            }
-                        ],
-                        "title": "Load",
-                        "description": "The percentage of the time during which Scylla utilized the CPU. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high."
-                    },
-                    {
-                        "class": "ops_panel",
-                        "span": 4,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + $func(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 4
-                            }
-                        ],
-                        "title": "Requests Served - Coordinator",
-                        "description": "Amount of requests served as the coordinator. Imbalances here represent dispersion at the client-side level or connection balancing level, not your data model."
-                    },
-                    {
-                        "class": "single_value_table",
-                        "span": 4,
-                        "description": "Nodes Information table",
-                        "targets": [
-                            {
-                              "refId": "A",
-                              "expr": "scylla_scylladb_current_version{cluster=~\"$cluster|$^\", dc=~\"$dc\"}",
-                              "intervalFactor": 1,
-                              "format": "table",
-                              "instant": true
-                            }
-                        ],
-                        "styles": [
-                            {
-                              "unit": "short",
-                              "type": "string",
-                              "alias": "",
-                              "decimals": 2,
-                              "colors": [
-                                "rgba(245, 54, 54, 0.9)",
-                                "rgba(237, 129, 40, 0.89)",
-                                "rgba(50, 172, 45, 0.97)"
-                              ],
-                              "colorMode": null,
-                              "pattern": "instance",
-                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                              "thresholds": [],
-                              "mappingType": 1,
-                              "link": true,
-                              "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_6}",
-                              "linkTooltip": "Jump to the detailed node information"
-                            },
-                            {
-                                "class":"hidden_column",
-                                "pattern": "Time"
-                            },
-                            {
-                                "class":"hidden_column",
-                                "pattern": "__name__"
-                            },
-                            {
-                                "class":"hidden_column",
-                                "pattern": "exported_instance"
-                            },
-                            {
-                                "class":"hidden_column",
-                                "pattern": "job"
-                            },
-                            {
-                                "class":"hidden_column",
-                                "pattern": "type"
-                            },
-                            {
-                                "class":"hidden_column",
-                                "pattern": "Value"
-                            },
-                            {
-                                "class":"hidden_column",
-                                "pattern": "cluster"
-                            }
-                        ],
-                        "title": "Nodes"
+                        "class": "plain_text",
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Latencies - Coordinator</h1>"
                     }
-                ],
-                "title": "New row"
+                ]
             },
             {
                 "class": "row",
@@ -273,15 +413,6 @@
                     }
                 ],
                 "title": "New row"
-            },
-            {
-                "class":"header_row",
-                "panels": [
-                    {
-                        "class": "plain_text",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Latencies - Coordinator</h1>"
-                    }
-                ]
             },
             {
                 "class": "row",
@@ -505,7 +636,7 @@
                         "type": "text"
                     },
                     {
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Materialized Views - Replica</h1>",
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Timeouts</h1>",
                         "editable": true,
                         "error": false,
                         "id": "auto",
@@ -555,56 +686,35 @@
                         "title": "Cache Misses",
                         "description" : "Number of rows that were not present in the cache, and had to be fetched from storage."
                     },
-                    {
-                        "class": "bytes_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(scylla_database_view_update_backlog{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "View Update Backlog",
-                        "description" : "Size in bytes of the view update backlog at each base replica."
-                    },
-                    {
-                        "class": "ops_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_database_dropped_view_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "Dropped View Updates",
-                        "description" : "Number of dropped view updates due to an excessive view update backlog."
-                    },
-                    {
-                        "class": "text_panel",
-                        "content": "",
-                        "mode": "markdown",
-                        "span": 9
-                    },
-                    {
+                     {
                         "class": "wps_panel",
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$func(scylla_storage_proxy_coordinator_current_throttled_base_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"})  by ([[by]])",
+                                "expr": "$func(irate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
                         ],
-                        "title": "Throttled Base Writes",
-                        "description" : "Currently throttled base writes, as a consequence of the respective view update backlog."
+                        "title": "Write Timeouts",
+                        "description": "Requests that Scylla tried to write but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas."
+                    },
+                    {
+                        "class": "rps_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$func(irate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Read Timeouts",
+                        "description": "Requests that Scylla tried to read but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas."
                     }
                 ],
                 "title": "New row"
@@ -647,6 +757,52 @@
                     "sort": 3
                 },
                 {
+                    "allValue": null,
+                    "current": {
+                        "text": "/var/lib/scylla",
+                        "value": "/var/lib/scylla"
+                    },
+                    "datasource": "prometheus",
+                    "hide": 0,
+                    "includeAll": false,
+                    "label": "Mounnt path",
+                    "multi": false,
+                    "name": "mount_point",
+                    "options": [],
+                    "query": "node_filesystem_avail_bytes",
+                    "refresh": 2,
+                    "regex": "/mountpoint=\"([^\"]*)\".*/",
+                    "sort": 0,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                },
+                {
+                    "allValue": null,
+                    "current": {
+                        "text": "/var/lib/scylla",
+                        "value": "/var/lib/scylla"
+                    },
+                    "datasource": "prometheus",
+                    "hide": 0,
+                    "includeAll": false,
+                    "label": "Mounnt path",
+                    "multi": false,
+                    "name": "mount_point",
+                    "options": [],
+                    "query": "node_filesystem_avail_bytes",
+                    "refresh": 2,
+                    "regex": "/mountpoint=\"([^\"]*)\".*/",
+                    "sort": 0,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                },
+                {
                     "class": "aggregation_function"
                 },
                 {
@@ -674,7 +830,7 @@
             "from": "now-30m",
             "to": "now"
         },
-        "title": "Scylla Overview Metrics",
+        "title": "Overview",
         "overwrite": true,
         "version": 3
     }

--- a/grafana/scylla-dash.3.1.template.json
+++ b/grafana/scylla-dash.3.1.template.json
@@ -69,94 +69,6 @@
                         "title": "Leaving"
                     },
                     {
-                        "class": "text_panel",
-                        "content": "##  ",
-                        "mode": "markdown",
-                        "span": 2,
-                        "style": {}
-                    },
-                    {
-                        "class": "dashlist",
-                        "tags": [
-                            "3.1"
-                        ]
-                    },
-                    {
-                        "class": "alert_table",
-                        "span":4,
-                        "styles": [
-                            {
-                                "alias": "Time",
-                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                                "pattern": "Time",
-                                "link": true,
-                                "linkTooltip": "Jump to the see the node",
-                                "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_4}&from=${__cell_0}",
-                                "type": "date"
-                            },
-                            {
-                                "class":"hidden_column",
-                                "pattern": "severity"
-                            },
-                            {
-                                "class":"hidden_column",
-                                "pattern": "alertname"
-                            },
-                            {
-                                "class":"hidden_column",
-                                "pattern": "cluster"
-                            },
-                            {
-                                "class":"hidden_column",
-                                "pattern": "monitor"
-                            },
-                            {
-                                "class":"hidden_column",
-                                "pattern": "summary"
-                            },
-                            {
-                              "alias": "Instance",
-                              "colorMode": null,
-                              "colors": [
-                                "rgba(245, 54, 54, 0.9)",
-                                "rgba(237, 129, 40, 0.89)",
-                                "rgba(50, 172, 45, 0.97)"
-                              ],
-                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                              "decimals": 2,
-                              "link": true,
-                              "linkTooltip": "Jump to the see the node",
-                              "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_4}",
-                              "mappingType": 1,
-                              "pattern": "instance",
-                              "thresholds": [],
-                              "type": "string",
-                              "unit": "short"
-                            },
-                            {
-                                "alias": "",
-                                "colorMode": null,
-                                "colors": [
-                                    "rgba(245, 54, 54, 0.9)",
-                                    "rgba(237, 129, 40, 0.89)",
-                                    "rgba(50, 172, 45, 0.97)"
-                                ],
-                                "decimals": 2,
-                                "pattern": "/.*/",
-                                "thresholds": [],
-                                "type": "number",
-                                "unit": "short"
-                            }
-                        ],
-                        "title": "Active Alerts"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
                         "class": "percent_panel",
                         "span": 4,
                         "targets": [
@@ -170,22 +82,6 @@
                         ],
                         "title": "Load",
                         "description": "The percentage of the time during which Scylla utilized the CPU. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high."
-                    },
-                    {
-                        "class": "ops_panel",
-                        "span": 4,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + $func(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 4
-                            }
-                        ],
-                        "title": "Requests Served - Coordinator",
-                        "description": "Amount of requests served as the coordinator. Imbalances here represent dispersion at the client-side level or connection balancing level, not your data model."
                     },
                     {
                         "class": "single_value_table",
@@ -217,7 +113,7 @@
                               "thresholds": [],
                               "mappingType": 1,
                               "link": true,
-                              "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_6}",
+                              "linkUrl": "/d/detailed-[[dash_version]]/Detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__cell}",
                               "linkTooltip": "Jump to the detailed node information"
                             },
                             {
@@ -239,6 +135,128 @@
                             {
                                 "class":"hidden_column",
                                 "pattern": "type"
+                            },
+                            {
+                              "alias": "OS",
+                              "unit": "short",
+                              "type": "string",
+                              "decimals": 2,
+                              "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                              ],
+                              "colorMode": null,
+                              "pattern": "OS",
+                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                              "thresholds": [],
+                              "mappingType": 1,
+                              "link": true,
+                              "linkUrl": "/d/OS-[[dash_version]]/OS-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                              "linkTooltip": "Jump to the OS node information",
+                              "valueMaps": [
+                                    {
+                                      "value": "os",
+                                      "text": "OS"
+                                    }
+                                ]
+                            },
+                            {
+                              "unit": "short",
+                              "type": "string",
+                              "decimals": 2,
+                              "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                              ],
+                              "colorMode": null,
+                              "pattern": "CQL",
+                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                              "thresholds": [],
+                              "mappingType": 1,
+                              "link": true,
+                              "linkUrl": "/d/cql-[[dash_version]]/scylla-cql?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                              "linkTooltip": "Jump to the CQL information",
+                              "valueMaps": [
+                                    {
+                                      "value": "cql",
+                                      "text": "CQL"
+                                    }
+                                ]
+                            },
+                            {
+                              "unit": "short",
+                              "type": "string",
+                              "decimals": 2,
+                              "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                              ],
+                              "colorMode": null,
+                              "pattern": "Errors",
+                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                              "thresholds": [],
+                              "mappingType": 1,
+                              "link": true,
+                              "linkUrl": "/d/error-[[dash_version]]/scylla-errors?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                              "linkTooltip": "Jump to the Errors metrics information",
+                              "valueMaps": [
+                                    {
+                                      "value": "errors",
+                                      "text": "Errors"
+                                    }
+                                ]
+                            },
+                            {
+                              "unit": "short",
+                              "type": "string",
+                              "decimals": 2,
+                              "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                              ],
+                              "colorMode": null,
+                              "pattern": "IO",
+                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                              "thresholds": [],
+                              "mappingType": 1,
+                              "link": true,
+                              "linkUrl": "/d/io-[[dash_version]]/i-o?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                              "linkTooltip": "Jump to the Errors metrics information",
+                              "valueMaps": [
+                                    {
+                                      "value": "io",
+                                      "text": "IO"
+                                    }
+                                ]
+                            },
+                            {
+                              "alias": "CPU",
+                              "unit": "short",
+                              "type": "string",
+                              "decimals": 2,
+                              "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                              ],
+                              "colorMode": null,
+                              "pattern": "CPU",
+                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                              "thresholds": [],
+                              "mappingType": 1,
+                              "link": true,
+                              "linkUrl": "/d/cpu-[[dash_version]]/CPU-Metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                              "linkTooltip": "Jump to the node CPU information",
+                              "valueMaps": [
+                                    {
+                                      "value": "cpu",
+                                      "text": "CPU"
+                                    }
+                                ]
                             },
                             {
                                 "pattern": "Value",
@@ -299,6 +317,112 @@
                 "title": "New row"
             },
             {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "bytes_panel",
+                        "span": 4,
+                        "targets": [
+                            {
+                                "expr": "sum(node_filesystem_size_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])-sum(node_filesystem_avail_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Disk Size by $by"
+                    },
+                    {
+                        "class": "ops_panel",
+                        "span": 4,
+                        "targets": [
+                            {
+                                "expr": "$func(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + $func(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 4
+                            }
+                        ],
+                        "title": "Requests Served - Coordinator",
+                        "description": "Amount of requests served as the coordinator. Imbalances here represent dispersion at the client-side level or connection balancing level, not your data model."
+                    },
+                    {
+                        "class": "alert_table",
+                        "span":4,
+                        "styles": [
+                            {
+                                "alias": "Time",
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                                "pattern": "Time",
+                                "link": true,
+                                "linkTooltip": "Jump to the see the node",
+                                "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}&from=${__cell_0}",
+                                "type": "date"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "severity"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "alertname"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "cluster"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "monitor"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "summary"
+                            },
+                            {
+                              "alias": "Instance",
+                              "colorMode": null,
+                              "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                              ],
+                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                              "decimals": 2,
+                              "link": true,
+                              "linkTooltip": "Jump to the see the node",
+                              "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                              "mappingType": 1,
+                              "pattern": "instance",
+                              "thresholds": [],
+                              "type": "string",
+                              "unit": "short"
+                            },
+                            {
+                                "alias": "",
+                                "colorMode": null,
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)",
+                                    "rgba(237, 129, 40, 0.89)",
+                                    "rgba(50, 172, 45, 0.97)"
+                                ],
+                                "decimals": 2,
+                                "pattern": "/.*/",
+                                "thresholds": [],
+                                "type": "number",
+                                "unit": "short"
+                            }
+                        ],
+                        "title": "Active Alerts"
+                    }
+                ],
+                "title": "New row"
+            },
+            {
                 "class":"header_row",
                 "panels": [
                     {
@@ -311,8 +435,22 @@
                 "class": "row",
                 "panels": [
                     {
+                        "class": "ops_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$func(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Writes"
+                    },
+                    {
                         "class": "us_panel",
-                        "span": 4,
+                        "span": 3,
                         "targets": [
                             {
                                 "expr": "$func(rate(scylla_storage_proxy_coordinator_write_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])/($func(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]]) + 1)",
@@ -326,7 +464,7 @@
                     },
                     {
                         "class": "us_panel",
-                        "span": 4,
+                        "span": 3,
                         "targets": [
                             {
                                 "expr": "histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]], le))",
@@ -341,7 +479,7 @@
                     },
                     {
                         "class": "us_panel",
-                        "span": 4,
+                        "span": 3,
                         "targets": [
                             {
                                 "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]], le))",
@@ -359,10 +497,25 @@
             },
             {
                 "class": "row",
+
                 "panels": [
                     {
+                        "class": "ops_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$func(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Reads"
+                    },
+                    {
                         "class": "us_panel",
-                        "span": 4,
+                        "span": 3,
                         "targets": [
                             {
                                 "expr": "$func(rate(scylla_storage_proxy_coordinator_read_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])/($func(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]]) + 1)",
@@ -376,7 +529,7 @@
                     },
                     {
                         "class": "us_panel",
-                        "span": 4,
+                        "span": 3,
                         "targets": [
                             {
                                 "expr": "histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]], le))",
@@ -391,7 +544,7 @@
                     },
                     {
                         "class": "us_panel",
-                        "span": 4,
+                        "span": 3,
                         "targets": [
                             {
                                 "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]], le))",
@@ -403,158 +556,6 @@
                             }
                         ],
                         "title": "99th percentile read latency by [[by]]"
-                    }
-                ],
-                "title": "New row"
-            },
-
-            {
-                "class": "row",
-                "height": "25px",
-                "gridPos": {"h": 2},
-                "panels": [
-                    {
-                        "class": "text_header_panel",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Reads and Writes - Coordinator</h1>"
-                    },
-                    {
-                        "class": "text_header_panel",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Timeouts and Errors - Coordinator</h1>"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "height": "200px",
-                "panels": [
-                    {
-                        "class": "queue_lenght_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(scylla_storage_proxy_coordinator_foreground_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "Foreground Writes",
-                        "description": "Foreground writes are writes that weren't acknowledged yet to the application. For instance, if a single replica responded and two are needed due to the consistency level. This metric represents a queue size, not a rate. High values here correlate with increased write latencies."
-                    },
-                    {
-                        "class": "queue_lenght_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(scylla_storage_proxy_coordinator_foreground_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "Foreground Reads",
-                        "description": "Foreground reads are reads that weren't acknowledged yet to the application. For instance, if a single replica responded and two are needed due to the consistency level. This metric represents a queue size, not a rate. High values here correlate with increased read latencies."
-                    },
-                    {
-                        "class": "wps_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "Write Timeouts",
-                        "description": "Requests that Scylla tried to write but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas."
-                    },
-                    {
-                        "class": "wps_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_storage_proxy_coordinator_write_unavailable{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "Write Unavailable",
-                        "description": "Requests that Scylla did not even try to write because replicas that were needed to execute this write were unavailable. Unavailable writes are counted in the node that received the request (the coordinator), not at the replicas."
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "height": "200px",
-                "panels": [
-                    {
-                        "class": "queue_lenght_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(scylla_storage_proxy_coordinator_background_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "Background Writes",
-                        "description": "Background writes are writes that are already acknowledged to the application but have additional work to be done. For instance, if a replica responded and only one is needed, this request is still listed as a background request until all replicas respond. This metric represents a queue size, not a rate. High values here correlate with increased write latencies."
-                    },
-                    {
-                        "class": "queue_lenght_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(scylla_storage_proxy_coordinator_background_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "Background Reads",
-                        "description": "Background reads are reads that are already acknowledged to the application but have additional work to be done. For instance, if a replica responded and only one is needed, this request is still listed as a background request until all replicas respond. This metric represents a queue size, not a rate. High values here correlate with increased read latencies."
-                    },
-                    {
-                        "class": "rps_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "Read Timeouts",
-                        "description": "Requests that Scylla tried to read but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas."
-                    },
-                    {
-                        "class": "rps_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_storage_proxy_coordinator_read_unavailable{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "Read Unavailable",
-                        "description": "Requests that Scylla did not even try to read because replicas that were needed to execute this write were unavailable. Unavailable reads are counted in the node that received the request (the coordinator), not at the replicas."
                     }
                 ],
                 "title": "New row"
@@ -579,7 +580,7 @@
                         "type": "text"
                     },
                     {
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Materialized Views - Replica</h1>",
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Timeouts</h1>",
                         "editable": true,
                         "error": false,
                         "id": "auto",
@@ -629,56 +630,35 @@
                         "title": "Cache Misses",
                         "description" : "Number of rows that were not present in the cache, and had to be fetched from storage."
                     },
-                    {
-                        "class": "bytes_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(scylla_database_view_update_backlog{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "View Update Backlog",
-                        "description" : "Size in bytes of the view update backlog at each base replica."
-                    },
-                    {
-                        "class": "ops_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_database_dropped_view_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "Dropped View Updates",
-                        "description" : "Number of dropped view updates due to an excessive view update backlog."
-                    },
-                    {
-                        "class": "text_panel",
-                        "content": "",
-                        "mode": "markdown",
-                        "span": 9
-                    },
-                    {
+                     {
                         "class": "wps_panel",
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$func(scylla_storage_proxy_coordinator_current_throttled_base_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"})  by ([[by]])",
+                                "expr": "$func(irate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
                         ],
-                        "title": "Throttled Base Writes",
-                        "description" : "Currently throttled base writes, as a consequence of the respective view update backlog."
+                        "title": "Write Timeouts",
+                        "description": "Requests that Scylla tried to write but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas."
+                    },
+                    {
+                        "class": "rps_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$func(irate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Read Timeouts",
+                        "description": "Requests that Scylla tried to read but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas."
                     }
                 ],
                 "title": "New row"
@@ -721,6 +701,29 @@
                     "sort": 3
                 },
                 {
+                    "allValue": null,
+                    "current": {
+                        "text": "/var/lib/scylla",
+                        "value": "/var/lib/scylla"
+                    },
+                    "datasource": "prometheus",
+                    "hide": 0,
+                    "includeAll": false,
+                    "label": "Mounnt path",
+                    "multi": false,
+                    "name": "mount_point",
+                    "options": [],
+                    "query": "node_filesystem_avail_bytes",
+                    "refresh": 2,
+                    "regex": "/mountpoint=\"([^\"]*)\".*/",
+                    "sort": 0,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                },
+                {
                     "class": "aggregation_function"
                 },
                 {
@@ -729,14 +732,14 @@
                     "options": [
                       {
                          "selected": true,
-                         "text": "3.1",
-                         "value": "3.1"
+                         "text": "3-1",
+                         "value": "3-1"
                       }
                     ],
-                    "query": "3.1",
+                    "query": "3-1",
                     "current": {
-                        "text": "3.1",
-                        "value": "3.1"
+                        "text": "3-1",
+                        "value": "3-1"
                     }
                 }
             ]
@@ -748,7 +751,7 @@
             "from": "now-30m",
             "to": "now"
         },
-        "title": "Scylla Overview Metrics",
+        "title": "Overview",
         "overwrite": true,
         "version": 3
     }

--- a/grafana/scylla-dash.master.template.json
+++ b/grafana/scylla-dash.master.template.json
@@ -69,94 +69,6 @@
                         "title": "Leaving"
                     },
                     {
-                        "class": "text_panel",
-                        "content": "##  ",
-                        "mode": "markdown",
-                        "span": 2,
-                        "style": {}
-                    },
-                    {
-                        "class": "dashlist",
-                        "tags": [
-                            "master"
-                        ]
-                    },
-                    {
-                        "class": "alert_table",
-                        "span":4,
-                        "styles": [
-                            {
-                                "alias": "Time",
-                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                                "pattern": "Time",
-                                "link": true,
-                                "linkTooltip": "Jump to the see the node",
-                                "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_4}&from=${__cell_0}",
-                                "type": "date"
-                            },
-                            {
-                                "class":"hidden_column",
-                                "pattern": "severity"
-                            },
-                            {
-                                "class":"hidden_column",
-                                "pattern": "alertname"
-                            },
-                            {
-                                "class":"hidden_column",
-                                "pattern": "cluster"
-                            },
-                            {
-                                "class":"hidden_column",
-                                "pattern": "monitor"
-                            },
-                            {
-                                "class":"hidden_column",
-                                "pattern": "summary"
-                            },
-                            {
-                              "alias": "Instance",
-                              "colorMode": null,
-                              "colors": [
-                                "rgba(245, 54, 54, 0.9)",
-                                "rgba(237, 129, 40, 0.89)",
-                                "rgba(50, 172, 45, 0.97)"
-                              ],
-                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                              "decimals": 2,
-                              "link": true,
-                              "linkTooltip": "Jump to the see the node",
-                              "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_4}",
-                              "mappingType": 1,
-                              "pattern": "instance",
-                              "thresholds": [],
-                              "type": "string",
-                              "unit": "short"
-                            },
-                            {
-                                "alias": "",
-                                "colorMode": null,
-                                "colors": [
-                                    "rgba(245, 54, 54, 0.9)",
-                                    "rgba(237, 129, 40, 0.89)",
-                                    "rgba(50, 172, 45, 0.97)"
-                                ],
-                                "decimals": 2,
-                                "pattern": "/.*/",
-                                "thresholds": [],
-                                "type": "number",
-                                "unit": "short"
-                            }
-                        ],
-                        "title": "Active Alerts"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
                         "class": "percent_panel",
                         "span": 4,
                         "targets": [
@@ -170,22 +82,6 @@
                         ],
                         "title": "Load",
                         "description": "The percentage of the time during which Scylla utilized the CPU. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high."
-                    },
-                    {
-                        "class": "ops_panel",
-                        "span": 4,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + $func(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 4
-                            }
-                        ],
-                        "title": "Requests Served - Coordinator",
-                        "description": "Amount of requests served as the coordinator. Imbalances here represent dispersion at the client-side level or connection balancing level, not your data model."
                     },
                     {
                         "class": "single_value_table",
@@ -217,7 +113,7 @@
                               "thresholds": [],
                               "mappingType": 1,
                               "link": true,
-                              "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_6}",
+                              "linkUrl": "/d/detailed-[[dash_version]]/Detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__cell}",
                               "linkTooltip": "Jump to the detailed node information"
                             },
                             {
@@ -239,6 +135,128 @@
                             {
                                 "class":"hidden_column",
                                 "pattern": "type"
+                            },
+                            {
+                              "alias": "OS",
+                              "unit": "short",
+                              "type": "string",
+                              "decimals": 2,
+                              "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                              ],
+                              "colorMode": null,
+                              "pattern": "OS",
+                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                              "thresholds": [],
+                              "mappingType": 1,
+                              "link": true,
+                              "linkUrl": "/d/OS-[[dash_version]]/OS-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                              "linkTooltip": "Jump to the OS node information",
+                              "valueMaps": [
+                                    {
+                                      "value": "os",
+                                      "text": "OS"
+                                    }
+                                ]
+                            },
+                            {
+                              "unit": "short",
+                              "type": "string",
+                              "decimals": 2,
+                              "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                              ],
+                              "colorMode": null,
+                              "pattern": "CQL",
+                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                              "thresholds": [],
+                              "mappingType": 1,
+                              "link": true,
+                              "linkUrl": "/d/cql-[[dash_version]]/scylla-cql?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                              "linkTooltip": "Jump to the CQL information",
+                              "valueMaps": [
+                                    {
+                                      "value": "cql",
+                                      "text": "CQL"
+                                    }
+                                ]
+                            },
+                            {
+                              "unit": "short",
+                              "type": "string",
+                              "decimals": 2,
+                              "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                              ],
+                              "colorMode": null,
+                              "pattern": "Errors",
+                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                              "thresholds": [],
+                              "mappingType": 1,
+                              "link": true,
+                              "linkUrl": "/d/error-[[dash_version]]/scylla-errors?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                              "linkTooltip": "Jump to the Errors metrics information",
+                              "valueMaps": [
+                                    {
+                                      "value": "errors",
+                                      "text": "Errors"
+                                    }
+                                ]
+                            },
+                            {
+                              "unit": "short",
+                              "type": "string",
+                              "decimals": 2,
+                              "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                              ],
+                              "colorMode": null,
+                              "pattern": "IO",
+                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                              "thresholds": [],
+                              "mappingType": 1,
+                              "link": true,
+                              "linkUrl": "/d/io-[[dash_version]]/i-o?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                              "linkTooltip": "Jump to the Errors metrics information",
+                              "valueMaps": [
+                                    {
+                                      "value": "io",
+                                      "text": "IO"
+                                    }
+                                ]
+                            },
+                            {
+                              "alias": "CPU",
+                              "unit": "short",
+                              "type": "string",
+                              "decimals": 2,
+                              "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                              ],
+                              "colorMode": null,
+                              "pattern": "CPU",
+                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                              "thresholds": [],
+                              "mappingType": 1,
+                              "link": true,
+                              "linkUrl": "/d/cpu-[[dash_version]]/CPU-Metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                              "linkTooltip": "Jump to the node CPU information",
+                              "valueMaps": [
+                                    {
+                                      "value": "cpu",
+                                      "text": "CPU"
+                                    }
+                                ]
                             },
                             {
                                 "pattern": "Value",
@@ -299,6 +317,112 @@
                 "title": "New row"
             },
             {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "bytes_panel",
+                        "span": 4,
+                        "targets": [
+                            {
+                                "expr": "sum(node_filesystem_size_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])-sum(node_filesystem_avail_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Disk Size by $by"
+                    },
+                    {
+                        "class": "ops_panel",
+                        "span": 4,
+                        "targets": [
+                            {
+                                "expr": "$func(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]]) + $func(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 4
+                            }
+                        ],
+                        "title": "Requests Served - Coordinator",
+                        "description": "Amount of requests served as the coordinator. Imbalances here represent dispersion at the client-side level or connection balancing level, not your data model."
+                    },
+                    {
+                        "class": "alert_table",
+                        "span":4,
+                        "styles": [
+                            {
+                                "alias": "Time",
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                                "pattern": "Time",
+                                "link": true,
+                                "linkTooltip": "Jump to the see the node",
+                                "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}&from=${__cell_0}",
+                                "type": "date"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "severity"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "alertname"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "cluster"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "monitor"
+                            },
+                            {
+                                "class":"hidden_column",
+                                "pattern": "summary"
+                            },
+                            {
+                              "alias": "Instance",
+                              "colorMode": null,
+                              "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                              ],
+                              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                              "decimals": 2,
+                              "link": true,
+                              "linkTooltip": "Jump to the see the node",
+                              "linkUrl": "/d/detail-[[dash_version]]/scylla-per-server-metrics-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_9}",
+                              "mappingType": 1,
+                              "pattern": "instance",
+                              "thresholds": [],
+                              "type": "string",
+                              "unit": "short"
+                            },
+                            {
+                                "alias": "",
+                                "colorMode": null,
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)",
+                                    "rgba(237, 129, 40, 0.89)",
+                                    "rgba(50, 172, 45, 0.97)"
+                                ],
+                                "decimals": 2,
+                                "pattern": "/.*/",
+                                "thresholds": [],
+                                "type": "number",
+                                "unit": "short"
+                            }
+                        ],
+                        "title": "Active Alerts"
+                    }
+                ],
+                "title": "New row"
+            },
+            {
                 "class":"header_row",
                 "panels": [
                     {
@@ -311,8 +435,22 @@
                 "class": "row",
                 "panels": [
                     {
+                        "class": "ops_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$func(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Writes"
+                    },
+                    {
                         "class": "us_panel",
-                        "span": 4,
+                        "span": 3,
                         "targets": [
                             {
                                 "expr": "$func(rate(scylla_storage_proxy_coordinator_write_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])/($func(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]]) + 1)",
@@ -326,7 +464,7 @@
                     },
                     {
                         "class": "us_panel",
-                        "span": 4,
+                        "span": 3,
                         "targets": [
                             {
                                 "expr": "histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]], le))",
@@ -341,7 +479,7 @@
                     },
                     {
                         "class": "us_panel",
-                        "span": 4,
+                        "span": 3,
                         "targets": [
                             {
                                 "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]], le))",
@@ -359,10 +497,25 @@
             },
             {
                 "class": "row",
+                
                 "panels": [
                     {
+                        "class": "ops_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$func(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Reads"
+                    },
+                    {
                         "class": "us_panel",
-                        "span": 4,
+                        "span": 3,
                         "targets": [
                             {
                                 "expr": "$func(rate(scylla_storage_proxy_coordinator_read_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])/($func(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]]) + 1)",
@@ -376,7 +529,7 @@
                     },
                     {
                         "class": "us_panel",
-                        "span": 4,
+                        "span": 3,
                         "targets": [
                             {
                                 "expr": "histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]], le))",
@@ -391,7 +544,7 @@
                     },
                     {
                         "class": "us_panel",
-                        "span": 4,
+                        "span": 3,
                         "targets": [
                             {
                                 "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]], le))",
@@ -403,158 +556,6 @@
                             }
                         ],
                         "title": "99th percentile read latency by [[by]]"
-                    }
-                ],
-                "title": "New row"
-            },
-
-            {
-                "class": "row",
-                "height": "25px",
-                "gridPos": {"h": 2},
-                "panels": [
-                    {
-                        "class": "text_header_panel",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Reads and Writes - Coordinator</h1>"
-                    },
-                    {
-                        "class": "text_header_panel",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Timeouts and Errors - Coordinator</h1>"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "height": "200px",
-                "panels": [
-                    {
-                        "class": "queue_lenght_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(scylla_storage_proxy_coordinator_foreground_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "Foreground Writes",
-                        "description": "Foreground writes are writes that weren't acknowledged yet to the application. For instance, if a single replica responded and two are needed due to the consistency level. This metric represents a queue size, not a rate. High values here correlate with increased write latencies."
-                    },
-                    {
-                        "class": "queue_lenght_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(scylla_storage_proxy_coordinator_foreground_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "Foreground Reads",
-                        "description": "Foreground reads are reads that weren't acknowledged yet to the application. For instance, if a single replica responded and two are needed due to the consistency level. This metric represents a queue size, not a rate. High values here correlate with increased read latencies."
-                    },
-                    {
-                        "class": "wps_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "Write Timeouts",
-                        "description": "Requests that Scylla tried to write but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas."
-                    },
-                    {
-                        "class": "wps_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_storage_proxy_coordinator_write_unavailable{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "Write Unavailable",
-                        "description": "Requests that Scylla did not even try to write because replicas that were needed to execute this write were unavailable. Unavailable writes are counted in the node that received the request (the coordinator), not at the replicas."
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "height": "200px",
-                "panels": [
-                    {
-                        "class": "queue_lenght_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(scylla_storage_proxy_coordinator_background_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "Background Writes",
-                        "description": "Background writes are writes that are already acknowledged to the application but have additional work to be done. For instance, if a replica responded and only one is needed, this request is still listed as a background request until all replicas respond. This metric represents a queue size, not a rate. High values here correlate with increased write latencies."
-                    },
-                    {
-                        "class": "queue_lenght_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(scylla_storage_proxy_coordinator_background_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "Background Reads",
-                        "description": "Background reads are reads that are already acknowledged to the application but have additional work to be done. For instance, if a replica responded and only one is needed, this request is still listed as a background request until all replicas respond. This metric represents a queue size, not a rate. High values here correlate with increased read latencies."
-                    },
-                    {
-                        "class": "rps_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "Read Timeouts",
-                        "description": "Requests that Scylla tried to read but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas."
-                    },
-                    {
-                        "class": "rps_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_storage_proxy_coordinator_read_unavailable{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "Read Unavailable",
-                        "description": "Requests that Scylla did not even try to read because replicas that were needed to execute this write were unavailable. Unavailable reads are counted in the node that received the request (the coordinator), not at the replicas."
                     }
                 ],
                 "title": "New row"
@@ -579,7 +580,7 @@
                         "type": "text"
                     },
                     {
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Materialized Views - Replica</h1>",
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Timeouts</h1>",
                         "editable": true,
                         "error": false,
                         "id": "auto",
@@ -629,56 +630,36 @@
                         "title": "Cache Misses",
                         "description" : "Number of rows that were not present in the cache, and had to be fetched from storage."
                     },
-                    {
-                        "class": "bytes_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(scylla_database_view_update_backlog{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "View Update Backlog",
-                        "description" : "Size in bytes of the view update backlog at each base replica."
-                    },
-                    {
-                        "class": "ops_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(irate(scylla_database_dropped_view_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 10
-                            }
-                        ],
-                        "title": "Dropped View Updates",
-                        "description" : "Number of dropped view updates due to an excessive view update backlog."
-                    },
-                    {
-                        "class": "text_panel",
-                        "content": "",
-                        "mode": "markdown",
-                        "span": 9
-                    },
-                    {
+                    
+                     {
                         "class": "wps_panel",
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$func(scylla_storage_proxy_coordinator_current_throttled_base_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"})  by ([[by]])",
+                                "expr": "$func(irate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
                                 "step": 10
                             }
                         ],
-                        "title": "Throttled Base Writes",
-                        "description" : "Currently throttled base writes, as a consequence of the respective view update backlog."
+                        "title": "Write Timeouts",
+                        "description": "Requests that Scylla tried to write but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas."
+                    },
+                    {
+                        "class": "rps_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$func(irate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Read Timeouts",
+                        "description": "Requests that Scylla tried to read but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas."
                     }
                 ],
                 "title": "New row"
@@ -721,6 +702,29 @@
                     "sort": 3
                 },
                 {
+                    "allValue": null,
+                    "current": {
+                        "text": "/var/lib/scylla",
+                        "value": "/var/lib/scylla"
+                    },
+                    "datasource": "prometheus",
+                    "hide": 0,
+                    "includeAll": false,
+                    "label": "Mounnt path",
+                    "multi": false,
+                    "name": "mount_point",
+                    "options": [],
+                    "query": "node_filesystem_avail_bytes",
+                    "refresh": 2,
+                    "regex": "/mountpoint=\"([^\"]*)\".*/",
+                    "sort": 0,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                },
+                {
                     "class": "aggregation_function"
                 },
                 {
@@ -748,7 +752,7 @@
             "from": "now-30m",
             "to": "now"
         },
-        "title": "Scylla Overview Metrics",
+        "title": "Overview",
         "overwrite": true,
         "version": 3
     }

--- a/prometheus/prometheus.yml.template
+++ b/prometheus/prometheus.yml.template
@@ -34,6 +34,28 @@ scrape_configs:
       regex:  '(.*):.+'
       target_label: instance
       replacement: '${1}'
+  metric_relabel_configs:
+    - source_labels: [version]
+      regex:  '(.*)'
+      target_label: CPU
+      replacement: 'cpu'
+    - source_labels: [version]
+      regex:  '(.*)'
+      target_label: CQL
+      replacement: 'cql'
+    - source_labels: [version]
+      regex:  '(.*)'
+      target_label: OS
+      replacement: 'os'
+    - source_labels: [version]
+      regex:  '(.*)'
+      target_label: IO
+      replacement: 'io'
+    - source_labels: [version]
+      regex:  '(.*)'
+      target_label: Errors
+      replacement: 'errors'
+   
 
 - job_name: node_exporter
   honor_labels: false


### PR DESCRIPTION
This is the biggest change we have done with the dashboard layout.
We try to reduce duplications (though they are still exist) and make each dashboard more readable.

To try this PR you should use `-v master`

## Scylla dashboard - now Overview
![image](https://user-images.githubusercontent.com/2118079/60820925-2a241c80-a1ab-11e9-9e53-5b2b4156d33d.png)

## Per node - now Detailed
![image](https://user-images.githubusercontent.com/2118079/60821050-70797b80-a1ab-11e9-9af4-7b24dda84ff4.png)

## Disk I/O - now I/O
![image](https://user-images.githubusercontent.com/2118079/60821131-930b9480-a1ab-11e9-939c-e8913004eda4.png)

## Errors
![image](https://user-images.githubusercontent.com/2118079/60821200-b9313480-a1ab-11e9-85b0-ace221260b59.png)

## Per Machine - now OS
![image](https://user-images.githubusercontent.com/2118079/60821265-de25a780-a1ab-11e9-84b1-0808e058b53b.png)

## CPU Metrics
![image](https://user-images.githubusercontent.com/2118079/60821320-fdbcd000-a1ab-11e9-8e52-30742fd979d2.png)

## CQL Optimization - Now CQL
![image](https://user-images.githubusercontent.com/2118079/60821373-188f4480-a1ac-11e9-8ac2-ea780d1292e4.png)

Fixes #675
Fixes #674 
Fixes #652
Fixes #651
Fixes #650 
Fixes #645 
