### PR TITLE
Using Row panel for CPU and IO Queue information

### DIFF
--- a/grafana/build/ver_2019.1/scylla-cpu.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-cpu.2019.1.json
@@ -257,7 +257,7 @@
         },
         {
             "class": "plain_text",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Task Quota Violation</h1>",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Information by Task Group</h1>",
             "datasource": null,
             "editable": true,
             "error": false,
@@ -279,13 +279,28 @@
             "type": "text"
         },
         {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 12
+            },
+            "id": 5,
+            "panels": [],
+            "repeat": "group",
+            "title": "$group",
+            "type": "row"
+        },
+        {
             "aliasColors": {},
             "bars": false,
             "class": "ms_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
-            "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. The maximum amount of time during which a task group can run is called the \"task quota\". Some task groups may disrespect that and run for longer. This may cause latency issues",
+            "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. This graph shows how much time was spent in $group group",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -293,12 +308,12 @@
             "grid": {},
             "gridPos": {
                 "h": 6,
-                "w": 6,
+                "w": 8,
                 "x": 0,
-                "y": 12
+                "y": 13
             },
             "hiddenSeries": false,
-            "id": 5,
+            "id": 6,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -320,10 +335,106 @@
             "pointradius": 1,
             "points": false,
             "renderer": "flot",
-            "repeat": "group",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 3,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_scheduler_runtime_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Time used by [[by]] - $group",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ms",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ms_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. The maximum amount of time during which a task group can run is called the \"task quota\". Some task groups may disrespect that and run for longer. This may cause latency issues",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 13
+            },
+            "hiddenSeries": false,
+            "id": 7,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -358,6 +469,103 @@
             "yaxes": [
                 {
                     "format": "ms",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Shares assigned to the $group. Shares determine how Scylla reactor distributes the task quotas between groups (Higher share gets more quotas)",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 13
+            },
+            "hiddenSeries": false,
+            "id": 8,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(scylla_scheduler_shares{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Scheduler shares [[by]] - $group",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_2019.1/scylla-cpu.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-cpu.2019.1.json
@@ -59,203 +59,6 @@
             "type": "text"
         },
         {
-            "aliasColors": {},
-            "bars": false,
-            "class": "percent_panel",
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "prometheus",
-            "description": "the percentage of the time during which the CPU is utilized by Scylla. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "fillGradient": 0,
-            "grid": {},
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 0,
-                "y": 4
-            },
-            "hiddenSeries": false,
-            "id": 2,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "options": {
-                "dataLinks": []
-            },
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "spaceLength": 10,
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "CPU Utilization per [[by]]",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-                {
-                    "format": "percent",
-                    "logBase": 1,
-                    "max": 101,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "percent_panel",
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "prometheus",
-            "description": "Time spent handling foreground requests (like reads, writes, and some system tasks). The remaining time is either idle, or used by background load like compactions and repairs. Background load in Scylla is opportunistic: background requests will try to use all resources available to complete as fast as possible and rely on the schedulers to provide isolation. This graph is better understood in conjunction with the main CPU load graph. For example, if there are spikes in CPU load that are not present in this graph, that indicates that the foreground load itself is stable.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "fillGradient": 0,
-            "grid": {},
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 10,
-                "y": 4
-            },
-            "hiddenSeries": false,
-            "id": 3,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "options": {
-                "dataLinks": []
-            },
-            "percentage": false,
-            "pointradius": 1,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "spaceLength": 10,
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "avg(irate(scylla_scheduler_runtime_ms{group=\"main\",instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])/10 + avg(irate(scylla_scheduler_runtime_ms{group=\"statement\",instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])/10",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 30
-                }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "Foreground CPU Utilization by [[by]]",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-                {
-                    "format": "percent",
-                    "logBase": 1,
-                    "max": 101,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
-        },
-        {
             "class": "plain_text",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Information by Task Group</h1>",
             "datasource": null,
@@ -265,9 +68,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 10
+                "y": 4
             },
-            "id": 4,
+            "id": 2,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -285,9 +88,9 @@
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 12
+                "y": 6
             },
-            "id": 5,
+            "id": 3,
             "panels": [],
             "repeat": "group",
             "title": "$group",
@@ -310,10 +113,10 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 13
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 6,
+            "id": 4,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -407,10 +210,10 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 13
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 7,
+            "id": 5,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -504,10 +307,10 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 13
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 8,
+            "id": 6,
             "isNew": true,
             "legend": {
                 "avg": false,

--- a/grafana/build/ver_2019.1/scylla-io.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-io.2019.1.json
@@ -60,7 +60,7 @@
         },
         {
             "class": "plain_text",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue delay</h1>",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue Information</h1>",
             "datasource": null,
             "editable": true,
             "error": false,
@@ -82,6 +82,21 @@
             "type": "text"
         },
         {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 6
+            },
+            "id": 3,
+            "panels": [],
+            "repeat": "classes",
+            "title": "$classes",
+            "type": "row"
+        },
+        {
             "aliasColors": {},
             "bars": false,
             "class": "us_panel",
@@ -97,10 +112,10 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 6
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 3,
+            "id": 4,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -122,7 +137,6 @@
             "pointradius": 5,
             "points": false,
             "renderer": "flot",
-            "repeat": "classes",
             "seriesOverrides": [
                 {}
             ],
@@ -181,29 +195,6 @@
             }
         },
         {
-            "class": "plain_text",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue total bytes</h1>",
-            "datasource": null,
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 2,
-                "w": 24,
-                "x": 0,
-                "y": 12
-            },
-            "id": 4,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "options": {},
-            "span": 12,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
             "aliasColors": {},
             "bars": false,
             "class": "bps_panel",
@@ -218,8 +209,8 @@
             "gridPos": {
                 "h": 6,
                 "w": 8,
-                "x": 0,
-                "y": 14
+                "x": 8,
+                "y": 7
             },
             "hiddenSeries": false,
             "id": 5,
@@ -244,7 +235,6 @@
             "pointradius": 5,
             "points": false,
             "renderer": "flot",
-            "repeat": "classes",
             "seriesOverrides": [],
             "spaceLength": 10,
             "span": 4,
@@ -301,29 +291,6 @@
             }
         },
         {
-            "class": "plain_text",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue total operations</h1>",
-            "datasource": null,
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 2,
-                "w": 24,
-                "x": 0,
-                "y": 20
-            },
-            "id": 6,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "options": {},
-            "span": 12,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
             "aliasColors": {},
             "bars": false,
             "class": "iops_panel",
@@ -338,11 +305,11 @@
             "gridPos": {
                 "h": 6,
                 "w": 8,
-                "x": 0,
-                "y": 22
+                "x": 16,
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 7,
+            "id": 6,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -364,7 +331,6 @@
             "pointradius": 5,
             "points": false,
             "renderer": "flot",
-            "repeat": "classes",
             "seriesOverrides": [],
             "spaceLength": 10,
             "span": 4,

--- a/grafana/build/ver_3.0/scylla-cpu.3.0.json
+++ b/grafana/build/ver_3.0/scylla-cpu.3.0.json
@@ -59,203 +59,6 @@
             "type": "text"
         },
         {
-            "aliasColors": {},
-            "bars": false,
-            "class": "percent_panel",
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "prometheus",
-            "description": "the percentage of the time during which the CPU is utilized by Scylla. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "fillGradient": 0,
-            "grid": {},
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 0,
-                "y": 4
-            },
-            "hiddenSeries": false,
-            "id": 2,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "options": {
-                "dataLinks": []
-            },
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "spaceLength": 10,
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "CPU Utilization per [[by]]",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-                {
-                    "format": "percent",
-                    "logBase": 1,
-                    "max": 101,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "percent_panel",
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "prometheus",
-            "description": "Time spent handling foreground requests (like reads, writes, and some system tasks). The remaining time is either idle, or used by background load like compactions and repairs. Background load in Scylla is opportunistic: background requests will try to use all resources available to complete as fast as possible and rely on the schedulers to provide isolation. This graph is better understood in conjunction with the main CPU load graph. For example, if there are spikes in CPU load that are not present in this graph, that indicates that the foreground load itself is stable.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "fillGradient": 0,
-            "grid": {},
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 10,
-                "y": 4
-            },
-            "hiddenSeries": false,
-            "id": 3,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "options": {
-                "dataLinks": []
-            },
-            "percentage": false,
-            "pointradius": 1,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "spaceLength": 10,
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "avg(irate(scylla_scheduler_runtime_ms{group=\"main\",instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])/10 + avg(irate(scylla_scheduler_runtime_ms{group=\"statement\",instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])/10",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 30
-                }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "Foreground CPU Utilization by [[by]]",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-                {
-                    "format": "percent",
-                    "logBase": 1,
-                    "max": 101,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
-        },
-        {
             "class": "plain_text",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Task Quota Violation</h1>",
             "datasource": null,
@@ -265,9 +68,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 10
+                "y": 4
             },
