### PR TITLE
Manager as Consul integration

### DIFF
--- a/prometheus/prometheus.consul.yml.template
+++ b/prometheus/prometheus.consul.yml.template
@@ -1,0 +1,88 @@
+global:
+  scrape_interval: 5s # By default, scrape targets every 5 second.
+  scrape_timeout: 4s # Timeout before trying to scape a target again
+
+  # Attach these labels to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  external_labels:
+    monitor: 'scylla-monitor'
+rule_files:
+  - /etc/prometheus/prometheus.rules.yml
+    #
+# Alerting specifies settings related to the Alertmanager.
+alerting:
+        #  alert_relabel_configs:
+        #    [ - <relabel_config> ... ]
+  alertmanagers:
+  - static_configs:
+    - targets:
+        - AM_ADDRESS
+
+scrape_configs:
+- job_name: scylla
+  honor_labels: false
+  consul_sd_configs:
+  - server: 'MANAGER_ADDRESS'
+    services:
+      - 'scylla'
+  relabel_configs:
+    - source_labels: [__meta_consul_tags]
+      separator: ','
+      regex: '([^=]+)=([^,]+)'
+      target_label: ${1}
+      replacement: ${2}
+    - source_labels: [__meta_consul_service_metadata_dc]
+      target_label: dc
+    - source_labels: [__address__]
+      regex:  '(.*):\d+'
+      target_label: instance
+      replacement: '${1}'
+  metric_relabel_configs:
+    - regex: 'help|exported_instance|type'
+      action: labeldrop
+    - source_labels: [version]
+      regex: '([0-9]+\.[0-9]+)(\.?[0-9]*).*'
+      replacement: '$1$2'
+      target_label: svr
+
+- job_name: node_exporter
+  honor_labels: false
+  consul_sd_configs:
+  - server: 'MANAGER_ADDRESS'
+    services:
+      - 'scylla'
+  relabel_configs:
+    - source_labels: [__meta_consul_tags]
+      separator: ','
+      regex: '([^=]+)=([^,]+)'
+      target_label: ${1}
+      replacement: ${2}
+    - source_labels: [__address__]
+      regex:  '(.*):\d+'
+      target_label: instance
+      replacement: '${1}'
+    - source_labels: [__meta_consul_service_metadata_dc]
+      target_label: dc
+    - source_labels: [instance]
+      regex:  '(.*)'
+      target_label: __address__
+      replacement: '${1}:9100'
+  metric_relabel_configs:
+    - regex: 'help|exported_instance|type'
+      action: labeldrop
+
+- job_name: scylla_manager
+  honor_labels: false
+  static_configs:
+    - targets:
+      - MANAGER_ADDRESS
+  metric_relabel_configs:
+    - source_labels: [host]
+      target_label: instance
+
+- job_name: 'prometheus'
+  # Override the global default and scrape targets from this job every 5 seconds.
+  scrape_interval: 5s
+  static_configs:
+    - targets:
+      - localhost:9090

--- a/prometheus/prometheus.rules.yml
+++ b/prometheus/prometheus.rules.yml
@@ -2,7 +2,7 @@ groups:
 - name: scylla.rules
   rules:
   - alert: InstanceDown
-    expr: up == 0
+    expr: up{job="scylla"} == 0
     for: 30s
     labels:
       severity: "2"

--- a/start-all.sh
+++ b/start-all.sh
@@ -28,7 +28,7 @@ else
 fi
 PROMETHEUS_RULES="$PWD/prometheus/prometheus.rules.yml"
 VERSIONS=$DEFAULT_VERSION
-usage="$(basename "$0") [-h] [--version] [-e] [-d Prometheus data-dir] [-G path to grafana data-dir] [-s scylla-target-file] [-n node-target-file] [-l] [-v comma separated versions] [-j additional dashboard to load to Grafana, multiple params are supported] [-c grafana environment variable, multiple params are supported] [-b Prometheus command line options] [-g grafana port ] [ -p prometheus port ] [-a admin password] [-m alertmanager port] [ -M scylla-manager version ] [-D encapsulate docker param] [-r alert-manager-config] [-R prometheus-alert-file] [-N manager target file] -- starts Grafana and Prometheus Docker instances"
+usage="$(basename "$0") [-h] [--version] [-e] [-d Prometheus data-dir] [-L resolve the servers from the manger running on the given address] [-G path to grafana data-dir] [-s scylla-target-file] [-n node-target-file] [-l] [-v comma separated versions] [-j additional dashboard to load to Grafana, multiple params are supported] [-c grafana environment variable, multiple params are supported] [-b Prometheus command line options] [-g grafana port ] [ -p prometheus port ] [-a admin password] [-m alertmanager port] [ -M scylla-manager version ] [-D encapsulate docker param] [-r alert-manager-config] [-R prometheus-alert-file] [-N manager target file] -- starts Grafana and Prometheus Docker instances"
 PROMETHEUS_VERSION=v2.10.0
 
 SCYLLA_TARGET_FILE=$PWD/prometheus/scylla_servers.yml
@@ -37,8 +37,9 @@ GRAFANA_ADMIN_PASSWORD=""
 ALERTMANAGER_PORT=""
 DOCKER_PARAM=""
 DATA_DIR=""
+CONSUL_ADDRESS=""
 
-while getopts ':hled:g:p:v:s:n:a:c:j:b:m:r:R:M:G:D:N:' option; do
+while getopts ':hled:g:p:v:s:n:a:c:j:b:m:r:R:M:G:D:L:N:' option; do
   case "$option" in
     h) echo "$usage"
        exit
