### PR TITLE
Add an ad hoc filter to all dashboards

### DIFF
--- a/grafana/build/ver_2019.1/scylla-cpu.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-cpu.2019.1.json
@@ -555,6 +555,16 @@
                 "useTags": false
             },
             {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {

--- a/grafana/build/ver_2019.1/scylla-cql.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-cql.2019.1.json
@@ -2746,6 +2746,16 @@
                 "useTags": false
             },
             {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {

--- a/grafana/build/ver_2019.1/scylla-detailed.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-detailed.2019.1.json
@@ -5133,6 +5133,16 @@
                 "type": "custom"
             },
             {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {

--- a/grafana/build/ver_2019.1/scylla-errors.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-errors.2019.1.json
@@ -933,6 +933,16 @@
                 "useTags": false
             },
             {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {

--- a/grafana/build/ver_2019.1/scylla-io.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-io.2019.1.json
@@ -1957,6 +1957,16 @@
                 "useTags": false
             },
             {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {

--- a/grafana/build/ver_2019.1/scylla-os.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-os.2019.1.json
@@ -1299,6 +1299,16 @@
                 "useTags": false
             },
             {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {

--- a/grafana/build/ver_2019.1/scylla-overview.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-overview.2019.1.json
@@ -2776,6 +2776,16 @@
                 "type": "custom"
             },
             {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {

--- a/grafana/build/ver_3.0/scylla-cpu.3.0.json
+++ b/grafana/build/ver_3.0/scylla-cpu.3.0.json
@@ -555,6 +555,16 @@
                 "useTags": false
             },
             {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {

--- a/grafana/build/ver_3.0/scylla-cql.3.0.json
+++ b/grafana/build/ver_3.0/scylla-cql.3.0.json
@@ -2048,6 +2048,16 @@
                 "useTags": false
             },
             {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {

--- a/grafana/build/ver_3.0/scylla-detailed.3.0.json
+++ b/grafana/build/ver_3.0/scylla-detailed.3.0.json
@@ -5133,6 +5133,16 @@
                 "type": "custom"
             },
             {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {

--- a/grafana/build/ver_3.0/scylla-errors.3.0.json
+++ b/grafana/build/ver_3.0/scylla-errors.3.0.json
@@ -933,6 +933,16 @@
                 "useTags": false
             },
             {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {

--- a/grafana/build/ver_3.0/scylla-io.3.0.json
+++ b/grafana/build/ver_3.0/scylla-io.3.0.json
@@ -1957,6 +1957,16 @@
                 "useTags": false
             },
             {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {

--- a/grafana/build/ver_3.0/scylla-os.3.0.json
+++ b/grafana/build/ver_3.0/scylla-os.3.0.json
@@ -1299,6 +1299,16 @@
                 "useTags": false
             },
             {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {

--- a/grafana/build/ver_3.0/scylla-overview.3.0.json
+++ b/grafana/build/ver_3.0/scylla-overview.3.0.json
@@ -3210,6 +3210,16 @@
                 "type": "custom"
             },
             {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {

--- a/grafana/build/ver_3.1/scylla-cpu.3.1.json
+++ b/grafana/build/ver_3.1/scylla-cpu.3.1.json
@@ -555,6 +555,16 @@
                 "useTags": false
             },
             {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {

--- a/grafana/build/ver_3.1/scylla-cql.3.1.json
+++ b/grafana/build/ver_3.1/scylla-cql.3.1.json
@@ -2746,6 +2746,16 @@
                 "useTags": false
             },
             {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {

--- a/grafana/build/ver_3.1/scylla-detailed.3.1.json
+++ b/grafana/build/ver_3.1/scylla-detailed.3.1.json
@@ -5133,6 +5133,16 @@
                 "type": "custom"
             },
             {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {

--- a/grafana/build/ver_3.1/scylla-errors.3.1.json
+++ b/grafana/build/ver_3.1/scylla-errors.3.1.json
@@ -933,6 +933,16 @@
                 "useTags": false
             },
             {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {

--- a/grafana/build/ver_3.1/scylla-io.3.1.json
+++ b/grafana/build/ver_3.1/scylla-io.3.1.json
@@ -1957,6 +1957,16 @@
                 "useTags": false
             },
             {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {

--- a/grafana/build/ver_3.1/scylla-os.3.1.json
+++ b/grafana/build/ver_3.1/scylla-os.3.1.json
@@ -1299,6 +1299,16 @@
                 "useTags": false
             },
             {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {

--- a/grafana/build/ver_3.1/scylla-overview.3.1.json
+++ b/grafana/build/ver_3.1/scylla-overview.3.1.json
@@ -2776,6 +2776,16 @@
                 "type": "custom"
             },
             {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {

--- a/grafana/build/ver_3.2/scylla-cpu.3.2.json
+++ b/grafana/build/ver_3.2/scylla-cpu.3.2.json
@@ -555,6 +555,16 @@
                 "useTags": false
             },
             {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {

--- a/grafana/build/ver_3.2/scylla-cql.3.2.json
+++ b/grafana/build/ver_3.2/scylla-cql.3.2.json
@@ -2746,6 +2746,16 @@
                 "useTags": false
             },
             {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {

--- a/grafana/build/ver_3.2/scylla-detailed.3.2.json
+++ b/grafana/build/ver_3.2/scylla-detailed.3.2.json
@@ -5133,6 +5133,16 @@
                 "type": "custom"
             },
             {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {

--- a/grafana/build/ver_3.2/scylla-errors.3.2.json
+++ b/grafana/build/ver_3.2/scylla-errors.3.2.json
@@ -933,6 +933,16 @@
                 "useTags": false
             },
             {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {

--- a/grafana/build/ver_3.2/scylla-io.3.2.json
+++ b/grafana/build/ver_3.2/scylla-io.3.2.json
@@ -1957,6 +1957,16 @@
                 "useTags": false
             },
             {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {

--- a/grafana/build/ver_3.2/scylla-os.3.2.json
+++ b/grafana/build/ver_3.2/scylla-os.3.2.json
@@ -1299,6 +1299,16 @@
                 "useTags": false
             },
             {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {

--- a/grafana/build/ver_3.2/scylla-overview.3.2.json
+++ b/grafana/build/ver_3.2/scylla-overview.3.2.json
@@ -2776,6 +2776,16 @@
                 "type": "custom"
             },
             {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {

--- a/grafana/scylla-cpu.2019.1.template.json
+++ b/grafana/scylla-cpu.2019.1.template.json
@@ -119,6 +119,9 @@
                     "sort": 3
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "2019.1",

--- a/grafana/scylla-cpu.3.0.template.json
+++ b/grafana/scylla-cpu.3.0.template.json
@@ -118,6 +118,9 @@
                     "sort": 3
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "3.0",

--- a/grafana/scylla-cpu.3.1.template.json
+++ b/grafana/scylla-cpu.3.1.template.json
@@ -118,6 +118,9 @@
                     "sort": 3
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "3.1",

--- a/grafana/scylla-cpu.3.2.template.json
+++ b/grafana/scylla-cpu.3.2.template.json
@@ -118,6 +118,9 @@
                     "sort": 3
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "3.2",

--- a/grafana/scylla-cpu.master.template.json
+++ b/grafana/scylla-cpu.master.template.json
@@ -118,6 +118,9 @@
                     "sort": 3
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "master",

--- a/grafana/scylla-cql.2019.1.template.json
+++ b/grafana/scylla-cql.2019.1.template.json
@@ -582,6 +582,9 @@
                     "sort": 3
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "2019.1",

--- a/grafana/scylla-cql.3.0.template.json
+++ b/grafana/scylla-cql.3.0.template.json
@@ -429,6 +429,9 @@
                     "sort": 3
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "3.0",

--- a/grafana/scylla-cql.3.1.template.json
+++ b/grafana/scylla-cql.3.1.template.json
@@ -582,6 +582,9 @@
                     "sort": 3
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "3.1",

--- a/grafana/scylla-cql.3.2.template.json
+++ b/grafana/scylla-cql.3.2.template.json
@@ -582,6 +582,9 @@
                     "sort": 3
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "3.2",

--- a/grafana/scylla-cql.master.template.json
+++ b/grafana/scylla-cql.master.template.json
@@ -582,6 +582,9 @@
                     "sort": 3
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "master",

--- a/grafana/scylla-detailed.2019.1.template.json
+++ b/grafana/scylla-detailed.2019.1.template.json
@@ -902,6 +902,9 @@
                     "class": "aggregation_function"
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "2019.1",

--- a/grafana/scylla-detailed.3.0.template.json
+++ b/grafana/scylla-detailed.3.0.template.json
@@ -902,6 +902,9 @@
                     "class": "aggregation_function"
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "3.0",

--- a/grafana/scylla-detailed.3.1.template.json
+++ b/grafana/scylla-detailed.3.1.template.json
@@ -902,6 +902,9 @@
                     "class": "aggregation_function"
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "3.1",

--- a/grafana/scylla-detailed.3.2.template.json
+++ b/grafana/scylla-detailed.3.2.template.json
@@ -902,6 +902,9 @@
                     "class": "aggregation_function"
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "3.2",

--- a/grafana/scylla-detailed.master.template.json
+++ b/grafana/scylla-detailed.master.template.json
@@ -902,6 +902,9 @@
                     "class": "aggregation_function"
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "master",

--- a/grafana/scylla-errors.2019.1.template.json
+++ b/grafana/scylla-errors.2019.1.template.json
@@ -216,6 +216,9 @@
                     "sort": 3
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "2019.1",

--- a/grafana/scylla-errors.3.0.template.json
+++ b/grafana/scylla-errors.3.0.template.json
@@ -216,6 +216,9 @@
                     "sort": 3
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "3.0",

--- a/grafana/scylla-errors.3.1.template.json
+++ b/grafana/scylla-errors.3.1.template.json
@@ -216,6 +216,9 @@
                     "sort": 3
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "3.1",

--- a/grafana/scylla-errors.3.2.template.json
+++ b/grafana/scylla-errors.3.2.template.json
@@ -216,6 +216,9 @@
                     "sort": 3
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "3.2",

--- a/grafana/scylla-errors.master.template.json
+++ b/grafana/scylla-errors.master.template.json
@@ -216,6 +216,9 @@
                     "sort": 3
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "master",

--- a/grafana/scylla-io.2019.1.template.json
+++ b/grafana/scylla-io.2019.1.template.json
@@ -329,6 +329,9 @@
                     "sort": 3
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "2019.1",

--- a/grafana/scylla-io.3.0.template.json
+++ b/grafana/scylla-io.3.0.template.json
@@ -329,6 +329,9 @@
                     "sort": 3
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "3.0",

--- a/grafana/scylla-io.3.1.template.json
+++ b/grafana/scylla-io.3.1.template.json
@@ -329,6 +329,9 @@
                     "sort": 3
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "3.1",

--- a/grafana/scylla-io.3.2.template.json
+++ b/grafana/scylla-io.3.2.template.json
@@ -329,6 +329,9 @@
                     "sort": 3
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "3.2",

--- a/grafana/scylla-io.master.template.json
+++ b/grafana/scylla-io.master.template.json
@@ -329,6 +329,9 @@
                     "sort": 3
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "master",

--- a/grafana/scylla-os.2019.1.template.json
+++ b/grafana/scylla-os.2019.1.template.json
@@ -429,6 +429,9 @@
                     "useTags": false
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "2019.1",

--- a/grafana/scylla-os.3.0.template.json
+++ b/grafana/scylla-os.3.0.template.json
@@ -429,6 +429,9 @@
                     "useTags": false
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "3.0",

--- a/grafana/scylla-os.3.1.template.json
+++ b/grafana/scylla-os.3.1.template.json
@@ -429,6 +429,9 @@
                     "useTags": false
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "3.1",

--- a/grafana/scylla-os.3.2.template.json
+++ b/grafana/scylla-os.3.2.template.json
@@ -429,6 +429,9 @@
                     "useTags": false
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "3.2",

--- a/grafana/scylla-os.master.template.json
+++ b/grafana/scylla-os.master.template.json
@@ -429,6 +429,9 @@
                     "useTags": false
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "master",

--- a/grafana/scylla-overview.2019.1.template.json
+++ b/grafana/scylla-overview.2019.1.template.json
@@ -735,6 +735,9 @@
                     "class": "aggregation_function"
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "2019-1",

--- a/grafana/scylla-overview.3.0.template.json
+++ b/grafana/scylla-overview.3.0.template.json
@@ -845,6 +845,9 @@
                     "class": "aggregation_function"
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "3-0",

--- a/grafana/scylla-overview.3.1.template.json
+++ b/grafana/scylla-overview.3.1.template.json
@@ -735,6 +735,9 @@
                     "class": "aggregation_function"
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "3-1",

--- a/grafana/scylla-overview.3.2.template.json
+++ b/grafana/scylla-overview.3.2.template.json
@@ -735,6 +735,9 @@
                     "class": "aggregation_function"
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "3-2",

--- a/grafana/scylla-overview.master.template.json
+++ b/grafana/scylla-overview.master.template.json
@@ -735,6 +735,9 @@
                     "class": "aggregation_function"
                 },
                 {
+                    "class": "adhoc_filter"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "master",

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -1011,6 +1011,15 @@
             "titleFormat": "restart",
             "type": "tags"
       },
+      "adhoc_filter" : {
+        "datasource": "prometheus",
+        "filters": [],
+        "hide": 0,
+        "label": "ad hoc",
+        "name": "adhoc",
+        "skipUrlSync": false,
+        "type": "adhoc"
+      },
         "by_template_var": {
                     "allValue": null,
                     "current": {


### PR DESCRIPTION
Grafana 6 support an ad-hoc functionality, this filter can be set on any label and can contain multiple parts
Fixes #773 

An example of using the filter:
![image](https://user-images.githubusercontent.com/2118079/70722927-c0331480-1d00-11ea-891c-d0045e6b4ef3.png)