-            "id": 4,
+            "id": 2,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -295,10 +98,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 12
+                "y": 6
             },
             "hiddenSeries": false,
-            "id": 5,
+            "id": 3,
             "isNew": true,
             "legend": {
                 "avg": false,

--- a/grafana/build/ver_3.1/scylla-cpu.3.1.json
+++ b/grafana/build/ver_3.1/scylla-cpu.3.1.json
@@ -257,7 +257,7 @@
         },
         {
             "class": "plain_text",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Task Quota Violation</h1>",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Information by Task Group</h1>",
             "datasource": null,
             "editable": true,
             "error": false,
@@ -279,13 +279,28 @@
             "type": "text"
         },
         {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 12
+            },
+            "id": 5,
+            "panels": [],
+            "repeat": "group",
+            "title": "$group",
+            "type": "row"
+        },
+        {
             "aliasColors": {},
             "bars": false,
             "class": "ms_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
-            "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. The maximum amount of time during which a task group can run is called the \"task quota\". Some task groups may disrespect that and run for longer. This may cause latency issues",
+            "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. This graph shows how much time was spent in $group group",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -293,12 +308,12 @@
             "grid": {},
             "gridPos": {
                 "h": 6,
-                "w": 6,
+                "w": 8,
                 "x": 0,
-                "y": 12
+                "y": 13
             },
             "hiddenSeries": false,
-            "id": 5,
+            "id": 6,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -320,10 +335,106 @@
             "pointradius": 1,
             "points": false,
             "renderer": "flot",
-            "repeat": "group",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 3,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_scheduler_runtime_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Time used by [[by]] - $group",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ms",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ms_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. The maximum amount of time during which a task group can run is called the \"task quota\". Some task groups may disrespect that and run for longer. This may cause latency issues",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 13
+            },
+            "hiddenSeries": false,
+            "id": 7,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -358,6 +469,103 @@
             "yaxes": [
                 {
                     "format": "ms",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Shares assigned to the $group. Shares determine how Scylla reactor distributes the task quotas between groups (Higher share gets more quotas)",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 13
+            },
+            "hiddenSeries": false,
+            "id": 8,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(scylla_scheduler_shares{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Scheduler shares [[by]] - $group",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_3.1/scylla-cpu.3.1.json
+++ b/grafana/build/ver_3.1/scylla-cpu.3.1.json
@@ -59,203 +59,6 @@
             "type": "text"
         },
         {
-            "aliasColors": {},
-            "bars": false,
-            "class": "percent_panel",
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "prometheus",
-            "description": "the percentage of the time during which the CPU is utilized by Scylla. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "fillGradient": 0,
-            "grid": {},
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 0,
-                "y": 4
-            },
-            "hiddenSeries": false,
-            "id": 2,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "options": {
-                "dataLinks": []
-            },
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "spaceLength": 10,
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "CPU Utilization per [[by]]",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-                {
-                    "format": "percent",
-                    "logBase": 1,
-                    "max": 101,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "percent_panel",
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "prometheus",
-            "description": "Time spent handling foreground requests (like reads, writes, and some system tasks). The remaining time is either idle, or used by background load like compactions and repairs. Background load in Scylla is opportunistic: background requests will try to use all resources available to complete as fast as possible and rely on the schedulers to provide isolation. This graph is better understood in conjunction with the main CPU load graph. For example, if there are spikes in CPU load that are not present in this graph, that indicates that the foreground load itself is stable.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "fillGradient": 0,
-            "grid": {},
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 10,
-                "y": 4
-            },
-            "hiddenSeries": false,
-            "id": 3,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "options": {
-                "dataLinks": []
-            },
-            "percentage": false,
-            "pointradius": 1,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "spaceLength": 10,
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "avg(irate(scylla_scheduler_runtime_ms{group=\"main\",instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])/10 + avg(irate(scylla_scheduler_runtime_ms{group=\"statement\",instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])/10",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 30
-                }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "Foreground CPU Utilization by [[by]]",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-                {
-                    "format": "percent",
-                    "logBase": 1,
-                    "max": 101,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
-        },
-        {
             "class": "plain_text",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Information by Task Group</h1>",
             "datasource": null,
@@ -265,9 +68,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 10
+                "y": 4
             },
-            "id": 4,
+            "id": 2,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -285,9 +88,9 @@
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 12
+                "y": 6
             },
-            "id": 5,
+            "id": 3,
             "panels": [],
             "repeat": "group",
             "title": "$group",
@@ -310,10 +113,10 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 13
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 6,
+            "id": 4,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -407,10 +210,10 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 13
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 7,
+            "id": 5,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -504,10 +307,10 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 13
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 8,
+            "id": 6,
             "isNew": true,
             "legend": {
                 "avg": false,

--- a/grafana/build/ver_3.1/scylla-io.3.1.json
+++ b/grafana/build/ver_3.1/scylla-io.3.1.json
@@ -60,7 +60,7 @@
         },
         {
             "class": "plain_text",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue delay</h1>",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue Information</h1>",
             "datasource": null,
             "editable": true,
             "error": false,
@@ -82,6 +82,21 @@
             "type": "text"
         },
         {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 6
+            },
+            "id": 3,
+            "panels": [],
+            "repeat": "classes",
+            "title": "$classes",
+            "type": "row"
+        },
+        {
             "aliasColors": {},
             "bars": false,
             "class": "us_panel",
@@ -97,10 +112,10 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 6
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 3,
+            "id": 4,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -122,7 +137,6 @@
             "pointradius": 5,
             "points": false,
             "renderer": "flot",
-            "repeat": "classes",
             "seriesOverrides": [
                 {}
             ],
@@ -181,29 +195,6 @@
             }
         },
         {
-            "class": "plain_text",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue total bytes</h1>",
-            "datasource": null,
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 2,
-                "w": 24,
-                "x": 0,
-                "y": 12
-            },
-            "id": 4,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "options": {},
-            "span": 12,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
             "aliasColors": {},
             "bars": false,
             "class": "bps_panel",
@@ -218,8 +209,8 @@
             "gridPos": {
                 "h": 6,
                 "w": 8,
-                "x": 0,
-                "y": 14
+                "x": 8,
+                "y": 7
             },
             "hiddenSeries": false,
             "id": 5,
@@ -244,7 +235,6 @@
             "pointradius": 5,
             "points": false,
             "renderer": "flot",
-            "repeat": "classes",
             "seriesOverrides": [],
             "spaceLength": 10,
             "span": 4,
@@ -301,29 +291,6 @@
             }
         },
         {
-            "class": "plain_text",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue total operations</h1>",
-            "datasource": null,
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 2,
-                "w": 24,
-                "x": 0,
-                "y": 20
-            },
-            "id": 6,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "options": {},
-            "span": 12,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
             "aliasColors": {},
             "bars": false,
             "class": "iops_panel",