@@ -67,6 +68,8 @@ while getopts ':hled:g:p:v:s:n:a:c:j:b:m:r:R:M:G:D:N:' option; do
        ;;
     l) DOCKER_PARAM="$DOCKER_PARAM --net=host"
        ;;
+    L) CONSUL_ADDRESS="$OPTARG"
+       ;;
     a) GRAFANA_ADMIN_PASSWORD="-a $OPTARG"
        ;;
     j) GRAFANA_DASHBOARD_ARRAY+=("$OPTARG")
@@ -90,28 +93,37 @@ while getopts ':hled:g:p:v:s:n:a:c:j:b:m:r:R:M:G:D:N:' option; do
   esac
 done
 
-if [ -z $NODE_TARGET_FILE ]; then
-   NODE_TARGET_FILE=$SCYLLA_TARGET_FILE
-fi
+if [ -z $CONSUL_ADDRESS ]; then
+    if [ -z $NODE_TARGET_FILE ]; then
+       NODE_TARGET_FILE=$SCYLLA_TARGET_FILE
+    fi
 
-if [ ! -f $SCYLLA_TARGET_FILE ]; then
-    echo "Scylla target file '${SCYLLA_TARGET_FILE}' does not exist, you can use prometheus/scylla_servers.example.yml as an example."
-    exit 1
-fi
+    if [ ! -f $SCYLLA_TARGET_FILE ]; then
+        echo "Scylla target file '${SCYLLA_TARGET_FILE}' does not exist, you can use prometheus/scylla_servers.example.yml as an example."
+        exit 1
+    fi
 
-if [ ! -f $NODE_TARGET_FILE ]; then
-    echo "Node target file '${NODE_TARGET_FILE}' does not exist"
-    exit 1
-fi
+    if [ ! -f $NODE_TARGET_FILE ]; then
+        echo "Node target file '${NODE_TARGET_FILE}' does not exist"
+        exit 1
+    fi
 
-if [ ! -f $SCYLLA_MANGER_TARGET_FILE ]; then
-    echo "Scylla-Manager target file '${SCYLLA_MANGER_TARGET_FILE}' does not exist, you can use prometheus/scylla_manager_servers.example.yml as an example."
-    exit 1
-fi
+    if [ ! -f $SCYLLA_MANGER_TARGET_FILE ]; then
+        echo "Scylla-Manager target file '${SCYLLA_MANGER_TARGET_FILE}' does not exist, you can use prometheus/scylla_manager_servers.example.yml as an example."
+        exit 1
+    fi
 
-SCYLLA_TARGET_FILE="-v "$(readlink -m $SCYLLA_TARGET_FILE)":/etc/scylla.d/prometheus/scylla_servers.yml:Z"
-SCYLLA_MANGER_TARGET_FILE="-v "$(readlink -m $SCYLLA_MANGER_TARGET_FILE)":/etc/scylla.d/prometheus/scylla_manager_servers.yml:Z"
-NODE_TARGET_FILE="-v "$(readlink -m $NODE_TARGET_FILE)":/etc/scylla.d/prometheus/node_exporter_servers.yml:Z"
+    SCYLLA_TARGET_FILE="-v "$(readlink -m $SCYLLA_TARGET_FILE)":/etc/scylla.d/prometheus/scylla_servers.yml:Z"
+    SCYLLA_MANGER_TARGET_FILE="-v "$(readlink -m $SCYLLA_MANGER_TARGET_FILE)":/etc/scylla.d/prometheus/scylla_manager_servers.yml:Z"
+    NODE_TARGET_FILE="-v "$(readlink -m $NODE_TARGET_FILE)":/etc/scylla.d/prometheus/node_exporter_servers.yml:Z"
+else
+    if [[ ! $CONSUL_ADDRESS = *":"* ]]; then
+        CONSUL_ADDRESS="$CONSUL_ADDRESS:56090"
+    fi
+    SCYLLA_TARGET_FILE=""
+    SCYLLA_MANGER_TARGET_FILE=""
+    NODE_TARGET_FILE=""
+fi
 
 if [[ $DOCKER_PARAM = *"--net=host"* ]]; then
     if [ ! -z "$ALERTMANAGER_PORT" ] || [ ! -z "$GRAFANA_PORT" ] || [ ! -z $PROMETHEUS_PORT ]; then
@@ -154,7 +166,11 @@ for val in "${PROMETHEUS_COMMAND_LINE_OPTIONS_ARRAY[@]}"; do
 done
 
 mkdir -p $PWD/prometheus/build/
-sed "s/AM_ADDRESS/$AM_ADDRESS/" $PWD/prometheus/prometheus.yml.template > $PWD/prometheus/build/prometheus.yml
+if [ -z $CONSUL_ADDRESS ]; then
+    sed "s/AM_ADDRESS/$AM_ADDRESS/" $PWD/prometheus/prometheus.yml.template > $PWD/prometheus/build/prometheus.yml
+else
+    sed "s/AM_ADDRESS/$AM_ADDRESS/" $PWD/prometheus/prometheus.consul.yml.template| sed "s/MANAGER_ADDRESS/$CONSUL_ADDRESS/" > $PWD/prometheus/build/prometheus.yml
+fi
 
 if [ -z $HOST_NETWORK ]; then
     PORT_MAPPING="-p $PROMETHEUS_PORT:9090"


### PR DESCRIPTION
This series adds an option to use scylla manger as a target configuration source.

To use it use the `-L` flag with the manager ip address.
Scylla monitoring will assume there is a node_exporter running on each scylla server.

The configuration is updated dynamically as nodes joining and leaving.

Fixes #470