### PR TITLE
remove redundant label from prometheus and make sure that the version…

### DIFF
--- a/prometheus/prometheus.yml.template
+++ b/prometheus/prometheus.yml.template
@@ -36,26 +36,27 @@ scrape_configs:
       replacement: '${1}'
   metric_relabel_configs:
     - source_labels: [version]
-      regex:  '(.*)'
+      regex:  '(.+)'
       target_label: CPU
       replacement: 'cpu'
     - source_labels: [version]
-      regex:  '(.*)'
+      regex:  '(.+)'
       target_label: CQL
       replacement: 'cql'
     - source_labels: [version]
-      regex:  '(.*)'
+      regex:  '(.+)'
       target_label: OS
       replacement: 'os'
     - source_labels: [version]
-      regex:  '(.*)'
+      regex:  '(.+)'
       target_label: IO
       replacement: 'io'
     - source_labels: [version]
-      regex:  '(.*)'
+      regex:  '(.+)'
       target_label: Errors
       replacement: 'errors'
-   
+    - regex: 'help|exported_instance|type'
+      action: labeldrop
 
 - job_name: node_exporter
   honor_labels: false


### PR DESCRIPTION
remove redundant labels from prometheus and make sure that the version label will only be added to the version

Fixes #687