### PR TITLE
Updates in the readme for python3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,8 @@ If you are running older docker version, remove it first by following the instru
 ##### Complete Prerequisites Installation
 
 ```bash
-sudo yum install -y git python-pip
-sudo pip install --upgrade pip
-sudo pip install pyyaml
+sudo yum install -y epel-release
+sudo yum install -y git python36 python36-PyYAML
 ```
 #### Ubuntu 16.04: Prerequisites Installation
 
@@ -51,9 +50,8 @@ On Ubuntu, the latest package name is `docker-ce` for "Community Edition". You m
 ##### Complete Prerequisites Installation
 
 ```bash
-sudo apt-get update && apt-get install -y python-pip
-sudo pip install --upgrade pip
-sudo pip install pyyaml
+sudo apt-get update 
+sudo apt-get install -y python3 python3-yaml
 ```
 
 ### Docker Post Installation


### PR DESCRIPTION
HI. I have installed scylla-monitoring lately, and while doing so I encountered a problem with the "copy/paste" installation of python in the readme. The scripts `genconfig.py` and `make_dashboards.py` were updated to use python3, however the instruction is still for python in version 2. Also I have added some small update to not install dependency through `pip` but use the distribution packages as it is often preferred way of maintaining the global python packages. Tested on Ubuntu 16.04 (yaml version 3.11) 18.04 (yaml version 3.12) and Centos 7.3 (yaml version 3.12). Looking at change log for PyYAML it looks like it was mostly porting to never versions of python and dropping support for the older ones and the API of functions that are used here did not change. 