### PR TITLE
Allow setting the role of the anonymous user

### DIFF
--- a/start-all.sh
+++ b/start-all.sh
@@ -28,7 +28,7 @@ else
 fi
 PROMETHEUS_RULES="$PWD/prometheus/prometheus.rules.yml"
 VERSIONS=$DEFAULT_VERSION
-usage="$(basename "$0") [-h] [--version] [-e] [-d Prometheus data-dir] [-L resolve the servers from the manger running on the given address] [-G path to grafana data-dir] [-s scylla-target-file] [-n node-target-file] [-l] [-v comma separated versions] [-j additional dashboard to load to Grafana, multiple params are supported] [-c grafana environment variable, multiple params are supported] [-b Prometheus command line options] [-g grafana port ] [ -p prometheus port ] [-a admin password] [-m alertmanager port] [ -M scylla-manager version ] [-D encapsulate docker param] [-r alert-manager-config] [-R prometheus-alert-file] [-N manager target file] [-A bind-to-ip-address] [-C alertmanager commands] -- starts Grafana and Prometheus Docker instances"
+usage="$(basename "$0") [-h] [--version] [-e] [-d Prometheus data-dir] [-L resolve the servers from the manger running on the given address] [-G path to grafana data-dir] [-s scylla-target-file] [-n node-target-file] [-l] [-v comma separated versions] [-j additional dashboard to load to Grafana, multiple params are supported] [-c grafana environment variable, multiple params are supported] [-b Prometheus command line options] [-g grafana port ] [ -p prometheus port ] [-a admin password] [-m alertmanager port] [ -M scylla-manager version ] [-D encapsulate docker param] [-r alert-manager-config] [-R prometheus-alert-file] [-N manager target file] [-A bind-to-ip-address] [-C alertmanager commands] [-Q Grafana anonymous role (Admin/Editor/Viewer)] -- starts Grafana and Prometheus Docker instances"
 PROMETHEUS_VERSION=v2.15.2
 
 SCYLLA_TARGET_FILES=($PWD/prometheus/scylla_servers.yml $PWD/scylla_servers.yml)
@@ -40,8 +40,9 @@ DATA_DIR=""
 CONSUL_ADDRESS=""
 BIND_ADDRESS=""
 BIND_ADDRESS_CONFIG=""
+GRAFNA_ANONYMOUS_ROLE=""
 
-while getopts ':hled:g:p:v:s:n:a:c:j:b:m:r:R:M:G:D:L:N:C:A:' option; do
+while getopts ':hled:g:p:v:s:n:a:c:j:b:m:r:R:M:G:D:L:N:C:Q:A:' option; do
   case "$option" in
     h) echo "$usage"
        exit
@@ -64,6 +65,8 @@ while getopts ':hled:g:p:v:s:n:a:c:j:b:m:r:R:M:G:D:L:N:C:A:' option; do
     g) GRAFANA_PORT="-g $OPTARG"
        ;;
     m) ALERTMANAGER_PORT="-p $OPTARG"
+       ;;
+    Q) GRAFNA_ANONYMOUS_ROLE="-Q $OPTARG"
        ;;
     p) PROMETHEUS_PORT=$OPTARG
        ;;
@@ -269,4 +272,4 @@ for val in "${GRAFANA_DASHBOARD_ARRAY[@]}"; do
         GRAFANA_DASHBOARD_COMMAND="$GRAFANA_DASHBOARD_COMMAND -j $val"
 done
 
-./start-grafana.sh $BIND_ADDRESS_CONFIG -p $DB_ADDRESS -D "$DOCKER_PARAM" $GRAFANA_PORT $EXTERNAL_VOLUME -m $AM_ADDRESS -M $MANAGER_VERSION -v $VERSIONS $GRAFANA_ENV_COMMAND $GRAFANA_DASHBOARD_COMMAND $GRAFANA_ADMIN_PASSWORD
+./start-grafana.sh $BIND_ADDRESS_CONFIG -p $DB_ADDRESS $GRAFNA_ANONYMOUS_ROLE -D "$DOCKER_PARAM" $GRAFANA_PORT $EXTERNAL_VOLUME -m $AM_ADDRESS -M $MANAGER_VERSION -v $VERSIONS $GRAFANA_ENV_COMMAND $GRAFANA_DASHBOARD_COMMAND $GRAFANA_ADMIN_PASSWORD

