### PR TITLE
Add annotation when Task is done

### DIFF
--- a/grafana/build/manager_2.0/scylla-manager.2.0.json
+++ b/grafana/build/manager_2.0/scylla-manager.2.0.json
@@ -41,18 +41,18 @@
                 "type": "tags"
             },
             {
-                "class": "annotation_manager_task_failed",
+                "class": "annotation_manager_task_completed",
                 "datasource": "prometheus",
-                "enable": false,
-                "expr": "changes(scylla_manager_task_run_total{status=\"ERROR\"}[1m])>0",
+                "enable": true,
+                "expr": "changes(scylla_manager_task_run_total{}[1m])>0",
                 "hide": false,
-                "iconColor": "rgba(255, 96, 96, 1)",
+                "iconColor": "#73BF69",
                 "limit": 100,
-                "name": "Error",
+                "name": "Done",
                 "showIn": 0,
-                "tagKeys": "type",
+                "tagKeys": "type,status",
                 "tags": [],
-                "titleFormat": "Task failed",
+                "titleFormat": "Task Completed",
                 "type": "tags"
             }
         ]

--- a/grafana/build/manager_master/scylla-manager.master.json
+++ b/grafana/build/manager_master/scylla-manager.master.json
@@ -41,18 +41,18 @@
                 "type": "tags"
             },
             {
-                "class": "annotation_manager_task_failed",
+                "class": "annotation_manager_task_completed",
                 "datasource": "prometheus",
-                "enable": false,
-                "expr": "changes(scylla_manager_task_run_total{status=\"ERROR\"}[1m])>0",
+                "enable": true,
+                "expr": "changes(scylla_manager_task_run_total{}[1m])>0",
                 "hide": false,
-                "iconColor": "rgba(255, 96, 96, 1)",
+                "iconColor": "#73BF69",
                 "limit": 100,
-                "name": "Error",
+                "name": "Done",
                 "showIn": 0,
-                "tagKeys": "type",
+                "tagKeys": "type,status",
                 "tags": [],
-                "titleFormat": "Task failed",
+                "titleFormat": "Task Completed",
                 "type": "tags"
             }
         ]

--- a/grafana/scylla-manager.2.0.template.json
+++ b/grafana/scylla-manager.2.0.template.json
@@ -219,7 +219,7 @@
               "class" : "annotation_manager_task"
               },
               {
-              "class" : "annotation_manager_task_failed"
+              "class" : "annotation_manager_task_completed"
               }
             ]
         },

--- a/grafana/scylla-manager.master.template.json
+++ b/grafana/scylla-manager.master.template.json
@@ -219,7 +219,7 @@
               "class" : "annotation_manager_task"
               },
               {
-              "class" : "annotation_manager_task_failed"
+              "class" : "annotation_manager_task_completed"
               }
           ]
         },

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -1046,18 +1046,18 @@
         "titleFormat": "Started",
         "type": "tags"
       },
-      "annotation_manager_task_failed": {
+      "annotation_manager_task_completed": {
         "datasource": "prometheus",
-        "enable": false,
-        "expr": "changes(scylla_manager_task_run_total{status=\"ERROR\"}[1m])>0",
+        "enable": true,
+        "expr": "changes(scylla_manager_task_run_total{}[1m])>0",
         "hide": false,
-        "iconColor": "rgba(255, 96, 96, 1)",
+        "iconColor": "#73BF69",
         "limit": 100,
-        "name": "Error",
+        "name": "Done",
         "showIn": 0,
-        "tagKeys": "type",
+        "tagKeys": "type,status",
         "tags": [],
-        "titleFormat": "Task failed",
+        "titleFormat": "Task Completed",
         "type": "tags"
       },
       "adhoc_filter" : {


### PR DESCRIPTION
This patch changes the annotations, so instead of only report an error, it now shows when a task is done and adds as a label the status of the task completion
![Screenshot from 2020-03-12 16-01-24](https://user-images.githubusercontent.com/2118079/76529838-839bc400-647b-11ea-8618-0afa89493acd.png)

Fixes #836