@@ -338,11 +305,11 @@
             "gridPos": {
                 "h": 6,
                 "w": 8,
-                "x": 0,
-                "y": 22
+                "x": 16,
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 7,
+            "id": 6,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -364,7 +331,6 @@
             "pointradius": 5,
             "points": false,
             "renderer": "flot",
-            "repeat": "classes",
             "seriesOverrides": [],
             "spaceLength": 10,
             "span": 4,

--- a/grafana/build/ver_3.2/scylla-cpu.3.2.json
+++ b/grafana/build/ver_3.2/scylla-cpu.3.2.json
@@ -257,7 +257,7 @@
         },
         {
             "class": "plain_text",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Task Quota Violation</h1>",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Information by Task Group</h1>",
             "datasource": null,
             "editable": true,
             "error": false,
@@ -279,13 +279,28 @@
             "type": "text"
         },
         {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 12
+            },
+            "id": 5,
+            "panels": [],
+            "repeat": "group",
+            "title": "$group",
+            "type": "row"
+        },
+        {
             "aliasColors": {},
             "bars": false,
             "class": "ms_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
-            "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. The maximum amount of time during which a task group can run is called the \"task quota\". Some task groups may disrespect that and run for longer. This may cause latency issues",
+            "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. This graph shows how much time was spent in $group group",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -293,12 +308,12 @@
             "grid": {},
             "gridPos": {
                 "h": 6,
-                "w": 6,
+                "w": 8,
                 "x": 0,
-                "y": 12
+                "y": 13
             },
             "hiddenSeries": false,
-            "id": 5,
+            "id": 6,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -320,10 +335,106 @@
             "pointradius": 1,
             "points": false,
             "renderer": "flot",
-            "repeat": "group",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 3,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_scheduler_runtime_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Time used by [[by]] - $group",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ms",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ms_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. The maximum amount of time during which a task group can run is called the \"task quota\". Some task groups may disrespect that and run for longer. This may cause latency issues",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 13
+            },
+            "hiddenSeries": false,
+            "id": 7,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -358,6 +469,103 @@
             "yaxes": [
                 {
                     "format": "ms",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Shares assigned to the $group. Shares determine how Scylla reactor distributes the task quotas between groups (Higher share gets more quotas)",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 13
+            },
+            "hiddenSeries": false,
+            "id": 8,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(scylla_scheduler_shares{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Scheduler shares [[by]] - $group",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_3.2/scylla-cpu.3.2.json
+++ b/grafana/build/ver_3.2/scylla-cpu.3.2.json
@@ -59,203 +59,6 @@
             "type": "text"
         },
         {
-            "aliasColors": {},
-            "bars": false,
-            "class": "percent_panel",
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "prometheus",
-            "description": "the percentage of the time during which the CPU is utilized by Scylla. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "fillGradient": 0,
-            "grid": {},
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 0,
-                "y": 4
-            },
-            "hiddenSeries": false,
-            "id": 2,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "options": {
-                "dataLinks": []
-            },
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "spaceLength": 10,
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "CPU Utilization per [[by]]",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-                {
-                    "format": "percent",
-                    "logBase": 1,
-                    "max": 101,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "percent_panel",
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "prometheus",
-            "description": "Time spent handling foreground requests (like reads, writes, and some system tasks). The remaining time is either idle, or used by background load like compactions and repairs. Background load in Scylla is opportunistic: background requests will try to use all resources available to complete as fast as possible and rely on the schedulers to provide isolation. This graph is better understood in conjunction with the main CPU load graph. For example, if there are spikes in CPU load that are not present in this graph, that indicates that the foreground load itself is stable.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "fillGradient": 0,
-            "grid": {},
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 10,
-                "y": 4
-            },
-            "hiddenSeries": false,
-            "id": 3,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "options": {
-                "dataLinks": []
-            },
-            "percentage": false,
-            "pointradius": 1,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "spaceLength": 10,
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "avg(irate(scylla_scheduler_runtime_ms{group=\"main\",instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])/10 + avg(irate(scylla_scheduler_runtime_ms{group=\"statement\",instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])/10",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 30
-                }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "Foreground CPU Utilization by [[by]]",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-                {
-                    "format": "percent",
-                    "logBase": 1,
-                    "max": 101,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
-        },
-        {
             "class": "plain_text",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Information by Task Group</h1>",
             "datasource": null,
@@ -265,9 +68,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 10
+                "y": 4
             },
-            "id": 4,
+            "id": 2,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -285,9 +88,9 @@
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 12
+                "y": 6
             },
-            "id": 5,
+            "id": 3,
             "panels": [],
             "repeat": "group",
             "title": "$group",
@@ -310,10 +113,10 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 13
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 6,
+            "id": 4,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -407,10 +210,10 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 13
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 7,
+            "id": 5,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -504,10 +307,10 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 13
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 8,
+            "id": 6,
             "isNew": true,
             "legend": {
                 "avg": false,

--- a/grafana/build/ver_3.2/scylla-io.3.2.json
+++ b/grafana/build/ver_3.2/scylla-io.3.2.json
@@ -60,7 +60,7 @@
         },
         {
             "class": "plain_text",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue delay</h1>",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue Information</h1>",
             "datasource": null,
             "editable": true,
             "error": false,
@@ -82,6 +82,21 @@
             "type": "text"
         },
         {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 6
+            },
+            "id": 3,
+            "panels": [],
+            "repeat": "classes",
+            "title": "$classes",
+            "type": "row"
+        },
+        {
             "aliasColors": {},
             "bars": false,
             "class": "us_panel",
@@ -97,10 +112,10 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 6
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 3,
+            "id": 4,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -122,7 +137,6 @@
             "pointradius": 5,
             "points": false,
             "renderer": "flot",
-            "repeat": "classes",
             "seriesOverrides": [
                 {}
             ],
@@ -181,29 +195,6 @@
             }
         },
         {
-            "class": "plain_text",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue total bytes</h1>",
-            "datasource": null,
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 2,
-                "w": 24,
-                "x": 0,
-                "y": 12
-            },
-            "id": 4,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "options": {},
-            "span": 12,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
             "aliasColors": {},
             "bars": false,
             "class": "bps_panel",
@@ -218,8 +209,8 @@
             "gridPos": {
                 "h": 6,
                 "w": 8,
-                "x": 0,
-                "y": 14
+                "x": 8,
+                "y": 7
             },
             "hiddenSeries": false,
             "id": 5,
@@ -244,7 +235,6 @@
             "pointradius": 5,
             "points": false,
             "renderer": "flot",
-            "repeat": "classes",
             "seriesOverrides": [],
             "spaceLength": 10,
             "span": 4,
@@ -301,29 +291,6 @@
             }
         },
         {
-            "class": "plain_text",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue total operations</h1>",
-            "datasource": null,
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 2,
-                "w": 24,
-                "x": 0,
-                "y": 20
-            },
-            "id": 6,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "options": {},
-            "span": 12,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
             "aliasColors": {},
             "bars": false,
             "class": "iops_panel",