--- a/start-grafana.sh
+++ b/start-grafana.sh
@@ -17,10 +17,11 @@ AM_ADDRESS=""
 DOCKER_PARAM=""
 EXTERNAL_VOLUME=""
 BIND_ADDRESS=""
+ANONYMOUS_ROLE="Admin"
 
-usage="$(basename "$0") [-h] [-v comma separated versions ] [-g grafana port ] [-G path to external dir] [-n grafana container name ] [-p ip:port address of prometheus ] [-j additional dashboard to load to Grafana, multiple params are supported] [-c grafana enviroment variable, multiple params are supported] [-x http_proxy_host:port] [-m alert_manager address] [-a admin password] [ -M scylla-manager version ] [-D encapsulate docker param] -- loads the prometheus datasource and the Scylla dashboards into an existing grafana installation"
+usage="$(basename "$0") [-h] [-v comma separated versions ] [-g grafana port ] [-G path to external dir] [-n grafana container name ] [-p ip:port address of prometheus ] [-j additional dashboard to load to Grafana, multiple params are supported] [-c grafana enviroment variable, multiple params are supported] [-x http_proxy_host:port] [-m alert_manager address] [-a admin password] [ -M scylla-manager version ] [-D encapsulate docker param] [-Q Grafana anonymous role (Admin/Editor/Viewer)] -- loads the prometheus datasource and the Scylla dashboards into an existing grafana installation"
 
-while getopts ':hlg:n:p:v:a:x:c:j:m:G:M:D:A:' option; do
+while getopts ':hlg:n:p:v:a:x:c:j:m:G:M:D:A:Q:' option; do
   case "$option" in
     h) echo "$usage"
        exit
@@ -43,6 +44,8 @@ while getopts ':hlg:n:p:v:a:x:c:j:m:G:M:D:A:' option; do
     l) DOCKER_PARAM="$DOCKER_PARAM --net=host"
        ;;
     D) DOCKER_PARAM="$DOCKER_PARAM $OPTARG"
+       ;;
+    Q) ANONYMOUS_ROLE=$OPTARG
        ;;
     a) GRAFANA_ADMIN_PASSWORD=$OPTARG
        GRAFANA_AUTH=true
@@ -119,7 +122,7 @@ fi
 docker run -d $DOCKER_PARAM -i $USER_PERMISSIONS $PORT_MAPPING \
      -e "GF_AUTH_BASIC_ENABLED=$GRAFANA_AUTH" \
      -e "GF_AUTH_ANONYMOUS_ENABLED=$GRAFANA_AUTH_ANONYMOUS" \
-     -e "GF_AUTH_ANONYMOUS_ORG_ROLE=Admin" \
+     -e "GF_AUTH_ANONYMOUS_ORG_ROLE=$ANONYMOUS_ROLE" \
      -e "GF_PANELS_DISABLE_SANITIZE_HTML=true" \
      -v $PWD/grafana/build:/var/lib/grafana/dashboards:z \
      -v $PWD/grafana/plugins:/var/lib/grafana/plugins:z \


### PR DESCRIPTION
This patch allows adding the -Q command line option with a role type
that will be used by the anonymous user.

Fixes #822
With the default Admin role, the dashboard looks like:
![image](https://user-images.githubusercontent.com/2118079/74719891-8a009c80-523d-11ea-8457-4aa4fe663733.png)
With the Viewer role the dashboard looks like:
![image](https://user-images.githubusercontent.com/2118079/74719946-9be23f80-523d-11ea-896d-3551b57d588a.png)