@@ -338,11 +305,11 @@
             "gridPos": {
                 "h": 6,
                 "w": 8,
-                "x": 0,
-                "y": 22
+                "x": 16,
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 7,
+            "id": 6,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -364,7 +331,6 @@
             "pointradius": 5,
             "points": false,
             "renderer": "flot",
-            "repeat": "classes",
             "seriesOverrides": [],
             "spaceLength": 10,
             "span": 4,

--- a/grafana/build/ver_3.3/scylla-cpu.3.3.json
+++ b/grafana/build/ver_3.3/scylla-cpu.3.3.json
@@ -287,7 +287,7 @@
         },
         {
             "class": "plain_text",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Task Quota Violation</h1>",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Information by Task Group</h1>",
             "datasource": null,
             "editable": true,
             "error": false,
@@ -309,13 +309,28 @@
             "type": "text"
         },
         {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 12
+            },
+            "id": 5,
+            "panels": [],
+            "repeat": "group",
+            "title": "$group",
+            "type": "row"
+        },
+        {
             "aliasColors": {},
             "bars": false,
             "class": "ms_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
-            "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. The maximum amount of time during which a task group can run is called the \"task quota\". Some task groups may disrespect that and run for longer. This may cause latency issues",
+            "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. This graph shows how much time was spent in $group group",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -323,12 +338,12 @@
             "grid": {},
             "gridPos": {
                 "h": 6,
-                "w": 6,
+                "w": 8,
                 "x": 0,
-                "y": 12
+                "y": 13
             },
             "hiddenSeries": false,
-            "id": 5,
+            "id": 6,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -350,10 +365,106 @@
             "pointradius": 1,
             "points": false,
             "renderer": "flot",
-            "repeat": "group",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 3,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_scheduler_runtime_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Time used by [[by]] - $group",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ms",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ms_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. The maximum amount of time during which a task group can run is called the \"task quota\". Some task groups may disrespect that and run for longer. This may cause latency issues",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 13
+            },
+            "hiddenSeries": false,
+            "id": 7,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -388,6 +499,103 @@
             "yaxes": [
                 {
                     "format": "ms",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Shares assigned to the $group. Shares determine how Scylla reactor distributes the task quotas between groups (Higher share gets more quotas)",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 13
+            },
+            "hiddenSeries": false,
+            "id": 8,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(scylla_scheduler_shares{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Scheduler shares [[by]] - $group",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_3.3/scylla-cpu.3.3.json
+++ b/grafana/build/ver_3.3/scylla-cpu.3.3.json
@@ -89,203 +89,6 @@
             "type": "text"
         },
         {
-            "aliasColors": {},
-            "bars": false,
-            "class": "percent_panel",
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "prometheus",
-            "description": "the percentage of the time during which the CPU is utilized by Scylla. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "fillGradient": 0,
-            "grid": {},
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 0,
-                "y": 4
-            },
-            "hiddenSeries": false,
-            "id": 2,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "options": {
-                "dataLinks": []
-            },
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "spaceLength": 10,
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "CPU Utilization per [[by]]",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-                {
-                    "format": "percent",
-                    "logBase": 1,
-                    "max": 101,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "percent_panel",
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "prometheus",
-            "description": "Time spent handling foreground requests (like reads, writes, and some system tasks). The remaining time is either idle, or used by background load like compactions and repairs. Background load in Scylla is opportunistic: background requests will try to use all resources available to complete as fast as possible and rely on the schedulers to provide isolation. This graph is better understood in conjunction with the main CPU load graph. For example, if there are spikes in CPU load that are not present in this graph, that indicates that the foreground load itself is stable.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "fillGradient": 0,
-            "grid": {},
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 10,
-                "y": 4
-            },
-            "hiddenSeries": false,
-            "id": 3,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "options": {
-                "dataLinks": []
-            },
-            "percentage": false,
-            "pointradius": 1,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "spaceLength": 10,
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "avg(irate(scylla_scheduler_runtime_ms{group=\"main\",instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])/10 + avg(irate(scylla_scheduler_runtime_ms{group=\"statement\",instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])/10",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 30
-                }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "Foreground CPU Utilization by [[by]]",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-                {
-                    "format": "percent",
-                    "logBase": 1,
-                    "max": 101,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
-        },
-        {
             "class": "plain_text",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Information by Task Group</h1>",
             "datasource": null,
@@ -295,9 +98,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 10
+                "y": 4
             },
-            "id": 4,
+            "id": 2,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -315,9 +118,9 @@
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 12
+                "y": 6
             },
-            "id": 5,
+            "id": 3,
             "panels": [],
             "repeat": "group",
             "title": "$group",
@@ -340,10 +143,10 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 13
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 6,
+            "id": 4,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -437,10 +240,10 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 13
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 7,
+            "id": 5,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -534,10 +337,10 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 13
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 8,
+            "id": 6,
             "isNew": true,
             "legend": {
                 "avg": false,

--- a/grafana/build/ver_3.3/scylla-io.3.3.json
+++ b/grafana/build/ver_3.3/scylla-io.3.3.json
@@ -90,7 +90,7 @@
         },
         {
             "class": "plain_text",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue delay</h1>",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue Information</h1>",
             "datasource": null,
             "editable": true,
             "error": false,
@@ -112,6 +112,21 @@
             "type": "text"
         },
         {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 6
+            },
+            "id": 3,
+            "panels": [],
+            "repeat": "classes",
+            "title": "$classes",
+            "type": "row"
+        },
+        {
             "aliasColors": {},
             "bars": false,
             "class": "us_panel",
@@ -127,10 +142,10 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 6
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 3,
+            "id": 4,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -152,7 +167,6 @@
             "pointradius": 5,
             "points": false,
             "renderer": "flot",
-            "repeat": "classes",
             "seriesOverrides": [
                 {}
             ],
@@ -211,29 +225,6 @@
             }
         },
         {
-            "class": "plain_text",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue total bytes</h1>",
-            "datasource": null,
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 2,
-                "w": 24,
-                "x": 0,
-                "y": 12
-            },
-            "id": 4,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "options": {},
-            "span": 12,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
             "aliasColors": {},
             "bars": false,
             "class": "bps_panel",
@@ -248,8 +239,8 @@
             "gridPos": {
                 "h": 6,
                 "w": 8,
-                "x": 0,
-                "y": 14
+                "x": 8,
+                "y": 7
             },
             "hiddenSeries": false,
             "id": 5,
@@ -274,7 +265,6 @@
             "pointradius": 5,
             "points": false,
             "renderer": "flot",
-            "repeat": "classes",
             "seriesOverrides": [],
             "spaceLength": 10,
             "span": 4,
@@ -331,29 +321,6 @@
             }
         },
         {
-            "class": "plain_text",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue total operations</h1>",
-            "datasource": null,
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 2,
-                "w": 24,
-                "x": 0,
-                "y": 20
-            },
-            "id": 6,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "options": {},
-            "span": 12,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
             "aliasColors": {},
             "bars": false,
             "class": "iops_panel",
@@ -368,11 +335,11 @@
             "gridPos": {
                 "h": 6,
                 "w": 8,
-                "x": 0,
-                "y": 22
+                "x": 16,
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 7,
+            "id": 6,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -394,7 +361,6 @@
             "pointradius": 5,
             "points": false,
             "renderer": "flot",
-            "repeat": "classes",
             "seriesOverrides": [],
             "spaceLength": 10,
             "span": 4,

--- a/grafana/build/ver_master/scylla-cpu.master.json
+++ b/grafana/build/ver_master/scylla-cpu.master.json
@@ -287,7 +287,7 @@
         },
         {
             "class": "plain_text",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Task Quota Violation</h1>",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Information by Task Group</h1>",
             "datasource": null,
             "editable": true,
             "error": false,
@@ -309,13 +309,28 @@
             "type": "text"
         },
         {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 12
+            },
+            "id": 5,
+            "panels": [],
+            "repeat": "group",
+            "title": "$group",
+            "type": "row"
+        },
+        {
             "aliasColors": {},
             "bars": false,
             "class": "ms_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
-            "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. The maximum amount of time during which a task group can run is called the \"task quota\". Some task groups may disrespect that and run for longer. This may cause latency issues",
+            "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. This graph shows how much time was spent in $group group",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -323,12 +338,12 @@
             "grid": {},
             "gridPos": {
                 "h": 6,
-                "w": 6,
+                "w": 8,
                 "x": 0,
-                "y": 12
+                "y": 13
             },
             "hiddenSeries": false,
-            "id": 5,
+            "id": 6,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -350,10 +365,106 @@
             "pointradius": 1,
             "points": false,
             "renderer": "flot",
-            "repeat": "group",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 3,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_scheduler_runtime_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Time used by [[by]] - $group",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ms",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ms_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. The maximum amount of time during which a task group can run is called the \"task quota\". Some task groups may disrespect that and run for longer. This may cause latency issues",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 13
+            },
+            "hiddenSeries": false,
+            "id": 7,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -388,6 +499,103 @@
             "yaxes": [
                 {
                     "format": "ms",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Shares assigned to the $group. Shares determine how Scylla reactor distributes the task quotas between groups (Higher share gets more quotas)",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 13
+            },
+            "hiddenSeries": false,
+            "id": 8,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(scylla_scheduler_shares{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Scheduler shares [[by]] - $group",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_master/scylla-cpu.master.json
+++ b/grafana/build/ver_master/scylla-cpu.master.json
@@ -89,203 +89,6 @@
             "type": "text"
         },
         {
-            "aliasColors": {},
-            "bars": false,
-            "class": "percent_panel",
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "prometheus",
-            "description": "the percentage of the time during which the CPU is utilized by Scylla. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "fillGradient": 0,
-            "grid": {},
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 0,
-                "y": 4
-            },
-            "hiddenSeries": false,
-            "id": 2,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "options": {
-                "dataLinks": []
-            },
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "spaceLength": 10,
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "CPU Utilization per [[by]]",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-                {
-                    "format": "percent",
-                    "logBase": 1,
-                    "max": 101,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "percent_panel",
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "prometheus",
-            "description": "Time spent handling foreground requests (like reads, writes, and some system tasks). The remaining time is either idle, or used by background load like compactions and repairs. Background load in Scylla is opportunistic: background requests will try to use all resources available to complete as fast as possible and rely on the schedulers to provide isolation. This graph is better understood in conjunction with the main CPU load graph. For example, if there are spikes in CPU load that are not present in this graph, that indicates that the foreground load itself is stable.",
-            "editable": true,
-            "error": false,
-            "fill": 0,
-            "fillGradient": 0,
-            "grid": {},
-            "gridPos": {
-                "h": 6,
-                "w": 10,
-                "x": 10,
-                "y": 4
-            },
-            "hiddenSeries": false,
-            "id": 3,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "options": {
-                "dataLinks": []
-            },
-            "percentage": false,
-            "pointradius": 1,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "spaceLength": 10,
-            "span": 5,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "avg(irate(scylla_scheduler_runtime_ms{group=\"main\",instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])/10 + avg(irate(scylla_scheduler_runtime_ms{group=\"statement\",instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])/10",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 30
-                }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "Foreground CPU Utilization by [[by]]",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-                {
-                    "format": "percent",
-                    "logBase": 1,
-                    "max": 101,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
-        },
-        {
             "class": "plain_text",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Information by Task Group</h1>",
             "datasource": null,
@@ -295,9 +98,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 10
+                "y": 4
             },
-            "id": 4,
+            "id": 2,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -315,9 +118,9 @@
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 12
+                "y": 6
             },
-            "id": 5,
+            "id": 3,
             "panels": [],
             "repeat": "group",
             "title": "$group",
@@ -340,10 +143,10 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 13
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 6,
+            "id": 4,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -437,10 +240,10 @@
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 13
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 7,
+            "id": 5,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -534,10 +337,10 @@
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 13
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 8,
+            "id": 6,
             "isNew": true,
             "legend": {
                 "avg": false,

--- a/grafana/build/ver_master/scylla-io.master.json
+++ b/grafana/build/ver_master/scylla-io.master.json
@@ -90,7 +90,7 @@
         },
         {
             "class": "plain_text",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue delay</h1>",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue Information</h1>",
             "datasource": null,
             "editable": true,
             "error": false,
@@ -112,6 +112,21 @@
             "type": "text"
         },
         {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 6
+            },
+            "id": 3,
+            "panels": [],
+            "repeat": "classes",
+            "title": "$classes",
+            "type": "row"
+        },
+        {
             "aliasColors": {},
             "bars": false,
             "class": "us_panel",
@@ -127,10 +142,10 @@
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 6
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 3,
+            "id": 4,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -152,7 +167,6 @@
             "pointradius": 5,
             "points": false,
             "renderer": "flot",
-            "repeat": "classes",
             "seriesOverrides": [
                 {}
             ],
@@ -211,29 +225,6 @@
             }
         },
         {
-            "class": "plain_text",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue total bytes</h1>",
-            "datasource": null,
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 2,
-                "w": 24,
-                "x": 0,
-                "y": 12
-            },
-            "id": 4,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "options": {},
-            "span": 12,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
             "aliasColors": {},
             "bars": false,
             "class": "bps_panel",
@@ -248,8 +239,8 @@
             "gridPos": {
                 "h": 6,
                 "w": 8,
-                "x": 0,
-                "y": 14
+                "x": 8,
+                "y": 7
             },
             "hiddenSeries": false,
             "id": 5,
@@ -274,7 +265,6 @@
             "pointradius": 5,
             "points": false,
             "renderer": "flot",
-            "repeat": "classes",
             "seriesOverrides": [],
             "spaceLength": 10,
             "span": 4,
@@ -331,29 +321,6 @@
             }
         },
         {
-            "class": "plain_text",
-            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue total operations</h1>",
-            "datasource": null,
-            "editable": true,
-            "error": false,
-            "gridPos": {
-                "h": 2,
-                "w": 24,
-                "x": 0,
-                "y": 20
-            },
-            "id": 6,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "options": {},
-            "span": 12,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
             "aliasColors": {},
             "bars": false,
             "class": "iops_panel",
@@ -368,11 +335,11 @@
             "gridPos": {
                 "h": 6,
                 "w": 8,
-                "x": 0,
-                "y": 22
+                "x": 16,
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 7,
+            "id": 6,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -394,7 +361,6 @@
             "pointradius": 5,
             "points": false,
             "renderer": "flot",
-            "repeat": "classes",
             "seriesOverrides": [],
             "spaceLength": 10,
             "span": 4,

--- a/grafana/scylla-cpu.2019.1.template.json
+++ b/grafana/scylla-cpu.2019.1.template.json
@@ -48,7 +48,7 @@
                 "panels": [
                     {
                         "class": "plain_text",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Task Quota Violation</h1>"
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Information by Task Group</h1>"
                     }
                 ],
                 "title": "New row"
@@ -58,9 +58,43 @@
                 "panels": [
 
                     {
+                      "collapsed": false,
+                      "datasource": null,
+                      "id": "auto",
+                      "gridPos": {
+                        "h": 1,
+                        "w": 24
+                      },
+                      "panels": [],
+                      "repeat": "group",
+                      "title": "$group",
+                      "type": "row"
+                    }
+                ]
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
                         "class": "ms_panel",
-                        "repeat": "group",
-                        "span":3,
+                        "span":4,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(scylla_scheduler_runtime_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "Time used by [[by]] - $group",
+                        "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. This graph shows how much time was spent in $group group"
+                    },
+                    {
+                        "class": "ms_panel",
+                        "span":4,
                         "pointradius": 1,
                         "targets": [
                             {
@@ -74,6 +108,23 @@
                         ],
                         "title": "Time spent in task quota violations by [[by]] - $group",
                         "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. The maximum amount of time during which a task group can run is called the \"task quota\". Some task groups may disrespect that and run for longer. This may cause latency issues"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span":4,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "avg(scylla_scheduler_shares{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "Scheduler shares [[by]] - $group",
+                        "description": "Shares assigned to the $group. Shares determine how Scylla reactor distributes the task quotas between groups (Higher share gets more quotas)"
                     }
                 ],
                 "title": "New row"

--- a/grafana/scylla-cpu.2019.1.template.json
+++ b/grafana/scylla-cpu.2019.1.template.json
@@ -8,41 +8,6 @@
             },
             {
                 "class": "row",
-                "panels": [
-                    {
-                        "class": "percent_panel",
-                        "targets": [
-                            {
-                                "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "CPU Utilization per [[by]]",
-                        "description" : "the percentage of the time during which the CPU is utilized by Scylla. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high"
-                    },
-                    {
-                        "class": "percent_panel",
-                        "pointradius": 1,
-                        "targets": [
-                            {
-                                "expr": "avg(irate(scylla_scheduler_runtime_ms{group=\"main\",instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])/10 + avg(irate(scylla_scheduler_runtime_ms{group=\"statement\",instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])/10",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 30
-                            }
-                        ],
-                        "title": "Foreground CPU Utilization by [[by]]",
-                        "description": "Time spent handling foreground requests (like reads, writes, and some system tasks). The remaining time is either idle, or used by background load like compactions and repairs. Background load in Scylla is opportunistic: background requests will try to use all resources available to complete as fast as possible and rely on the schedulers to provide isolation. This graph is better understood in conjunction with the main CPU load graph. For example, if there are spikes in CPU load that are not present in this graph, that indicates that the foreground load itself is stable."
-                    }
-                ]
-            },
-            {
-                "class": "row",
                 "height": "25px",
                 "gridPos": {"h": 2},
                 "panels": [

--- a/grafana/scylla-cpu.3.0.template.json
+++ b/grafana/scylla-cpu.3.0.template.json
@@ -8,41 +8,6 @@
             },
             {
                 "class": "row",
-                "panels": [
-                    {
-                        "class": "percent_panel",
-                        "targets": [
-                            {
-                                "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "CPU Utilization per [[by]]",
-                        "description" : "the percentage of the time during which the CPU is utilized by Scylla. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high"
-                    },
-                    {
-                        "class": "percent_panel",
-                        "pointradius": 1,
-                        "targets": [
-                            {
-                                "expr": "avg(irate(scylla_scheduler_runtime_ms{group=\"main\",instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])/10 + avg(irate(scylla_scheduler_runtime_ms{group=\"statement\",instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])/10",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 30
-                            }
-                        ],
-                        "title": "Foreground CPU Utilization by [[by]]",
-                        "description": "Time spent handling foreground requests (like reads, writes, and some system tasks). The remaining time is either idle, or used by background load like compactions and repairs. Background load in Scylla is opportunistic: background requests will try to use all resources available to complete as fast as possible and rely on the schedulers to provide isolation. This graph is better understood in conjunction with the main CPU load graph. For example, if there are spikes in CPU load that are not present in this graph, that indicates that the foreground load itself is stable."
-                    }
-                ]
-            },
-            {
-                "class": "row",
                 "height": "25px",
                 "gridPos": {"h": 2},
                 "panels": [

--- a/grafana/scylla-cpu.3.1.template.json
+++ b/grafana/scylla-cpu.3.1.template.json
@@ -48,7 +48,7 @@
                 "panels": [
                     {
                         "class": "plain_text",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Task Quota Violation</h1>"
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Information by Task Group</h1>"
                     }
                 ],
                 "title": "New row"
@@ -57,9 +57,43 @@
                 "class": "row",
                 "panels": [
                     {
+                      "collapsed": false,
+                      "datasource": null,
+                      "id": "auto",
+                      "gridPos": {
+                        "h": 1,
+                        "w": 24
+                      },
+                      "panels": [],
+                      "repeat": "group",
+                      "title": "$group",
+                      "type": "row"
+                    }
+                ]
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
                         "class": "ms_panel",
-                        "repeat": "group",
-                        "span":3,
+                        "span":4,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(scylla_scheduler_runtime_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "Time used by [[by]] - $group",
+                        "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. This graph shows how much time was spent in $group group"
+                    },
+                    {
+                        "class": "ms_panel",
+                        "span":4,
                         "pointradius": 1,
                         "targets": [
                             {
@@ -73,6 +107,23 @@
                         ],
                         "title": "Time spent in task quota violations by [[by]] - $group",
                         "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. The maximum amount of time during which a task group can run is called the \"task quota\". Some task groups may disrespect that and run for longer. This may cause latency issues"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span":4,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "avg(scylla_scheduler_shares{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "Scheduler shares [[by]] - $group",
+                        "description": "Shares assigned to the $group. Shares determine how Scylla reactor distributes the task quotas between groups (Higher share gets more quotas)"
                     }
                 ],
                 "title": "New row"

--- a/grafana/scylla-cpu.3.1.template.json
+++ b/grafana/scylla-cpu.3.1.template.json
@@ -8,41 +8,6 @@
             },
             {
                 "class": "row",
-                "panels": [
-                    {
-                        "class": "percent_panel",
-                        "targets": [
-                            {
-                                "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "CPU Utilization per [[by]]",
-                        "description" : "the percentage of the time during which the CPU is utilized by Scylla. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high"
-                    },
-                    {
-                        "class": "percent_panel",
-                        "pointradius": 1,
-                        "targets": [
-                            {
-                                "expr": "avg(irate(scylla_scheduler_runtime_ms{group=\"main\",instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])/10 + avg(irate(scylla_scheduler_runtime_ms{group=\"statement\",instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])/10",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 30
-                            }
-                        ],
-                        "title": "Foreground CPU Utilization by [[by]]",
-                        "description": "Time spent handling foreground requests (like reads, writes, and some system tasks). The remaining time is either idle, or used by background load like compactions and repairs. Background load in Scylla is opportunistic: background requests will try to use all resources available to complete as fast as possible and rely on the schedulers to provide isolation. This graph is better understood in conjunction with the main CPU load graph. For example, if there are spikes in CPU load that are not present in this graph, that indicates that the foreground load itself is stable."
-                    }
-                ]
-            },
-            {
-                "class": "row",
                 "height": "25px",
                 "gridPos": {"h": 2},
                 "panels": [

--- a/grafana/scylla-cpu.3.2.template.json
+++ b/grafana/scylla-cpu.3.2.template.json
@@ -48,7 +48,7 @@
                 "panels": [
                     {
                         "class": "plain_text",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Task Quota Violation</h1>"
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Information by Task Group</h1>"
                     }
                 ],
                 "title": "New row"
@@ -57,9 +57,43 @@
                 "class": "row",
                 "panels": [
                     {
+                      "collapsed": false,
+                      "datasource": null,
+                      "id": "auto",
+                      "gridPos": {
+                        "h": 1,
+                        "w": 24
+                      },
+                      "panels": [],
+                      "repeat": "group",
+                      "title": "$group",
+                      "type": "row"
+                    }
+                ]
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
                         "class": "ms_panel",
-                        "repeat": "group",
-                        "span":3,
+                        "span":4,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(scylla_scheduler_runtime_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "Time used by [[by]] - $group",
+                        "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. This graph shows how much time was spent in $group group"
+                    },
+                    {
+                        "class": "ms_panel",
+                        "span":4,
                         "pointradius": 1,
                         "targets": [
                             {
@@ -73,6 +107,23 @@
                         ],
                         "title": "Time spent in task quota violations by [[by]] - $group",
                         "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. The maximum amount of time during which a task group can run is called the \"task quota\". Some task groups may disrespect that and run for longer. This may cause latency issues"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span":4,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "avg(scylla_scheduler_shares{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "Scheduler shares [[by]] - $group",
+                        "description": "Shares assigned to the $group. Shares determine how Scylla reactor distributes the task quotas between groups (Higher share gets more quotas)"
                     }
                 ],
                 "title": "New row"

--- a/grafana/scylla-cpu.3.2.template.json
+++ b/grafana/scylla-cpu.3.2.template.json
@@ -8,41 +8,6 @@
             },
             {
                 "class": "row",
-                "panels": [
-                    {
-                        "class": "percent_panel",
-                        "targets": [
-                            {
-                                "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "CPU Utilization per [[by]]",
-                        "description" : "the percentage of the time during which the CPU is utilized by Scylla. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high"
-                    },
-                    {
-                        "class": "percent_panel",
-                        "pointradius": 1,
-                        "targets": [
-                            {
-                                "expr": "avg(irate(scylla_scheduler_runtime_ms{group=\"main\",instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])/10 + avg(irate(scylla_scheduler_runtime_ms{group=\"statement\",instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])/10",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 30
-                            }
-                        ],
-                        "title": "Foreground CPU Utilization by [[by]]",
-                        "description": "Time spent handling foreground requests (like reads, writes, and some system tasks). The remaining time is either idle, or used by background load like compactions and repairs. Background load in Scylla is opportunistic: background requests will try to use all resources available to complete as fast as possible and rely on the schedulers to provide isolation. This graph is better understood in conjunction with the main CPU load graph. For example, if there are spikes in CPU load that are not present in this graph, that indicates that the foreground load itself is stable."
-                    }
-                ]
-            },
-            {
-                "class": "row",
                 "height": "25px",
                 "gridPos": {"h": 2},
                 "panels": [

--- a/grafana/scylla-cpu.3.3.template.json
+++ b/grafana/scylla-cpu.3.3.template.json
@@ -48,7 +48,7 @@
                 "panels": [
                     {
                         "class": "plain_text",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Task Quota Violation</h1>"
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Information by Task Group</h1>"
                     }
                 ],
                 "title": "New row"
@@ -57,9 +57,43 @@
                 "class": "row",
                 "panels": [
                     {
+                      "collapsed": false,
+                      "datasource": null,
+                      "id": "auto",
+                      "gridPos": {
+                        "h": 1,
+                        "w": 24
+                      },
+                      "panels": [],
+                      "repeat": "group",
+                      "title": "$group",
+                      "type": "row"
+                    }
+                ]
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
                         "class": "ms_panel",
-                        "repeat": "group",
-                        "span":3,
+                        "span":4,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(scylla_scheduler_runtime_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "Time used by [[by]] - $group",
+                        "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. This graph shows how much time was spent in $group group"
+                    },
+                    {
+                        "class": "ms_panel",
+                        "span":4,
                         "pointradius": 1,
                         "targets": [
                             {
@@ -73,6 +107,23 @@
                         ],
                         "title": "Time spent in task quota violations by [[by]] - $group",
                         "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. The maximum amount of time during which a task group can run is called the \"task quota\". Some task groups may disrespect that and run for longer. This may cause latency issues"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span":4,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "avg(scylla_scheduler_shares{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "Scheduler shares [[by]] - $group",
+                        "description": "Shares assigned to the $group. Shares determine how Scylla reactor distributes the task quotas between groups (Higher share gets more quotas)"
                     }
                 ],
                 "title": "New row"

--- a/grafana/scylla-cpu.3.3.template.json
+++ b/grafana/scylla-cpu.3.3.template.json
@@ -8,41 +8,6 @@
             },
             {
                 "class": "row",
-                "panels": [
-                    {
-                        "class": "percent_panel",
-                        "targets": [
-                            {
-                                "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "CPU Utilization per [[by]]",
-                        "description" : "the percentage of the time during which the CPU is utilized by Scylla. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high"
-                    },
-                    {
-                        "class": "percent_panel",
-                        "pointradius": 1,
-                        "targets": [
-                            {
-                                "expr": "avg(irate(scylla_scheduler_runtime_ms{group=\"main\",instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])/10 + avg(irate(scylla_scheduler_runtime_ms{group=\"statement\",instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])/10",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 30
-                            }
-                        ],
-                        "title": "Foreground CPU Utilization by [[by]]",
-                        "description": "Time spent handling foreground requests (like reads, writes, and some system tasks). The remaining time is either idle, or used by background load like compactions and repairs. Background load in Scylla is opportunistic: background requests will try to use all resources available to complete as fast as possible and rely on the schedulers to provide isolation. This graph is better understood in conjunction with the main CPU load graph. For example, if there are spikes in CPU load that are not present in this graph, that indicates that the foreground load itself is stable."
-                    }
-                ]
-            },
-            {
-                "class": "row",
                 "height": "25px",
                 "gridPos": {"h": 2},
                 "panels": [

--- a/grafana/scylla-cpu.master.template.json
+++ b/grafana/scylla-cpu.master.template.json
@@ -48,7 +48,7 @@
                 "panels": [
                     {
                         "class": "plain_text",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Task Quota Violation</h1>"
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Information by Task Group</h1>"
                     }
                 ],
                 "title": "New row"
@@ -57,9 +57,43 @@
                 "class": "row",
                 "panels": [
                     {
+                      "collapsed": false,
+                      "datasource": null,
+                      "id": "auto",
+                      "gridPos": {
+                        "h": 1,
+                        "w": 24
+                      },
+                      "panels": [],
+                      "repeat": "group",
+                      "title": "$group",
+                      "type": "row"
+                    }
+                ]
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
                         "class": "ms_panel",
-                        "repeat": "group",
-                        "span":3,
+                        "span":4,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "sum(irate(scylla_scheduler_runtime_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "Time used by [[by]] - $group",
+                        "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. This graph shows how much time was spent in $group group"
+                    },
+                    {
+                        "class": "ms_panel",
+                        "span":4,
                         "pointradius": 1,
                         "targets": [
                             {
@@ -73,6 +107,23 @@
                         ],
                         "title": "Time spent in task quota violations by [[by]] - $group",
                         "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. The maximum amount of time during which a task group can run is called the \"task quota\". Some task groups may disrespect that and run for longer. This may cause latency issues"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span":4,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "avg(scylla_scheduler_shares{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "Scheduler shares [[by]] - $group",
+                        "description": "Shares assigned to the $group. Shares determine how Scylla reactor distributes the task quotas between groups (Higher share gets more quotas)"
                     }
                 ],
                 "title": "New row"

--- a/grafana/scylla-cpu.master.template.json
+++ b/grafana/scylla-cpu.master.template.json
@@ -8,41 +8,6 @@
             },
             {
                 "class": "row",
-                "panels": [
-                    {
-                        "class": "percent_panel",
-                        "targets": [
-                            {
-                                "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "CPU Utilization per [[by]]",
-                        "description" : "the percentage of the time during which the CPU is utilized by Scylla. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high"
-                    },
-                    {
-                        "class": "percent_panel",
-                        "pointradius": 1,
-                        "targets": [
-                            {
-                                "expr": "avg(irate(scylla_scheduler_runtime_ms{group=\"main\",instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])/10 + avg(irate(scylla_scheduler_runtime_ms{group=\"statement\",instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])/10",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 30
-                            }
-                        ],
-                        "title": "Foreground CPU Utilization by [[by]]",
-                        "description": "Time spent handling foreground requests (like reads, writes, and some system tasks). The remaining time is either idle, or used by background load like compactions and repairs. Background load in Scylla is opportunistic: background requests will try to use all resources available to complete as fast as possible and rely on the schedulers to provide isolation. This graph is better understood in conjunction with the main CPU load graph. For example, if there are spikes in CPU load that are not present in this graph, that indicates that the foreground load itself is stable."
-                    }
-                ]
-            },
-            {
-                "class": "row",
                 "height": "25px",
                 "gridPos": {"h": 2},
                 "panels": [

--- a/grafana/scylla-io.2019.1.template.json
+++ b/grafana/scylla-io.2019.1.template.json
@@ -13,7 +13,7 @@
                 "panels": [
                     {
                         "class": "plain_text",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue delay</h1>"
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue Information</h1>"
                     }
                 ],
                 "title": "New row"
@@ -22,9 +22,26 @@
                 "class": "row",
                 "panels": [
                     {
+                      "collapsed": false,
+                      "datasource": null,
+                      "id": "auto",
+                      "gridPos": {
+                        "h": 1,
+                        "w": 24
+                      },
+                      "panels": [],
+                      "repeat": "classes",
+                      "title": "$classes",
+                      "type": "row"
+                    }
+                ]
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
                         "class": "us_panel",
                         "span": 4,
-                        "repeat": "classes",
                         "targets": [
                             {
                                 "expr": "1000000*max(scylla_io_queue_delay{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
@@ -36,28 +53,10 @@
                             }
                         ],
                         "title": "$classes I/O Queue delay by [[by]]"
-                    }
-                 ]
-             },
-            {
-                "class": "row",
-                "height": "25px",
-                "gridPos": {"h": 2},
-                "panels": [
-                    {
-                        "class": "plain_text",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue total bytes</h1>"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
+                    },
                     {
                         "class": "bps_panel",
                         "span": 4,
-                        "repeat": "classes",
                         "targets": [
                             {
                                 "expr": "sum(irate(scylla_io_queue_total_bytes{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
@@ -69,28 +68,10 @@
                             }
                         ],
                         "title": "$classes I/O Queue bandwidth by [[by]]"
-                    }
-                    ]
-             },
-            {
-                "class": "row",
-                "height": "25px",
-                "gridPos": {"h": 2},
-                "panels": [
-                    {
-                        "class": "plain_text",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue total operations</h1>"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
+                    },
                     {
                         "class": "iops_panel",
                         "span": 4,
-                        "repeat": "classes",
                         "targets": [
                             {
                                 "expr": "sum(irate(scylla_io_queue_total_operations{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",

--- a/grafana/scylla-io.3.1.template.json
+++ b/grafana/scylla-io.3.1.template.json
@@ -13,7 +13,7 @@
                 "panels": [
                     {
                         "class": "plain_text",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue delay</h1>"
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue Information</h1>"
                     }
                 ],
                 "title": "New row"
@@ -22,9 +22,26 @@
                 "class": "row",
                 "panels": [
                     {
+                      "collapsed": false,
+                      "datasource": null,
+                      "id": "auto",
+                      "gridPos": {
+                        "h": 1,
+                        "w": 24
+                      },
+                      "panels": [],
+                      "repeat": "classes",
+                      "title": "$classes",
+                      "type": "row"
+                    }
+                ]
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
                         "class": "us_panel",
                         "span": 4,
-                        "repeat": "classes",
                         "targets": [
                             {
                                 "expr": "1000000*max(scylla_io_queue_delay{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
@@ -36,28 +53,10 @@
                             }
                         ],
                         "title": "$classes I/O Queue delay by [[by]]"
-                    }
-                 ]
-             },
-            {
-                "class": "row",
-                "height": "25px",
-                "gridPos": {"h": 2},
-                "panels": [
-                    {
-                        "class": "plain_text",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue total bytes</h1>"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
+                    },
                     {
                         "class": "bps_panel",
                         "span": 4,
-                        "repeat": "classes",
                         "targets": [
                             {
                                 "expr": "sum(irate(scylla_io_queue_total_bytes{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
@@ -69,28 +68,10 @@
                             }
                         ],
                         "title": "$classes I/O Queue bandwidth by [[by]]"
-                    }
-                    ]
-             },
-            {
-                "class": "row",
-                "height": "25px",
-                "gridPos": {"h": 2},
-                "panels": [
-                    {
-                        "class": "plain_text",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue total operations</h1>"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
+                    },
                     {
                         "class": "iops_panel",
                         "span": 4,
-                        "repeat": "classes",
                         "targets": [
                             {
                                 "expr": "sum(irate(scylla_io_queue_total_operations{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",

--- a/grafana/scylla-io.3.2.template.json
+++ b/grafana/scylla-io.3.2.template.json
@@ -13,7 +13,7 @@
                 "panels": [
                     {
                         "class": "plain_text",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue delay</h1>"
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue Information</h1>"
                     }
                 ],
                 "title": "New row"
@@ -22,9 +22,26 @@
                 "class": "row",
                 "panels": [
                     {
+                      "collapsed": false,
+                      "datasource": null,
+                      "id": "auto",
+                      "gridPos": {
+                        "h": 1,
+                        "w": 24
+                      },
+                      "panels": [],
+                      "repeat": "classes",
+                      "title": "$classes",
+                      "type": "row"
+                    }
+                ]
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
                         "class": "us_panel",
                         "span": 4,
-                        "repeat": "classes",
                         "targets": [
                             {
                                 "expr": "1000000*max(scylla_io_queue_delay{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
@@ -36,28 +53,10 @@
                             }
                         ],
                         "title": "$classes I/O Queue delay by [[by]]"
-                    }
-                 ]
-             },
-            {
-                "class": "row",
-                "height": "25px",
-                "gridPos": {"h": 2},
-                "panels": [
-                    {
-                        "class": "plain_text",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue total bytes</h1>"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
+                    },
                     {
                         "class": "bps_panel",
                         "span": 4,
-                        "repeat": "classes",
                         "targets": [
                             {
                                 "expr": "sum(irate(scylla_io_queue_total_bytes{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
@@ -69,28 +68,10 @@
                             }
                         ],
                         "title": "$classes I/O Queue bandwidth by [[by]]"
-                    }
-                    ]
-             },
-            {
-                "class": "row",
-                "height": "25px",
-                "gridPos": {"h": 2},
-                "panels": [
-                    {
-                        "class": "plain_text",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue total operations</h1>"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
+                    },
                     {
                         "class": "iops_panel",
                         "span": 4,
-                        "repeat": "classes",
                         "targets": [
                             {
                                 "expr": "sum(irate(scylla_io_queue_total_operations{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",

--- a/grafana/scylla-io.3.3.template.json
+++ b/grafana/scylla-io.3.3.template.json
@@ -13,7 +13,7 @@
                 "panels": [
                     {
                         "class": "plain_text",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue delay</h1>"
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue Information</h1>"
                     }
                 ],
                 "title": "New row"
@@ -22,9 +22,26 @@
                 "class": "row",
                 "panels": [
                     {
+                      "collapsed": false,
+                      "datasource": null,
+                      "id": "auto",
+                      "gridPos": {
+                        "h": 1,
+                        "w": 24
+                      },
+                      "panels": [],
+                      "repeat": "classes",
+                      "title": "$classes",
+                      "type": "row"
+                    }
+                ]
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
                         "class": "us_panel",
                         "span": 4,
-                        "repeat": "classes",
                         "targets": [
                             {
                                 "expr": "1000000*max(scylla_io_queue_delay{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
@@ -36,28 +53,10 @@
                             }
                         ],
                         "title": "$classes I/O Queue delay by [[by]]"
-                    }
-                 ]
-             },
-            {
-                "class": "row",
-                "height": "25px",
-                "gridPos": {"h": 2},
-                "panels": [
-                    {
-                        "class": "plain_text",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue total bytes</h1>"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
+                    },
                     {
                         "class": "bps_panel",
                         "span": 4,
-                        "repeat": "classes",
                         "targets": [
                             {
                                 "expr": "sum(irate(scylla_io_queue_total_bytes{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
@@ -69,28 +68,10 @@
                             }
                         ],
                         "title": "$classes I/O Queue bandwidth by [[by]]"
-                    }
-                    ]
-             },
-            {
-                "class": "row",
-                "height": "25px",
-                "gridPos": {"h": 2},
-                "panels": [
-                    {
-                        "class": "plain_text",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue total operations</h1>"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
+                    },
                     {
                         "class": "iops_panel",
                         "span": 4,
-                        "repeat": "classes",
                         "targets": [
                             {
                                 "expr": "sum(irate(scylla_io_queue_total_operations{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",

--- a/grafana/scylla-io.master.template.json
+++ b/grafana/scylla-io.master.template.json
@@ -13,7 +13,7 @@
                 "panels": [
                     {
                         "class": "plain_text",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue delay</h1>"
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue Information</h1>"
                     }
                 ],
                 "title": "New row"
@@ -22,9 +22,26 @@
                 "class": "row",
                 "panels": [
                     {
+                      "collapsed": false,
+                      "datasource": null,
+                      "id": "auto",
+                      "gridPos": {
+                        "h": 1,
+                        "w": 24
+                      },
+                      "panels": [],
+                      "repeat": "classes",
+                      "title": "$classes",
+                      "type": "row"
+                    }
+                ]
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
                         "class": "us_panel",
                         "span": 4,
-                        "repeat": "classes",
                         "targets": [
                             {
                                 "expr": "1000000*max(scylla_io_queue_delay{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
@@ -36,28 +53,10 @@
                             }
                         ],
                         "title": "$classes I/O Queue delay by [[by]]"
-                    }
-                 ]
-             },
-            {
-                "class": "row",
-                "height": "25px",
-                "gridPos": {"h": 2},
-                "panels": [
-                    {
-                        "class": "plain_text",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue total bytes</h1>"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
+                    },
                     {
                         "class": "bps_panel",
                         "span": 4,
-                        "repeat": "classes",
                         "targets": [
                             {
                                 "expr": "sum(irate(scylla_io_queue_total_bytes{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
@@ -69,28 +68,10 @@
                             }
                         ],
                         "title": "$classes I/O Queue bandwidth by [[by]]"
-                    }
-                    ]
-             },
-            {
-                "class": "row",
-                "height": "25px",
-                "gridPos": {"h": 2},
-                "panels": [
-                    {
-                        "class": "plain_text",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue total operations</h1>"
-                    }
-                ],
-                "title": "New row"
-            },
-            {
-                "class": "row",
-                "panels": [
+                    },
                     {
                         "class": "iops_panel",
                         "span": 4,
-                        "repeat": "classes",
                         "targets": [
                             {
                                 "expr": "sum(irate(scylla_io_queue_total_operations{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",


### PR DESCRIPTION
This series makes use of Grafana Row-Panel to combine information in a templated row (multiple instances of the same row with different parameter values).
The CPU dashboard, has now row per task-group, with utilization, quota violation and share.

The IO queue information is now collected in rows.
![image](https://user-images.githubusercontent.com/2118079/77880333-15ba0f80-7265-11ea-9edd-142120cfd27a.png)
![image](https://user-images.githubusercontent.com/2118079/77880347-1e124a80-7265-11ea-9b37-b14506f92919.png)

Fixes #857
Fixes #846