### PR TITLE
Alternator as product

### DIFF
--- a/alternator-start-all.sh
+++ b/alternator-start-all.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+./start-all.sh -S alternator $@

--- a/dashboards.sh
+++ b/dashboards.sh
@@ -1,1 +1,5 @@
-DASHBOARDS=(scylla-overview scylla-detailed scylla-io scylla-cpu scylla-os scylla-cql scylla-errors alternator)
+if [[ -z "$DASHBOARDS" ]]; then
+    DASHBOARDS=(scylla-overview scylla-detailed scylla-io scylla-cpu scylla-os scylla-cql scylla-errors alternator)
+else
+    read -ra DASHBOARDS <<< "$DASHBOARDS"
+fi

--- a/generate-alternator.sh
+++ b/generate-alternator.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+usage="$(basename "$0") [-h] [-v version]"
+VERSIONS="master"
+while getopts ':hv:' option; do
+  case "$option" in
+    h) echo "$usage"
+       exit
+       ;;
+    v) VERSIONS=$OPTARG
+       ;;
+    :) printf "missing argument for -%s\n" "$OPTARG" >&2
+       echo "$usage" >&2
+       exit 1
+       ;;
+   \?) printf "illegal option: -%s\n" "$OPTARG" >&2
+       echo "$usage" >&2
+       exit 1
+       ;;
+  esac
+done
+
+
+DASHBOARDS="scylla-io scylla-cpu scylla-os scylla-errors alternator" ./generate-dashboards.sh -v $VERSIONS -S alternator

--- a/generate-dashboards.sh
+++ b/generate-dashboards.sh
@@ -9,9 +9,11 @@ fi
 
 FORMAT_COMAND=""
 FORCEUPDATE=""
-usage="$(basename "$0") [-h] [-v comma separated versions ]  [-j additional dashboard to load to Grafana, multiple params are supported] [-M scylla-manager version ] [-t] [-F force update]-- Generates the grafana dashboards and their load files"
+SPECIFIC_SOLUTION=""
 
-while getopts ':htv:j:M:F' option; do
+usage="$(basename "$0") [-h] [-v comma separated versions ]  [-j additional dashboard to load to Grafana, multiple params are supported] [-M scylla-manager version ] [-t] [-F force update] [-S start with a system specific dashboard set] -- Generates the grafana dashboards and their load files"
+
+while getopts ':htv:j:M:S:F' option; do
   case "$option" in
     h) echo "$usage"
        exit
@@ -25,6 +27,8 @@ while getopts ':htv:j:M:F' option; do
        FORMAT_COMAND="$FORMAT_COMAND -M $OPTARG"
        ;;
     F) FORCEUPDATE="1"
+       ;;
+    S) SPECIFIC_SOLUTION="$OPTARG"
        ;;
     j) GRAFANA_DASHBOARD_ARRAY+=("$OPTARG")
        FORMAT_COMAND="$FORMAT_COMAND -j $OPTARG"
@@ -43,11 +47,20 @@ function set_loader {
 }
 
 IFS=',' ;for v in $VERSIONS; do
-VERDIR="grafana/build/ver_$v"
+
+if [[ -z "$SPECIFIC_SOLUTION" ]]; then
+    VERDIR_NAME="ver_$v"
+else
+    VERDIR_NAME=$SPECIFIC_SOLUTION"_$v"
+fi
+
+VERDIR="grafana/build/$VERDIR_NAME"
 if [[ -z "$TEST_ONLY" ]]; then
    mkdir -p $VERDIR
 fi
-set_loader $v $v "ver_$v"
+
+set_loader $v $v "$VERDIR_NAME"
+
 CURRENT_VERSION=`cat CURRENT_VERSION.sh`
 
 for f in "${DASHBOARDS[@]}"; do

--- a/grafana/alternator.4.0.template.json
+++ b/grafana/alternator.4.0.template.json
@@ -1080,7 +1080,7 @@
             ]
         },
         "title": "Alternator",
-        "uid": "alternator-4.0",
+        "uid": "alternator-4-0",
         "version": 1
     }
 }

--- a/grafana/build/alternator_4.0/alternator.4.0.json
+++ b/grafana/build/alternator_4.0/alternator.4.0.json
@@ -4050,6 +4050,6 @@
     },
     "timezone": "browser",
     "title": "Alternator",
-    "uid": "alternator-4.0",
+    "uid": "alternator-4-0",
     "version": 1
 }

--- a/grafana/build/alternator_4.0/alternator.4.0.json
+++ b/grafana/build/alternator_4.0/alternator.4.0.json
@@ -1,0 +1,4055 @@
+{
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            },
+            {
+                "class": "annotation_restart",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "resets(scylla_gossip_heart_beat[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "node_restart",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "restart",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_stall",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_stall_detector_reported[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "stall detector",
+                "showIn": 0,
+                "tagKeys": "dc,instance,shard",
+                "tags": [],
+                "titleFormat": "Stall found",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_schema_changed",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_database_schema_changed[30s])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "Schema Changed",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "schema changed",
+                "type": "tags"
+            }
+        ]
+    },
+    "class": "dashboard",
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 1,
+    "hideControls": true,
+    "id": null,
+    "links": [],
+    "originalTitle": "Scylla Cluster Metrics",
+    "overwrite": true,
+    "panels": [
+        {
+            "class": "text_panel",
+            "content": "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAkYAAAB2CAYAAAAtOFzoAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAD6VJREFUeNrs3Y1V20oWwHGRkwLcwSoVxKkgooJHKoioAKggpgKTCuxUYKcCOxXAqwC/CvBWwOqGcY4fi0HSvZov/3/n6JDzdjHyaEZz57soAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABA5E6O5Ys+Pj6Omx+jgwlxcrImO/RO27L5Ub7yf7lr0ndLSgEACIzCVNRV80Ouz831akD0AgmQ7prrb/l3U6FvyCb/Ci7l+uh+dk3bu2dpe0eqAgAIjIaptM+aH38111nHyrpNZf6zuebHGCTtpasEmqXxx0t6LpvrR0xBUvOda6Pvumm+19zzvU8s8nxz38uU0r2538kRlUlJozqVPJlxw7uLG3rN4SuDjprrsrnuH/1YuUKR/Yu3uWbN9fDoz62rGKN48Rl+r7HPoCi1e352/6u+N3xsFbPmHUbNoU7/PvXNJSkHL61LjwHRSwHSOMM0rTSVk5H7GIJPFxia5BWPwaxFIDsNmOYERgRGuab9PamHoXuJQlfewSuRASrVWNJ0ZyHPOnA+s+oxO/NwvwujoDRkmhMYERjFnvaaclaTgml4l1imlF4aibyrSG7p0g0BjRMu6JPI0nRHgolgvUduPsC50cdNB36GlUsvrXPmQQCHG5DKcvaVVCQwss6UEm3fFrYTqy1IULRyhSa1XiJJz28R3+bIpW2QlpabgGwxCbk0mhR9yMzgM27YsgJ41YXy96scp2AQGIUNimYR3+JdSivW3NDOrQvqUjAL2A0tvUYWvSgXQwxTuYBLG5RL3r3mdQgcLGdSdi3eQRekJoGRRYaUyjvmuTyyzPxLQgVcCveiiK/nLcrgyHBITdL7m/GzLI1etAyhAa+rjd6Zdch5fMggMHIZKOZKXIKi01QqlQR63toER97zguGQ2qXxkOvUoGwwhAa8zbKnh6X7BEYq0sIuI723LUGR9/T+FDC9rYbUZkbPsyr0E67l+zCEBrxe1s6M6yGG0wiMemfGMuLImqDIL+mZ+xByd2z3rK8MPqoyWmln8TwZQgP8BzIjlu4TGPUV62qpXVCUxDlfCczRess8liDUHaWwDh3UGE24XoY49gNIiWugVwN8NL1GEXsfcWa0jqjXrufhv8/+e9eDZr8kFBT5mKO1Oxj2nxf+t8+uAu9biV81aX0TWbLKkJp22whZvn/Z57sZTbi23KMJyNlQDfSx9Bwzvw9dXv6XhsdLtFoFID0rLc4HqxNLx+mAu1KftZ0I7fZMmnQ4wuXBx27RgfPnQ5+J5EY7XJ9Fmq7sfN0undj52lPDcuDzImekMry8IPdMFIVhmkFQVA1RkLWrqlyg+vDGYbJj8uhgz3SRY5oSGBEYRdxAf01JSqNthtSqjV4+D6meieYCDCumwcor592tUtnjw/DQ1rLD39QemvwQc/oSGBEYRZbOPg4pn5LSaJMZx7F0T7p7STEoqo17iUYD3ecs5ReEUYty0fJvTWJoMBAYERgdSRrXj348PLLhIwYu9I+cRWPa0pl5uNdpyktXjYbUKg+9U6uc05J3JIFRhOU6iwYL4siQqpYx6Wc2t4iJgX56OB/dYb6v/Y2FQau0JDCijBMYeSvTnRYJkepxeUcSZMdif4z1yckJy7lbcFs3aHePHh9qNRrtcH2d0iHHQAbv0C5Ko01fQWB0MNovj/VhurFqi2MivlA0OgVHk+JpLyeNbwfmGmh77tYR7gUFxPwOrfuWNU35J/UJjIZUH/HztNif5ppjInrR9rBJQH/57CU9KXQ7XLORI9BN32OoNsqyVrF0n8DorZe5xsURT8D+S/n7G3oX+jEaUrvYvRyNdrhmCA3o5mvP3/vhyprmmB16jQiMDtIOSUhX6OpIgyP1XBSKhCo4mijz72jv5TgtdMeOMIQGdODm+ZU9f32+C5A072+W7hMYDRUY7SqYW7fCbXQkhbpSfsTGHZIKHe3QVe2G0LRB7hWPAuikb2/Rctcz6w5m3ijqrZrHQGD0Uqt7q8hYz0nr+94FSGXmz1LbQ8ZJ6zb5VwL7G4N8q3GdykHHQEQNy76Nyx+G79ILngaBkY9KerQXIN263YpzDJI+Kn//B8XBzLVhcN/VnRvSA9Be396iresl2vddcR8lGz4SGB3yfaDPlV6VqQuS7t2uy1Umz1IT7G3pYbDjej1DrQZjFRrQgWso9w1G5i+Uf2kUrQMEacg5MHIZa+4hkJClmSu3M7Cc23WW8LPUDKURFNnnYXkx+p78zBAa0F2t+N1DjXhND3zF0VYERgdf8oV+6X5bu0lvi70gqUrsWWommf+iKAyWhzee/hZDaEA/fef1rA9th+EWsmwD3BNyDoxchguxsmYXJK3cnKQ69odosPJuQ1EYJA/7HFJjCA3o/u6sFY3Kt3qF5opbq1m6T2BUvBJ1h9yLRbozZ24+UhVxUmm7XQmMhsvDaw95+IYhNKCXvj0z2xbbm2jnyl7yeAiMDlUsV4GDI1EWTz1IM6J49DDksPCmYGNOoDPX2O3bqHxz5bTBJGyG0wiM3gyOzgt/c44OqV2AVJJ10CH/Djmkds7ZdkAvmtVfbXuDNJOwRyzdJzB6q3KZNz8+KSNwC9LCuGXVADrm32Vhv4nmjRuqA9CBcon+XduhayZhExj5qFzk2IrT5p+ngQMkGU5bMKyGjix7PTcFQ2hAX7Xid7vOHZprGuIZ7bVHYDRwgLTeC5BCHWUhLY5ZJEmyMfguGD7fWg6pMYQG9OAatL0nXfeoc7SnCrDhI4FR5wDpS/PPD8XT0v6N51s4i2FTyEN7aRAYRZlnLYbUGEIDFO/tov8S/WXXBokbdtOsGq2Z10pg1CswaC6pLCRAknlIN4W/3ZynGSThR4qCV9peI4bQgP40hzT37f3RLt1nrhGBkSpIkolxV80lAdKuJ2nIIKmMZAxY04PARHK/eXQb8veBY+Xe1WXPX98oemqll1hTbtnwkcDIrALa9STtB0mbAf5UDGPAmkJX0lUL4Ahoel569/q4xoxmCF2CojMeH4HRUEGSBEjWq9qqCL7i38rfp9AByJZr/Gnec9q5gdrhtG88RQKjIYOk/VVtFsNsZQTdnNpAj5UPAHKm6S1aahe5GEzCLlm6T2DkK0CSYba5wceFnqejDfDYLwNAllzDtVZ8xE+jW6HXiMAomQBJVgktE/8OW4PgiEIHIEeaJfptDoxtSzsJu2I+KIGRT9pdiasIvoN2I7GKXiMAGdI0+swazQaTsGnAEhj5Y5RhQ7O4/ym5AUAu3Ca8peIjvhvfkvbzzlJcui8H4jbXrLnuH/+fHM4+iaU3jMDo3/5JPLjbFDZzjaaeC0xJ1gMwEM2k603bA2M7vKe1k7AlKLpMKCC6bK6H4ukIrfpAkFoVTz1h9y5IClonJBcYyan2kUbLd5Hch0XrRjJy7el5Vq4w0FMFYIhGVxX4fTrE535NIO1HzXVbPI1CdKmz5Xnd+qqDkg+MJChqfqzcNYT/KH43it2I3SRBi3uZDX0OnHuei71g7Nb9NwCwoJ2PM9T0Cu0k7DJk4NDy3X5f9F+tPXJ1UJCD2pMJjFzkv3IJNnbdbSPjz9dktJiOabBq5SyGKnx7Qe7+M/z932Iu8ACSqTO0u0WvDQ7oPtSAtZjT+jXidF8U/VcB7qupD15JaNeb8Nyt1VikC7R6izC97h/tTI3vT1a/PbzxN2c5nw2US14zTpMVadK6/PS1OqJ0ulS+9+qB729s8G4eR5jui0d7jCS0DIp2pIKdKD9/pXxoqwjTrTbOmPfapfwuracd/ma2Q2sERgRGBEaDp5Omcfjgo2FmUPfMMsqb0eTbkxRelkW7yXPS5SlDSPM2p4+7TC8z+y8Muvyu5By2hNOui3XxtF/Ssu0p73vDlH3SeuvSd55bYNS70DZyDYwU+XXt8VavrFcqda18iv7zLC02gm3rrkmnq0BpJENoC8VHzN3Gv4M3YIun1VoaH4Ya8oukztk5ldMqjj4wctFw3fMl+cu9AJ5X3vLQPha2h6ZGkzFfCEhuC5ux3q7pXLp0lvS26PWZuwppW2SAwMj7SzXJF/QAgZFPuzMpU8xLn3wFv24pu+Ydfd3c6ySS+uZ+wD/hJVgV7zMMinbBT+Wx8G9iTEO5ryYdz5Utp1jSWfKCjMmfh2ytA4g+wB4r30sbz+8YafRp9iWSnvhJBElfJf75f7yLNGNfFroVYj5dx3xzTQGXlQ83RR5YtQagTaCg8d3z/Wr/3iiSd+LHgT+/PNrAyD3gVDb7W4fsUu8QHF25VkkOsl2pBkBdf4wMGtVe35VuxEFbj1xEkPxjD8+3OrrAyGgimk9XqdyoG5vNITia5zYRG4AZ7VEZ80DzGLUHgI85ADzDwMiNC6d0LMRVanNdMgiO7nxNvgOQJO2mhz9C3LTRiQUXPP7MAqPiqRsulWGSeYzL8zsERyneuwShpxRZAAca13Whm4eyCTw1QjvX6Czw4au/PNRfXp5PNIGRi5hPi7iO1jgUFCXda+HmHH1JIK3/pHnxtEQ6i6X6AAah7S36Hvj+5wafEbLXaOOhcexFVHOMXDT4qYjnpPrsgqK9tF66tF5HfquyR8c5QRGAQwyW6FsFJpp3sgQW2vPT6oBHKS0H/nxvdVV0q9IkczSXVNgxLYOXSvk8t/ktLq2ll+7cQ7Tfp/VxGsPGZQCip+0pWUbS+NLOcdIenKupT7YDB5feevTexZrLXYX4wUMU2iZK/ZTzSij33XbBaOiXw9bdx6cUtkIAEJbREv0fMXwX15OvbaR+C/gVhurQmPvcSPldzBne9WjIXJjTAAGSVMrSY3Ea687W1tH+XjAqPUi+hzN3AZEcrzJh6AxAS9ol+hsXkMRCG6SV7qy4IHV2Yb+45/d5mT6/x/sUcr3rOVjvHUYqk+zKgSpnKSDfj/XYib3u0Lkbt5e0PiuG23VU0lm6SJdHFgytqc9ezAspiKFXdc3z/OOjMj1+RpZu8v79rPyMcRFotEUW97g9law2fPQ+xzTZwyj3Jtt9dj/7TjiTAiXLDNcM3bya3uVeeo8VmX7zLM03pC4AZFVfSH28MgiOzkNMYznJ7EHs9kIav1Ex/76olE2CU0nvsni9R0lajlsCTwA4quBI5jv1GeqUuvkLB4YDAIDcAqSqueTw7zYemmsScMuB3054bAAAYOAAqSye5qvKdIzngY/0DP2KbBI8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAR+p8AAwBZhVVEP80/TAAAAABJRU5ErkJggg==\" height=\"70\">\n<span style=\"font-size:50px\" ></span><span style=\"font-size:40px\"> [[cluster]]</span><hr style=\"border-top: 3px solid #5780c1;\">",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 4,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 1,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "cacheTimeout": null,
+            "class": "single_stat_panel",
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "format": "none",
+            "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 2,
+                "x": 0,
+                "y": 4
+            },
+            "id": 2,
+            "interval": null,
+            "isNew": true,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+                {
+                    "name": "value to text",
+                    "value": 1
+                },
+                {
+                    "name": "range to text",
+                    "value": 2
+                }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "options": {},
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+                {
+                    "from": "null",
+                    "text": "N/A",
+                    "to": "null"
+                }
+            ],
+            "span": 1,
+            "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+                {
+                    "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
+                    "intervalFactor": 1,
+                    "legendFormat": "Total Nodes",
+                    "refId": "A",
+                    "step": 40
+                }
+            ],
+            "thresholds": "",
+            "title": "Total Nodes",
+            "transparent": true,
+            "type": "singlestat",
+            "valueFontSize": "150%",
+            "valueMaps": [
+                {
+                    "op": "=",
+                    "text": "N/A",
+                    "value": "null"
+                }
+            ],
+            "valueName": "current"
+        },
+        {
+            "cacheTimeout": null,
+            "class": "single_stat_panel_fail",
+            "colorBackground": false,
+            "colorValue": true,
+            "colors": [
+                "rgba(50, 172, 45, 0.97)",
+                "rgba(250, 113, 0, 0.89)",
+                "rgba(255, 0, 0, 0.9)"
+            ],
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "format": "none",
+            "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": false
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 2,
+                "x": 2,
+                "y": 4
+            },
+            "id": 3,
+            "interval": null,
+            "isNew": true,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+                {
+                    "name": "value to text",
+                    "value": 1
+                },
+                {
+                    "name": "range to text",
+                    "value": 2
+                }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "options": {},
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+                {
+                    "from": "null",
+                    "text": "N/A",
+                    "to": "null"
+                }
+            ],
+            "span": 1,
+            "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+                {
+                    "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
+                    "intervalFactor": 1,
+                    "legendFormat": "Unreachable",
+                    "refId": "A",
+                    "step": 20
+                }
+            ],
+            "thresholds": "1,2",
+            "title": "Unreachable",
+            "transparent": true,
+            "type": "singlestat",
+            "valueFontSize": "150%",
+            "valueMaps": [
+                {
+                    "op": "=",
+                    "text": "N/A",
+                    "value": "null"
+                }
+            ],
+            "valueName": "current"
+        },
+        {
+            "cacheTimeout": null,
+            "class": "single_stat_panel_fail",
+            "colorBackground": false,
+            "colorValue": true,
+            "colors": [
+                "rgba(50, 172, 45, 0.97)",
+                "rgba(250, 113, 0, 0.89)",
+                "rgba(255, 0, 0, 0.9)"
+            ],
+            "datasource": "prometheus",
+            "description": "Number of nodes that reported their status as Starting or Joining",
+            "editable": true,
+            "error": false,
+            "format": "none",
+            "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": false
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 2,
+                "x": 4,
+                "y": 4
+            },
+            "id": 4,
+            "interval": null,
+            "isNew": true,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+                {
+                    "name": "value to text",
+                    "value": 1
+                },
+                {
+                    "name": "range to text",
+                    "value": 2
+                }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "options": {},
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+                {
+                    "from": "null",
+                    "text": "N/A",
+                    "to": "null"
+                }
+            ],
+            "span": 1,
+            "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+                {
+                    "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
+                    "intervalFactor": 1,
+                    "legendFormat": "Joining",
+                    "refId": "A",
+                    "step": 20
+                }
+            ],
+            "thresholds": "1,2",
+            "title": "Joining",
+            "transparent": true,
+            "type": "singlestat",
+            "valueFontSize": "150%",
+            "valueMaps": [
+                {
+                    "op": "=",
+                    "text": "N/A",
+                    "value": "null"
+                }
+            ],
+            "valueName": "current"
+        },
+        {
+            "cacheTimeout": null,
+            "class": "single_stat_panel_fail",
+            "colorBackground": false,
+            "colorValue": true,
+            "colors": [
+                "rgba(50, 172, 45, 0.97)",
+                "rgba(250, 113, 0, 0.89)",
+                "rgba(255, 0, 0, 0.9)"
+            ],
+            "datasource": "prometheus",
+            "description": "Number of nodes that reported their status as  Leaving, Decommissioned, Draining or Drained",
+            "editable": true,
+            "error": false,
+            "format": "none",
+            "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": false
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 2,
+                "x": 6,
+                "y": 4
+            },
+            "id": 5,
+            "interval": null,
+            "isNew": true,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+                {
+                    "name": "value to text",
+                    "value": 1
+                },
+                {
+                    "name": "range to text",
+                    "value": 2
+                }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "options": {},
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+                {
+                    "from": "null",
+                    "text": "N/A",
+                    "to": "null"
+                }
+            ],
+            "span": 1,
+            "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+                {
+                    "expr": "count(scylla_node_operation_mode>3)OR vector(0)",
+                    "intervalFactor": 1,
+                    "legendFormat": "Leaving",
+                    "refId": "A",
+                    "step": 20
+                }
+            ],
+            "thresholds": "1,2",
+            "title": "Leaving",
+            "transparent": true,
+            "type": "singlestat",
+            "valueFontSize": "150%",
+            "valueMaps": [
+                {
+                    "op": "=",
+                    "text": "N/A",
+                    "value": "null"
+                }
+            ],
+            "valueName": "current"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "percent_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "The percentage of the time during which Scylla utilized the CPU. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 4
+            },
+            "hiddenSeries": false,
+            "id": 6,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 4
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Load",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "percent",
+                    "logBase": 1,
+                    "max": 101,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "single_value_table",
+            "columns": [
+                {
+                    "text": "Avg",
+                    "value": "avg"
+                }
+            ],
+            "datasource": "prometheus",
+            "description": "Nodes Information table",
+            "fontSize": "100%",
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 4
+            },
+            "id": 7,
+            "links": [],
+            "options": {},
+            "pageSize": null,
+            "scroll": true,
+            "showHeader": true,
+            "sort": {
+                "col": 0,
+                "desc": true
+            },
+            "span": 4,
+            "styles": [
+                {
+                    "alias": "",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the detailed node information",
+                    "linkUrl": "/d/detailed-[[dash_version]]/Detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__cell}",
+                    "mappingType": 1,
+                    "pattern": "instance",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "Time",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "__name__",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "exported_instance",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "job",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "version",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "type",
+                    "type": "hidden"
+                },
+                {
+                    "alias": "Version",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "${__cell_11}",
+                    "linkUrl": "/d/OS-[[dash_version]]/OS-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
+                    "mappingType": 1,
+                    "pattern": "svr",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short"
+                },
+                {
+                    "alias": "OS",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the OS node information",
+                    "linkUrl": "/d/OS-[[dash_version]]/OS-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
+                    "mappingType": 1,
+                    "pattern": "OS",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "OS",
+                            "value": "os"
+                        }
+                    ]
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "CQL",
+                    "type": "hidden"
+                },
+                {
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the Errors metrics information",
+                    "linkUrl": "/d/error-[[dash_version]]/scylla-errors?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
+                    "mappingType": 1,
+                    "pattern": "Errors",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "Errors",
+                            "value": "errors"
+                        }
+                    ]
+                },
+                {
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the Errors metrics information",
+                    "linkUrl": "/d/io-[[dash_version]]/i-o?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
+                    "mappingType": 1,
+                    "pattern": "IO",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "IO",
+                            "value": "io"
+                        }
+                    ]
+                },
+                {
+                    "alias": "CPU",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the node CPU information",
+                    "linkUrl": "/d/cpu-[[dash_version]]/CPU-Metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
+                    "mappingType": 1,
+                    "pattern": "CPU",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "CPU",
+                            "value": "cpu"
+                        }
+                    ]
+                },
+                {
+                    "alias": "Status",
+                    "mappingType": 2,
+                    "pattern": "Value",
+                    "rangeMaps": [
+                        {
+                            "from": "1",
+                            "text": "Starting",
+                            "to": "1"
+                        },
+                        {
+                            "from": "2",
+                            "text": "Joining",
+                            "to": "2"
+                        },
+                        {
+                            "from": "3",
+                            "text": "Normal",
+                            "to": "3"
+                        },
+                        {
+                            "from": "4",
+                            "text": "Leaving",
+                            "to": "4"
+                        },
+                        {
+                            "from": "5",
+                            "text": "Decommissioned",
+                            "to": "5"
+                        },
+                        {
+                            "from": "6",
+                            "text": "Draining",
+                            "to": "6"
+                        },
+                        {
+                            "from": "7",
+                            "text": "Drained",
+                            "to": "7"
+                        },
+                        {
+                            "from": "8",
+                            "text": "Moving",
+                            "to": "8"
+                        }
+                    ],
+                    "type": "string"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "cluster",
+                    "type": "hidden"
+                }
+            ],
+            "targets": [
+                {
+                    "expr": "0*scylla_scylladb_current_version{cluster=~\"$cluster|$^\", dc=~\"$dc\"} + on (instance) group_left() scylla_node_operation_mode",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 1,
+                    "refId": "A"
+                }
+            ],
+            "title": "Nodes",
+            "transform": "table",
+            "type": "table"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bytes_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 10
+            },
+            "hiddenSeries": false,
+            "id": 8,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(node_filesystem_size_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])-sum(node_filesystem_avail_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                },
+                {
+                    "expr": "sum(node_filesystem_size{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])-sum(node_filesystem_avail{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "B",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Disk Size by $by",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "bytes",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of Alternator Actions",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 10
+            },
+            "hiddenSeries": false,
+            "id": 9,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_alternator_total_operations{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 4
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Total Actions",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "alert_table",
+            "columns": [],
+            "datasource": "alertmanager",
+            "fontSize": "100%",
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 10
+            },
+            "id": 10,
+            "links": [],
+            "options": {},
+            "pageSize": null,
+            "scroll": true,
+            "showHeader": true,
+            "sort": {
+                "col": 0,
+                "desc": true
+            },
+            "span": 4,
+            "styles": [
+                {
+                    "alias": "Time",
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "link": true,
+                    "linkTooltip": "Jump to the see the node",
+                    "linkUrl": "/d/detailed-[[dash_version]]/detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_4}&from=${__cell_0}",
+                    "pattern": "Time",
+                    "type": "date"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "severity",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "alertname",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "cluster",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "monitor",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "summary",
+                    "type": "hidden"
+                },
+                {
+                    "alias": "Instance",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the see the node",
+                    "linkUrl": "/d/detailed-[[dash_version]]/detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__cell}",
+                    "mappingType": 1,
+                    "pattern": "instance",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short"
+                },
+                {
+                    "alias": "",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "decimals": 2,
+                    "pattern": "/.*/",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "short"
+                }
+            ],
+            "targets": [
+                {
+                    "annotations": true,
+                    "expr": "job!=\"scylla_manager\"",
+                    "legendFormat": "{{description}}",
+                    "refId": "A",
+                    "target": "Query",
+                    "type": "table"
+                }
+            ],
+            "title": "Active Alerts",
+            "transform": "table",
+            "type": "table"
+        },
+        {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Data Plane Actions</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 16
+            },
+            "id": 11,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 18
+            },
+            "hiddenSeries": false,
+            "id": 12,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": "alternator_item_ops",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"$alternator_item_ops\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "$alternator_item_ops by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Data Plane Latencies</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 24
+            },
+            "id": 13,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 26
+            },
+            "hiddenSeries": false,
+            "id": 14,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_op_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"PutItem\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Completed PutItem",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 26
+            },
+            "hiddenSeries": false,
+            "id": 15,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_op_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"PutItem\"}[60s])) by ([[by]])/($func(rate(scylla_alternator_op_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"PutItem\"}[60s])) by ([[by]]) + 1)",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Average PutItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 26
+            },
+            "hiddenSeries": false,
+            "id": 16,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.95, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"PutItem\"}[60s])) by ([[by]], le))",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "95th percentile PutItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 26
+            },
+            "hiddenSeries": false,
+            "id": 17,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.99, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"PutItem\"}[60s])) by ([[by]], le))",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "99th percentile PutItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 32
+            },
+            "hiddenSeries": false,
+            "id": 18,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_op_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"GetItem\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Completed GetItem",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 32
+            },
+            "hiddenSeries": false,
+            "id": 19,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_op_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"GetItem\"}[60s])) by ([[by]])/($func(rate(scylla_alternator_op_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"GetItem\"}[60s])) by ([[by]]) + 1)",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Average GetItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 32
+            },
+            "hiddenSeries": false,
+            "id": 20,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.95, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"GetItem\"}[60s])) by ([[by]], le))",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "95th percentile GetItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 32
+            },
+            "hiddenSeries": false,
+            "id": 21,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.99, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"GetItem\"}[60s])) by ([[by]], le))",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "99th percentile GetItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 38
+            },
+            "hiddenSeries": false,
+            "id": 22,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_op_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"UpdateItem\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Completed UpdateItem",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 38
+            },
+            "hiddenSeries": false,
+            "id": 23,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_op_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"UpdateItem\"}[60s])) by ([[by]])/($func(rate(scylla_alternator_op_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"UpdateItem\"}[60s])) by ([[by]]) + 1)",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Average UpdateItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 38
+            },
+            "hiddenSeries": false,
+            "id": 24,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.95, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"UpdateItem\"}[60s])) by ([[by]], le))",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "95th percentile UpdateItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 38
+            },
+            "hiddenSeries": false,
+            "id": 25,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.99, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"UpdateItem\"}[60s])) by ([[by]], le))",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "99th percentile UpdateItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 44
+            },
+            "hiddenSeries": false,
+            "id": 26,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_op_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"DeleteItem\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Completed DeleteItem",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 44
+            },
+            "hiddenSeries": false,
+            "id": 27,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_op_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"DeleteItem\"}[60s])) by ([[by]])/($func(rate(scylla_alternator_op_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"DeleteItem\"}[60s])) by ([[by]]) + 1)",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Average DeleteItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 44
+            },
+            "hiddenSeries": false,
+            "id": 28,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.95, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"DeleteItem\"}[60s])) by ([[by]], le))",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "95th percentile DeleteItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 44
+            },
+            "hiddenSeries": false,
+            "id": 29,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.99, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"DeleteItem\"}[60s])) by ([[by]], le))",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "99th percentile DeleteItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Control Plane Actions</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 50
+            },
+            "id": 30,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 52
+            },
+            "hiddenSeries": false,
+            "id": 31,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": "alternator_ops",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"$alternator_ops\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "$alternator_ops by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "text_panel",
+            "content": "##  ",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 6,
+                "w": 16,
+                "x": 8,
+                "y": 52
+            },
+            "id": 32,
+            "isNew": true,
+            "links": [],
+            "mode": "markdown",
+            "options": {},
+            "span": 8,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Cache</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 12,
+                "x": 0,
+                "y": 58
+            },
+            "id": 33,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 6,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Timeouts</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 12,
+                "x": 12,
+                "y": 58
+            },
+            "id": 34,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 6,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of rows that were read from the cache, without needing to be fetched from storage.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 60
+            },
+            "hiddenSeries": false,
+            "id": 35,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_cache_row_hits{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Cache Hits",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of rows that were not present in the cache, and had to be fetched from storage.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 60
+            },
+            "hiddenSeries": false,
+            "id": 36,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_cache_row_misses{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Cache Misses",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wpm_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Requests that Scylla tried to write but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 60
+            },
+            "hiddenSeries": false,
+            "id": 37,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(delta(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Write Timeouts/Minutes by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "decimals": 0,
+                    "format": "wpm",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rpm_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Requests that Scylla tried to read but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 60
+            },
+            "hiddenSeries": false,
+            "id": 38,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(delta(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Read Timeouts/Minutes by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "decimals": 0,
+                    "format": "rpm",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Your Panels</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 66
+            },
+            "id": 39,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "user_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "This graph panel was left empty on purpose for ad-hoc usage. Change it when needed. Pay attention that changes to the panel will not be saved.\n\nIf you do need a panel that can be saved, create a new dashboard, or edit the panel inside the json file",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 0,
+                "y": 68
+            },
+            "hiddenSeries": false,
+            "id": 40,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Your Graph here",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "user_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "This graph panel was left empty on purpose for ad-hoc usage. Change it when needed. Pay attention that changes to the panel will not be saved.\n\nIf you do need a panel that can be saved, create a new dashboard, or edit the panel inside the json file",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 12,
+                "y": 68
+            },
+            "hiddenSeries": false,
+            "id": 41,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Your Graph here",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "plain_text",
+            "content": "<h4 style=\"color:#5881c2; border-bottom: 0px solid #5881c2;\">Scylla Monitoring version - master</h4>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 74
+            },
+            "id": 42,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        }
+    ],
+    "refresh": "30s",
+    "schemaVersion": 16,
+    "style": "dark",
+    "tags": [
+        "4.0"
+    ],
+    "templating": {
+        "list": [
+            {
+                "allValue": null,
+                "class": "by_template_var",
+                "current": {
+                    "tags": [],
+                    "text": "Instance",
+                    "value": "instance"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": "by",
+                "multi": false,
+                "name": "by",
+                "options": [
+                    {
+                        "selected": false,
+                        "text": "Cluster",
+                        "value": "cluster"
+                    },
+                    {
+                        "selected": false,
+                        "text": "DC",
+                        "value": "dc"
+                    },
+                    {
+                        "selected": true,
+                        "text": "Instance",
+                        "value": "instance"
+                    },
+                    {
+                        "selected": false,
+                        "text": "instance,shard",
+                        "value": "instance,shard"
+                    }
+                ],
+                "query": "Cluster,DC,Instance,Shard",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_single",
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": false,
+                "label": "cluster",
+                "multi": false,
+                "name": "cluster",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "dc",
+                "multi": true,
+                "name": "dc",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster\"}, dc)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "node",
+                "multi": true,
+                "name": "node",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster|$^\", dc=~\"$dc\"}, instance)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "shard",
+                "multi": true,
+                "name": "shard",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization,shard)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 3,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_single",
+                "current": {
+                    "text": "/var/lib/scylla",
+                    "value": "/var/lib/scylla"
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": false,
+                "label": "Mount path",
+                "multi": false,
+                "name": "mount_point",
+                "options": [],
+                "query": "node_filesystem_avail_bytes",
+                "refresh": 2,
+                "regex": "/mountpoint=\"([^\"]*)\".*/",
+                "skipUrlSync": false,
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "aggregation_function",
+                "current": {
+                    "tags": [],
+                    "text": "sum",
+                    "value": "sum"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": "Function",
+                "multi": false,
+                "name": "func",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "sum",
+                        "value": "sum"
+                    },
+                    {
+                        "selected": false,
+                        "text": "avg",
+                        "value": "avg"
+                    },
+                    {
+                        "selected": false,
+                        "text": "max",
+                        "value": "max"
+                    },
+                    {
+                        "selected": false,
+                        "text": "min",
+                        "value": "min"
+                    },
+                    {
+                        "selected": false,
+                        "text": "stddev",
+                        "value": "stddev"
+                    },
+                    {
+                        "selected": false,
+                        "text": "stdvar",
+                        "value": "stdvar"
+                    }
+                ],
+                "query": "sum,avg,max,min,stddev,stdvar",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
+                    "text": "4.0",
+                    "value": "4.0"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "dash_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "4.0",
+                        "value": "4.0"
+                    }
+                ],
+                "query": "4.0",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
+                    "text": "GetItem",
+                    "value": "GetItem"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "alternator_ops",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "CreateTable",
+                        "value": "CreateTable"
+                    },
+                    {
+                        "selected": true,
+                        "text": "DeleteTable",
+                        "value": "DeleteTable"
+                    },
+                    {
+                        "selected": true,
+                        "text": "DescribeEndpoints",
+                        "value": "DescribeEndpoints"
+                    },
+                    {
+                        "selected": true,
+                        "text": "DescribeTable",
+                        "value": "DescribeTable"
+                    },
+                    {
+                        "selected": true,
+                        "text": "ListTables",
+                        "value": "ListTables"
+                    }
+                ],
+                "query": "CreateTable,DeleteTable,DescribeTable,ListTables,DescribeEndpoints",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
+                    "text": "GetItem",
+                    "value": "GetItem"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "alternator_item_ops",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "BatchWriteItem",
+                        "value": "BatchWriteItem"
+                    },
+                    {
+                        "selected": true,
+                        "text": "DeleteItem",
+                        "value": "DeleteItem"
+                    },
+                    {
+                        "selected": true,
+                        "text": "GetItem",
+                        "value": "GetItem"
+                    },
+                    {
+                        "selected": true,
+                        "text": "PutItem",
+                        "value": "PutItem"
+                    },
+                    {
+                        "selected": true,
+                        "text": "UpdateItem",
+                        "value": "UpdateItem"
+                    },
+                    {
+                        "selected": true,
+                        "text": "Query",
+                        "value": "Query"
+                    },
+                    {
+                        "selected": true,
+                        "text": "Scan",
+                        "value": "Scan"
+                    }
+                ],
+                "query": "GetItem,PutItem,UpdateItem,DeleteItem,BatchWriteItem,Query,Scan",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
+                    "text": "GetItem",
+                    "value": "GetItem"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "alternator_latency_ops",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "GetItem",
+                        "value": "GetItem"
+                    },
+                    {
+                        "selected": true,
+                        "text": "PutItem",
+                        "value": "PutItem"
+                    },
+                    {
+                        "selected": true,
+                        "text": "UpdateItem",
+                        "value": "UpdateItem"
+                    },
+                    {
+                        "selected": true,
+                        "text": "DeleteItem",
+                        "value": "DeleteItem"
+                    }
+                ],
+                "query": "GetItem,PutItem,UpdateItem,DeleteItem",
+                "skipUrlSync": false,
+                "type": "custom"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-30m",
+        "to": "now"
+    },
+    "timepicker": {
+        "now": true,
+        "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+        ],
+        "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+        ]
+    },
+    "timezone": "browser",
+    "title": "Alternator",
+    "uid": "alternator-4.0",
+    "version": 1
+}

--- a/grafana/build/alternator_4.0/scylla-cpu.4.0.json
+++ b/grafana/build/alternator_4.0/scylla-cpu.4.0.json
@@ -1,0 +1,700 @@
+{
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            },
+            {
+                "class": "annotation_restart",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "resets(scylla_gossip_heart_beat[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "node_restart",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "restart",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_stall",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_stall_detector_reported[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "stall detector",
+                "showIn": 0,
+                "tagKeys": "dc,instance,shard",
+                "tags": [],
+                "titleFormat": "Stall found",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_schema_changed",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_database_schema_changed[30s])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "Schema Changed",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "schema changed",
+                "type": "tags"
+            }
+        ]
+    },
+    "class": "dashboard",
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 1,
+    "hideControls": true,
+    "id": null,
+    "links": [],
+    "overwrite": true,
+    "panels": [
+        {
+            "class": "text_panel",
+            "content": "<div id=\"amnon\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPoAAAA6CAYAAACZBESJAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAGm9JREFUeNrsXQd8VFXWP+9NTe+NEOmgSIdFiuxSIqB0krCssrCI0sKGLnVZV/qCCqx0ERdQ+ehFCKEtCAuCCAkdQkkhlPQ2yfT5znkzwWTyJslMJqDfd//8zo+ZVydz5//+55x777kADAwMDAwMDL99cC/yZjKpUtqxWUQbvUFbD982Q9OjKdE6oz1Gu4HGo6VzHPdzsabw+uU7h4tYMzEw/IqJLpUouE7NIwL1Bl0kvh1gIbQr8DzIgvyA9/EGMJnKnGPSG0CXnAYmjQY/HWfATTeR9HuL1Pknr9w9cpo1GQPDr4ToUomc79g88jWDQTcf3w7ipFJwad8SFE0agLxuKMgb1wcwGGxfAMlvKCgE3b1kKLp0DTR37oP+cboBJPx1juPXFKnzNiHpDaz5GBheAtGlEhnXsVnkqwajfgGq8WBZaBB4Rb4DyhavAaeQl1PvKgPP0yY9grxdh0FzIxEdfsP9Ik3eR1fuxu1hTcjA8AKJLpHIZJ2aRY4zmAxLkeBKIrhrh9aCK+5M6NMzIe+7g6A6+5OeVypjVcU5Y+ITjz5hTcnAUMNER5K7IMm3GnlThHuPzuD1p/7AyWSOK3iFn5gjRQd1wk3I+moHmLLzbqi0+SOQ7D+z5mRgsMHRal+Alyo7NY/aZpRyEX7Rw8Gzbw8zGWsSPAfSkEBwaf066J88C+TS8/v5+YRdepp9P5k1KQODk4lOJO/YPHKLScpH+o4bBm4d2oDJ8OJyZBIvD1A2awLa1DQPPr2gB5L9FJL9KWtWBgYnue5IchmSfIZJws33Hf9nJDnG4wajeSf+r752G1RnLoLm7gMwZOc9V3lOKgEFktO1fStw7dSm+i4+z+P1cyFr9RbQXL3zs8pQ0Dsh8Vgma1oGhmoSHUnOd2wW2dEkgbNeUX3Bc0C4OemGhNU9fgZZa78BQ1IqNG3RGP7Qoz00a9UEDKj0RqMRUpOfwMXzV+H44bPgEhoM5AkomzasXtIOHyLahymQuWyjIf/xw+0JD04OY03LwFBNovMUl7eIOi1t+Er74E+mgkmnE0iuufMAMpeshXp1Q2DuognQ+NV6Nq/x9EkGfLpwE5z+4TL49Q8H7+ERYFJrHCY69csX/XgFMv+5Ia1IqnkXVf0H1rwMDA7G6Dwv4Ts1i+ppkvDT/SeMAImPF6BUo4v+ELKWroMWLRrB+q0LICDQt9y5pOp3bj2EtNRn4O3jCX0GdgM3pRxObN4HMpkUlM2bVDyQpiJgSMC7uYLhyTNPVVJyg2d5SV+z5mVgcJDoHMfLw4Kbfa1o1jjUa2BPgZgmrRYyl2+EZvVDYeWmeSCVSsudp9XqYOc3h2F69BKI+/4H+H7vSUHx3xnYFVzlMjjx9T5wf60hSAP9hQeH/TABr1QC5+4GutOXpX7+dX56lv0ghTUxA4N5Aok9as6hmtc3cdDerUt7MBEhDUYoPH0BJJnZMHthtCjJCepiDez69gjIkNQcutoF+Sr4eOZKuHguASLfewfaNm8AGVv3AIcK7xBM+BCS8CAPq0WeQZBJp/+QNS8DgwNEFzwADgbyHm7g1uV3AslNej0UHTwBfSPDIbR2kM0T9XoD3LubDBIJb/EMiOxFsGr5FnBxVcL4Se9BQWIKqBNuAWfjYVEp142o6vjZlG+0lLpLPVq2bBjOWpiBwQGi88jQPyjQxQYklZBlz8gCyM2HLt1+V4nLz4E7ktBUpivNBFkZOXABVb1+wzCoGxYEhZeuCvG2Y0w3AeeiBEWjepTF98QtLVkTMzA4RvSW8jqh5r5vInpyGkjlUmjXoXmFJ8oVMniza1tB2cvE7hodxP98S3gIdO7SCoofZwDH8w7/QRzPgcTbE6ShQW4mg/F11sQMDPYS3US5OD5Y8WpD5LhRcJX1KY8hJDSw0lPd3Fxg/rLJMHrCUPDx8QQjnsvhP8rEU1cbZxnDrk99LAyCcRgUq6PrL/UVbtKxJr60Pn36yNEzaYc2FW0r2lm002ixaCvRInbt2uVRE/eOiYlxweu/iTYRbTPaf9FOoR1H24Q2asmSJbXtve6iRYvq47k90bqWsu50rylTpvhXdv66deukeGwLtHCra7yF1mD48OGVumn4ncnw2NZoPazOr9uvXz/emd/jhQsXAvG6ndC6lbpXz1atWrm/aBKmp6d3tvrOG3p7ezv1761yMMxzEq5T86i6RqNB1CWvqtq6e7haue+lY2wjGIuKqzVWnq7Nofcgqx0MpnjnDsft3bu3JDY2tivxAq29rcOIjxEREQVExJ07dy4fMmRIanXvHR0dXfeLL76Yji/fRfOu4ND3Z8yYoUOLXbx48d9nz54dX8VbvIn2BVq5B9Snn366xGg0zlqxYkVF51NRkbVor4nsm4S2sgqfwQftX5ZrlcYnaEvQip3YnN3R6A+yTiy1Rot/gSRvGRAQcAhfepXajPEw1EfLfxmKTuyrSySUBPiYlZPc5LAQSLz9sNKTi4vUsOTjdfDpok2Qm1uAos3hJUyCm+7h7mq+gVwG8iYNHO9Lr0H07NnTH0n+Ob48XgHJS4MIExMVFfWf7du393T0vuPGjePwgfEXJPlP+HZ8JSQvgQyt/6xZsy7guZMWLFhQlVttQfvWxr7h9BXYOnHNmjUwZsyYsTZIfnDEiBH7t2zZwvxncfwVqOpSWfjl5OQM8vT0lL4Mootl2EDq7wtGdLkfpVY8l0St1sKRg2eEgTFlYnckd6u2TaGwQAX/PRMPLrUCzN12vy6Su8TFxY21NIq9KERzaL48kkeGJCI124zm78AlqK9y6Zw5cyZ98sknFR6Iyg/oAWy2oWa1Pv/888hJkybZcmvHofUT2Z41cuTIVUjyJMbn8nj69KkXqvkgy4O5XJSGpngZRDcKPwIq85SRY9Z3JLq8bm0wenrAzm2HK3WpicxcGbecg4AgX+jeqyPcT0yBpJQn4Nq00a9R0duizXfgvPvous8YOnToNXtP/PDDD2UY987Fl3Or+dnvL1y48Mq8efMqPRDJfmHp0qUbwVy00xpRFnfXWs3D0OugmoBi8Ru58qcYpW1igoial6BNXl5eW1R1/oUS3WgywLlrO3N53iqnIpGAokNrOLTnBOTlFdpOBkgl0LBxHeSw8Tnx3d1d4P2xUaDVaGHLl/vAo1EdcO3YBkw6fTWcDAwJNDrQPXqq5ySSasc44eHhfqjm79rYnYu23aJoRIStaKqS8AtJPh/j8zgHSA4bNmygiTkVsZPm3q+zxOwRxDm0O9ZuM5K8/9y5c+0pqrnR8jdZwxtV/f2YmJjniT4MJyi0iBZ7ABDBUc23ff3113rGZ1E1h6CgoBFgroJsC05TdfueFhwl241PNbfvUfrdvAkJ7PF2V9AplTBn0jLbPiS66F26tQO9Xi+Q3MVFCcM/HAQ9UM3/Z8v3cPr8VQgQJrZoq/1HCUm9YnURfsgbTviO/NDEBgncO3jw4AB8sPwJbR3aLrThgwcPpn7GNbt3716MJP+3g/ekWHeEjX15aDNXrFhRH+83Du07tD1o0dOnT2+F+/4GQgYFNqErHoUkv2fPjWfOnKlDVV+NLxNEdg9YuXJlXyR7yfsuNlx2zQcffPAZkvwOo7RN9BNJBFojAlU9wMOj+h049gb79ANKMhYVB5cRdR8v8P3rSLi+fD2sWLIZoqcME4a6lobSRSFsr1MvFFSqYug3uDt4eLjBvh3HYMPGveDfpxsoXm8M+vQs0D9JB3n9MOAUCvvnqpOiF6tBm/hQz8klzshakmsVar3x0KFDd/r3719uhtzevXsfEukcvdmoUaNIzbviyz+I7H60atWqmIkTJ+4VO3f58uVqiUSybMmSJWuR5Cp0xR2aDohk/xGv8+W0adM+F/mNDEtLSzv98ccf34qOjh6D75uKXOJTtFjG5QpBIVlVGDwRbRaa9kUS3YjES9Amp3Wgck5g+IVcikZ1weMvkbDnq51w9/ZDmLMgutyQWLlCDoOH9hJeZyChVyzdDNu/iwP/gW+Bz4hIMOQVgOrUecjdtg+ULV4F/4/GAO/iYtckF4ua02eihR+u11Qr9enTx+fAgQNuSHaVky9dC62rjX0UGuyt6GRUYw2ZEz7HerSOltCgNDrv2rXr92DujhNT89Oo5ls3bdrEXHYbePz4cXN02xtB+WniFI6FWXnawy0hXLWIbn+gbzLlGTKzy39GCQ9undqB/4yxcD0tE97tNxH+MWsVnDhyDpIeppkD2px8OH/2CiyatwaGvDMR9sddgOBRQ8B72CAwqtXCQBlpcABIawWC9n4KFHx/EniFHZNcSM21WozPn1DugAiY5IR20YF4f2anfv36HUeyt3Xy74AaWmyY4X9Xr179b1TzF/JjxDBAhx4C9atfFRN9MPdte1q77KNHj/4MSX6b0blCzBFR82MWlbceK+Cfn58/Et33anW12XuyAYl+Sp+R/ZFoyQpUeXmT+hCydCYq84/ww6VrEDf1U+AkkjLHyEICwbVfD3AL7wwSL0+h4ITm9n3I2xUrlJ5yfaM1uPfoBOqbiTYH19gkukYL+rR0KNTk6K+lnXVK3gTtJFoTkX0dkOzn8TNewtf70W2Pwxi9uoMtPG3EbrdFkm01jfNo+9BaWG2va+N4cvUPMx5XqOaeISEh3UW49x3aTssDtJ5IUu4rEO8NqakYnUuiCS2aW/dBju66mFtNQ1Ddw98UjPbrktLMii2VgLxObeCU5kQikbLg8ElQnbmEx6SConkTCF4yQziGikwqmjayu+oMlaQyZudo0Ds454yGOX78eFavXr3+HRcX92d8K9aPLLO4uB0HDRq0GEl/H19/sXv37nWRkZGOuNCvoFlX7dCjmt+aMGHCC/1Roqrj18h/PmXKFCL6wEoOv4Rq/j8bN25kLrv9ag4BAQH7MzMzNVlZWft9fX2joWzfeiNU9e7u7u6HVSqVQ4NM7HLdjUaD6dy1nUk8x4Oe3PeqjFSlddbqhwmklTeoIyyvlL//GGQsXgNpY2ZD0Y5D0NQX+ePtBcELp4OsdojDlWQ5i6JrU59q0ItIdWLjXEabXIUnKn0jDdFWRERE3NuxY0eEk+6PT0lQvYxf5dSpU3M/++wzysInVnIodfXFMx7bxqNHjwDVnNYgtO5S22JpY8K/Sr0Gq1hd9qIUnX7KlJC7qEtJa891bgumX54CUHzlBmT8cz3IwoJB4uvzPGNOxNWiB0BxPLnxktBgkOblw3vD3hG62LZ+uQ8up6YDVHe9B87sJWCMXoT3uemsBjp69KgOVf1LVHVy0Smj3L0Kp9WOiopajWR3r0Y3268FNOyX+tb/ZmP/2rFjx25HNWdsrhiU2Kwlsv2Lktjcz8/vQU5OzmVvb+8uVkIcVVhY+A9U9Zuo6nYzxZFRN0aT0RivTU4rO/kElduldTNBlWkxRcBYe1TvN2BEj3ZQePsBeEW9AyHL50DYthUQNPevwDd4BX46ewV+PBsP33wbC96d2ghFLKoDmk1nVBWRu1+EpHdqxh3JTh5D/Ntvv90DzF1KpHLPKjktCMn+wfbt2wOqeXsKGQJf1q8TVR1WrFjxGb48IJY7GD9+/Lb169erGI8rRbRI+JcQGBh4F9320uRdZUPVRzgkzg4S3YRKnawTiM6XT8Y1rAOeA3uBEfcl3X8Ebdu/jq85cPldC5ojLqg7r5SDW3gXuJOYAvNmrBQSeN5/7CeoseNqXibjTl1rSTXRUkeOHCHC30Kb0L9/f8qQv4G2Ac3WOu60DnyUHbegOnfZ5X4h0dGNaSTay8LkyZNzkewPRHZlgHkQD0PFbnvn0NDQ16B8wLtVhNQHLN+rNWJQ1QNcqMv5RSg6Uj2BlFOflS06pVTq5wM+00dD7PdnYMyIeeDVvDEohKWSjc/Vnyq+hq5dAMGLPoKAGeOeF7KoFtGLNaC7lwIqXd7DhHvHa7zxDh48qEPCX0QbM3DgwMZgzpqKqXGIHZfFGAbECEWj3rowyvyfUnMC9WqUSdr6+Pjoc3NzabvO6ljKYlNSVFLjRDcaDcZz13ee4jkJGDLEiU7KTuWmQlZ/AoFzJoD/5FFgtM6e43m8hzvG8yEOVn0Vic/R9TdQxp3jU190K+7fvz9t8ODBS/HlfZE8SCM7LkWfXWwSzOuo6sNWrlzJKPMbQ2pqqjuqeXeRZNpBdNvTMzLExFtIyom5uH93JCnn4MwYDoNhYzp1sXG2ikTQvHUksuLVBsA7MpTVbp6T666jjHsBJ+XPO/v6NFXVZDL9MTY2drIDp1d5muqmTZuyR48efcTG7pExMTGzKiL7jBkz6uLnPIa2b9GiRT6MZr8KzIayhSVKu+2ixTRQ1e/n5+f/DOZZo6URWFRU1A3dd7u46+hoGwP+kOK1KWk9ywyFfZmwxOj6R09UoJBcdzLJIS4ujgovbO/du3cx/u21Dh06NLtv377PXasBAwYE7NmzhwpDNLA6vQjsn49OI312oA2x2k5P8oVI9oZGo3EGxs3P15ibNm0aLFu2rBO+XA7mfn2YNWvWCTxu7Ny5cy/+xolS58CBA7+3kMLWD1zRo0ePiydPnsypzo2uXLnSDsxTbmW2fUcoatKkSfzdu3crHSeBag61a9cWm6WWFxwc/B9U84oy0JSUowlV1kE5DY88AXYMi3WU6EYwmhJ0RPSaXiK5iiSnATm0WgxIpUgsvdOIHh4eTiSnutElJVLoS5/Wp0+fcUj4HyxudlNL/Cz21E62ELfK2Lhx42P876sNGzbQfX1FfmjvT5o06U9o1N13BsxVZ94C84iq0m3aes6cOUfRPpo/f/6GqsxJ/5ViBNiezVca1CNyspr3qkofIY0p6IaWVoVjqWCJ2OSVbVB5aSxKytHDPMxqey9U9Qao6rfVanWVXGWHXHfOPBT2tB5jdGECyUsnOghz0Gnoq0qbm5GQeEzvLJIfO3aMfjy7ofy4bnrqv432EVpfGyQn0GAbR0bp0Tx2Gvpo6wt2sTxcyC0cb8kDiD246XNRzbbfMw/6pYDqCogl4baA7Z4ac8N5eenQfaeknN5GrF71mo8OKzqNgqLhrdTNxvMvnekWt10DvFPddpqO+xcRklcVF3fu3Dlv6NCh9svKxo0wduzYb/Dl6ArIXhWQe0fdf2zRyReM5OTk3ui2N4XyXWpn0W2/8+zZs6qo8SobLvqA4uJiX6VSWXNENxj1cO76rhwe+AwhIce/XPddGPpKiTgaESflnUb048ePP33rrbcmWb5se/EfJPl7Q4YMeeDo/devXw/jx4+nhA3lBy45cInbCxcu7Infz4rfsNv+W8Z7NtS8Km57iarfKygouAzlk3JKiwhJaozov8TpxiRtisjAmZfhupOipz4pBonkhjMvbZnUQskPGviyq5LD6QlN3Wvjdu/e3R1Jfq+691+7di09yM5MmDCBEm00//tYZS6fJXactXjx4q52lpFicJ6a13rllVcox2Kd1MuvVavWHlRze0aH2VL1iVV13x2WYp6Xyjq3iFrM1wqYGvLZ34Shp4UnzoFnn27CDLKSSi852/aC3/jhAhEt8gvG/ELIXLUZ/Ea/C5KgUqunGoygvnkXVGcvQcCUD36J/zE0MGTlQP7+o+A37s/m7UgpmlijfZgCrh1aQ+Gxs5D9xdZ7RRJ1B4zRs2qqAXv37u0WGxtLo+FozjgNbTVYLG3v3r1nBg8efLemf0QxMTG+K1eupPu/ZknUUPafJu5T4u/k0qVLH86cOZPNImN4Docns3PCmHdT/POEHJK78MgpcGnVFKQhAQIRTTodFJ39CfxjRiLRrbXPJCzWIKUHQokq0zZVsfCAKJPNNxhAl/YU1Am38fmIH1nNCdemOezqhJvC/HVzIi6v6OqjH7Jq8gs7cuSIChWWMrsnX1ajrVq1KhuNlJqpNUPNxegl9ENynn6ekJPwIPH1Bm3yo+eFI4msnFwOmlv3hP2V+98iK7XQgwCJbswrABmt+UbDaOlQtQZ0D5KFijQmjUZIxHESyTnWpAwMTiQ6JeTOX9uVTQk5LSorFZugVUw1NxJ/ITXNRQ8LEdx6rgpRArn8tJabdRafyj9rU5+UelhYJrA8yQBZoL8wvJYScbj/OmtSBgbnKrpZ1UumrCI5qXJM2emrpMbiXXBUxFGPcTdUJWNPMTwSm1aFodclWXZ9eibI6tYWJrPoU58UMkVnYKgZolMRiqu6lDShvjupty7p0fNlj6nbTervAwZUdCi7QItAWKHIZGUj6yxVYzT3U0AW5C/E8bSSqyG/UDDew02I1c0j4oApOgNDTSi6ySgUiwQjkpFiaIqndSWqjoSnmu9aJw+qMWn1oEt9DLyLEqTouuuSH1MiLiM+8aiONSkDQ0247hwkmCwJOYm7m1CemfrWS1S9RLk5R8fEW8pDaR+goterTbl+cyLuYSq+DxPGuOvThEQcU3MGhpog+vOEnInP1JrdZ5DWDgEtuu8Ue5M7TwUn9M8yqxaL6ynp9hg4kQw9PTiExRyowA3G5yWJOCK9FuNzkPAsPmdgqCFFN6u60XhafesecDIJyGsHC/XYy7jqQkKuVDadut1kMlDT8NmSmu+cOXFHq7XIKQSgBBxtQyJT0UlK9En8zQUnhVFw6Zl4XC0wZOWC/tHTYqboDAw1S3S9QPTrd6DoQjy4tGsB2jsPoGD/MYGcitcbAeeigKyN35qXQ0aiEkkpaae+ehsKT54DTi4TBskUxJ4SYm81egeGXPPiKOQd0Hb5K7WEElX6zBzI3mRe7JNG1eVuP4DXV9KQzyusORkYbEbA1YdEInPp1CxyK0p7hJB5x/iZFmsQusNQpfUl2XVUb1loEJHcgOpOc3qpRE0f3s1ViO31GdmF6OLvQe/8j5xCppBjDK6+kSiEAEKZaF8vMOSrBEXnXV2Ea6Pi31apc6PjE4+eZM3JwFCDRLeQXYJkD8e4nRbfo8obNLmkDZinWFKlRprFNQpNgY77LbVOdeDKnSOGN1sO7aU3aDtxHJdXrCncnZB49B5uC9PpNVSwnvx6KuxAJKbVRTug0SLstExSXY7jk1TFOfuR5FmsKRkYGBgY/l/jfwUYAPw0FqsWp2FrAAAAAElFTkSuQmCC\" style=\"margin-top:-20px\" height=\"55\">\n<span style=\"font-size:40px\">  [[cluster]]</span><span style=\"padding-top: 25px;float:right\"><a href=\"https://github.com/scylladb/scylla-monitoring/issues/new?body=scylla-version%3D[[scylla_dash_version]]%0Amonitoring-version%3D[[monitoring_version]]\" target=\"_blank\"><input title=\"Report an issue with Scylla Monitoring\" type=\"button\" style=\"background-color:#57d1e5;color:black;font-size:20px\" value=\"Report an issue\"></a></span><hr style=\"border-top: 3px solid #5780c1;\"></div>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 4,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 1,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Information by Task Group</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 4
+            },
+            "id": 2,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 6
+            },
+            "id": 3,
+            "panels": [],
+            "repeat": "group",
+            "title": "$group",
+            "type": "row"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ms_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. This graph shows how much time was spent in $group group",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 7
+            },
+            "hiddenSeries": false,
+            "id": 4,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_scheduler_runtime_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Time used by [[by]] - $group",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ms",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ms_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. The maximum amount of time during which a task group can run is called the \"task quota\". Some task groups may disrespect that and run for longer. This may cause latency issues",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 7
+            },
+            "hiddenSeries": false,
+            "id": 5,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_scheduler_time_spent_on_task_quota_violations_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Time spent in task quota violations by [[by]] - $group",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ms",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Shares assigned to the $group. Shares determine how Scylla reactor distributes the task quotas between groups (Higher share gets more quotas)",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 7
+            },
+            "hiddenSeries": false,
+            "id": 6,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(scylla_scheduler_shares{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Scheduler shares [[by]] - $group",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        }
+    ],
+    "refresh": "30s",
+    "schemaVersion": 16,
+    "style": "dark",
+    "tags": [
+        "4.0"
+    ],
+    "templating": {
+        "list": [
+            {
+                "allValue": null,
+                "class": "by_template_var",
+                "current": {
+                    "tags": [],
+                    "text": "Instance",
+                    "value": "instance"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": "by",
+                "multi": false,
+                "name": "by",
+                "options": [
+                    {
+                        "selected": false,
+                        "text": "Cluster",
+                        "value": "cluster"
+                    },
+                    {
+                        "selected": false,
+                        "text": "DC",
+                        "value": "dc"
+                    },
+                    {
+                        "selected": true,
+                        "text": "Instance",
+                        "value": "instance"
+                    },
+                    {
+                        "selected": false,
+                        "text": "instance,shard",
+                        "value": "instance,shard"
+                    }
+                ],
+                "query": "Cluster,DC,Instance,Shard",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_single",
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": false,
+                "label": "cluster",
+                "multi": false,
+                "name": "cluster",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "dc",
+                "multi": true,
+                "name": "dc",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster\"}, dc)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "node",
+                "multi": true,
+                "name": "node",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster|$^\", dc=~\"$dc\"}, instance)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "shard",
+                "multi": true,
+                "name": "shard",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization,shard)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 3,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 2,
+                "includeAll": true,
+                "label": "group",
+                "multi": true,
+                "name": "group",
+                "options": [],
+                "query": "label_values(scylla_scheduler_time_spent_on_task_quota_violations_ms,group)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 3,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
+                    "text": "4.0",
+                    "value": "4.0"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "scylla_dash_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "4.0",
+                        "value": "4.0"
+                    }
+                ],
+                "query": "4.0",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "monitor_version_var",
+                "current": {
+                    "text": "master",
+                    "value": "master"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "monitoring_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "master",
+                        "value": "master"
+                    }
+                ],
+                "query": "master",
+                "skipUrlSync": false,
+                "type": "custom"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-30m",
+        "to": "now"
+    },
+    "timepicker": {
+        "now": true,
+        "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+        ],
+        "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+        ]
+    },
+    "timezone": "browser",
+    "title": "CPU Metrics",
+    "uid": "cpu-4-0",
+    "version": 5
+}

--- a/grafana/build/alternator_4.0/scylla-errors.4.0.json
+++ b/grafana/build/alternator_4.0/scylla-errors.4.0.json
@@ -1,0 +1,1148 @@
+{
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            },
+            {
+                "class": "annotation_restart",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "resets(scylla_gossip_heart_beat[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "node_restart",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "restart",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_stall",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_stall_detector_reported[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "stall detector",
+                "showIn": 0,
+                "tagKeys": "dc,instance,shard",
+                "tags": [],
+                "titleFormat": "Stall found",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_schema_changed",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_database_schema_changed[30s])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "Schema Changed",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "schema changed",
+                "type": "tags"
+            }
+        ]
+    },
+    "class": "dashboard",
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 1,
+    "hideControls": true,
+    "id": null,
+    "links": [],
+    "overwrite": true,
+    "panels": [
+        {
+            "class": "text_panel",
+            "content": "<div id=\"amnon\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPoAAAA6CAYAAACZBESJAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAGm9JREFUeNrsXQd8VFXWP+9NTe+NEOmgSIdFiuxSIqB0krCssrCI0sKGLnVZV/qCCqx0ERdQ+ehFCKEtCAuCCAkdQkkhlPQ2yfT5znkzwWTyJslMJqDfd//8zo+ZVydz5//+55x777kADAwMDAwMDL99cC/yZjKpUtqxWUQbvUFbD982Q9OjKdE6oz1Gu4HGo6VzHPdzsabw+uU7h4tYMzEw/IqJLpUouE7NIwL1Bl0kvh1gIbQr8DzIgvyA9/EGMJnKnGPSG0CXnAYmjQY/HWfATTeR9HuL1Pknr9w9cpo1GQPDr4ToUomc79g88jWDQTcf3w7ipFJwad8SFE0agLxuKMgb1wcwGGxfAMlvKCgE3b1kKLp0DTR37oP+cboBJPx1juPXFKnzNiHpDaz5GBheAtGlEhnXsVnkqwajfgGq8WBZaBB4Rb4DyhavAaeQl1PvKgPP0yY9grxdh0FzIxEdfsP9Ik3eR1fuxu1hTcjA8AKJLpHIZJ2aRY4zmAxLkeBKIrhrh9aCK+5M6NMzIe+7g6A6+5OeVypjVcU5Y+ITjz5hTcnAUMNER5K7IMm3GnlThHuPzuD1p/7AyWSOK3iFn5gjRQd1wk3I+moHmLLzbqi0+SOQ7D+z5mRgsMHRal+Alyo7NY/aZpRyEX7Rw8Gzbw8zGWsSPAfSkEBwaf066J88C+TS8/v5+YRdepp9P5k1KQODk4lOJO/YPHKLScpH+o4bBm4d2oDJ8OJyZBIvD1A2awLa1DQPPr2gB5L9FJL9KWtWBgYnue5IchmSfIZJws33Hf9nJDnG4wajeSf+r752G1RnLoLm7gMwZOc9V3lOKgEFktO1fStw7dSm+i4+z+P1cyFr9RbQXL3zs8pQ0Dsh8Vgma1oGhmoSHUnOd2wW2dEkgbNeUX3Bc0C4OemGhNU9fgZZa78BQ1IqNG3RGP7Qoz00a9UEDKj0RqMRUpOfwMXzV+H44bPgEhoM5AkomzasXtIOHyLahymQuWyjIf/xw+0JD04OY03LwFBNovMUl7eIOi1t+Er74E+mgkmnE0iuufMAMpeshXp1Q2DuognQ+NV6Nq/x9EkGfLpwE5z+4TL49Q8H7+ERYFJrHCY69csX/XgFMv+5Ia1IqnkXVf0H1rwMDA7G6Dwv4Ts1i+ppkvDT/SeMAImPF6BUo4v+ELKWroMWLRrB+q0LICDQt9y5pOp3bj2EtNRn4O3jCX0GdgM3pRxObN4HMpkUlM2bVDyQpiJgSMC7uYLhyTNPVVJyg2d5SV+z5mVgcJDoHMfLw4Kbfa1o1jjUa2BPgZgmrRYyl2+EZvVDYeWmeSCVSsudp9XqYOc3h2F69BKI+/4H+H7vSUHx3xnYFVzlMjjx9T5wf60hSAP9hQeH/TABr1QC5+4GutOXpX7+dX56lv0ghTUxA4N5Aok9as6hmtc3cdDerUt7MBEhDUYoPH0BJJnZMHthtCjJCepiDez69gjIkNQcutoF+Sr4eOZKuHguASLfewfaNm8AGVv3AIcK7xBM+BCS8CAPq0WeQZBJp/+QNS8DgwNEFzwADgbyHm7g1uV3AslNej0UHTwBfSPDIbR2kM0T9XoD3LubDBIJb/EMiOxFsGr5FnBxVcL4Se9BQWIKqBNuAWfjYVEp142o6vjZlG+0lLpLPVq2bBjOWpiBwQGi88jQPyjQxQYklZBlz8gCyM2HLt1+V4nLz4E7ktBUpivNBFkZOXABVb1+wzCoGxYEhZeuCvG2Y0w3AeeiBEWjepTF98QtLVkTMzA4RvSW8jqh5r5vInpyGkjlUmjXoXmFJ8oVMniza1tB2cvE7hodxP98S3gIdO7SCoofZwDH8w7/QRzPgcTbE6ShQW4mg/F11sQMDPYS3US5OD5Y8WpD5LhRcJX1KY8hJDSw0lPd3Fxg/rLJMHrCUPDx8QQjnsvhP8rEU1cbZxnDrk99LAyCcRgUq6PrL/UVbtKxJr60Pn36yNEzaYc2FW0r2lm002ixaCvRInbt2uVRE/eOiYlxweu/iTYRbTPaf9FOoR1H24Q2asmSJbXtve6iRYvq47k90bqWsu50rylTpvhXdv66deukeGwLtHCra7yF1mD48OGVumn4ncnw2NZoPazOr9uvXz/emd/jhQsXAvG6ndC6lbpXz1atWrm/aBKmp6d3tvrOG3p7ezv1761yMMxzEq5T86i6RqNB1CWvqtq6e7haue+lY2wjGIuKqzVWnq7Nofcgqx0MpnjnDsft3bu3JDY2tivxAq29rcOIjxEREQVExJ07dy4fMmRIanXvHR0dXfeLL76Yji/fRfOu4ND3Z8yYoUOLXbx48d9nz54dX8VbvIn2BVq5B9Snn366xGg0zlqxYkVF51NRkbVor4nsm4S2sgqfwQftX5ZrlcYnaEvQip3YnN3R6A+yTiy1Rot/gSRvGRAQcAhfepXajPEw1EfLfxmKTuyrSySUBPiYlZPc5LAQSLz9sNKTi4vUsOTjdfDpok2Qm1uAos3hJUyCm+7h7mq+gVwG8iYNHO9Lr0H07NnTH0n+Ob48XgHJS4MIExMVFfWf7du393T0vuPGjePwgfEXJPlP+HZ8JSQvgQyt/6xZsy7guZMWLFhQlVttQfvWxr7h9BXYOnHNmjUwZsyYsTZIfnDEiBH7t2zZwvxncfwVqOpSWfjl5OQM8vT0lL4Mootl2EDq7wtGdLkfpVY8l0St1sKRg2eEgTFlYnckd6u2TaGwQAX/PRMPLrUCzN12vy6Su8TFxY21NIq9KERzaL48kkeGJCI124zm78AlqK9y6Zw5cyZ98sknFR6Iyg/oAWy2oWa1Pv/888hJkybZcmvHofUT2Z41cuTIVUjyJMbn8nj69KkXqvkgy4O5XJSGpngZRDcKPwIq85SRY9Z3JLq8bm0wenrAzm2HK3WpicxcGbecg4AgX+jeqyPcT0yBpJQn4Nq00a9R0duizXfgvPvous8YOnToNXtP/PDDD2UY987Fl3Or+dnvL1y48Mq8efMqPRDJfmHp0qUbwVy00xpRFnfXWs3D0OugmoBi8Ru58qcYpW1igoial6BNXl5eW1R1/oUS3WgywLlrO3N53iqnIpGAokNrOLTnBOTlFdpOBkgl0LBxHeSw8Tnx3d1d4P2xUaDVaGHLl/vAo1EdcO3YBkw6fTWcDAwJNDrQPXqq5ySSasc44eHhfqjm79rYnYu23aJoRIStaKqS8AtJPh/j8zgHSA4bNmygiTkVsZPm3q+zxOwRxDm0O9ZuM5K8/9y5c+0pqrnR8jdZwxtV/f2YmJjniT4MJyi0iBZ7ABDBUc23ff3113rGZ1E1h6CgoBFgroJsC05TdfueFhwl241PNbfvUfrdvAkJ7PF2V9AplTBn0jLbPiS66F26tQO9Xi+Q3MVFCcM/HAQ9UM3/Z8v3cPr8VQgQJrZoq/1HCUm9YnURfsgbTviO/NDEBgncO3jw4AB8sPwJbR3aLrThgwcPpn7GNbt3716MJP+3g/ekWHeEjX15aDNXrFhRH+83Du07tD1o0dOnT2+F+/4GQgYFNqErHoUkv2fPjWfOnKlDVV+NLxNEdg9YuXJlXyR7yfsuNlx2zQcffPAZkvwOo7RN9BNJBFojAlU9wMOj+h049gb79ANKMhYVB5cRdR8v8P3rSLi+fD2sWLIZoqcME4a6lobSRSFsr1MvFFSqYug3uDt4eLjBvh3HYMPGveDfpxsoXm8M+vQs0D9JB3n9MOAUCvvnqpOiF6tBm/hQz8klzshakmsVar3x0KFDd/r3719uhtzevXsfEukcvdmoUaNIzbviyz+I7H60atWqmIkTJ+4VO3f58uVqiUSybMmSJWuR5Cp0xR2aDohk/xGv8+W0adM+F/mNDEtLSzv98ccf34qOjh6D75uKXOJTtFjG5QpBIVlVGDwRbRaa9kUS3YjES9Amp3Wgck5g+IVcikZ1weMvkbDnq51w9/ZDmLMgutyQWLlCDoOH9hJeZyChVyzdDNu/iwP/gW+Bz4hIMOQVgOrUecjdtg+ULV4F/4/GAO/iYtckF4ua02eihR+u11Qr9enTx+fAgQNuSHaVky9dC62rjX0UGuyt6GRUYw2ZEz7HerSOltCgNDrv2rXr92DujhNT89Oo5ls3bdrEXHYbePz4cXN02xtB+WniFI6FWXnawy0hXLWIbn+gbzLlGTKzy39GCQ9undqB/4yxcD0tE97tNxH+MWsVnDhyDpIeppkD2px8OH/2CiyatwaGvDMR9sddgOBRQ8B72CAwqtXCQBlpcABIawWC9n4KFHx/EniFHZNcSM21WozPn1DugAiY5IR20YF4f2anfv36HUeyt3Xy74AaWmyY4X9Xr179b1TzF/JjxDBAhx4C9atfFRN9MPdte1q77KNHj/4MSX6b0blCzBFR82MWlbceK+Cfn58/Et33anW12XuyAYl+Sp+R/ZFoyQpUeXmT+hCydCYq84/ww6VrEDf1U+AkkjLHyEICwbVfD3AL7wwSL0+h4ITm9n3I2xUrlJ5yfaM1uPfoBOqbiTYH19gkukYL+rR0KNTk6K+lnXVK3gTtJFoTkX0dkOzn8TNewtf70W2Pwxi9uoMtPG3EbrdFkm01jfNo+9BaWG2va+N4cvUPMx5XqOaeISEh3UW49x3aTssDtJ5IUu4rEO8NqakYnUuiCS2aW/dBju66mFtNQ1Ddw98UjPbrktLMii2VgLxObeCU5kQikbLg8ElQnbmEx6SConkTCF4yQziGikwqmjayu+oMlaQyZudo0Ds454yGOX78eFavXr3+HRcX92d8K9aPLLO4uB0HDRq0GEl/H19/sXv37nWRkZGOuNCvoFlX7dCjmt+aMGHCC/1Roqrj18h/PmXKFCL6wEoOv4Rq/j8bN25kLrv9ag4BAQH7MzMzNVlZWft9fX2joWzfeiNU9e7u7u6HVSqVQ4NM7HLdjUaD6dy1nUk8x4Oe3PeqjFSlddbqhwmklTeoIyyvlL//GGQsXgNpY2ZD0Y5D0NQX+ePtBcELp4OsdojDlWQ5i6JrU59q0ItIdWLjXEabXIUnKn0jDdFWRERE3NuxY0eEk+6PT0lQvYxf5dSpU3M/++wzysInVnIodfXFMx7bxqNHjwDVnNYgtO5S22JpY8K/Sr0Gq1hd9qIUnX7KlJC7qEtJa891bgumX54CUHzlBmT8cz3IwoJB4uvzPGNOxNWiB0BxPLnxktBgkOblw3vD3hG62LZ+uQ8up6YDVHe9B87sJWCMXoT3uemsBjp69KgOVf1LVHVy0Smj3L0Kp9WOiopajWR3r0Y3268FNOyX+tb/ZmP/2rFjx25HNWdsrhiU2Kwlsv2Lktjcz8/vQU5OzmVvb+8uVkIcVVhY+A9U9Zuo6nYzxZFRN0aT0RivTU4rO/kElduldTNBlWkxRcBYe1TvN2BEj3ZQePsBeEW9AyHL50DYthUQNPevwDd4BX46ewV+PBsP33wbC96d2ghFLKoDmk1nVBWRu1+EpHdqxh3JTh5D/Ntvv90DzF1KpHLPKjktCMn+wfbt2wOqeXsKGQJf1q8TVR1WrFjxGb48IJY7GD9+/Lb169erGI8rRbRI+JcQGBh4F9320uRdZUPVRzgkzg4S3YRKnawTiM6XT8Y1rAOeA3uBEfcl3X8Ebdu/jq85cPldC5ojLqg7r5SDW3gXuJOYAvNmrBQSeN5/7CeoseNqXibjTl1rSTXRUkeOHCHC30Kb0L9/f8qQv4G2Ac3WOu60DnyUHbegOnfZ5X4h0dGNaSTay8LkyZNzkewPRHZlgHkQD0PFbnvn0NDQ16B8wLtVhNQHLN+rNWJQ1QNcqMv5RSg6Uj2BlFOflS06pVTq5wM+00dD7PdnYMyIeeDVvDEohKWSjc/Vnyq+hq5dAMGLPoKAGeOeF7KoFtGLNaC7lwIqXd7DhHvHa7zxDh48qEPCX0QbM3DgwMZgzpqKqXGIHZfFGAbECEWj3rowyvyfUnMC9WqUSdr6+Pjoc3NzabvO6ljKYlNSVFLjRDcaDcZz13ee4jkJGDLEiU7KTuWmQlZ/AoFzJoD/5FFgtM6e43m8hzvG8yEOVn0Vic/R9TdQxp3jU190K+7fvz9t8ODBS/HlfZE8SCM7LkWfXWwSzOuo6sNWrlzJKPMbQ2pqqjuqeXeRZNpBdNvTMzLExFtIyom5uH93JCnn4MwYDoNhYzp1sXG2ikTQvHUksuLVBsA7MpTVbp6T666jjHsBJ+XPO/v6NFXVZDL9MTY2drIDp1d5muqmTZuyR48efcTG7pExMTGzKiL7jBkz6uLnPIa2b9GiRT6MZr8KzIayhSVKu+2ixTRQ1e/n5+f/DOZZo6URWFRU1A3dd7u46+hoGwP+kOK1KWk9ywyFfZmwxOj6R09UoJBcdzLJIS4ujgovbO/du3cx/u21Dh06NLtv377PXasBAwYE7NmzhwpDNLA6vQjsn49OI312oA2x2k5P8oVI9oZGo3EGxs3P15ibNm0aLFu2rBO+XA7mfn2YNWvWCTxu7Ny5cy/+xolS58CBA7+3kMLWD1zRo0ePiydPnsypzo2uXLnSDsxTbmW2fUcoatKkSfzdu3crHSeBag61a9cWm6WWFxwc/B9U84oy0JSUowlV1kE5DY88AXYMi3WU6EYwmhJ0RPSaXiK5iiSnATm0WgxIpUgsvdOIHh4eTiSnutElJVLoS5/Wp0+fcUj4HyxudlNL/Cz21E62ELfK2Lhx42P876sNGzbQfX1FfmjvT5o06U9o1N13BsxVZ94C84iq0m3aes6cOUfRPpo/f/6GqsxJ/5ViBNiezVca1CNyspr3qkofIY0p6IaWVoVjqWCJ2OSVbVB5aSxKytHDPMxqey9U9Qao6rfVanWVXGWHXHfOPBT2tB5jdGECyUsnOghz0Gnoq0qbm5GQeEzvLJIfO3aMfjy7ofy4bnrqv432EVpfGyQn0GAbR0bp0Tx2Gvpo6wt2sTxcyC0cb8kDiD246XNRzbbfMw/6pYDqCogl4baA7Z4ac8N5eenQfaeknN5GrF71mo8OKzqNgqLhrdTNxvMvnekWt10DvFPddpqO+xcRklcVF3fu3Dlv6NCh9svKxo0wduzYb/Dl6ArIXhWQe0fdf2zRyReM5OTk3ui2N4XyXWpn0W2/8+zZs6qo8SobLvqA4uJiX6VSWXNENxj1cO76rhwe+AwhIce/XPddGPpKiTgaESflnUb048ePP33rrbcmWb5se/EfJPl7Q4YMeeDo/devXw/jx4+nhA3lBy45cInbCxcu7Infz4rfsNv+W8Z7NtS8Km57iarfKygouAzlk3JKiwhJaozov8TpxiRtisjAmZfhupOipz4pBonkhjMvbZnUQskPGviyq5LD6QlN3Wvjdu/e3R1Jfq+691+7di09yM5MmDCBEm00//tYZS6fJXactXjx4q52lpFicJ6a13rllVcox2Kd1MuvVavWHlRze0aH2VL1iVV13x2WYp6Xyjq3iFrM1wqYGvLZ34Shp4UnzoFnn27CDLKSSi852/aC3/jhAhEt8gvG/ELIXLUZ/Ea/C5KgUqunGoygvnkXVGcvQcCUD36J/zE0MGTlQP7+o+A37s/m7UgpmlijfZgCrh1aQ+Gxs5D9xdZ7RRJ1B4zRs2qqAXv37u0WGxtLo+FozjgNbTVYLG3v3r1nBg8efLemf0QxMTG+K1eupPu/ZknUUPafJu5T4u/k0qVLH86cOZPNImN4Docns3PCmHdT/POEHJK78MgpcGnVFKQhAQIRTTodFJ39CfxjRiLRrbXPJCzWIKUHQokq0zZVsfCAKJPNNxhAl/YU1Am38fmIH1nNCdemOezqhJvC/HVzIi6v6OqjH7Jq8gs7cuSIChWWMrsnX1ajrVq1KhuNlJqpNUPNxegl9ENynn6ekJPwIPH1Bm3yo+eFI4msnFwOmlv3hP2V+98iK7XQgwCJbswrABmt+UbDaOlQtQZ0D5KFijQmjUZIxHESyTnWpAwMTiQ6JeTOX9uVTQk5LSorFZugVUw1NxJ/ITXNRQ8LEdx6rgpRArn8tJabdRafyj9rU5+UelhYJrA8yQBZoL8wvJYScbj/OmtSBgbnKrpZ1UumrCI5qXJM2emrpMbiXXBUxFGPcTdUJWNPMTwSm1aFodclWXZ9eibI6tYWJrPoU58UMkVnYKgZolMRiqu6lDShvjupty7p0fNlj6nbTervAwZUdCi7QItAWKHIZGUj6yxVYzT3U0AW5C/E8bSSqyG/UDDew02I1c0j4oApOgNDTSi6ySgUiwQjkpFiaIqndSWqjoSnmu9aJw+qMWn1oEt9DLyLEqTouuuSH1MiLiM+8aiONSkDQ0247hwkmCwJOYm7m1CemfrWS1S9RLk5R8fEW8pDaR+goterTbl+cyLuYSq+DxPGuOvThEQcU3MGhpog+vOEnInP1JrdZ5DWDgEtuu8Ue5M7TwUn9M8yqxaL6ynp9hg4kQw9PTiExRyowA3G5yWJOCK9FuNzkPAsPmdgqCFFN6u60XhafesecDIJyGsHC/XYy7jqQkKuVDadut1kMlDT8NmSmu+cOXFHq7XIKQSgBBxtQyJT0UlK9En8zQUnhVFw6Zl4XC0wZOWC/tHTYqboDAw1S3S9QPTrd6DoQjy4tGsB2jsPoGD/MYGcitcbAeeigKyN35qXQ0aiEkkpaae+ehsKT54DTi4TBskUxJ4SYm81egeGXPPiKOQd0Hb5K7WEElX6zBzI3mRe7JNG1eVuP4DXV9KQzyusORkYbEbA1YdEInPp1CxyK0p7hJB5x/iZFmsQusNQpfUl2XVUb1loEJHcgOpOc3qpRE0f3s1ViO31GdmF6OLvQe/8j5xCppBjDK6+kSiEAEKZaF8vMOSrBEXnXV2Ea6Pi31apc6PjE4+eZM3JwFCDRLeQXYJkD8e4nRbfo8obNLmkDZinWFKlRprFNQpNgY77LbVOdeDKnSOGN1sO7aU3aDtxHJdXrCncnZB49B5uC9PpNVSwnvx6KuxAJKbVRTug0SLstExSXY7jk1TFOfuR5FmsKRkYGBgY/l/jfwUYAPw0FqsWp2FrAAAAAElFTkSuQmCC\" style=\"margin-top:-20px\" height=\"55\">\n<span style=\"font-size:40px\">  [[cluster]]</span><span style=\"padding-top: 25px;float:right\"><a href=\"https://github.com/scylladb/scylla-monitoring/issues/new?body=scylla-version%3D[[scylla_dash_version]]%0Amonitoring-version%3D[[monitoring_version]]\" target=\"_blank\"><input title=\"Report an issue with Scylla Monitoring\" type=\"button\" style=\"background-color:#57d1e5;color:black;font-size:20px\" value=\"Report an issue\"></a></span><hr style=\"border-top: 3px solid #5780c1;\"></div>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 4,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 1,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of Read requests that failed due to an 'unavailable' error",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 4
+            },
+            "hiddenSeries": false,
+            "id": 2,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(irate(scylla_storage_proxy_coordinator_read_errors_local_node{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Local Reads Error by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of write requests that failed due to an 'unavailable' error",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 4
+            },
+            "hiddenSeries": false,
+            "id": 3,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(irate(scylla_storage_proxy_coordinator_write_errors_local_node{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Local Write Error by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "text_panel",
+            "content": "##  ",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 4
+            },
+            "id": 4,
+            "isNew": true,
+            "links": [],
+            "mode": "markdown",
+            "options": {},
+            "span": 4,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of Read requests that failed due to an 'unavailable' error",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 10
+            },
+            "hiddenSeries": false,
+            "id": 5,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(irate(scylla_storage_proxy_coordinator_read_unavailable{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Reads Unavailable Error by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of write requests that failed on a local Node",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 10
+            },
+            "hiddenSeries": false,
+            "id": 6,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(irate(scylla_storage_proxy_coordinator_write_unavailable{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Write Unavailable Error by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of write requests that failed on a local Node",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 10
+            },
+            "hiddenSeries": false,
+            "id": 7,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(irate(scylla_storage_proxy_coordinator_range_unavailable{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Range Unavailable Error by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of AIO Errors",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 16
+            },
+            "hiddenSeries": false,
+            "id": 8,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(irate(scylla_reactor_aio_errors{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "AIO Error by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Total number of abandoned failed futures, futures destroyed while still containing an exception.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 16
+            },
+            "hiddenSeries": false,
+            "id": 9,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_reactor_abandoned_failed_futures{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Ignored Future By [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of C++ exceptions thrown.\n\n A peak in the number of exceptions is an indication of a potential problem.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 16
+            },
+            "hiddenSeries": false,
+            "id": 10,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_reactor_cpp_exceptions{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "C++ Exceptions [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        }
+    ],
+    "refresh": "30s",
+    "schemaVersion": 16,
+    "style": "dark",
+    "tags": [
+        "4.0"
+    ],
+    "templating": {
+        "list": [
+            {
+                "allValue": null,
+                "current": {
+                    "tags": [],
+                    "text": "Instance",
+                    "value": "instance"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": "by",
+                "multi": false,
+                "name": "by",
+                "options": [
+                    {
+                        "selected": false,
+                        "text": "Cluster",
+                        "value": "cluster"
+                    },
+                    {
+                        "selected": false,
+                        "text": "DC",
+                        "value": "dc"
+                    },
+                    {
+                        "selected": true,
+                        "text": "Instance",
+                        "value": "instance"
+                    },
+                    {
+                        "selected": false,
+                        "text": "Shard",
+                        "value": "instance,shard"
+                    }
+                ],
+                "query": "Cluster,DC,Instance,Shard",
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_single",
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": false,
+                "label": "cluster",
+                "multi": false,
+                "name": "cluster",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "dc",
+                "multi": true,
+                "name": "dc",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster\"}, dc)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "node",
+                "multi": true,
+                "name": "node",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster|$^\", dc=~\"$dc\"}, instance)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "shard",
+                "multi": true,
+                "name": "shard",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization,shard)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 3,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
+                    "text": "4.0",
+                    "value": "4.0"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "scylla_dash_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "4.0",
+                        "value": "4.0"
+                    }
+                ],
+                "query": "4.0",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "monitor_version_var",
+                "current": {
+                    "text": "master",
+                    "value": "master"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "monitoring_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "master",
+                        "value": "master"
+                    }
+                ],
+                "query": "master",
+                "skipUrlSync": false,
+                "type": "custom"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-30m",
+        "to": "now"
+    },
+    "timepicker": {
+        "now": true,
+        "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+        ],
+        "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+        ]
+    },
+    "timezone": "browser",
+    "title": "Scylla Errors Monitoring",
+    "uid": "error-4-0",
+    "version": 5
+}

--- a/grafana/build/alternator_4.0/scylla-io.4.0.json
+++ b/grafana/build/alternator_4.0/scylla-io.4.0.json
@@ -1,0 +1,699 @@
+{
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            },
+            {
+                "class": "annotation_restart",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "resets(scylla_gossip_heart_beat[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "node_restart",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "restart",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_stall",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_stall_detector_reported[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "stall detector",
+                "showIn": 0,
+                "tagKeys": "dc,instance,shard",
+                "tags": [],
+                "titleFormat": "Stall found",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_schema_changed",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_database_schema_changed[30s])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "Schema Changed",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "schema changed",
+                "type": "tags"
+            }
+        ]
+    },
+    "class": "dashboard",
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 1,
+    "hideControls": true,
+    "id": null,
+    "links": [],
+    "overwrite": true,
+    "panels": [
+        {
+            "class": "text_panel",
+            "content": "<div id=\"amnon\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPoAAAA6CAYAAACZBESJAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAGm9JREFUeNrsXQd8VFXWP+9NTe+NEOmgSIdFiuxSIqB0krCssrCI0sKGLnVZV/qCCqx0ERdQ+ehFCKEtCAuCCAkdQkkhlPQ2yfT5znkzwWTyJslMJqDfd//8zo+ZVydz5//+55x777kADAwMDAwMDL99cC/yZjKpUtqxWUQbvUFbD982Q9OjKdE6oz1Gu4HGo6VzHPdzsabw+uU7h4tYMzEw/IqJLpUouE7NIwL1Bl0kvh1gIbQr8DzIgvyA9/EGMJnKnGPSG0CXnAYmjQY/HWfATTeR9HuL1Pknr9w9cpo1GQPDr4ToUomc79g88jWDQTcf3w7ipFJwad8SFE0agLxuKMgb1wcwGGxfAMlvKCgE3b1kKLp0DTR37oP+cboBJPx1juPXFKnzNiHpDaz5GBheAtGlEhnXsVnkqwajfgGq8WBZaBB4Rb4DyhavAaeQl1PvKgPP0yY9grxdh0FzIxEdfsP9Ik3eR1fuxu1hTcjA8AKJLpHIZJ2aRY4zmAxLkeBKIrhrh9aCK+5M6NMzIe+7g6A6+5OeVypjVcU5Y+ITjz5hTcnAUMNER5K7IMm3GnlThHuPzuD1p/7AyWSOK3iFn5gjRQd1wk3I+moHmLLzbqi0+SOQ7D+z5mRgsMHRal+Alyo7NY/aZpRyEX7Rw8Gzbw8zGWsSPAfSkEBwaf066J88C+TS8/v5+YRdepp9P5k1KQODk4lOJO/YPHKLScpH+o4bBm4d2oDJ8OJyZBIvD1A2awLa1DQPPr2gB5L9FJL9KWtWBgYnue5IchmSfIZJws33Hf9nJDnG4wajeSf+r752G1RnLoLm7gMwZOc9V3lOKgEFktO1fStw7dSm+i4+z+P1cyFr9RbQXL3zs8pQ0Dsh8Vgma1oGhmoSHUnOd2wW2dEkgbNeUX3Bc0C4OemGhNU9fgZZa78BQ1IqNG3RGP7Qoz00a9UEDKj0RqMRUpOfwMXzV+H44bPgEhoM5AkomzasXtIOHyLahymQuWyjIf/xw+0JD04OY03LwFBNovMUl7eIOi1t+Er74E+mgkmnE0iuufMAMpeshXp1Q2DuognQ+NV6Nq/x9EkGfLpwE5z+4TL49Q8H7+ERYFJrHCY69csX/XgFMv+5Ia1IqnkXVf0H1rwMDA7G6Dwv4Ts1i+ppkvDT/SeMAImPF6BUo4v+ELKWroMWLRrB+q0LICDQt9y5pOp3bj2EtNRn4O3jCX0GdgM3pRxObN4HMpkUlM2bVDyQpiJgSMC7uYLhyTNPVVJyg2d5SV+z5mVgcJDoHMfLw4Kbfa1o1jjUa2BPgZgmrRYyl2+EZvVDYeWmeSCVSsudp9XqYOc3h2F69BKI+/4H+H7vSUHx3xnYFVzlMjjx9T5wf60hSAP9hQeH/TABr1QC5+4GutOXpX7+dX56lv0ghTUxA4N5Aok9as6hmtc3cdDerUt7MBEhDUYoPH0BJJnZMHthtCjJCepiDez69gjIkNQcutoF+Sr4eOZKuHguASLfewfaNm8AGVv3AIcK7xBM+BCS8CAPq0WeQZBJp/+QNS8DgwNEFzwADgbyHm7g1uV3AslNej0UHTwBfSPDIbR2kM0T9XoD3LubDBIJb/EMiOxFsGr5FnBxVcL4Se9BQWIKqBNuAWfjYVEp142o6vjZlG+0lLpLPVq2bBjOWpiBwQGi88jQPyjQxQYklZBlz8gCyM2HLt1+V4nLz4E7ktBUpivNBFkZOXABVb1+wzCoGxYEhZeuCvG2Y0w3AeeiBEWjepTF98QtLVkTMzA4RvSW8jqh5r5vInpyGkjlUmjXoXmFJ8oVMniza1tB2cvE7hodxP98S3gIdO7SCoofZwDH8w7/QRzPgcTbE6ShQW4mg/F11sQMDPYS3US5OD5Y8WpD5LhRcJX1KY8hJDSw0lPd3Fxg/rLJMHrCUPDx8QQjnsvhP8rEU1cbZxnDrk99LAyCcRgUq6PrL/UVbtKxJr60Pn36yNEzaYc2FW0r2lm002ixaCvRInbt2uVRE/eOiYlxweu/iTYRbTPaf9FOoR1H24Q2asmSJbXtve6iRYvq47k90bqWsu50rylTpvhXdv66deukeGwLtHCra7yF1mD48OGVumn4ncnw2NZoPazOr9uvXz/emd/jhQsXAvG6ndC6lbpXz1atWrm/aBKmp6d3tvrOG3p7ezv1761yMMxzEq5T86i6RqNB1CWvqtq6e7haue+lY2wjGIuKqzVWnq7Nofcgqx0MpnjnDsft3bu3JDY2tivxAq29rcOIjxEREQVExJ07dy4fMmRIanXvHR0dXfeLL76Yji/fRfOu4ND3Z8yYoUOLXbx48d9nz54dX8VbvIn2BVq5B9Snn366xGg0zlqxYkVF51NRkbVor4nsm4S2sgqfwQftX5ZrlcYnaEvQip3YnN3R6A+yTiy1Rot/gSRvGRAQcAhfepXajPEw1EfLfxmKTuyrSySUBPiYlZPc5LAQSLz9sNKTi4vUsOTjdfDpok2Qm1uAos3hJUyCm+7h7mq+gVwG8iYNHO9Lr0H07NnTH0n+Ob48XgHJS4MIExMVFfWf7du393T0vuPGjePwgfEXJPlP+HZ8JSQvgQyt/6xZsy7guZMWLFhQlVttQfvWxr7h9BXYOnHNmjUwZsyYsTZIfnDEiBH7t2zZwvxncfwVqOpSWfjl5OQM8vT0lL4Mootl2EDq7wtGdLkfpVY8l0St1sKRg2eEgTFlYnckd6u2TaGwQAX/PRMPLrUCzN12vy6Su8TFxY21NIq9KERzaL48kkeGJCI124zm78AlqK9y6Zw5cyZ98sknFR6Iyg/oAWy2oWa1Pv/888hJkybZcmvHofUT2Z41cuTIVUjyJMbn8nj69KkXqvkgy4O5XJSGpngZRDcKPwIq85SRY9Z3JLq8bm0wenrAzm2HK3WpicxcGbecg4AgX+jeqyPcT0yBpJQn4Nq00a9R0duizXfgvPvous8YOnToNXtP/PDDD2UY987Fl3Or+dnvL1y48Mq8efMqPRDJfmHp0qUbwVy00xpRFnfXWs3D0OugmoBi8Ru58qcYpW1igoial6BNXl5eW1R1/oUS3WgywLlrO3N53iqnIpGAokNrOLTnBOTlFdpOBkgl0LBxHeSw8Tnx3d1d4P2xUaDVaGHLl/vAo1EdcO3YBkw6fTWcDAwJNDrQPXqq5ySSasc44eHhfqjm79rYnYu23aJoRIStaKqS8AtJPh/j8zgHSA4bNmygiTkVsZPm3q+zxOwRxDm0O9ZuM5K8/9y5c+0pqrnR8jdZwxtV/f2YmJjniT4MJyi0iBZ7ABDBUc23ff3113rGZ1E1h6CgoBFgroJsC05TdfueFhwl241PNbfvUfrdvAkJ7PF2V9AplTBn0jLbPiS66F26tQO9Xi+Q3MVFCcM/HAQ9UM3/Z8v3cPr8VQgQJrZoq/1HCUm9YnURfsgbTviO/NDEBgncO3jw4AB8sPwJbR3aLrThgwcPpn7GNbt3716MJP+3g/ekWHeEjX15aDNXrFhRH+83Du07tD1o0dOnT2+F+/4GQgYFNqErHoUkv2fPjWfOnKlDVV+NLxNEdg9YuXJlXyR7yfsuNlx2zQcffPAZkvwOo7RN9BNJBFojAlU9wMOj+h049gb79ANKMhYVB5cRdR8v8P3rSLi+fD2sWLIZoqcME4a6lobSRSFsr1MvFFSqYug3uDt4eLjBvh3HYMPGveDfpxsoXm8M+vQs0D9JB3n9MOAUCvvnqpOiF6tBm/hQz8klzshakmsVar3x0KFDd/r3719uhtzevXsfEukcvdmoUaNIzbviyz+I7H60atWqmIkTJ+4VO3f58uVqiUSybMmSJWuR5Cp0xR2aDohk/xGv8+W0adM+F/mNDEtLSzv98ccf34qOjh6D75uKXOJTtFjG5QpBIVlVGDwRbRaa9kUS3YjES9Amp3Wgck5g+IVcikZ1weMvkbDnq51w9/ZDmLMgutyQWLlCDoOH9hJeZyChVyzdDNu/iwP/gW+Bz4hIMOQVgOrUecjdtg+ULV4F/4/GAO/iYtckF4ua02eihR+u11Qr9enTx+fAgQNuSHaVky9dC62rjX0UGuyt6GRUYw2ZEz7HerSOltCgNDrv2rXr92DujhNT89Oo5ls3bdrEXHYbePz4cXN02xtB+WniFI6FWXnawy0hXLWIbn+gbzLlGTKzy39GCQ9undqB/4yxcD0tE97tNxH+MWsVnDhyDpIeppkD2px8OH/2CiyatwaGvDMR9sddgOBRQ8B72CAwqtXCQBlpcABIawWC9n4KFHx/EniFHZNcSM21WozPn1DugAiY5IR20YF4f2anfv36HUeyt3Xy74AaWmyY4X9Xr179b1TzF/JjxDBAhx4C9atfFRN9MPdte1q77KNHj/4MSX6b0blCzBFR82MWlbceK+Cfn58/Et33anW12XuyAYl+Sp+R/ZFoyQpUeXmT+hCydCYq84/ww6VrEDf1U+AkkjLHyEICwbVfD3AL7wwSL0+h4ITm9n3I2xUrlJ5yfaM1uPfoBOqbiTYH19gkukYL+rR0KNTk6K+lnXVK3gTtJFoTkX0dkOzn8TNewtf70W2Pwxi9uoMtPG3EbrdFkm01jfNo+9BaWG2va+N4cvUPMx5XqOaeISEh3UW49x3aTssDtJ5IUu4rEO8NqakYnUuiCS2aW/dBju66mFtNQ1Ddw98UjPbrktLMii2VgLxObeCU5kQikbLg8ElQnbmEx6SConkTCF4yQziGikwqmjayu+oMlaQyZudo0Ds454yGOX78eFavXr3+HRcX92d8K9aPLLO4uB0HDRq0GEl/H19/sXv37nWRkZGOuNCvoFlX7dCjmt+aMGHCC/1Roqrj18h/PmXKFCL6wEoOv4Rq/j8bN25kLrv9ag4BAQH7MzMzNVlZWft9fX2joWzfeiNU9e7u7u6HVSqVQ4NM7HLdjUaD6dy1nUk8x4Oe3PeqjFSlddbqhwmklTeoIyyvlL//GGQsXgNpY2ZD0Y5D0NQX+ePtBcELp4OsdojDlWQ5i6JrU59q0ItIdWLjXEabXIUnKn0jDdFWRERE3NuxY0eEk+6PT0lQvYxf5dSpU3M/++wzysInVnIodfXFMx7bxqNHjwDVnNYgtO5S22JpY8K/Sr0Gq1hd9qIUnX7KlJC7qEtJa891bgumX54CUHzlBmT8cz3IwoJB4uvzPGNOxNWiB0BxPLnxktBgkOblw3vD3hG62LZ+uQ8up6YDVHe9B87sJWCMXoT3uemsBjp69KgOVf1LVHVy0Smj3L0Kp9WOiopajWR3r0Y3268FNOyX+tb/ZmP/2rFjx25HNWdsrhiU2Kwlsv2Lktjcz8/vQU5OzmVvb+8uVkIcVVhY+A9U9Zuo6nYzxZFRN0aT0RivTU4rO/kElduldTNBlWkxRcBYe1TvN2BEj3ZQePsBeEW9AyHL50DYthUQNPevwDd4BX46ewV+PBsP33wbC96d2ghFLKoDmk1nVBWRu1+EpHdqxh3JTh5D/Ntvv90DzF1KpHLPKjktCMn+wfbt2wOqeXsKGQJf1q8TVR1WrFjxGb48IJY7GD9+/Lb169erGI8rRbRI+JcQGBh4F9320uRdZUPVRzgkzg4S3YRKnawTiM6XT8Y1rAOeA3uBEfcl3X8Ebdu/jq85cPldC5ojLqg7r5SDW3gXuJOYAvNmrBQSeN5/7CeoseNqXibjTl1rSTXRUkeOHCHC30Kb0L9/f8qQv4G2Ac3WOu60DnyUHbegOnfZ5X4h0dGNaSTay8LkyZNzkewPRHZlgHkQD0PFbnvn0NDQ16B8wLtVhNQHLN+rNWJQ1QNcqMv5RSg6Uj2BlFOflS06pVTq5wM+00dD7PdnYMyIeeDVvDEohKWSjc/Vnyq+hq5dAMGLPoKAGeOeF7KoFtGLNaC7lwIqXd7DhHvHa7zxDh48qEPCX0QbM3DgwMZgzpqKqXGIHZfFGAbECEWj3rowyvyfUnMC9WqUSdr6+Pjoc3NzabvO6ljKYlNSVFLjRDcaDcZz13ee4jkJGDLEiU7KTuWmQlZ/AoFzJoD/5FFgtM6e43m8hzvG8yEOVn0Vic/R9TdQxp3jU190K+7fvz9t8ODBS/HlfZE8SCM7LkWfXWwSzOuo6sNWrlzJKPMbQ2pqqjuqeXeRZNpBdNvTMzLExFtIyom5uH93JCnn4MwYDoNhYzp1sXG2ikTQvHUksuLVBsA7MpTVbp6T666jjHsBJ+XPO/v6NFXVZDL9MTY2drIDp1d5muqmTZuyR48efcTG7pExMTGzKiL7jBkz6uLnPIa2b9GiRT6MZr8KzIayhSVKu+2ixTRQ1e/n5+f/DOZZo6URWFRU1A3dd7u46+hoGwP+kOK1KWk9ywyFfZmwxOj6R09UoJBcdzLJIS4ujgovbO/du3cx/u21Dh06NLtv377PXasBAwYE7NmzhwpDNLA6vQjsn49OI312oA2x2k5P8oVI9oZGo3EGxs3P15ibNm0aLFu2rBO+XA7mfn2YNWvWCTxu7Ny5cy/+xolS58CBA7+3kMLWD1zRo0ePiydPnsypzo2uXLnSDsxTbmW2fUcoatKkSfzdu3crHSeBag61a9cWm6WWFxwc/B9U84oy0JSUowlV1kE5DY88AXYMi3WU6EYwmhJ0RPSaXiK5iiSnATm0WgxIpUgsvdOIHh4eTiSnutElJVLoS5/Wp0+fcUj4HyxudlNL/Cz21E62ELfK2Lhx42P876sNGzbQfX1FfmjvT5o06U9o1N13BsxVZ94C84iq0m3aes6cOUfRPpo/f/6GqsxJ/5ViBNiezVca1CNyspr3qkofIY0p6IaWVoVjqWCJ2OSVbVB5aSxKytHDPMxqey9U9Qao6rfVanWVXGWHXHfOPBT2tB5jdGECyUsnOghz0Gnoq0qbm5GQeEzvLJIfO3aMfjy7ofy4bnrqv432EVpfGyQn0GAbR0bp0Tx2Gvpo6wt2sTxcyC0cb8kDiD246XNRzbbfMw/6pYDqCogl4baA7Z4ac8N5eenQfaeknN5GrF71mo8OKzqNgqLhrdTNxvMvnekWt10DvFPddpqO+xcRklcVF3fu3Dlv6NCh9svKxo0wduzYb/Dl6ArIXhWQe0fdf2zRyReM5OTk3ui2N4XyXWpn0W2/8+zZs6qo8SobLvqA4uJiX6VSWXNENxj1cO76rhwe+AwhIce/XPddGPpKiTgaESflnUb048ePP33rrbcmWb5se/EfJPl7Q4YMeeDo/devXw/jx4+nhA3lBy45cInbCxcu7Infz4rfsNv+W8Z7NtS8Km57iarfKygouAzlk3JKiwhJaozov8TpxiRtisjAmZfhupOipz4pBonkhjMvbZnUQskPGviyq5LD6QlN3Wvjdu/e3R1Jfq+691+7di09yM5MmDCBEm00//tYZS6fJXactXjx4q52lpFicJ6a13rllVcox2Kd1MuvVavWHlRze0aH2VL1iVV13x2WYp6Xyjq3iFrM1wqYGvLZ34Shp4UnzoFnn27CDLKSSi852/aC3/jhAhEt8gvG/ELIXLUZ/Ea/C5KgUqunGoygvnkXVGcvQcCUD36J/zE0MGTlQP7+o+A37s/m7UgpmlijfZgCrh1aQ+Gxs5D9xdZ7RRJ1B4zRs2qqAXv37u0WGxtLo+FozjgNbTVYLG3v3r1nBg8efLemf0QxMTG+K1eupPu/ZknUUPafJu5T4u/k0qVLH86cOZPNImN4Docns3PCmHdT/POEHJK78MgpcGnVFKQhAQIRTTodFJ39CfxjRiLRrbXPJCzWIKUHQokq0zZVsfCAKJPNNxhAl/YU1Am38fmIH1nNCdemOezqhJvC/HVzIi6v6OqjH7Jq8gs7cuSIChWWMrsnX1ajrVq1KhuNlJqpNUPNxegl9ENynn6ekJPwIPH1Bm3yo+eFI4msnFwOmlv3hP2V+98iK7XQgwCJbswrABmt+UbDaOlQtQZ0D5KFijQmjUZIxHESyTnWpAwMTiQ6JeTOX9uVTQk5LSorFZugVUw1NxJ/ITXNRQ8LEdx6rgpRArn8tJabdRafyj9rU5+UelhYJrA8yQBZoL8wvJYScbj/OmtSBgbnKrpZ1UumrCI5qXJM2emrpMbiXXBUxFGPcTdUJWNPMTwSm1aFodclWXZ9eibI6tYWJrPoU58UMkVnYKgZolMRiqu6lDShvjupty7p0fNlj6nbTervAwZUdCi7QItAWKHIZGUj6yxVYzT3U0AW5C/E8bSSqyG/UDDew02I1c0j4oApOgNDTSi6ySgUiwQjkpFiaIqndSWqjoSnmu9aJw+qMWn1oEt9DLyLEqTouuuSH1MiLiM+8aiONSkDQ0247hwkmCwJOYm7m1CemfrWS1S9RLk5R8fEW8pDaR+goterTbl+cyLuYSq+DxPGuOvThEQcU3MGhpog+vOEnInP1JrdZ5DWDgEtuu8Ue5M7TwUn9M8yqxaL6ynp9hg4kQw9PTiExRyowA3G5yWJOCK9FuNzkPAsPmdgqCFFN6u60XhafesecDIJyGsHC/XYy7jqQkKuVDadut1kMlDT8NmSmu+cOXFHq7XIKQSgBBxtQyJT0UlK9En8zQUnhVFw6Zl4XC0wZOWC/tHTYqboDAw1S3S9QPTrd6DoQjy4tGsB2jsPoGD/MYGcitcbAeeigKyN35qXQ0aiEkkpaae+ehsKT54DTi4TBskUxJ4SYm81egeGXPPiKOQd0Hb5K7WEElX6zBzI3mRe7JNG1eVuP4DXV9KQzyusORkYbEbA1YdEInPp1CxyK0p7hJB5x/iZFmsQusNQpfUl2XVUb1loEJHcgOpOc3qpRE0f3s1ViO31GdmF6OLvQe/8j5xCppBjDK6+kSiEAEKZaF8vMOSrBEXnXV2Ea6Pi31apc6PjE4+eZM3JwFCDRLeQXYJkD8e4nRbfo8obNLmkDZinWFKlRprFNQpNgY77LbVOdeDKnSOGN1sO7aU3aDtxHJdXrCncnZB49B5uC9PpNVSwnvx6KuxAJKbVRTug0SLstExSXY7jk1TFOfuR5FmsKRkYGBgY/l/jfwUYAPw0FqsWp2FrAAAAAElFTkSuQmCC\" style=\"margin-top:-20px\" height=\"55\">\n<span style=\"font-size:40px\">  [[cluster]]</span><span style=\"padding-top: 25px;float:right\"><a href=\"https://github.com/scylladb/scylla-monitoring/issues/new?body=scylla-version%3D[[scylla_dash_version]]%0Amonitoring-version%3D[[monitoring_version]]\" target=\"_blank\"><input title=\"Report an issue with Scylla Monitoring\" type=\"button\" style=\"background-color:#57d1e5;color:black;font-size:20px\" value=\"Report an issue\"></a></span><hr style=\"border-top: 3px solid #5780c1;\"></div>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 4,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 1,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue Information</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 4
+            },
+            "id": 2,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 6
+            },
+            "id": 3,
+            "panels": [],
+            "repeat": "classes",
+            "title": "$classes",
+            "type": "row"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 7
+            },
+            "hiddenSeries": false,
+            "id": 4,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "1000000*max(scylla_io_queue_delay{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "seastar_io_queue_delay",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "$classes I/O Queue delay by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 7
+            },
+            "hiddenSeries": false,
+            "id": 5,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_io_queue_total_bytes{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "seastar_io_queue_delay",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "$classes I/O Queue bandwidth by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "Bps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "iops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 7
+            },
+            "hiddenSeries": false,
+            "id": 6,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_io_queue_total_operations{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "seastar_io_queue_delay",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "$classes I/O Queue IOPS by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "iops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        }
+    ],
+    "refresh": "30s",
+    "schemaVersion": 16,
+    "style": "dark",
+    "tags": [
+        "4.0"
+    ],
+    "templating": {
+        "list": [
+            {
+                "allValue": null,
+                "class": "by_template_var",
+                "current": {
+                    "tags": [],
+                    "text": "Instance",
+                    "value": "instance"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": "by",
+                "multi": false,
+                "name": "by",
+                "options": [
+                    {
+                        "selected": false,
+                        "text": "Cluster",
+                        "value": "cluster"
+                    },
+                    {
+                        "selected": false,
+                        "text": "DC",
+                        "value": "dc"
+                    },
+                    {
+                        "selected": true,
+                        "text": "Instance",
+                        "value": "instance"
+                    },
+                    {
+                        "selected": false,
+                        "text": "instance,shard",
+                        "value": "instance,shard"
+                    }
+                ],
+                "query": "Cluster,DC,Instance,Shard",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_single",
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": false,
+                "label": "cluster",
+                "multi": false,
+                "name": "cluster",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "dc",
+                "multi": true,
+                "name": "dc",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster\"}, dc)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "node",
+                "multi": true,
+                "name": "node",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster|$^\", dc=~\"$dc\"}, instance)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "shard",
+                "multi": true,
+                "name": "shard",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization,shard)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 3,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 2,
+                "includeAll": true,
+                "label": "classes",
+                "multi": true,
+                "name": "classes",
+                "options": [],
+                "query": "label_values(scylla_io_queue_delay,class)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 3,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
+                    "text": "4.0",
+                    "value": "4.0"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "scylla_dash_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "4.0",
+                        "value": "4.0"
+                    }
+                ],
+                "query": "4.0",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "monitor_version_var",
+                "current": {
+                    "text": "master",
+                    "value": "master"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "monitoring_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "master",
+                        "value": "master"
+                    }
+                ],
+                "query": "master",
+                "skipUrlSync": false,
+                "type": "custom"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-3h",
+        "to": "now"
+    },
+    "timepicker": {
+        "now": true,
+        "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+        ],
+        "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+        ]
+    },
+    "timezone": "browser",
+    "title": "I/O",
+    "uid": "io-4-0",
+    "version": 0
+}

--- a/grafana/build/alternator_4.0/scylla-os.4.0.json
+++ b/grafana/build/alternator_4.0/scylla-os.4.0.json
@@ -1,0 +1,1441 @@
+{
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            },
+            {
+                "class": "annotation_restart",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "resets(scylla_gossip_heart_beat[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "node_restart",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "restart",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_stall",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_stall_detector_reported[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "stall detector",
+                "showIn": 0,
+                "tagKeys": "dc,instance,shard",
+                "tags": [],
+                "titleFormat": "Stall found",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_schema_changed",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_database_schema_changed[30s])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "Schema Changed",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "schema changed",
+                "type": "tags"
+            }
+        ]
+    },
+    "class": "dashboard",
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 1,
+    "hideControls": true,
+    "id": null,
+    "links": [],
+    "overwrite": true,
+    "panels": [
+        {
+            "class": "text_panel",
+            "content": "<div id=\"amnon\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPoAAAA6CAYAAACZBESJAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAGm9JREFUeNrsXQd8VFXWP+9NTe+NEOmgSIdFiuxSIqB0krCssrCI0sKGLnVZV/qCCqx0ERdQ+ehFCKEtCAuCCAkdQkkhlPQ2yfT5znkzwWTyJslMJqDfd//8zo+ZVydz5//+55x777kADAwMDAwMDL99cC/yZjKpUtqxWUQbvUFbD982Q9OjKdE6oz1Gu4HGo6VzHPdzsabw+uU7h4tYMzEw/IqJLpUouE7NIwL1Bl0kvh1gIbQr8DzIgvyA9/EGMJnKnGPSG0CXnAYmjQY/HWfATTeR9HuL1Pknr9w9cpo1GQPDr4ToUomc79g88jWDQTcf3w7ipFJwad8SFE0agLxuKMgb1wcwGGxfAMlvKCgE3b1kKLp0DTR37oP+cboBJPx1juPXFKnzNiHpDaz5GBheAtGlEhnXsVnkqwajfgGq8WBZaBB4Rb4DyhavAaeQl1PvKgPP0yY9grxdh0FzIxEdfsP9Ik3eR1fuxu1hTcjA8AKJLpHIZJ2aRY4zmAxLkeBKIrhrh9aCK+5M6NMzIe+7g6A6+5OeVypjVcU5Y+ITjz5hTcnAUMNER5K7IMm3GnlThHuPzuD1p/7AyWSOK3iFn5gjRQd1wk3I+moHmLLzbqi0+SOQ7D+z5mRgsMHRal+Alyo7NY/aZpRyEX7Rw8Gzbw8zGWsSPAfSkEBwaf066J88C+TS8/v5+YRdepp9P5k1KQODk4lOJO/YPHKLScpH+o4bBm4d2oDJ8OJyZBIvD1A2awLa1DQPPr2gB5L9FJL9KWtWBgYnue5IchmSfIZJws33Hf9nJDnG4wajeSf+r752G1RnLoLm7gMwZOc9V3lOKgEFktO1fStw7dSm+i4+z+P1cyFr9RbQXL3zs8pQ0Dsh8Vgma1oGhmoSHUnOd2wW2dEkgbNeUX3Bc0C4OemGhNU9fgZZa78BQ1IqNG3RGP7Qoz00a9UEDKj0RqMRUpOfwMXzV+H44bPgEhoM5AkomzasXtIOHyLahymQuWyjIf/xw+0JD04OY03LwFBNovMUl7eIOi1t+Er74E+mgkmnE0iuufMAMpeshXp1Q2DuognQ+NV6Nq/x9EkGfLpwE5z+4TL49Q8H7+ERYFJrHCY69csX/XgFMv+5Ia1IqnkXVf0H1rwMDA7G6Dwv4Ts1i+ppkvDT/SeMAImPF6BUo4v+ELKWroMWLRrB+q0LICDQt9y5pOp3bj2EtNRn4O3jCX0GdgM3pRxObN4HMpkUlM2bVDyQpiJgSMC7uYLhyTNPVVJyg2d5SV+z5mVgcJDoHMfLw4Kbfa1o1jjUa2BPgZgmrRYyl2+EZvVDYeWmeSCVSsudp9XqYOc3h2F69BKI+/4H+H7vSUHx3xnYFVzlMjjx9T5wf60hSAP9hQeH/TABr1QC5+4GutOXpX7+dX56lv0ghTUxA4N5Aok9as6hmtc3cdDerUt7MBEhDUYoPH0BJJnZMHthtCjJCepiDez69gjIkNQcutoF+Sr4eOZKuHguASLfewfaNm8AGVv3AIcK7xBM+BCS8CAPq0WeQZBJp/+QNS8DgwNEFzwADgbyHm7g1uV3AslNej0UHTwBfSPDIbR2kM0T9XoD3LubDBIJb/EMiOxFsGr5FnBxVcL4Se9BQWIKqBNuAWfjYVEp142o6vjZlG+0lLpLPVq2bBjOWpiBwQGi88jQPyjQxQYklZBlz8gCyM2HLt1+V4nLz4E7ktBUpivNBFkZOXABVb1+wzCoGxYEhZeuCvG2Y0w3AeeiBEWjepTF98QtLVkTMzA4RvSW8jqh5r5vInpyGkjlUmjXoXmFJ8oVMniza1tB2cvE7hodxP98S3gIdO7SCoofZwDH8w7/QRzPgcTbE6ShQW4mg/F11sQMDPYS3US5OD5Y8WpD5LhRcJX1KY8hJDSw0lPd3Fxg/rLJMHrCUPDx8QQjnsvhP8rEU1cbZxnDrk99LAyCcRgUq6PrL/UVbtKxJr60Pn36yNEzaYc2FW0r2lm002ixaCvRInbt2uVRE/eOiYlxweu/iTYRbTPaf9FOoR1H24Q2asmSJbXtve6iRYvq47k90bqWsu50rylTpvhXdv66deukeGwLtHCra7yF1mD48OGVumn4ncnw2NZoPazOr9uvXz/emd/jhQsXAvG6ndC6lbpXz1atWrm/aBKmp6d3tvrOG3p7ezv1761yMMxzEq5T86i6RqNB1CWvqtq6e7haue+lY2wjGIuKqzVWnq7Nofcgqx0MpnjnDsft3bu3JDY2tivxAq29rcOIjxEREQVExJ07dy4fMmRIanXvHR0dXfeLL76Yji/fRfOu4ND3Z8yYoUOLXbx48d9nz54dX8VbvIn2BVq5B9Snn366xGg0zlqxYkVF51NRkbVor4nsm4S2sgqfwQftX5ZrlcYnaEvQip3YnN3R6A+yTiy1Rot/gSRvGRAQcAhfepXajPEw1EfLfxmKTuyrSySUBPiYlZPc5LAQSLz9sNKTi4vUsOTjdfDpok2Qm1uAos3hJUyCm+7h7mq+gVwG8iYNHO9Lr0H07NnTH0n+Ob48XgHJS4MIExMVFfWf7du393T0vuPGjePwgfEXJPlP+HZ8JSQvgQyt/6xZsy7guZMWLFhQlVttQfvWxr7h9BXYOnHNmjUwZsyYsTZIfnDEiBH7t2zZwvxncfwVqOpSWfjl5OQM8vT0lL4Mootl2EDq7wtGdLkfpVY8l0St1sKRg2eEgTFlYnckd6u2TaGwQAX/PRMPLrUCzN12vy6Su8TFxY21NIq9KERzaL48kkeGJCI124zm78AlqK9y6Zw5cyZ98sknFR6Iyg/oAWy2oWa1Pv/888hJkybZcmvHofUT2Z41cuTIVUjyJMbn8nj69KkXqvkgy4O5XJSGpngZRDcKPwIq85SRY9Z3JLq8bm0wenrAzm2HK3WpicxcGbecg4AgX+jeqyPcT0yBpJQn4Nq00a9R0duizXfgvPvous8YOnToNXtP/PDDD2UY987Fl3Or+dnvL1y48Mq8efMqPRDJfmHp0qUbwVy00xpRFnfXWs3D0OugmoBi8Ru58qcYpW1igoial6BNXl5eW1R1/oUS3WgywLlrO3N53iqnIpGAokNrOLTnBOTlFdpOBkgl0LBxHeSw8Tnx3d1d4P2xUaDVaGHLl/vAo1EdcO3YBkw6fTWcDAwJNDrQPXqq5ySSasc44eHhfqjm79rYnYu23aJoRIStaKqS8AtJPh/j8zgHSA4bNmygiTkVsZPm3q+zxOwRxDm0O9ZuM5K8/9y5c+0pqrnR8jdZwxtV/f2YmJjniT4MJyi0iBZ7ABDBUc23ff3113rGZ1E1h6CgoBFgroJsC05TdfueFhwl241PNbfvUfrdvAkJ7PF2V9AplTBn0jLbPiS66F26tQO9Xi+Q3MVFCcM/HAQ9UM3/Z8v3cPr8VQgQJrZoq/1HCUm9YnURfsgbTviO/NDEBgncO3jw4AB8sPwJbR3aLrThgwcPpn7GNbt3716MJP+3g/ekWHeEjX15aDNXrFhRH+83Du07tD1o0dOnT2+F+/4GQgYFNqErHoUkv2fPjWfOnKlDVV+NLxNEdg9YuXJlXyR7yfsuNlx2zQcffPAZkvwOo7RN9BNJBFojAlU9wMOj+h049gb79ANKMhYVB5cRdR8v8P3rSLi+fD2sWLIZoqcME4a6lobSRSFsr1MvFFSqYug3uDt4eLjBvh3HYMPGveDfpxsoXm8M+vQs0D9JB3n9MOAUCvvnqpOiF6tBm/hQz8klzshakmsVar3x0KFDd/r3719uhtzevXsfEukcvdmoUaNIzbviyz+I7H60atWqmIkTJ+4VO3f58uVqiUSybMmSJWuR5Cp0xR2aDohk/xGv8+W0adM+F/mNDEtLSzv98ccf34qOjh6D75uKXOJTtFjG5QpBIVlVGDwRbRaa9kUS3YjES9Amp3Wgck5g+IVcikZ1weMvkbDnq51w9/ZDmLMgutyQWLlCDoOH9hJeZyChVyzdDNu/iwP/gW+Bz4hIMOQVgOrUecjdtg+ULV4F/4/GAO/iYtckF4ua02eihR+u11Qr9enTx+fAgQNuSHaVky9dC62rjX0UGuyt6GRUYw2ZEz7HerSOltCgNDrv2rXr92DujhNT89Oo5ls3bdrEXHYbePz4cXN02xtB+WniFI6FWXnawy0hXLWIbn+gbzLlGTKzy39GCQ9undqB/4yxcD0tE97tNxH+MWsVnDhyDpIeppkD2px8OH/2CiyatwaGvDMR9sddgOBRQ8B72CAwqtXCQBlpcABIawWC9n4KFHx/EniFHZNcSM21WozPn1DugAiY5IR20YF4f2anfv36HUeyt3Xy74AaWmyY4X9Xr179b1TzF/JjxDBAhx4C9atfFRN9MPdte1q77KNHj/4MSX6b0blCzBFR82MWlbceK+Cfn58/Et33anW12XuyAYl+Sp+R/ZFoyQpUeXmT+hCydCYq84/ww6VrEDf1U+AkkjLHyEICwbVfD3AL7wwSL0+h4ITm9n3I2xUrlJ5yfaM1uPfoBOqbiTYH19gkukYL+rR0KNTk6K+lnXVK3gTtJFoTkX0dkOzn8TNewtf70W2Pwxi9uoMtPG3EbrdFkm01jfNo+9BaWG2va+N4cvUPMx5XqOaeISEh3UW49x3aTssDtJ5IUu4rEO8NqakYnUuiCS2aW/dBju66mFtNQ1Ddw98UjPbrktLMii2VgLxObeCU5kQikbLg8ElQnbmEx6SConkTCF4yQziGikwqmjayu+oMlaQyZudo0Ds454yGOX78eFavXr3+HRcX92d8K9aPLLO4uB0HDRq0GEl/H19/sXv37nWRkZGOuNCvoFlX7dCjmt+aMGHCC/1Roqrj18h/PmXKFCL6wEoOv4Rq/j8bN25kLrv9ag4BAQH7MzMzNVlZWft9fX2joWzfeiNU9e7u7u6HVSqVQ4NM7HLdjUaD6dy1nUk8x4Oe3PeqjFSlddbqhwmklTeoIyyvlL//GGQsXgNpY2ZD0Y5D0NQX+ePtBcELp4OsdojDlWQ5i6JrU59q0ItIdWLjXEabXIUnKn0jDdFWRERE3NuxY0eEk+6PT0lQvYxf5dSpU3M/++wzysInVnIodfXFMx7bxqNHjwDVnNYgtO5S22JpY8K/Sr0Gq1hd9qIUnX7KlJC7qEtJa891bgumX54CUHzlBmT8cz3IwoJB4uvzPGNOxNWiB0BxPLnxktBgkOblw3vD3hG62LZ+uQ8up6YDVHe9B87sJWCMXoT3uemsBjp69KgOVf1LVHVy0Smj3L0Kp9WOiopajWR3r0Y3268FNOyX+tb/ZmP/2rFjx25HNWdsrhiU2Kwlsv2Lktjcz8/vQU5OzmVvb+8uVkIcVVhY+A9U9Zuo6nYzxZFRN0aT0RivTU4rO/kElduldTNBlWkxRcBYe1TvN2BEj3ZQePsBeEW9AyHL50DYthUQNPevwDd4BX46ewV+PBsP33wbC96d2ghFLKoDmk1nVBWRu1+EpHdqxh3JTh5D/Ntvv90DzF1KpHLPKjktCMn+wfbt2wOqeXsKGQJf1q8TVR1WrFjxGb48IJY7GD9+/Lb169erGI8rRbRI+JcQGBh4F9320uRdZUPVRzgkzg4S3YRKnawTiM6XT8Y1rAOeA3uBEfcl3X8Ebdu/jq85cPldC5ojLqg7r5SDW3gXuJOYAvNmrBQSeN5/7CeoseNqXibjTl1rSTXRUkeOHCHC30Kb0L9/f8qQv4G2Ac3WOu60DnyUHbegOnfZ5X4h0dGNaSTay8LkyZNzkewPRHZlgHkQD0PFbnvn0NDQ16B8wLtVhNQHLN+rNWJQ1QNcqMv5RSg6Uj2BlFOflS06pVTq5wM+00dD7PdnYMyIeeDVvDEohKWSjc/Vnyq+hq5dAMGLPoKAGeOeF7KoFtGLNaC7lwIqXd7DhHvHa7zxDh48qEPCX0QbM3DgwMZgzpqKqXGIHZfFGAbECEWj3rowyvyfUnMC9WqUSdr6+Pjoc3NzabvO6ljKYlNSVFLjRDcaDcZz13ee4jkJGDLEiU7KTuWmQlZ/AoFzJoD/5FFgtM6e43m8hzvG8yEOVn0Vic/R9TdQxp3jU190K+7fvz9t8ODBS/HlfZE8SCM7LkWfXWwSzOuo6sNWrlzJKPMbQ2pqqjuqeXeRZNpBdNvTMzLExFtIyom5uH93JCnn4MwYDoNhYzp1sXG2ikTQvHUksuLVBsA7MpTVbp6T666jjHsBJ+XPO/v6NFXVZDL9MTY2drIDp1d5muqmTZuyR48efcTG7pExMTGzKiL7jBkz6uLnPIa2b9GiRT6MZr8KzIayhSVKu+2ixTRQ1e/n5+f/DOZZo6URWFRU1A3dd7u46+hoGwP+kOK1KWk9ywyFfZmwxOj6R09UoJBcdzLJIS4ujgovbO/du3cx/u21Dh06NLtv377PXasBAwYE7NmzhwpDNLA6vQjsn49OI312oA2x2k5P8oVI9oZGo3EGxs3P15ibNm0aLFu2rBO+XA7mfn2YNWvWCTxu7Ny5cy/+xolS58CBA7+3kMLWD1zRo0ePiydPnsypzo2uXLnSDsxTbmW2fUcoatKkSfzdu3crHSeBag61a9cWm6WWFxwc/B9U84oy0JSUowlV1kE5DY88AXYMi3WU6EYwmhJ0RPSaXiK5iiSnATm0WgxIpUgsvdOIHh4eTiSnutElJVLoS5/Wp0+fcUj4HyxudlNL/Cz21E62ELfK2Lhx42P876sNGzbQfX1FfmjvT5o06U9o1N13BsxVZ94C84iq0m3aes6cOUfRPpo/f/6GqsxJ/5ViBNiezVca1CNyspr3qkofIY0p6IaWVoVjqWCJ2OSVbVB5aSxKytHDPMxqey9U9Qao6rfVanWVXGWHXHfOPBT2tB5jdGECyUsnOghz0Gnoq0qbm5GQeEzvLJIfO3aMfjy7ofy4bnrqv432EVpfGyQn0GAbR0bp0Tx2Gvpo6wt2sTxcyC0cb8kDiD246XNRzbbfMw/6pYDqCogl4baA7Z4ac8N5eenQfaeknN5GrF71mo8OKzqNgqLhrdTNxvMvnekWt10DvFPddpqO+xcRklcVF3fu3Dlv6NCh9svKxo0wduzYb/Dl6ArIXhWQe0fdf2zRyReM5OTk3ui2N4XyXWpn0W2/8+zZs6qo8SobLvqA4uJiX6VSWXNENxj1cO76rhwe+AwhIce/XPddGPpKiTgaESflnUb048ePP33rrbcmWb5se/EfJPl7Q4YMeeDo/devXw/jx4+nhA3lBy45cInbCxcu7Infz4rfsNv+W8Z7NtS8Km57iarfKygouAzlk3JKiwhJaozov8TpxiRtisjAmZfhupOipz4pBonkhjMvbZnUQskPGviyq5LD6QlN3Wvjdu/e3R1Jfq+691+7di09yM5MmDCBEm00//tYZS6fJXactXjx4q52lpFicJ6a13rllVcox2Kd1MuvVavWHlRze0aH2VL1iVV13x2WYp6Xyjq3iFrM1wqYGvLZ34Shp4UnzoFnn27CDLKSSi852/aC3/jhAhEt8gvG/ELIXLUZ/Ea/C5KgUqunGoygvnkXVGcvQcCUD36J/zE0MGTlQP7+o+A37s/m7UgpmlijfZgCrh1aQ+Gxs5D9xdZ7RRJ1B4zRs2qqAXv37u0WGxtLo+FozjgNbTVYLG3v3r1nBg8efLemf0QxMTG+K1eupPu/ZknUUPafJu5T4u/k0qVLH86cOZPNImN4Docns3PCmHdT/POEHJK78MgpcGnVFKQhAQIRTTodFJ39CfxjRiLRrbXPJCzWIKUHQokq0zZVsfCAKJPNNxhAl/YU1Am38fmIH1nNCdemOezqhJvC/HVzIi6v6OqjH7Jq8gs7cuSIChWWMrsnX1ajrVq1KhuNlJqpNUPNxegl9ENynn6ekJPwIPH1Bm3yo+eFI4msnFwOmlv3hP2V+98iK7XQgwCJbswrABmt+UbDaOlQtQZ0D5KFijQmjUZIxHESyTnWpAwMTiQ6JeTOX9uVTQk5LSorFZugVUw1NxJ/ITXNRQ8LEdx6rgpRArn8tJabdRafyj9rU5+UelhYJrA8yQBZoL8wvJYScbj/OmtSBgbnKrpZ1UumrCI5qXJM2emrpMbiXXBUxFGPcTdUJWNPMTwSm1aFodclWXZ9eibI6tYWJrPoU58UMkVnYKgZolMRiqu6lDShvjupty7p0fNlj6nbTervAwZUdCi7QItAWKHIZGUj6yxVYzT3U0AW5C/E8bSSqyG/UDDew02I1c0j4oApOgNDTSi6ySgUiwQjkpFiaIqndSWqjoSnmu9aJw+qMWn1oEt9DLyLEqTouuuSH1MiLiM+8aiONSkDQ0247hwkmCwJOYm7m1CemfrWS1S9RLk5R8fEW8pDaR+goterTbl+cyLuYSq+DxPGuOvThEQcU3MGhpog+vOEnInP1JrdZ5DWDgEtuu8Ue5M7TwUn9M8yqxaL6ynp9hg4kQw9PTiExRyowA3G5yWJOCK9FuNzkPAsPmdgqCFFN6u60XhafesecDIJyGsHC/XYy7jqQkKuVDadut1kMlDT8NmSmu+cOXFHq7XIKQSgBBxtQyJT0UlK9En8zQUnhVFw6Zl4XC0wZOWC/tHTYqboDAw1S3S9QPTrd6DoQjy4tGsB2jsPoGD/MYGcitcbAeeigKyN35qXQ0aiEkkpaae+ehsKT54DTi4TBskUxJ4SYm81egeGXPPiKOQd0Hb5K7WEElX6zBzI3mRe7JNG1eVuP4DXV9KQzyusORkYbEbA1YdEInPp1CxyK0p7hJB5x/iZFmsQusNQpfUl2XVUb1loEJHcgOpOc3qpRE0f3s1ViO31GdmF6OLvQe/8j5xCppBjDK6+kSiEAEKZaF8vMOSrBEXnXV2Ea6Pi31apc6PjE4+eZM3JwFCDRLeQXYJkD8e4nRbfo8obNLmkDZinWFKlRprFNQpNgY77LbVOdeDKnSOGN1sO7aU3aDtxHJdXrCncnZB49B5uC9PpNVSwnvx6KuxAJKbVRTug0SLstExSXY7jk1TFOfuR5FmsKRkYGBgY/l/jfwUYAPw0FqsWp2FrAAAAAElFTkSuQmCC\" style=\"margin-top:-20px\" height=\"55\">\n<span style=\"font-size:40px\">  [[cluster]]</span><span style=\"padding-top: 25px;float:right\"><a href=\"https://github.com/scylladb/scylla-monitoring/issues/new?body=scylla-version%3D[[scylla_dash_version]]%0Amonitoring-version%3D[[monitoring_version]]\" target=\"_blank\"><input title=\"Report an issue with Scylla Monitoring\" type=\"button\" style=\"background-color:#57d1e5;color:black;font-size:20px\" value=\"Report an issue\"></a></span><hr style=\"border-top: 3px solid #5780c1;\"></div>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 4,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 1,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "cacheTimeout": null,
+            "class": "pie_chart_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fontSize": "80%",
+            "format": "bytes",
+            "gridPos": {
+                "h": 8,
+                "w": 4,
+                "x": 0,
+                "y": 4
+            },
+            "height": "250px",
+            "id": 2,
+            "interval": null,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": true
+            },
+            "legendType": "On graph",
+            "links": [],
+            "maxDataPoints": 3,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "options": {},
+            "pieType": "pie",
+            "repeat": "node",
+            "span": 2,
+            "strokeWidth": 1,
+            "targets": [
+                {
+                    "expr": "sum(node_filesystem_avail_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"})",
+                    "instant": true,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "Free",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 7200
+                },
+                {
+                    "expr": "(sum(node_filesystem_size_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"})-sum(node_filesystem_avail_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}))",
+                    "instant": true,
+                    "intervalFactor": 1,
+                    "legendFormat": "Used",
+                    "refId": "B",
+                    "step": 7200
+                }
+            ],
+            "title": "Total Storage $node",
+            "type": "grafana-piechart-panel",
+            "valueName": "current"
+        },
+        {
+            "class": "text_panel",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Disk $monitor_disk</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 12
+            },
+            "id": 3,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bytes_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 14
+            },
+            "hiddenSeries": false,
+            "id": 4,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(node_filesystem_size_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])-sum(node_filesystem_avail_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                },
+                {
+                    "expr": "sum(node_filesystem_size{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])-sum(node_filesystem_avail{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "B",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Disk Size by $by",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "bytes",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 14
+            },
+            "hiddenSeries": false,
+            "id": 5,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                },
+                {
+                    "expr": "sum(irate(node_disk_writes_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "B",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Disk Writes per $by",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 14
+            },
+            "hiddenSeries": false,
+            "id": 6,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                },
+                {
+                    "expr": "sum(irate(node_disk_reads_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "B",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Disk Reads per $by",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "text_panel",
+            "content": "",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 20
+            },
+            "id": 7,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 3,
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 20
+            },
+            "hiddenSeries": false,
+            "id": 8,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                },
+                {
+                    "expr": "sum(irate(node_disk_bytes_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "B",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Disk Writes Bps per $by",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "Bps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 20
+            },
+            "hiddenSeries": false,
+            "id": 9,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                },
+                {
+                    "expr": "sum(irate(node_disk_bytes_read{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "B",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Disk Read Bps per $by",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "Bps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "text_panel",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Network $monitor_network_interface</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 26
+            },
+            "id": 10,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "pps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 0,
+                "y": 28
+            },
+            "hiddenSeries": false,
+            "id": 11,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(node_network_receive_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                },
+                {
+                    "expr": "sum(irate(node_network_receive_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "B",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Interface Rx Packets",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "pps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "pps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 12,
+                "y": 28
+            },
+            "hiddenSeries": false,
+            "id": 12,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(node_network_transmit_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                },
+                {
+                    "expr": "sum(irate(node_network_transmit_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "B",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Interface Tx Packets",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "pps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 0,
+                "y": 34
+            },
+            "hiddenSeries": false,
+            "id": 13,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(node_network_receive_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                },
+                {
+                    "expr": "sum(irate(node_network_receive_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "B",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Interface Rx Bps",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "Bps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 12,
+                "y": 34
+            },
+            "hiddenSeries": false,
+            "id": 14,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(node_network_transmit_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                },
+                {
+                    "expr": "sum(irate(node_network_transmit_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "B",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Interface Tx Bps",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "Bps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        }
+    ],
+    "refresh": "30s",
+    "schemaVersion": 16,
+    "style": "dark",
+    "tags": [
+        "4.0"
+    ],
+    "templating": {
+        "list": [
+            {
+                "allValue": null,
+                "class": "template_variable_single",
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": false,
+                "label": "cluster",
+                "multi": false,
+                "name": "cluster",
+                "options": [],
+                "query": "label_values(node_filesystem_avail_bytes, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "dc",
+                "multi": true,
+                "name": "dc",
+                "options": [],
+                "query": "label_values(node_filesystem_avail_bytes{cluster=~\"$cluster\"}, dc)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "node",
+                "multi": true,
+                "name": "node",
+                "options": [],
+                "query": "label_values(node_filesystem_avail_bytes{cluster=~\"$cluster|$^\", dc=~\"$dc\"}, instance)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "current": {
+                    "tags": [],
+                    "text": "Instance",
+                    "value": "instance"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": "by",
+                "multi": false,
+                "name": "by",
+                "options": [
+                    {
+                        "selected": false,
+                        "text": "Cluster",
+                        "value": "cluster"
+                    },
+                    {
+                        "selected": false,
+                        "text": "DC",
+                        "value": "dc"
+                    },
+                    {
+                        "selected": true,
+                        "text": "Instance",
+                        "value": "instance"
+                    }
+                ],
+                "query": "Cluster,DC,Instance",
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "current": {
+                    "isNone": true,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": "prometheus",
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "monitor_disk",
+                "options": [],
+                "query": "node_disk_read_bytes_total",
+                "refresh": 2,
+                "regex": "/.*device=\"([^\\\"]*)\".*/",
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "current": {
+                    "isNone": true,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": "prometheus",
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "monitor_network_interface",
+                "options": [],
+                "query": "node_network_receive_packets_total",
+                "refresh": 2,
+                "regex": "/.*device=\"([^\\\"]*)\".*/",
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "current": {
+                    "text": "/var/lib/scylla",
+                    "value": "/var/lib/scylla"
+                },
+                "datasource": "prometheus",
+                "hide": 0,
+                "includeAll": false,
+                "label": "Mount path",
+                "multi": false,
+                "name": "mount_point",
+                "options": [],
+                "query": "node_filesystem_avail_bytes",
+                "refresh": 2,
+                "regex": "/mountpoint=\"([^\"]*)\".*/",
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
+                    "text": "4.0",
+                    "value": "4.0"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "scylla_dash_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "4.0",
+                        "value": "4.0"
+                    }
+                ],
+                "query": "4.0",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "monitor_version_var",
+                "current": {
+                    "text": "master",
+                    "value": "master"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "monitoring_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "master",
+                        "value": "master"
+                    }
+                ],
+                "query": "master",
+                "skipUrlSync": false,
+                "type": "custom"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-30m",
+        "to": "now"
+    },
+    "timepicker": {
+        "now": true,
+        "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+        ],
+        "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+        ]
+    },
+    "timezone": "browser",
+    "title": "OS Metrics",
+    "uid": "OS-4-0",
+    "version": 5
+}

--- a/grafana/build/alternator_master/alternator.master.json
+++ b/grafana/build/alternator_master/alternator.master.json
@@ -1,0 +1,4055 @@
+{
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            },
+            {
+                "class": "annotation_restart",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "resets(scylla_gossip_heart_beat[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "node_restart",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "restart",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_stall",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_stall_detector_reported[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "stall detector",
+                "showIn": 0,
+                "tagKeys": "dc,instance,shard",
+                "tags": [],
+                "titleFormat": "Stall found",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_schema_changed",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_database_schema_changed[30s])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "Schema Changed",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "schema changed",
+                "type": "tags"
+            }
+        ]
+    },
+    "class": "dashboard",
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 1,
+    "hideControls": true,
+    "id": null,
+    "links": [],
+    "originalTitle": "Scylla Cluster Metrics",
+    "overwrite": true,
+    "panels": [
+        {
+            "class": "text_panel",
+            "content": "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAkYAAAB2CAYAAAAtOFzoAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAD6VJREFUeNrs3Y1V20oWwHGRkwLcwSoVxKkgooJHKoioAKggpgKTCuxUYKcCOxXAqwC/CvBWwOqGcY4fi0HSvZov/3/n6JDzdjHyaEZz57soAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABA5E6O5Ys+Pj6Omx+jgwlxcrImO/RO27L5Ub7yf7lr0ndLSgEACIzCVNRV80Ouz831akD0AgmQ7prrb/l3U6FvyCb/Ci7l+uh+dk3bu2dpe0eqAgAIjIaptM+aH38111nHyrpNZf6zuebHGCTtpasEmqXxx0t6LpvrR0xBUvOda6Pvumm+19zzvU8s8nxz38uU0r2538kRlUlJozqVPJlxw7uLG3rN4SuDjprrsrnuH/1YuUKR/Yu3uWbN9fDoz62rGKN48Rl+r7HPoCi1e352/6u+N3xsFbPmHUbNoU7/PvXNJSkHL61LjwHRSwHSOMM0rTSVk5H7GIJPFxia5BWPwaxFIDsNmOYERgRGuab9PamHoXuJQlfewSuRASrVWNJ0ZyHPOnA+s+oxO/NwvwujoDRkmhMYERjFnvaaclaTgml4l1imlF4aibyrSG7p0g0BjRMu6JPI0nRHgolgvUduPsC50cdNB36GlUsvrXPmQQCHG5DKcvaVVCQwss6UEm3fFrYTqy1IULRyhSa1XiJJz28R3+bIpW2QlpabgGwxCbk0mhR9yMzgM27YsgJ41YXy96scp2AQGIUNimYR3+JdSivW3NDOrQvqUjAL2A0tvUYWvSgXQwxTuYBLG5RL3r3mdQgcLGdSdi3eQRekJoGRRYaUyjvmuTyyzPxLQgVcCveiiK/nLcrgyHBITdL7m/GzLI1etAyhAa+rjd6Zdch5fMggMHIZKOZKXIKi01QqlQR63toER97zguGQ2qXxkOvUoGwwhAa8zbKnh6X7BEYq0sIuI723LUGR9/T+FDC9rYbUZkbPsyr0E67l+zCEBrxe1s6M6yGG0wiMemfGMuLImqDIL+mZ+xByd2z3rK8MPqoyWmln8TwZQgP8BzIjlu4TGPUV62qpXVCUxDlfCczRess8liDUHaWwDh3UGE24XoY49gNIiWugVwN8NL1GEXsfcWa0jqjXrufhv8/+e9eDZr8kFBT5mKO1Oxj2nxf+t8+uAu9biV81aX0TWbLKkJp22whZvn/Z57sZTbi23KMJyNlQDfSx9Bwzvw9dXv6XhsdLtFoFID0rLc4HqxNLx+mAu1KftZ0I7fZMmnQ4wuXBx27RgfPnQ5+J5EY7XJ9Fmq7sfN0undj52lPDcuDzImekMry8IPdMFIVhmkFQVA1RkLWrqlyg+vDGYbJj8uhgz3SRY5oSGBEYRdxAf01JSqNthtSqjV4+D6meieYCDCumwcor592tUtnjw/DQ1rLD39QemvwQc/oSGBEYRZbOPg4pn5LSaJMZx7F0T7p7STEoqo17iUYD3ecs5ReEUYty0fJvTWJoMBAYERgdSRrXj348PLLhIwYu9I+cRWPa0pl5uNdpyktXjYbUKg+9U6uc05J3JIFRhOU6iwYL4siQqpYx6Wc2t4iJgX56OB/dYb6v/Y2FQau0JDCijBMYeSvTnRYJkepxeUcSZMdif4z1yckJy7lbcFs3aHePHh9qNRrtcH2d0iHHQAbv0C5Ko01fQWB0MNovj/VhurFqi2MivlA0OgVHk+JpLyeNbwfmGmh77tYR7gUFxPwOrfuWNU35J/UJjIZUH/HztNif5ppjInrR9rBJQH/57CU9KXQ7XLORI9BN32OoNsqyVrF0n8DorZe5xsURT8D+S/n7G3oX+jEaUrvYvRyNdrhmCA3o5mvP3/vhyprmmB16jQiMDtIOSUhX6OpIgyP1XBSKhCo4mijz72jv5TgtdMeOMIQGdODm+ZU9f32+C5A072+W7hMYDRUY7SqYW7fCbXQkhbpSfsTGHZIKHe3QVe2G0LRB7hWPAuikb2/Rctcz6w5m3ijqrZrHQGD0Uqt7q8hYz0nr+94FSGXmz1LbQ8ZJ6zb5VwL7G4N8q3GdykHHQEQNy76Nyx+G79ILngaBkY9KerQXIN263YpzDJI+Kn//B8XBzLVhcN/VnRvSA9Be396iresl2vddcR8lGz4SGB3yfaDPlV6VqQuS7t2uy1Umz1IT7G3pYbDjej1DrQZjFRrQgWso9w1G5i+Uf2kUrQMEacg5MHIZa+4hkJClmSu3M7Cc23WW8LPUDKURFNnnYXkx+p78zBAa0F2t+N1DjXhND3zF0VYERgdf8oV+6X5bu0lvi70gqUrsWWommf+iKAyWhzee/hZDaEA/fef1rA9th+EWsmwD3BNyDoxchguxsmYXJK3cnKQ69odosPJuQ1EYJA/7HFJjCA3o/u6sFY3Kt3qF5opbq1m6T2BUvBJ1h9yLRbozZ24+UhVxUmm7XQmMhsvDaw95+IYhNKCXvj0z2xbbm2jnyl7yeAiMDlUsV4GDI1EWTz1IM6J49DDksPCmYGNOoDPX2O3bqHxz5bTBJGyG0wiM3gyOzgt/c44OqV2AVJJ10CH/Djmkds7ZdkAvmtVfbXuDNJOwRyzdJzB6q3KZNz8+KSNwC9LCuGXVADrm32Vhv4nmjRuqA9CBcon+XduhayZhExj5qFzk2IrT5p+ngQMkGU5bMKyGjix7PTcFQ2hAX7Xid7vOHZprGuIZ7bVHYDRwgLTeC5BCHWUhLY5ZJEmyMfguGD7fWg6pMYQG9OAatL0nXfeoc7SnCrDhI4FR5wDpS/PPD8XT0v6N51s4i2FTyEN7aRAYRZlnLYbUGEIDFO/tov8S/WXXBokbdtOsGq2Z10pg1CswaC6pLCRAknlIN4W/3ZynGSThR4qCV9peI4bQgP40hzT37f3RLt1nrhGBkSpIkolxV80lAdKuJ2nIIKmMZAxY04PARHK/eXQb8veBY+Xe1WXPX98oemqll1hTbtnwkcDIrALa9STtB0mbAf5UDGPAmkJX0lUL4Ahoel569/q4xoxmCF2CojMeH4HRUEGSBEjWq9qqCL7i38rfp9AByJZr/Gnec9q5gdrhtG88RQKjIYOk/VVtFsNsZQTdnNpAj5UPAHKm6S1aahe5GEzCLlm6T2DkK0CSYba5wceFnqejDfDYLwNAllzDtVZ8xE+jW6HXiMAomQBJVgktE/8OW4PgiEIHIEeaJfptDoxtSzsJu2I+KIGRT9pdiasIvoN2I7GKXiMAGdI0+swazQaTsGnAEhj5Y5RhQ7O4/ym5AUAu3Ca8peIjvhvfkvbzzlJcui8H4jbXrLnuH/+fHM4+iaU3jMDo3/5JPLjbFDZzjaaeC0xJ1gMwEM2k603bA2M7vKe1k7AlKLpMKCC6bK6H4ukIrfpAkFoVTz1h9y5IClonJBcYyan2kUbLd5Hch0XrRjJy7el5Vq4w0FMFYIhGVxX4fTrE535NIO1HzXVbPI1CdKmz5Xnd+qqDkg+MJChqfqzcNYT/KH43it2I3SRBi3uZDX0OnHuei71g7Nb9NwCwoJ2PM9T0Cu0k7DJk4NDy3X5f9F+tPXJ1UJCD2pMJjFzkv3IJNnbdbSPjz9dktJiOabBq5SyGKnx7Qe7+M/z932Iu8ACSqTO0u0WvDQ7oPtSAtZjT+jXidF8U/VcB7qupD15JaNeb8Nyt1VikC7R6izC97h/tTI3vT1a/PbzxN2c5nw2US14zTpMVadK6/PS1OqJ0ulS+9+qB729s8G4eR5jui0d7jCS0DIp2pIKdKD9/pXxoqwjTrTbOmPfapfwuracd/ma2Q2sERgRGBEaDp5Omcfjgo2FmUPfMMsqb0eTbkxRelkW7yXPS5SlDSPM2p4+7TC8z+y8Muvyu5By2hNOui3XxtF/Ssu0p73vDlH3SeuvSd55bYNS70DZyDYwU+XXt8VavrFcqda18iv7zLC02gm3rrkmnq0BpJENoC8VHzN3Gv4M3YIun1VoaH4Ya8oukztk5ldMqjj4wctFw3fMl+cu9AJ5X3vLQPha2h6ZGkzFfCEhuC5ux3q7pXLp0lvS26PWZuwppW2SAwMj7SzXJF/QAgZFPuzMpU8xLn3wFv24pu+Ydfd3c6ySS+uZ+wD/hJVgV7zMMinbBT+Wx8G9iTEO5ryYdz5Utp1jSWfKCjMmfh2ytA4g+wB4r30sbz+8YafRp9iWSnvhJBElfJf75f7yLNGNfFroVYj5dx3xzTQGXlQ83RR5YtQagTaCg8d3z/Wr/3iiSd+LHgT+/PNrAyD3gVDb7W4fsUu8QHF25VkkOsl2pBkBdf4wMGtVe35VuxEFbj1xEkPxjD8+3OrrAyGgimk9XqdyoG5vNITia5zYRG4AZ7VEZ80DzGLUHgI85ADzDwMiNC6d0LMRVanNdMgiO7nxNvgOQJO2mhz9C3LTRiQUXPP7MAqPiqRsulWGSeYzL8zsERyneuwShpxRZAAca13Whm4eyCTw1QjvX6Czw4au/PNRfXp5PNIGRi5hPi7iO1jgUFCXda+HmHH1JIK3/pHnxtEQ6i6X6AAah7S36Hvj+5wafEbLXaOOhcexFVHOMXDT4qYjnpPrsgqK9tF66tF5HfquyR8c5QRGAQwyW6FsFJpp3sgQW2vPT6oBHKS0H/nxvdVV0q9IkczSXVNgxLYOXSvk8t/ktLq2ll+7cQ7Tfp/VxGsPGZQCip+0pWUbS+NLOcdIenKupT7YDB5feevTexZrLXYX4wUMU2iZK/ZTzSij33XbBaOiXw9bdx6cUtkIAEJbREv0fMXwX15OvbaR+C/gVhurQmPvcSPldzBne9WjIXJjTAAGSVMrSY3Ea687W1tH+XjAqPUi+hzN3AZEcrzJh6AxAS9ol+hsXkMRCG6SV7qy4IHV2Yb+45/d5mT6/x/sUcr3rOVjvHUYqk+zKgSpnKSDfj/XYib3u0Lkbt5e0PiuG23VU0lm6SJdHFgytqc9ezAspiKFXdc3z/OOjMj1+RpZu8v79rPyMcRFotEUW97g9law2fPQ+xzTZwyj3Jtt9dj/7TjiTAiXLDNcM3bya3uVeeo8VmX7zLM03pC4AZFVfSH28MgiOzkNMYznJ7EHs9kIav1Ex/76olE2CU0nvsni9R0lajlsCTwA4quBI5jv1GeqUuvkLB4YDAIDcAqSqueTw7zYemmsScMuB3054bAAAYOAAqSye5qvKdIzngY/0DP2KbBI8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAR+p8AAwBZhVVEP80/TAAAAABJRU5ErkJggg==\" height=\"70\">\n<span style=\"font-size:50px\" ></span><span style=\"font-size:40px\"> [[cluster]]</span><hr style=\"border-top: 3px solid #5780c1;\">",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 4,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 1,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "cacheTimeout": null,
+            "class": "single_stat_panel",
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "format": "none",
+            "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 2,
+                "x": 0,
+                "y": 4
+            },
+            "id": 2,
+            "interval": null,
+            "isNew": true,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+                {
+                    "name": "value to text",
+                    "value": 1
+                },
+                {
+                    "name": "range to text",
+                    "value": 2
+                }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "options": {},
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+                {
+                    "from": "null",
+                    "text": "N/A",
+                    "to": "null"
+                }
+            ],
+            "span": 1,
+            "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+                {
+                    "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
+                    "intervalFactor": 1,
+                    "legendFormat": "Total Nodes",
+                    "refId": "A",
+                    "step": 40
+                }
+            ],
+            "thresholds": "",
+            "title": "Total Nodes",
+            "transparent": true,
+            "type": "singlestat",
+            "valueFontSize": "150%",
+            "valueMaps": [
+                {
+                    "op": "=",
+                    "text": "N/A",
+                    "value": "null"
+                }
+            ],
+            "valueName": "current"
+        },
+        {
+            "cacheTimeout": null,
+            "class": "single_stat_panel_fail",
+            "colorBackground": false,
+            "colorValue": true,
+            "colors": [
+                "rgba(50, 172, 45, 0.97)",
+                "rgba(250, 113, 0, 0.89)",
+                "rgba(255, 0, 0, 0.9)"
+            ],
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "format": "none",
+            "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": false
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 2,
+                "x": 2,
+                "y": 4
+            },
+            "id": 3,
+            "interval": null,
+            "isNew": true,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+                {
+                    "name": "value to text",
+                    "value": 1
+                },
+                {
+                    "name": "range to text",
+                    "value": 2
+                }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "options": {},
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+                {
+                    "from": "null",
+                    "text": "N/A",
+                    "to": "null"
+                }
+            ],
+            "span": 1,
+            "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+                {
+                    "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
+                    "intervalFactor": 1,
+                    "legendFormat": "Unreachable",
+                    "refId": "A",
+                    "step": 20
+                }
+            ],
+            "thresholds": "1,2",
+            "title": "Unreachable",
+            "transparent": true,
+            "type": "singlestat",
+            "valueFontSize": "150%",
+            "valueMaps": [
+                {
+                    "op": "=",
+                    "text": "N/A",
+                    "value": "null"
+                }
+            ],
+            "valueName": "current"
+        },
+        {
+            "cacheTimeout": null,
+            "class": "single_stat_panel_fail",
+            "colorBackground": false,
+            "colorValue": true,
+            "colors": [
+                "rgba(50, 172, 45, 0.97)",
+                "rgba(250, 113, 0, 0.89)",
+                "rgba(255, 0, 0, 0.9)"
+            ],
+            "datasource": "prometheus",
+            "description": "Number of nodes that reported their status as Starting or Joining",
+            "editable": true,
+            "error": false,
+            "format": "none",
+            "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": false
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 2,
+                "x": 4,
+                "y": 4
+            },
+            "id": 4,
+            "interval": null,
+            "isNew": true,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+                {
+                    "name": "value to text",
+                    "value": 1
+                },
+                {
+                    "name": "range to text",
+                    "value": 2
+                }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "options": {},
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+                {
+                    "from": "null",
+                    "text": "N/A",
+                    "to": "null"
+                }
+            ],
+            "span": 1,
+            "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+                {
+                    "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
+                    "intervalFactor": 1,
+                    "legendFormat": "Joining",
+                    "refId": "A",
+                    "step": 20
+                }
+            ],
+            "thresholds": "1,2",
+            "title": "Joining",
+            "transparent": true,
+            "type": "singlestat",
+            "valueFontSize": "150%",
+            "valueMaps": [
+                {
+                    "op": "=",
+                    "text": "N/A",
+                    "value": "null"
+                }
+            ],
+            "valueName": "current"
+        },
+        {
+            "cacheTimeout": null,
+            "class": "single_stat_panel_fail",
+            "colorBackground": false,
+            "colorValue": true,
+            "colors": [
+                "rgba(50, 172, 45, 0.97)",
+                "rgba(250, 113, 0, 0.89)",
+                "rgba(255, 0, 0, 0.9)"
+            ],
+            "datasource": "prometheus",
+            "description": "Number of nodes that reported their status as  Leaving, Decommissioned, Draining or Drained",
+            "editable": true,
+            "error": false,
+            "format": "none",
+            "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": false
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 2,
+                "x": 6,
+                "y": 4
+            },
+            "id": 5,
+            "interval": null,
+            "isNew": true,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+                {
+                    "name": "value to text",
+                    "value": 1
+                },
+                {
+                    "name": "range to text",
+                    "value": 2
+                }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "options": {},
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+                {
+                    "from": "null",
+                    "text": "N/A",
+                    "to": "null"
+                }
+            ],
+            "span": 1,
+            "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+                {
+                    "expr": "count(scylla_node_operation_mode>3)OR vector(0)",
+                    "intervalFactor": 1,
+                    "legendFormat": "Leaving",
+                    "refId": "A",
+                    "step": 20
+                }
+            ],
+            "thresholds": "1,2",
+            "title": "Leaving",
+            "transparent": true,
+            "type": "singlestat",
+            "valueFontSize": "150%",
+            "valueMaps": [
+                {
+                    "op": "=",
+                    "text": "N/A",
+                    "value": "null"
+                }
+            ],
+            "valueName": "current"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "percent_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "The percentage of the time during which Scylla utilized the CPU. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 4
+            },
+            "hiddenSeries": false,
+            "id": 6,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 4
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Load",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "percent",
+                    "logBase": 1,
+                    "max": 101,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "single_value_table",
+            "columns": [
+                {
+                    "text": "Avg",
+                    "value": "avg"
+                }
+            ],
+            "datasource": "prometheus",
+            "description": "Nodes Information table",
+            "fontSize": "100%",
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 4
+            },
+            "id": 7,
+            "links": [],
+            "options": {},
+            "pageSize": null,
+            "scroll": true,
+            "showHeader": true,
+            "sort": {
+                "col": 0,
+                "desc": true
+            },
+            "span": 4,
+            "styles": [
+                {
+                    "alias": "",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the detailed node information",
+                    "linkUrl": "/d/detailed-[[dash_version]]/Detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__cell}",
+                    "mappingType": 1,
+                    "pattern": "instance",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "Time",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "__name__",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "exported_instance",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "job",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "version",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "type",
+                    "type": "hidden"
+                },
+                {
+                    "alias": "Version",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "${__cell_11}",
+                    "linkUrl": "/d/OS-[[dash_version]]/OS-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
+                    "mappingType": 1,
+                    "pattern": "svr",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short"
+                },
+                {
+                    "alias": "OS",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the OS node information",
+                    "linkUrl": "/d/OS-[[dash_version]]/OS-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
+                    "mappingType": 1,
+                    "pattern": "OS",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "OS",
+                            "value": "os"
+                        }
+                    ]
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "CQL",
+                    "type": "hidden"
+                },
+                {
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the Errors metrics information",
+                    "linkUrl": "/d/error-[[dash_version]]/scylla-errors?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
+                    "mappingType": 1,
+                    "pattern": "Errors",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "Errors",
+                            "value": "errors"
+                        }
+                    ]
+                },
+                {
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the Errors metrics information",
+                    "linkUrl": "/d/io-[[dash_version]]/i-o?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
+                    "mappingType": 1,
+                    "pattern": "IO",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "IO",
+                            "value": "io"
+                        }
+                    ]
+                },
+                {
+                    "alias": "CPU",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the node CPU information",
+                    "linkUrl": "/d/cpu-[[dash_version]]/CPU-Metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
+                    "mappingType": 1,
+                    "pattern": "CPU",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "CPU",
+                            "value": "cpu"
+                        }
+                    ]
+                },
+                {
+                    "alias": "Status",
+                    "mappingType": 2,
+                    "pattern": "Value",
+                    "rangeMaps": [
+                        {
+                            "from": "1",
+                            "text": "Starting",
+                            "to": "1"
+                        },
+                        {
+                            "from": "2",
+                            "text": "Joining",
+                            "to": "2"
+                        },
+                        {
+                            "from": "3",
+                            "text": "Normal",
+                            "to": "3"
+                        },
+                        {
+                            "from": "4",
+                            "text": "Leaving",
+                            "to": "4"
+                        },
+                        {
+                            "from": "5",
+                            "text": "Decommissioned",
+                            "to": "5"
+                        },
+                        {
+                            "from": "6",
+                            "text": "Draining",
+                            "to": "6"
+                        },
+                        {
+                            "from": "7",
+                            "text": "Drained",
+                            "to": "7"
+                        },
+                        {
+                            "from": "8",
+                            "text": "Moving",
+                            "to": "8"
+                        }
+                    ],
+                    "type": "string"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "cluster",
+                    "type": "hidden"
+                }
+            ],
+            "targets": [
+                {
+                    "expr": "0*scylla_scylladb_current_version{cluster=~\"$cluster|$^\", dc=~\"$dc\"} + on (instance) group_left() scylla_node_operation_mode",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 1,
+                    "refId": "A"
+                }
+            ],
+            "title": "Nodes",
+            "transform": "table",
+            "type": "table"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bytes_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 10
+            },
+            "hiddenSeries": false,
+            "id": 8,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(node_filesystem_size_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])-sum(node_filesystem_avail_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                },
+                {
+                    "expr": "sum(node_filesystem_size{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])-sum(node_filesystem_avail{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "B",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Disk Size by $by",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "bytes",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of Alternator Actions",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 10
+            },
+            "hiddenSeries": false,
+            "id": 9,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_alternator_total_operations{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 4
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Total Actions",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "alert_table",
+            "columns": [],
+            "datasource": "alertmanager",
+            "fontSize": "100%",
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 10
+            },
+            "id": 10,
+            "links": [],
+            "options": {},
+            "pageSize": null,
+            "scroll": true,
+            "showHeader": true,
+            "sort": {
+                "col": 0,
+                "desc": true
+            },
+            "span": 4,
+            "styles": [
+                {
+                    "alias": "Time",
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "link": true,
+                    "linkTooltip": "Jump to the see the node",
+                    "linkUrl": "/d/detailed-[[dash_version]]/detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_4}&from=${__cell_0}",
+                    "pattern": "Time",
+                    "type": "date"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "severity",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "alertname",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "cluster",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "monitor",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "summary",
+                    "type": "hidden"
+                },
+                {
+                    "alias": "Instance",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the see the node",
+                    "linkUrl": "/d/detailed-[[dash_version]]/detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__cell}",
+                    "mappingType": 1,
+                    "pattern": "instance",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short"
+                },
+                {
+                    "alias": "",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "decimals": 2,
+                    "pattern": "/.*/",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "short"
+                }
+            ],
+            "targets": [
+                {
+                    "annotations": true,
+                    "expr": "job!=\"scylla_manager\"",
+                    "legendFormat": "{{description}}",
+                    "refId": "A",
+                    "target": "Query",
+                    "type": "table"
+                }
+            ],
+            "title": "Active Alerts",
+            "transform": "table",
+            "type": "table"
+        },
+        {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Data Plane Actions</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 16
+            },
+            "id": 11,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 18
+            },
+            "hiddenSeries": false,
+            "id": 12,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": "alternator_item_ops",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"$alternator_item_ops\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "$alternator_item_ops by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Data Plane Latencies</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 24
+            },
+            "id": 13,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 26
+            },
+            "hiddenSeries": false,
+            "id": 14,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_op_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"PutItem\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Completed PutItem",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 26
+            },
+            "hiddenSeries": false,
+            "id": 15,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_op_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"PutItem\"}[60s])) by ([[by]])/($func(rate(scylla_alternator_op_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"PutItem\"}[60s])) by ([[by]]) + 1)",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Average PutItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 26
+            },
+            "hiddenSeries": false,
+            "id": 16,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.95, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"PutItem\"}[60s])) by ([[by]], le))",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "95th percentile PutItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 26
+            },
+            "hiddenSeries": false,
+            "id": 17,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.99, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"PutItem\"}[60s])) by ([[by]], le))",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "99th percentile PutItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 32
+            },
+            "hiddenSeries": false,
+            "id": 18,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_op_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"GetItem\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Completed GetItem",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 32
+            },
+            "hiddenSeries": false,
+            "id": 19,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_op_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"GetItem\"}[60s])) by ([[by]])/($func(rate(scylla_alternator_op_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"GetItem\"}[60s])) by ([[by]]) + 1)",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Average GetItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 32
+            },
+            "hiddenSeries": false,
+            "id": 20,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.95, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"GetItem\"}[60s])) by ([[by]], le))",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "95th percentile GetItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 32
+            },
+            "hiddenSeries": false,
+            "id": 21,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.99, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"GetItem\"}[60s])) by ([[by]], le))",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "99th percentile GetItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 38
+            },
+            "hiddenSeries": false,
+            "id": 22,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_op_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"UpdateItem\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Completed UpdateItem",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 38
+            },
+            "hiddenSeries": false,
+            "id": 23,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_op_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"UpdateItem\"}[60s])) by ([[by]])/($func(rate(scylla_alternator_op_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"UpdateItem\"}[60s])) by ([[by]]) + 1)",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Average UpdateItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 38
+            },
+            "hiddenSeries": false,
+            "id": 24,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.95, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"UpdateItem\"}[60s])) by ([[by]], le))",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "95th percentile UpdateItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 38
+            },
+            "hiddenSeries": false,
+            "id": 25,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.99, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"UpdateItem\"}[60s])) by ([[by]], le))",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "99th percentile UpdateItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 44
+            },
+            "hiddenSeries": false,
+            "id": 26,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_op_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"DeleteItem\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Completed DeleteItem",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 44
+            },
+            "hiddenSeries": false,
+            "id": 27,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_op_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"DeleteItem\"}[60s])) by ([[by]])/($func(rate(scylla_alternator_op_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"DeleteItem\"}[60s])) by ([[by]]) + 1)",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Average DeleteItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 44
+            },
+            "hiddenSeries": false,
+            "id": 28,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.95, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"DeleteItem\"}[60s])) by ([[by]], le))",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "95th percentile DeleteItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 44
+            },
+            "hiddenSeries": false,
+            "id": 29,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.99, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"DeleteItem\"}[60s])) by ([[by]], le))",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "99th percentile DeleteItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Control Plane Actions</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 50
+            },
+            "id": 30,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 52
+            },
+            "hiddenSeries": false,
+            "id": 31,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": "alternator_ops",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"$alternator_ops\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "$alternator_ops by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "text_panel",
+            "content": "##  ",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 6,
+                "w": 16,
+                "x": 8,
+                "y": 52
+            },
+            "id": 32,
+            "isNew": true,
+            "links": [],
+            "mode": "markdown",
+            "options": {},
+            "span": 8,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Cache</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 12,
+                "x": 0,
+                "y": 58
+            },
+            "id": 33,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 6,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Timeouts</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 12,
+                "x": 12,
+                "y": 58
+            },
+            "id": 34,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 6,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of rows that were read from the cache, without needing to be fetched from storage.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 60
+            },
+            "hiddenSeries": false,
+            "id": 35,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_cache_row_hits{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Cache Hits",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of rows that were not present in the cache, and had to be fetched from storage.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 60
+            },
+            "hiddenSeries": false,
+            "id": 36,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_cache_row_misses{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Cache Misses",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wpm_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Requests that Scylla tried to write but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 60
+            },
+            "hiddenSeries": false,
+            "id": 37,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(delta(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Write Timeouts/Minutes by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "decimals": 0,
+                    "format": "wpm",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rpm_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Requests that Scylla tried to read but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 60
+            },
+            "hiddenSeries": false,
+            "id": 38,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(delta(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Read Timeouts/Minutes by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "decimals": 0,
+                    "format": "rpm",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Your Panels</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 66
+            },
+            "id": 39,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "user_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "This graph panel was left empty on purpose for ad-hoc usage. Change it when needed. Pay attention that changes to the panel will not be saved.\n\nIf you do need a panel that can be saved, create a new dashboard, or edit the panel inside the json file",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 0,
+                "y": 68
+            },
+            "hiddenSeries": false,
+            "id": 40,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Your Graph here",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "user_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "This graph panel was left empty on purpose for ad-hoc usage. Change it when needed. Pay attention that changes to the panel will not be saved.\n\nIf you do need a panel that can be saved, create a new dashboard, or edit the panel inside the json file",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 12,
+                "y": 68
+            },
+            "hiddenSeries": false,
+            "id": 41,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Your Graph here",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "plain_text",
+            "content": "<h4 style=\"color:#5881c2; border-bottom: 0px solid #5881c2;\">Scylla Monitoring version - master</h4>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 74
+            },
+            "id": 42,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        }
+    ],
+    "refresh": "30s",
+    "schemaVersion": 16,
+    "style": "dark",
+    "tags": [
+        "master"
+    ],
+    "templating": {
+        "list": [
+            {
+                "allValue": null,
+                "class": "by_template_var",
+                "current": {
+                    "tags": [],
+                    "text": "Instance",
+                    "value": "instance"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": "by",
+                "multi": false,
+                "name": "by",
+                "options": [
+                    {
+                        "selected": false,
+                        "text": "Cluster",
+                        "value": "cluster"
+                    },
+                    {
+                        "selected": false,
+                        "text": "DC",
+                        "value": "dc"
+                    },
+                    {
+                        "selected": true,
+                        "text": "Instance",
+                        "value": "instance"
+                    },
+                    {
+                        "selected": false,
+                        "text": "instance,shard",
+                        "value": "instance,shard"
+                    }
+                ],
+                "query": "Cluster,DC,Instance,Shard",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_single",
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": false,
+                "label": "cluster",
+                "multi": false,
+                "name": "cluster",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "dc",
+                "multi": true,
+                "name": "dc",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster\"}, dc)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "node",
+                "multi": true,
+                "name": "node",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster|$^\", dc=~\"$dc\"}, instance)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "shard",
+                "multi": true,
+                "name": "shard",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization,shard)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 3,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_single",
+                "current": {
+                    "text": "/var/lib/scylla",
+                    "value": "/var/lib/scylla"
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": false,
+                "label": "Mount path",
+                "multi": false,
+                "name": "mount_point",
+                "options": [],
+                "query": "node_filesystem_avail_bytes",
+                "refresh": 2,
+                "regex": "/mountpoint=\"([^\"]*)\".*/",
+                "skipUrlSync": false,
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "aggregation_function",
+                "current": {
+                    "tags": [],
+                    "text": "sum",
+                    "value": "sum"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": "Function",
+                "multi": false,
+                "name": "func",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "sum",
+                        "value": "sum"
+                    },
+                    {
+                        "selected": false,
+                        "text": "avg",
+                        "value": "avg"
+                    },
+                    {
+                        "selected": false,
+                        "text": "max",
+                        "value": "max"
+                    },
+                    {
+                        "selected": false,
+                        "text": "min",
+                        "value": "min"
+                    },
+                    {
+                        "selected": false,
+                        "text": "stddev",
+                        "value": "stddev"
+                    },
+                    {
+                        "selected": false,
+                        "text": "stdvar",
+                        "value": "stdvar"
+                    }
+                ],
+                "query": "sum,avg,max,min,stddev,stdvar",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
+                    "text": "master",
+                    "value": "master"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "dash_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "master",
+                        "value": "master"
+                    }
+                ],
+                "query": "master",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
+                    "text": "GetItem",
+                    "value": "GetItem"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "alternator_ops",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "CreateTable",
+                        "value": "CreateTable"
+                    },
+                    {
+                        "selected": true,
+                        "text": "DeleteTable",
+                        "value": "DeleteTable"
+                    },
+                    {
+                        "selected": true,
+                        "text": "DescribeEndpoints",
+                        "value": "DescribeEndpoints"
+                    },
+                    {
+                        "selected": true,
+                        "text": "DescribeTable",
+                        "value": "DescribeTable"
+                    },
+                    {
+                        "selected": true,
+                        "text": "ListTables",
+                        "value": "ListTables"
+                    }
+                ],
+                "query": "CreateTable,DeleteTable,DescribeTable,ListTables,DescribeEndpoints",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
+                    "text": "GetItem",
+                    "value": "GetItem"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "alternator_item_ops",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "BatchWriteItem",
+                        "value": "BatchWriteItem"
+                    },
+                    {
+                        "selected": true,
+                        "text": "DeleteItem",
+                        "value": "DeleteItem"
+                    },
+                    {
+                        "selected": true,
+                        "text": "GetItem",
+                        "value": "GetItem"
+                    },
+                    {
+                        "selected": true,
+                        "text": "PutItem",
+                        "value": "PutItem"
+                    },
+                    {
+                        "selected": true,
+                        "text": "UpdateItem",
+                        "value": "UpdateItem"
+                    },
+                    {
+                        "selected": true,
+                        "text": "Query",
+                        "value": "Query"
+                    },
+                    {
+                        "selected": true,
+                        "text": "Scan",
+                        "value": "Scan"
+                    }
+                ],
+                "query": "GetItem,PutItem,UpdateItem,DeleteItem,BatchWriteItem,Query,Scan",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
+                    "text": "GetItem",
+                    "value": "GetItem"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "alternator_latency_ops",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "GetItem",
+                        "value": "GetItem"
+                    },
+                    {
+                        "selected": true,
+                        "text": "PutItem",
+                        "value": "PutItem"
+                    },
+                    {
+                        "selected": true,
+                        "text": "UpdateItem",
+                        "value": "UpdateItem"
+                    },
+                    {
+                        "selected": true,
+                        "text": "DeleteItem",
+                        "value": "DeleteItem"
+                    }
+                ],
+                "query": "GetItem,PutItem,UpdateItem,DeleteItem",
+                "skipUrlSync": false,
+                "type": "custom"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-30m",
+        "to": "now"
+    },
+    "timepicker": {
+        "now": true,
+        "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+        ],
+        "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+        ]
+    },
+    "timezone": "browser",
+    "title": "Alternator",
+    "uid": "alternator-master",
+    "version": 1
+}

--- a/grafana/build/alternator_master/scylla-cpu.master.json
+++ b/grafana/build/alternator_master/scylla-cpu.master.json
@@ -1,0 +1,700 @@
+{
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            },
+            {
+                "class": "annotation_restart",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "resets(scylla_gossip_heart_beat[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "node_restart",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "restart",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_stall",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_stall_detector_reported[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "stall detector",
+                "showIn": 0,
+                "tagKeys": "dc,instance,shard",
+                "tags": [],
+                "titleFormat": "Stall found",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_schema_changed",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_database_schema_changed[30s])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "Schema Changed",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "schema changed",
+                "type": "tags"
+            }
+        ]
+    },
+    "class": "dashboard",
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 1,
+    "hideControls": true,
+    "id": null,
+    "links": [],
+    "overwrite": true,
+    "panels": [
+        {
+            "class": "text_panel",
+            "content": "<div id=\"amnon\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPoAAAA6CAYAAACZBESJAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAGm9JREFUeNrsXQd8VFXWP+9NTe+NEOmgSIdFiuxSIqB0krCssrCI0sKGLnVZV/qCCqx0ERdQ+ehFCKEtCAuCCAkdQkkhlPQ2yfT5znkzwWTyJslMJqDfd//8zo+ZVydz5//+55x777kADAwMDAwMDL99cC/yZjKpUtqxWUQbvUFbD982Q9OjKdE6oz1Gu4HGo6VzHPdzsabw+uU7h4tYMzEw/IqJLpUouE7NIwL1Bl0kvh1gIbQr8DzIgvyA9/EGMJnKnGPSG0CXnAYmjQY/HWfATTeR9HuL1Pknr9w9cpo1GQPDr4ToUomc79g88jWDQTcf3w7ipFJwad8SFE0agLxuKMgb1wcwGGxfAMlvKCgE3b1kKLp0DTR37oP+cboBJPx1juPXFKnzNiHpDaz5GBheAtGlEhnXsVnkqwajfgGq8WBZaBB4Rb4DyhavAaeQl1PvKgPP0yY9grxdh0FzIxEdfsP9Ik3eR1fuxu1hTcjA8AKJLpHIZJ2aRY4zmAxLkeBKIrhrh9aCK+5M6NMzIe+7g6A6+5OeVypjVcU5Y+ITjz5hTcnAUMNER5K7IMm3GnlThHuPzuD1p/7AyWSOK3iFn5gjRQd1wk3I+moHmLLzbqi0+SOQ7D+z5mRgsMHRal+Alyo7NY/aZpRyEX7Rw8Gzbw8zGWsSPAfSkEBwaf066J88C+TS8/v5+YRdepp9P5k1KQODk4lOJO/YPHKLScpH+o4bBm4d2oDJ8OJyZBIvD1A2awLa1DQPPr2gB5L9FJL9KWtWBgYnue5IchmSfIZJws33Hf9nJDnG4wajeSf+r752G1RnLoLm7gMwZOc9V3lOKgEFktO1fStw7dSm+i4+z+P1cyFr9RbQXL3zs8pQ0Dsh8Vgma1oGhmoSHUnOd2wW2dEkgbNeUX3Bc0C4OemGhNU9fgZZa78BQ1IqNG3RGP7Qoz00a9UEDKj0RqMRUpOfwMXzV+H44bPgEhoM5AkomzasXtIOHyLahymQuWyjIf/xw+0JD04OY03LwFBNovMUl7eIOi1t+Er74E+mgkmnE0iuufMAMpeshXp1Q2DuognQ+NV6Nq/x9EkGfLpwE5z+4TL49Q8H7+ERYFJrHCY69csX/XgFMv+5Ia1IqnkXVf0H1rwMDA7G6Dwv4Ts1i+ppkvDT/SeMAImPF6BUo4v+ELKWroMWLRrB+q0LICDQt9y5pOp3bj2EtNRn4O3jCX0GdgM3pRxObN4HMpkUlM2bVDyQpiJgSMC7uYLhyTNPVVJyg2d5SV+z5mVgcJDoHMfLw4Kbfa1o1jjUa2BPgZgmrRYyl2+EZvVDYeWmeSCVSsudp9XqYOc3h2F69BKI+/4H+H7vSUHx3xnYFVzlMjjx9T5wf60hSAP9hQeH/TABr1QC5+4GutOXpX7+dX56lv0ghTUxA4N5Aok9as6hmtc3cdDerUt7MBEhDUYoPH0BJJnZMHthtCjJCepiDez69gjIkNQcutoF+Sr4eOZKuHguASLfewfaNm8AGVv3AIcK7xBM+BCS8CAPq0WeQZBJp/+QNS8DgwNEFzwADgbyHm7g1uV3AslNej0UHTwBfSPDIbR2kM0T9XoD3LubDBIJb/EMiOxFsGr5FnBxVcL4Se9BQWIKqBNuAWfjYVEp142o6vjZlG+0lLpLPVq2bBjOWpiBwQGi88jQPyjQxQYklZBlz8gCyM2HLt1+V4nLz4E7ktBUpivNBFkZOXABVb1+wzCoGxYEhZeuCvG2Y0w3AeeiBEWjepTF98QtLVkTMzA4RvSW8jqh5r5vInpyGkjlUmjXoXmFJ8oVMniza1tB2cvE7hodxP98S3gIdO7SCoofZwDH8w7/QRzPgcTbE6ShQW4mg/F11sQMDPYS3US5OD5Y8WpD5LhRcJX1KY8hJDSw0lPd3Fxg/rLJMHrCUPDx8QQjnsvhP8rEU1cbZxnDrk99LAyCcRgUq6PrL/UVbtKxJr60Pn36yNEzaYc2FW0r2lm002ixaCvRInbt2uVRE/eOiYlxweu/iTYRbTPaf9FOoR1H24Q2asmSJbXtve6iRYvq47k90bqWsu50rylTpvhXdv66deukeGwLtHCra7yF1mD48OGVumn4ncnw2NZoPazOr9uvXz/emd/jhQsXAvG6ndC6lbpXz1atWrm/aBKmp6d3tvrOG3p7ezv1761yMMxzEq5T86i6RqNB1CWvqtq6e7haue+lY2wjGIuKqzVWnq7Nofcgqx0MpnjnDsft3bu3JDY2tivxAq29rcOIjxEREQVExJ07dy4fMmRIanXvHR0dXfeLL76Yji/fRfOu4ND3Z8yYoUOLXbx48d9nz54dX8VbvIn2BVq5B9Snn366xGg0zlqxYkVF51NRkbVor4nsm4S2sgqfwQftX5ZrlcYnaEvQip3YnN3R6A+yTiy1Rot/gSRvGRAQcAhfepXajPEw1EfLfxmKTuyrSySUBPiYlZPc5LAQSLz9sNKTi4vUsOTjdfDpok2Qm1uAos3hJUyCm+7h7mq+gVwG8iYNHO9Lr0H07NnTH0n+Ob48XgHJS4MIExMVFfWf7du393T0vuPGjePwgfEXJPlP+HZ8JSQvgQyt/6xZsy7guZMWLFhQlVttQfvWxr7h9BXYOnHNmjUwZsyYsTZIfnDEiBH7t2zZwvxncfwVqOpSWfjl5OQM8vT0lL4Mootl2EDq7wtGdLkfpVY8l0St1sKRg2eEgTFlYnckd6u2TaGwQAX/PRMPLrUCzN12vy6Su8TFxY21NIq9KERzaL48kkeGJCI124zm78AlqK9y6Zw5cyZ98sknFR6Iyg/oAWy2oWa1Pv/888hJkybZcmvHofUT2Z41cuTIVUjyJMbn8nj69KkXqvkgy4O5XJSGpngZRDcKPwIq85SRY9Z3JLq8bm0wenrAzm2HK3WpicxcGbecg4AgX+jeqyPcT0yBpJQn4Nq00a9R0duizXfgvPvous8YOnToNXtP/PDDD2UY987Fl3Or+dnvL1y48Mq8efMqPRDJfmHp0qUbwVy00xpRFnfXWs3D0OugmoBi8Ru58qcYpW1igoial6BNXl5eW1R1/oUS3WgywLlrO3N53iqnIpGAokNrOLTnBOTlFdpOBkgl0LBxHeSw8Tnx3d1d4P2xUaDVaGHLl/vAo1EdcO3YBkw6fTWcDAwJNDrQPXqq5ySSasc44eHhfqjm79rYnYu23aJoRIStaKqS8AtJPh/j8zgHSA4bNmygiTkVsZPm3q+zxOwRxDm0O9ZuM5K8/9y5c+0pqrnR8jdZwxtV/f2YmJjniT4MJyi0iBZ7ABDBUc23ff3113rGZ1E1h6CgoBFgroJsC05TdfueFhwl241PNbfvUfrdvAkJ7PF2V9AplTBn0jLbPiS66F26tQO9Xi+Q3MVFCcM/HAQ9UM3/Z8v3cPr8VQgQJrZoq/1HCUm9YnURfsgbTviO/NDEBgncO3jw4AB8sPwJbR3aLrThgwcPpn7GNbt3716MJP+3g/ekWHeEjX15aDNXrFhRH+83Du07tD1o0dOnT2+F+/4GQgYFNqErHoUkv2fPjWfOnKlDVV+NLxNEdg9YuXJlXyR7yfsuNlx2zQcffPAZkvwOo7RN9BNJBFojAlU9wMOj+h049gb79ANKMhYVB5cRdR8v8P3rSLi+fD2sWLIZoqcME4a6lobSRSFsr1MvFFSqYug3uDt4eLjBvh3HYMPGveDfpxsoXm8M+vQs0D9JB3n9MOAUCvvnqpOiF6tBm/hQz8klzshakmsVar3x0KFDd/r3719uhtzevXsfEukcvdmoUaNIzbviyz+I7H60atWqmIkTJ+4VO3f58uVqiUSybMmSJWuR5Cp0xR2aDohk/xGv8+W0adM+F/mNDEtLSzv98ccf34qOjh6D75uKXOJTtFjG5QpBIVlVGDwRbRaa9kUS3YjES9Amp3Wgck5g+IVcikZ1weMvkbDnq51w9/ZDmLMgutyQWLlCDoOH9hJeZyChVyzdDNu/iwP/gW+Bz4hIMOQVgOrUecjdtg+ULV4F/4/GAO/iYtckF4ua02eihR+u11Qr9enTx+fAgQNuSHaVky9dC62rjX0UGuyt6GRUYw2ZEz7HerSOltCgNDrv2rXr92DujhNT89Oo5ls3bdrEXHYbePz4cXN02xtB+WniFI6FWXnawy0hXLWIbn+gbzLlGTKzy39GCQ9undqB/4yxcD0tE97tNxH+MWsVnDhyDpIeppkD2px8OH/2CiyatwaGvDMR9sddgOBRQ8B72CAwqtXCQBlpcABIawWC9n4KFHx/EniFHZNcSM21WozPn1DugAiY5IR20YF4f2anfv36HUeyt3Xy74AaWmyY4X9Xr179b1TzF/JjxDBAhx4C9atfFRN9MPdte1q77KNHj/4MSX6b0blCzBFR82MWlbceK+Cfn58/Et33anW12XuyAYl+Sp+R/ZFoyQpUeXmT+hCydCYq84/ww6VrEDf1U+AkkjLHyEICwbVfD3AL7wwSL0+h4ITm9n3I2xUrlJ5yfaM1uPfoBOqbiTYH19gkukYL+rR0KNTk6K+lnXVK3gTtJFoTkX0dkOzn8TNewtf70W2Pwxi9uoMtPG3EbrdFkm01jfNo+9BaWG2va+N4cvUPMx5XqOaeISEh3UW49x3aTssDtJ5IUu4rEO8NqakYnUuiCS2aW/dBju66mFtNQ1Ddw98UjPbrktLMii2VgLxObeCU5kQikbLg8ElQnbmEx6SConkTCF4yQziGikwqmjayu+oMlaQyZudo0Ds454yGOX78eFavXr3+HRcX92d8K9aPLLO4uB0HDRq0GEl/H19/sXv37nWRkZGOuNCvoFlX7dCjmt+aMGHCC/1Roqrj18h/PmXKFCL6wEoOv4Rq/j8bN25kLrv9ag4BAQH7MzMzNVlZWft9fX2joWzfeiNU9e7u7u6HVSqVQ4NM7HLdjUaD6dy1nUk8x4Oe3PeqjFSlddbqhwmklTeoIyyvlL//GGQsXgNpY2ZD0Y5D0NQX+ePtBcELp4OsdojDlWQ5i6JrU59q0ItIdWLjXEabXIUnKn0jDdFWRERE3NuxY0eEk+6PT0lQvYxf5dSpU3M/++wzysInVnIodfXFMx7bxqNHjwDVnNYgtO5S22JpY8K/Sr0Gq1hd9qIUnX7KlJC7qEtJa891bgumX54CUHzlBmT8cz3IwoJB4uvzPGNOxNWiB0BxPLnxktBgkOblw3vD3hG62LZ+uQ8up6YDVHe9B87sJWCMXoT3uemsBjp69KgOVf1LVHVy0Smj3L0Kp9WOiopajWR3r0Y3268FNOyX+tb/ZmP/2rFjx25HNWdsrhiU2Kwlsv2Lktjcz8/vQU5OzmVvb+8uVkIcVVhY+A9U9Zuo6nYzxZFRN0aT0RivTU4rO/kElduldTNBlWkxRcBYe1TvN2BEj3ZQePsBeEW9AyHL50DYthUQNPevwDd4BX46ewV+PBsP33wbC96d2ghFLKoDmk1nVBWRu1+EpHdqxh3JTh5D/Ntvv90DzF1KpHLPKjktCMn+wfbt2wOqeXsKGQJf1q8TVR1WrFjxGb48IJY7GD9+/Lb169erGI8rRbRI+JcQGBh4F9320uRdZUPVRzgkzg4S3YRKnawTiM6XT8Y1rAOeA3uBEfcl3X8Ebdu/jq85cPldC5ojLqg7r5SDW3gXuJOYAvNmrBQSeN5/7CeoseNqXibjTl1rSTXRUkeOHCHC30Kb0L9/f8qQv4G2Ac3WOu60DnyUHbegOnfZ5X4h0dGNaSTay8LkyZNzkewPRHZlgHkQD0PFbnvn0NDQ16B8wLtVhNQHLN+rNWJQ1QNcqMv5RSg6Uj2BlFOflS06pVTq5wM+00dD7PdnYMyIeeDVvDEohKWSjc/Vnyq+hq5dAMGLPoKAGeOeF7KoFtGLNaC7lwIqXd7DhHvHa7zxDh48qEPCX0QbM3DgwMZgzpqKqXGIHZfFGAbECEWj3rowyvyfUnMC9WqUSdr6+Pjoc3NzabvO6ljKYlNSVFLjRDcaDcZz13ee4jkJGDLEiU7KTuWmQlZ/AoFzJoD/5FFgtM6e43m8hzvG8yEOVn0Vic/R9TdQxp3jU190K+7fvz9t8ODBS/HlfZE8SCM7LkWfXWwSzOuo6sNWrlzJKPMbQ2pqqjuqeXeRZNpBdNvTMzLExFtIyom5uH93JCnn4MwYDoNhYzp1sXG2ikTQvHUksuLVBsA7MpTVbp6T666jjHsBJ+XPO/v6NFXVZDL9MTY2drIDp1d5muqmTZuyR48efcTG7pExMTGzKiL7jBkz6uLnPIa2b9GiRT6MZr8KzIayhSVKu+2ixTRQ1e/n5+f/DOZZo6URWFRU1A3dd7u46+hoGwP+kOK1KWk9ywyFfZmwxOj6R09UoJBcdzLJIS4ujgovbO/du3cx/u21Dh06NLtv377PXasBAwYE7NmzhwpDNLA6vQjsn49OI312oA2x2k5P8oVI9oZGo3EGxs3P15ibNm0aLFu2rBO+XA7mfn2YNWvWCTxu7Ny5cy/+xolS58CBA7+3kMLWD1zRo0ePiydPnsypzo2uXLnSDsxTbmW2fUcoatKkSfzdu3crHSeBag61a9cWm6WWFxwc/B9U84oy0JSUowlV1kE5DY88AXYMi3WU6EYwmhJ0RPSaXiK5iiSnATm0WgxIpUgsvdOIHh4eTiSnutElJVLoS5/Wp0+fcUj4HyxudlNL/Cz21E62ELfK2Lhx42P876sNGzbQfX1FfmjvT5o06U9o1N13BsxVZ94C84iq0m3aes6cOUfRPpo/f/6GqsxJ/5ViBNiezVca1CNyspr3qkofIY0p6IaWVoVjqWCJ2OSVbVB5aSxKytHDPMxqey9U9Qao6rfVanWVXGWHXHfOPBT2tB5jdGECyUsnOghz0Gnoq0qbm5GQeEzvLJIfO3aMfjy7ofy4bnrqv432EVpfGyQn0GAbR0bp0Tx2Gvpo6wt2sTxcyC0cb8kDiD246XNRzbbfMw/6pYDqCogl4baA7Z4ac8N5eenQfaeknN5GrF71mo8OKzqNgqLhrdTNxvMvnekWt10DvFPddpqO+xcRklcVF3fu3Dlv6NCh9svKxo0wduzYb/Dl6ArIXhWQe0fdf2zRyReM5OTk3ui2N4XyXWpn0W2/8+zZs6qo8SobLvqA4uJiX6VSWXNENxj1cO76rhwe+AwhIce/XPddGPpKiTgaESflnUb048ePP33rrbcmWb5se/EfJPl7Q4YMeeDo/devXw/jx4+nhA3lBy45cInbCxcu7Infz4rfsNv+W8Z7NtS8Km57iarfKygouAzlk3JKiwhJaozov8TpxiRtisjAmZfhupOipz4pBonkhjMvbZnUQskPGviyq5LD6QlN3Wvjdu/e3R1Jfq+691+7di09yM5MmDCBEm00//tYZS6fJXactXjx4q52lpFicJ6a13rllVcox2Kd1MuvVavWHlRze0aH2VL1iVV13x2WYp6Xyjq3iFrM1wqYGvLZ34Shp4UnzoFnn27CDLKSSi852/aC3/jhAhEt8gvG/ELIXLUZ/Ea/C5KgUqunGoygvnkXVGcvQcCUD36J/zE0MGTlQP7+o+A37s/m7UgpmlijfZgCrh1aQ+Gxs5D9xdZ7RRJ1B4zRs2qqAXv37u0WGxtLo+FozjgNbTVYLG3v3r1nBg8efLemf0QxMTG+K1eupPu/ZknUUPafJu5T4u/k0qVLH86cOZPNImN4Docns3PCmHdT/POEHJK78MgpcGnVFKQhAQIRTTodFJ39CfxjRiLRrbXPJCzWIKUHQokq0zZVsfCAKJPNNxhAl/YU1Am38fmIH1nNCdemOezqhJvC/HVzIi6v6OqjH7Jq8gs7cuSIChWWMrsnX1ajrVq1KhuNlJqpNUPNxegl9ENynn6ekJPwIPH1Bm3yo+eFI4msnFwOmlv3hP2V+98iK7XQgwCJbswrABmt+UbDaOlQtQZ0D5KFijQmjUZIxHESyTnWpAwMTiQ6JeTOX9uVTQk5LSorFZugVUw1NxJ/ITXNRQ8LEdx6rgpRArn8tJabdRafyj9rU5+UelhYJrA8yQBZoL8wvJYScbj/OmtSBgbnKrpZ1UumrCI5qXJM2emrpMbiXXBUxFGPcTdUJWNPMTwSm1aFodclWXZ9eibI6tYWJrPoU58UMkVnYKgZolMRiqu6lDShvjupty7p0fNlj6nbTervAwZUdCi7QItAWKHIZGUj6yxVYzT3U0AW5C/E8bSSqyG/UDDew02I1c0j4oApOgNDTSi6ySgUiwQjkpFiaIqndSWqjoSnmu9aJw+qMWn1oEt9DLyLEqTouuuSH1MiLiM+8aiONSkDQ0247hwkmCwJOYm7m1CemfrWS1S9RLk5R8fEW8pDaR+goterTbl+cyLuYSq+DxPGuOvThEQcU3MGhpog+vOEnInP1JrdZ5DWDgEtuu8Ue5M7TwUn9M8yqxaL6ynp9hg4kQw9PTiExRyowA3G5yWJOCK9FuNzkPAsPmdgqCFFN6u60XhafesecDIJyGsHC/XYy7jqQkKuVDadut1kMlDT8NmSmu+cOXFHq7XIKQSgBBxtQyJT0UlK9En8zQUnhVFw6Zl4XC0wZOWC/tHTYqboDAw1S3S9QPTrd6DoQjy4tGsB2jsPoGD/MYGcitcbAeeigKyN35qXQ0aiEkkpaae+ehsKT54DTi4TBskUxJ4SYm81egeGXPPiKOQd0Hb5K7WEElX6zBzI3mRe7JNG1eVuP4DXV9KQzyusORkYbEbA1YdEInPp1CxyK0p7hJB5x/iZFmsQusNQpfUl2XVUb1loEJHcgOpOc3qpRE0f3s1ViO31GdmF6OLvQe/8j5xCppBjDK6+kSiEAEKZaF8vMOSrBEXnXV2Ea6Pi31apc6PjE4+eZM3JwFCDRLeQXYJkD8e4nRbfo8obNLmkDZinWFKlRprFNQpNgY77LbVOdeDKnSOGN1sO7aU3aDtxHJdXrCncnZB49B5uC9PpNVSwnvx6KuxAJKbVRTug0SLstExSXY7jk1TFOfuR5FmsKRkYGBgY/l/jfwUYAPw0FqsWp2FrAAAAAElFTkSuQmCC\" style=\"margin-top:-20px\" height=\"55\">\n<span style=\"font-size:40px\">  [[cluster]]</span><span style=\"padding-top: 25px;float:right\"><a href=\"https://github.com/scylladb/scylla-monitoring/issues/new?body=scylla-version%3D[[scylla_dash_version]]%0Amonitoring-version%3D[[monitoring_version]]\" target=\"_blank\"><input title=\"Report an issue with Scylla Monitoring\" type=\"button\" style=\"background-color:#57d1e5;color:black;font-size:20px\" value=\"Report an issue\"></a></span><hr style=\"border-top: 3px solid #5780c1;\"></div>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 4,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 1,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Information by Task Group</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 4
+            },
+            "id": 2,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 6
+            },
+            "id": 3,
+            "panels": [],
+            "repeat": "group",
+            "title": "$group",
+            "type": "row"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ms_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. This graph shows how much time was spent in $group group",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 7
+            },
+            "hiddenSeries": false,
+            "id": 4,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_scheduler_runtime_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Time used by [[by]] - $group",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ms",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ms_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. The maximum amount of time during which a task group can run is called the \"task quota\". Some task groups may disrespect that and run for longer. This may cause latency issues",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 7
+            },
+            "hiddenSeries": false,
+            "id": 5,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_scheduler_time_spent_on_task_quota_violations_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Time spent in task quota violations by [[by]] - $group",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ms",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Shares assigned to the $group. Shares determine how Scylla reactor distributes the task quotas between groups (Higher share gets more quotas)",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 7
+            },
+            "hiddenSeries": false,
+            "id": 6,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(scylla_scheduler_shares{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Scheduler shares [[by]] - $group",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        }
+    ],
+    "refresh": "30s",
+    "schemaVersion": 16,
+    "style": "dark",
+    "tags": [
+        "master"
+    ],
+    "templating": {
+        "list": [
+            {
+                "allValue": null,
+                "class": "by_template_var",
+                "current": {
+                    "tags": [],
+                    "text": "Instance",
+                    "value": "instance"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": "by",
+                "multi": false,
+                "name": "by",
+                "options": [
+                    {
+                        "selected": false,
+                        "text": "Cluster",
+                        "value": "cluster"
+                    },
+                    {
+                        "selected": false,
+                        "text": "DC",
+                        "value": "dc"
+                    },
+                    {
+                        "selected": true,
+                        "text": "Instance",
+                        "value": "instance"
+                    },
+                    {
+                        "selected": false,
+                        "text": "instance,shard",
+                        "value": "instance,shard"
+                    }
+                ],
+                "query": "Cluster,DC,Instance,Shard",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_single",
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": false,
+                "label": "cluster",
+                "multi": false,
+                "name": "cluster",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "dc",
+                "multi": true,
+                "name": "dc",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster\"}, dc)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "node",
+                "multi": true,
+                "name": "node",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster|$^\", dc=~\"$dc\"}, instance)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "shard",
+                "multi": true,
+                "name": "shard",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization,shard)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 3,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 2,
+                "includeAll": true,
+                "label": "group",
+                "multi": true,
+                "name": "group",
+                "options": [],
+                "query": "label_values(scylla_scheduler_time_spent_on_task_quota_violations_ms,group)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 3,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
+                    "text": "master",
+                    "value": "master"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "scylla_dash_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "master",
+                        "value": "master"
+                    }
+                ],
+                "query": "master",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "monitor_version_var",
+                "current": {
+                    "text": "master",
+                    "value": "master"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "monitoring_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "master",
+                        "value": "master"
+                    }
+                ],
+                "query": "master",
+                "skipUrlSync": false,
+                "type": "custom"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-30m",
+        "to": "now"
+    },
+    "timepicker": {
+        "now": true,
+        "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+        ],
+        "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+        ]
+    },
+    "timezone": "browser",
+    "title": "CPU Metrics",
+    "uid": "cpu-master",
+    "version": 5
+}

--- a/grafana/build/alternator_master/scylla-errors.master.json
+++ b/grafana/build/alternator_master/scylla-errors.master.json
@@ -1,0 +1,1148 @@
+{
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            },
+            {
+                "class": "annotation_restart",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "resets(scylla_gossip_heart_beat[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "node_restart",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "restart",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_stall",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_stall_detector_reported[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "stall detector",
+                "showIn": 0,
+                "tagKeys": "dc,instance,shard",
+                "tags": [],
+                "titleFormat": "Stall found",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_schema_changed",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_database_schema_changed[30s])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "Schema Changed",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "schema changed",
+                "type": "tags"
+            }
+        ]
+    },
+    "class": "dashboard",
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 1,
+    "hideControls": true,
+    "id": null,
+    "links": [],
+    "overwrite": true,
+    "panels": [
+        {
+            "class": "text_panel",
+            "content": "<div id=\"amnon\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPoAAAA6CAYAAACZBESJAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAGm9JREFUeNrsXQd8VFXWP+9NTe+NEOmgSIdFiuxSIqB0krCssrCI0sKGLnVZV/qCCqx0ERdQ+ehFCKEtCAuCCAkdQkkhlPQ2yfT5znkzwWTyJslMJqDfd//8zo+ZVydz5//+55x777kADAwMDAwMDL99cC/yZjKpUtqxWUQbvUFbD982Q9OjKdE6oz1Gu4HGo6VzHPdzsabw+uU7h4tYMzEw/IqJLpUouE7NIwL1Bl0kvh1gIbQr8DzIgvyA9/EGMJnKnGPSG0CXnAYmjQY/HWfATTeR9HuL1Pknr9w9cpo1GQPDr4ToUomc79g88jWDQTcf3w7ipFJwad8SFE0agLxuKMgb1wcwGGxfAMlvKCgE3b1kKLp0DTR37oP+cboBJPx1juPXFKnzNiHpDaz5GBheAtGlEhnXsVnkqwajfgGq8WBZaBB4Rb4DyhavAaeQl1PvKgPP0yY9grxdh0FzIxEdfsP9Ik3eR1fuxu1hTcjA8AKJLpHIZJ2aRY4zmAxLkeBKIrhrh9aCK+5M6NMzIe+7g6A6+5OeVypjVcU5Y+ITjz5hTcnAUMNER5K7IMm3GnlThHuPzuD1p/7AyWSOK3iFn5gjRQd1wk3I+moHmLLzbqi0+SOQ7D+z5mRgsMHRal+Alyo7NY/aZpRyEX7Rw8Gzbw8zGWsSPAfSkEBwaf066J88C+TS8/v5+YRdepp9P5k1KQODk4lOJO/YPHKLScpH+o4bBm4d2oDJ8OJyZBIvD1A2awLa1DQPPr2gB5L9FJL9KWtWBgYnue5IchmSfIZJws33Hf9nJDnG4wajeSf+r752G1RnLoLm7gMwZOc9V3lOKgEFktO1fStw7dSm+i4+z+P1cyFr9RbQXL3zs8pQ0Dsh8Vgma1oGhmoSHUnOd2wW2dEkgbNeUX3Bc0C4OemGhNU9fgZZa78BQ1IqNG3RGP7Qoz00a9UEDKj0RqMRUpOfwMXzV+H44bPgEhoM5AkomzasXtIOHyLahymQuWyjIf/xw+0JD04OY03LwFBNovMUl7eIOi1t+Er74E+mgkmnE0iuufMAMpeshXp1Q2DuognQ+NV6Nq/x9EkGfLpwE5z+4TL49Q8H7+ERYFJrHCY69csX/XgFMv+5Ia1IqnkXVf0H1rwMDA7G6Dwv4Ts1i+ppkvDT/SeMAImPF6BUo4v+ELKWroMWLRrB+q0LICDQt9y5pOp3bj2EtNRn4O3jCX0GdgM3pRxObN4HMpkUlM2bVDyQpiJgSMC7uYLhyTNPVVJyg2d5SV+z5mVgcJDoHMfLw4Kbfa1o1jjUa2BPgZgmrRYyl2+EZvVDYeWmeSCVSsudp9XqYOc3h2F69BKI+/4H+H7vSUHx3xnYFVzlMjjx9T5wf60hSAP9hQeH/TABr1QC5+4GutOXpX7+dX56lv0ghTUxA4N5Aok9as6hmtc3cdDerUt7MBEhDUYoPH0BJJnZMHthtCjJCepiDez69gjIkNQcutoF+Sr4eOZKuHguASLfewfaNm8AGVv3AIcK7xBM+BCS8CAPq0WeQZBJp/+QNS8DgwNEFzwADgbyHm7g1uV3AslNej0UHTwBfSPDIbR2kM0T9XoD3LubDBIJb/EMiOxFsGr5FnBxVcL4Se9BQWIKqBNuAWfjYVEp142o6vjZlG+0lLpLPVq2bBjOWpiBwQGi88jQPyjQxQYklZBlz8gCyM2HLt1+V4nLz4E7ktBUpivNBFkZOXABVb1+wzCoGxYEhZeuCvG2Y0w3AeeiBEWjepTF98QtLVkTMzA4RvSW8jqh5r5vInpyGkjlUmjXoXmFJ8oVMniza1tB2cvE7hodxP98S3gIdO7SCoofZwDH8w7/QRzPgcTbE6ShQW4mg/F11sQMDPYS3US5OD5Y8WpD5LhRcJX1KY8hJDSw0lPd3Fxg/rLJMHrCUPDx8QQjnsvhP8rEU1cbZxnDrk99LAyCcRgUq6PrL/UVbtKxJr60Pn36yNEzaYc2FW0r2lm002ixaCvRInbt2uVRE/eOiYlxweu/iTYRbTPaf9FOoR1H24Q2asmSJbXtve6iRYvq47k90bqWsu50rylTpvhXdv66deukeGwLtHCra7yF1mD48OGVumn4ncnw2NZoPazOr9uvXz/emd/jhQsXAvG6ndC6lbpXz1atWrm/aBKmp6d3tvrOG3p7ezv1761yMMxzEq5T86i6RqNB1CWvqtq6e7haue+lY2wjGIuKqzVWnq7Nofcgqx0MpnjnDsft3bu3JDY2tivxAq29rcOIjxEREQVExJ07dy4fMmRIanXvHR0dXfeLL76Yji/fRfOu4ND3Z8yYoUOLXbx48d9nz54dX8VbvIn2BVq5B9Snn366xGg0zlqxYkVF51NRkbVor4nsm4S2sgqfwQftX5ZrlcYnaEvQip3YnN3R6A+yTiy1Rot/gSRvGRAQcAhfepXajPEw1EfLfxmKTuyrSySUBPiYlZPc5LAQSLz9sNKTi4vUsOTjdfDpok2Qm1uAos3hJUyCm+7h7mq+gVwG8iYNHO9Lr0H07NnTH0n+Ob48XgHJS4MIExMVFfWf7du393T0vuPGjePwgfEXJPlP+HZ8JSQvgQyt/6xZsy7guZMWLFhQlVttQfvWxr7h9BXYOnHNmjUwZsyYsTZIfnDEiBH7t2zZwvxncfwVqOpSWfjl5OQM8vT0lL4Mootl2EDq7wtGdLkfpVY8l0St1sKRg2eEgTFlYnckd6u2TaGwQAX/PRMPLrUCzN12vy6Su8TFxY21NIq9KERzaL48kkeGJCI124zm78AlqK9y6Zw5cyZ98sknFR6Iyg/oAWy2oWa1Pv/888hJkybZcmvHofUT2Z41cuTIVUjyJMbn8nj69KkXqvkgy4O5XJSGpngZRDcKPwIq85SRY9Z3JLq8bm0wenrAzm2HK3WpicxcGbecg4AgX+jeqyPcT0yBpJQn4Nq00a9R0duizXfgvPvous8YOnToNXtP/PDDD2UY987Fl3Or+dnvL1y48Mq8efMqPRDJfmHp0qUbwVy00xpRFnfXWs3D0OugmoBi8Ru58qcYpW1igoial6BNXl5eW1R1/oUS3WgywLlrO3N53iqnIpGAokNrOLTnBOTlFdpOBkgl0LBxHeSw8Tnx3d1d4P2xUaDVaGHLl/vAo1EdcO3YBkw6fTWcDAwJNDrQPXqq5ySSasc44eHhfqjm79rYnYu23aJoRIStaKqS8AtJPh/j8zgHSA4bNmygiTkVsZPm3q+zxOwRxDm0O9ZuM5K8/9y5c+0pqrnR8jdZwxtV/f2YmJjniT4MJyi0iBZ7ABDBUc23ff3113rGZ1E1h6CgoBFgroJsC05TdfueFhwl241PNbfvUfrdvAkJ7PF2V9AplTBn0jLbPiS66F26tQO9Xi+Q3MVFCcM/HAQ9UM3/Z8v3cPr8VQgQJrZoq/1HCUm9YnURfsgbTviO/NDEBgncO3jw4AB8sPwJbR3aLrThgwcPpn7GNbt3716MJP+3g/ekWHeEjX15aDNXrFhRH+83Du07tD1o0dOnT2+F+/4GQgYFNqErHoUkv2fPjWfOnKlDVV+NLxNEdg9YuXJlXyR7yfsuNlx2zQcffPAZkvwOo7RN9BNJBFojAlU9wMOj+h049gb79ANKMhYVB5cRdR8v8P3rSLi+fD2sWLIZoqcME4a6lobSRSFsr1MvFFSqYug3uDt4eLjBvh3HYMPGveDfpxsoXm8M+vQs0D9JB3n9MOAUCvvnqpOiF6tBm/hQz8klzshakmsVar3x0KFDd/r3719uhtzevXsfEukcvdmoUaNIzbviyz+I7H60atWqmIkTJ+4VO3f58uVqiUSybMmSJWuR5Cp0xR2aDohk/xGv8+W0adM+F/mNDEtLSzv98ccf34qOjh6D75uKXOJTtFjG5QpBIVlVGDwRbRaa9kUS3YjES9Amp3Wgck5g+IVcikZ1weMvkbDnq51w9/ZDmLMgutyQWLlCDoOH9hJeZyChVyzdDNu/iwP/gW+Bz4hIMOQVgOrUecjdtg+ULV4F/4/GAO/iYtckF4ua02eihR+u11Qr9enTx+fAgQNuSHaVky9dC62rjX0UGuyt6GRUYw2ZEz7HerSOltCgNDrv2rXr92DujhNT89Oo5ls3bdrEXHYbePz4cXN02xtB+WniFI6FWXnawy0hXLWIbn+gbzLlGTKzy39GCQ9undqB/4yxcD0tE97tNxH+MWsVnDhyDpIeppkD2px8OH/2CiyatwaGvDMR9sddgOBRQ8B72CAwqtXCQBlpcABIawWC9n4KFHx/EniFHZNcSM21WozPn1DugAiY5IR20YF4f2anfv36HUeyt3Xy74AaWmyY4X9Xr179b1TzF/JjxDBAhx4C9atfFRN9MPdte1q77KNHj/4MSX6b0blCzBFR82MWlbceK+Cfn58/Et33anW12XuyAYl+Sp+R/ZFoyQpUeXmT+hCydCYq84/ww6VrEDf1U+AkkjLHyEICwbVfD3AL7wwSL0+h4ITm9n3I2xUrlJ5yfaM1uPfoBOqbiTYH19gkukYL+rR0KNTk6K+lnXVK3gTtJFoTkX0dkOzn8TNewtf70W2Pwxi9uoMtPG3EbrdFkm01jfNo+9BaWG2va+N4cvUPMx5XqOaeISEh3UW49x3aTssDtJ5IUu4rEO8NqakYnUuiCS2aW/dBju66mFtNQ1Ddw98UjPbrktLMii2VgLxObeCU5kQikbLg8ElQnbmEx6SConkTCF4yQziGikwqmjayu+oMlaQyZudo0Ds454yGOX78eFavXr3+HRcX92d8K9aPLLO4uB0HDRq0GEl/H19/sXv37nWRkZGOuNCvoFlX7dCjmt+aMGHCC/1Roqrj18h/PmXKFCL6wEoOv4Rq/j8bN25kLrv9ag4BAQH7MzMzNVlZWft9fX2joWzfeiNU9e7u7u6HVSqVQ4NM7HLdjUaD6dy1nUk8x4Oe3PeqjFSlddbqhwmklTeoIyyvlL//GGQsXgNpY2ZD0Y5D0NQX+ePtBcELp4OsdojDlWQ5i6JrU59q0ItIdWLjXEabXIUnKn0jDdFWRERE3NuxY0eEk+6PT0lQvYxf5dSpU3M/++wzysInVnIodfXFMx7bxqNHjwDVnNYgtO5S22JpY8K/Sr0Gq1hd9qIUnX7KlJC7qEtJa891bgumX54CUHzlBmT8cz3IwoJB4uvzPGNOxNWiB0BxPLnxktBgkOblw3vD3hG62LZ+uQ8up6YDVHe9B87sJWCMXoT3uemsBjp69KgOVf1LVHVy0Smj3L0Kp9WOiopajWR3r0Y3268FNOyX+tb/ZmP/2rFjx25HNWdsrhiU2Kwlsv2Lktjcz8/vQU5OzmVvb+8uVkIcVVhY+A9U9Zuo6nYzxZFRN0aT0RivTU4rO/kElduldTNBlWkxRcBYe1TvN2BEj3ZQePsBeEW9AyHL50DYthUQNPevwDd4BX46ewV+PBsP33wbC96d2ghFLKoDmk1nVBWRu1+EpHdqxh3JTh5D/Ntvv90DzF1KpHLPKjktCMn+wfbt2wOqeXsKGQJf1q8TVR1WrFjxGb48IJY7GD9+/Lb169erGI8rRbRI+JcQGBh4F9320uRdZUPVRzgkzg4S3YRKnawTiM6XT8Y1rAOeA3uBEfcl3X8Ebdu/jq85cPldC5ojLqg7r5SDW3gXuJOYAvNmrBQSeN5/7CeoseNqXibjTl1rSTXRUkeOHCHC30Kb0L9/f8qQv4G2Ac3WOu60DnyUHbegOnfZ5X4h0dGNaSTay8LkyZNzkewPRHZlgHkQD0PFbnvn0NDQ16B8wLtVhNQHLN+rNWJQ1QNcqMv5RSg6Uj2BlFOflS06pVTq5wM+00dD7PdnYMyIeeDVvDEohKWSjc/Vnyq+hq5dAMGLPoKAGeOeF7KoFtGLNaC7lwIqXd7DhHvHa7zxDh48qEPCX0QbM3DgwMZgzpqKqXGIHZfFGAbECEWj3rowyvyfUnMC9WqUSdr6+Pjoc3NzabvO6ljKYlNSVFLjRDcaDcZz13ee4jkJGDLEiU7KTuWmQlZ/AoFzJoD/5FFgtM6e43m8hzvG8yEOVn0Vic/R9TdQxp3jU190K+7fvz9t8ODBS/HlfZE8SCM7LkWfXWwSzOuo6sNWrlzJKPMbQ2pqqjuqeXeRZNpBdNvTMzLExFtIyom5uH93JCnn4MwYDoNhYzp1sXG2ikTQvHUksuLVBsA7MpTVbp6T666jjHsBJ+XPO/v6NFXVZDL9MTY2drIDp1d5muqmTZuyR48efcTG7pExMTGzKiL7jBkz6uLnPIa2b9GiRT6MZr8KzIayhSVKu+2ixTRQ1e/n5+f/DOZZo6URWFRU1A3dd7u46+hoGwP+kOK1KWk9ywyFfZmwxOj6R09UoJBcdzLJIS4ujgovbO/du3cx/u21Dh06NLtv377PXasBAwYE7NmzhwpDNLA6vQjsn49OI312oA2x2k5P8oVI9oZGo3EGxs3P15ibNm0aLFu2rBO+XA7mfn2YNWvWCTxu7Ny5cy/+xolS58CBA7+3kMLWD1zRo0ePiydPnsypzo2uXLnSDsxTbmW2fUcoatKkSfzdu3crHSeBag61a9cWm6WWFxwc/B9U84oy0JSUowlV1kE5DY88AXYMi3WU6EYwmhJ0RPSaXiK5iiSnATm0WgxIpUgsvdOIHh4eTiSnutElJVLoS5/Wp0+fcUj4HyxudlNL/Cz21E62ELfK2Lhx42P876sNGzbQfX1FfmjvT5o06U9o1N13BsxVZ94C84iq0m3aes6cOUfRPpo/f/6GqsxJ/5ViBNiezVca1CNyspr3qkofIY0p6IaWVoVjqWCJ2OSVbVB5aSxKytHDPMxqey9U9Qao6rfVanWVXGWHXHfOPBT2tB5jdGECyUsnOghz0Gnoq0qbm5GQeEzvLJIfO3aMfjy7ofy4bnrqv432EVpfGyQn0GAbR0bp0Tx2Gvpo6wt2sTxcyC0cb8kDiD246XNRzbbfMw/6pYDqCogl4baA7Z4ac8N5eenQfaeknN5GrF71mo8OKzqNgqLhrdTNxvMvnekWt10DvFPddpqO+xcRklcVF3fu3Dlv6NCh9svKxo0wduzYb/Dl6ArIXhWQe0fdf2zRyReM5OTk3ui2N4XyXWpn0W2/8+zZs6qo8SobLvqA4uJiX6VSWXNENxj1cO76rhwe+AwhIce/XPddGPpKiTgaESflnUb048ePP33rrbcmWb5se/EfJPl7Q4YMeeDo/devXw/jx4+nhA3lBy45cInbCxcu7Infz4rfsNv+W8Z7NtS8Km57iarfKygouAzlk3JKiwhJaozov8TpxiRtisjAmZfhupOipz4pBonkhjMvbZnUQskPGviyq5LD6QlN3Wvjdu/e3R1Jfq+691+7di09yM5MmDCBEm00//tYZS6fJXactXjx4q52lpFicJ6a13rllVcox2Kd1MuvVavWHlRze0aH2VL1iVV13x2WYp6Xyjq3iFrM1wqYGvLZ34Shp4UnzoFnn27CDLKSSi852/aC3/jhAhEt8gvG/ELIXLUZ/Ea/C5KgUqunGoygvnkXVGcvQcCUD36J/zE0MGTlQP7+o+A37s/m7UgpmlijfZgCrh1aQ+Gxs5D9xdZ7RRJ1B4zRs2qqAXv37u0WGxtLo+FozjgNbTVYLG3v3r1nBg8efLemf0QxMTG+K1eupPu/ZknUUPafJu5T4u/k0qVLH86cOZPNImN4Docns3PCmHdT/POEHJK78MgpcGnVFKQhAQIRTTodFJ39CfxjRiLRrbXPJCzWIKUHQokq0zZVsfCAKJPNNxhAl/YU1Am38fmIH1nNCdemOezqhJvC/HVzIi6v6OqjH7Jq8gs7cuSIChWWMrsnX1ajrVq1KhuNlJqpNUPNxegl9ENynn6ekJPwIPH1Bm3yo+eFI4msnFwOmlv3hP2V+98iK7XQgwCJbswrABmt+UbDaOlQtQZ0D5KFijQmjUZIxHESyTnWpAwMTiQ6JeTOX9uVTQk5LSorFZugVUw1NxJ/ITXNRQ8LEdx6rgpRArn8tJabdRafyj9rU5+UelhYJrA8yQBZoL8wvJYScbj/OmtSBgbnKrpZ1UumrCI5qXJM2emrpMbiXXBUxFGPcTdUJWNPMTwSm1aFodclWXZ9eibI6tYWJrPoU58UMkVnYKgZolMRiqu6lDShvjupty7p0fNlj6nbTervAwZUdCi7QItAWKHIZGUj6yxVYzT3U0AW5C/E8bSSqyG/UDDew02I1c0j4oApOgNDTSi6ySgUiwQjkpFiaIqndSWqjoSnmu9aJw+qMWn1oEt9DLyLEqTouuuSH1MiLiM+8aiONSkDQ0247hwkmCwJOYm7m1CemfrWS1S9RLk5R8fEW8pDaR+goterTbl+cyLuYSq+DxPGuOvThEQcU3MGhpog+vOEnInP1JrdZ5DWDgEtuu8Ue5M7TwUn9M8yqxaL6ynp9hg4kQw9PTiExRyowA3G5yWJOCK9FuNzkPAsPmdgqCFFN6u60XhafesecDIJyGsHC/XYy7jqQkKuVDadut1kMlDT8NmSmu+cOXFHq7XIKQSgBBxtQyJT0UlK9En8zQUnhVFw6Zl4XC0wZOWC/tHTYqboDAw1S3S9QPTrd6DoQjy4tGsB2jsPoGD/MYGcitcbAeeigKyN35qXQ0aiEkkpaae+ehsKT54DTi4TBskUxJ4SYm81egeGXPPiKOQd0Hb5K7WEElX6zBzI3mRe7JNG1eVuP4DXV9KQzyusORkYbEbA1YdEInPp1CxyK0p7hJB5x/iZFmsQusNQpfUl2XVUb1loEJHcgOpOc3qpRE0f3s1ViO31GdmF6OLvQe/8j5xCppBjDK6+kSiEAEKZaF8vMOSrBEXnXV2Ea6Pi31apc6PjE4+eZM3JwFCDRLeQXYJkD8e4nRbfo8obNLmkDZinWFKlRprFNQpNgY77LbVOdeDKnSOGN1sO7aU3aDtxHJdXrCncnZB49B5uC9PpNVSwnvx6KuxAJKbVRTug0SLstExSXY7jk1TFOfuR5FmsKRkYGBgY/l/jfwUYAPw0FqsWp2FrAAAAAElFTkSuQmCC\" style=\"margin-top:-20px\" height=\"55\">\n<span style=\"font-size:40px\">  [[cluster]]</span><span style=\"padding-top: 25px;float:right\"><a href=\"https://github.com/scylladb/scylla-monitoring/issues/new?body=scylla-version%3D[[scylla_dash_version]]%0Amonitoring-version%3D[[monitoring_version]]\" target=\"_blank\"><input title=\"Report an issue with Scylla Monitoring\" type=\"button\" style=\"background-color:#57d1e5;color:black;font-size:20px\" value=\"Report an issue\"></a></span><hr style=\"border-top: 3px solid #5780c1;\"></div>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 4,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 1,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of Read requests that failed due to an 'unavailable' error",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 4
+            },
+            "hiddenSeries": false,
+            "id": 2,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(irate(scylla_storage_proxy_coordinator_read_errors_local_node{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Local Reads Error by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of write requests that failed due to an 'unavailable' error",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 4
+            },
+            "hiddenSeries": false,
+            "id": 3,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(irate(scylla_storage_proxy_coordinator_write_errors_local_node{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Local Write Error by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "text_panel",
+            "content": "##  ",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 4
+            },
+            "id": 4,
+            "isNew": true,
+            "links": [],
+            "mode": "markdown",
+            "options": {},
+            "span": 4,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of Read requests that failed due to an 'unavailable' error",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 10
+            },
+            "hiddenSeries": false,
+            "id": 5,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(irate(scylla_storage_proxy_coordinator_read_unavailable{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Reads Unavailable Error by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of write requests that failed on a local Node",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 10
+            },
+            "hiddenSeries": false,
+            "id": 6,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(irate(scylla_storage_proxy_coordinator_write_unavailable{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Write Unavailable Error by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of write requests that failed on a local Node",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 10
+            },
+            "hiddenSeries": false,
+            "id": 7,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(irate(scylla_storage_proxy_coordinator_range_unavailable{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Range Unavailable Error by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of AIO Errors",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 16
+            },
+            "hiddenSeries": false,
+            "id": 8,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(irate(scylla_reactor_aio_errors{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "AIO Error by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Total number of abandoned failed futures, futures destroyed while still containing an exception.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 16
+            },
+            "hiddenSeries": false,
+            "id": 9,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_reactor_abandoned_failed_futures{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Ignored Future By [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of C++ exceptions thrown.\n\n A peak in the number of exceptions is an indication of a potential problem.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 16
+            },
+            "hiddenSeries": false,
+            "id": 10,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_reactor_cpp_exceptions{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "C++ Exceptions [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        }
+    ],
+    "refresh": "30s",
+    "schemaVersion": 16,
+    "style": "dark",
+    "tags": [
+        "master"
+    ],
+    "templating": {
+        "list": [
+            {
+                "allValue": null,
+                "current": {
+                    "tags": [],
+                    "text": "Instance",
+                    "value": "instance"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": "by",
+                "multi": false,
+                "name": "by",
+                "options": [
+                    {
+                        "selected": false,
+                        "text": "Cluster",
+                        "value": "cluster"
+                    },
+                    {
+                        "selected": false,
+                        "text": "DC",
+                        "value": "dc"
+                    },
+                    {
+                        "selected": true,
+                        "text": "Instance",
+                        "value": "instance"
+                    },
+                    {
+                        "selected": false,
+                        "text": "Shard",
+                        "value": "instance,shard"
+                    }
+                ],
+                "query": "Cluster,DC,Instance,Shard",
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_single",
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": false,
+                "label": "cluster",
+                "multi": false,
+                "name": "cluster",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "dc",
+                "multi": true,
+                "name": "dc",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster\"}, dc)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "node",
+                "multi": true,
+                "name": "node",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster|$^\", dc=~\"$dc\"}, instance)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "shard",
+                "multi": true,
+                "name": "shard",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization,shard)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 3,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
+                    "text": "master",
+                    "value": "master"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "scylla_dash_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "master",
+                        "value": "master"
+                    }
+                ],
+                "query": "master",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "monitor_version_var",
+                "current": {
+                    "text": "master",
+                    "value": "master"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "monitoring_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "master",
+                        "value": "master"
+                    }
+                ],
+                "query": "master",
+                "skipUrlSync": false,
+                "type": "custom"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-30m",
+        "to": "now"
+    },
+    "timepicker": {
+        "now": true,
+        "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+        ],
+        "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+        ]
+    },
+    "timezone": "browser",
+    "title": "Scylla Errors Monitoring",
+    "uid": "error-master",
+    "version": 5
+}

--- a/grafana/build/alternator_master/scylla-io.master.json
+++ b/grafana/build/alternator_master/scylla-io.master.json
@@ -1,0 +1,699 @@
+{
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            },
+            {
+                "class": "annotation_restart",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "resets(scylla_gossip_heart_beat[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "node_restart",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "restart",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_stall",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_stall_detector_reported[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "stall detector",
+                "showIn": 0,
+                "tagKeys": "dc,instance,shard",
+                "tags": [],
+                "titleFormat": "Stall found",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_schema_changed",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_database_schema_changed[30s])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "Schema Changed",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "schema changed",
+                "type": "tags"
+            }
+        ]
+    },
+    "class": "dashboard",
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 1,
+    "hideControls": true,
+    "id": null,
+    "links": [],
+    "overwrite": true,
+    "panels": [
+        {
+            "class": "text_panel",
+            "content": "<div id=\"amnon\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPoAAAA6CAYAAACZBESJAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAGm9JREFUeNrsXQd8VFXWP+9NTe+NEOmgSIdFiuxSIqB0krCssrCI0sKGLnVZV/qCCqx0ERdQ+ehFCKEtCAuCCAkdQkkhlPQ2yfT5znkzwWTyJslMJqDfd//8zo+ZVydz5//+55x777kADAwMDAwMDL99cC/yZjKpUtqxWUQbvUFbD982Q9OjKdE6oz1Gu4HGo6VzHPdzsabw+uU7h4tYMzEw/IqJLpUouE7NIwL1Bl0kvh1gIbQr8DzIgvyA9/EGMJnKnGPSG0CXnAYmjQY/HWfATTeR9HuL1Pknr9w9cpo1GQPDr4ToUomc79g88jWDQTcf3w7ipFJwad8SFE0agLxuKMgb1wcwGGxfAMlvKCgE3b1kKLp0DTR37oP+cboBJPx1juPXFKnzNiHpDaz5GBheAtGlEhnXsVnkqwajfgGq8WBZaBB4Rb4DyhavAaeQl1PvKgPP0yY9grxdh0FzIxEdfsP9Ik3eR1fuxu1hTcjA8AKJLpHIZJ2aRY4zmAxLkeBKIrhrh9aCK+5M6NMzIe+7g6A6+5OeVypjVcU5Y+ITjz5hTcnAUMNER5K7IMm3GnlThHuPzuD1p/7AyWSOK3iFn5gjRQd1wk3I+moHmLLzbqi0+SOQ7D+z5mRgsMHRal+Alyo7NY/aZpRyEX7Rw8Gzbw8zGWsSPAfSkEBwaf066J88C+TS8/v5+YRdepp9P5k1KQODk4lOJO/YPHKLScpH+o4bBm4d2oDJ8OJyZBIvD1A2awLa1DQPPr2gB5L9FJL9KWtWBgYnue5IchmSfIZJws33Hf9nJDnG4wajeSf+r752G1RnLoLm7gMwZOc9V3lOKgEFktO1fStw7dSm+i4+z+P1cyFr9RbQXL3zs8pQ0Dsh8Vgma1oGhmoSHUnOd2wW2dEkgbNeUX3Bc0C4OemGhNU9fgZZa78BQ1IqNG3RGP7Qoz00a9UEDKj0RqMRUpOfwMXzV+H44bPgEhoM5AkomzasXtIOHyLahymQuWyjIf/xw+0JD04OY03LwFBNovMUl7eIOi1t+Er74E+mgkmnE0iuufMAMpeshXp1Q2DuognQ+NV6Nq/x9EkGfLpwE5z+4TL49Q8H7+ERYFJrHCY69csX/XgFMv+5Ia1IqnkXVf0H1rwMDA7G6Dwv4Ts1i+ppkvDT/SeMAImPF6BUo4v+ELKWroMWLRrB+q0LICDQt9y5pOp3bj2EtNRn4O3jCX0GdgM3pRxObN4HMpkUlM2bVDyQpiJgSMC7uYLhyTNPVVJyg2d5SV+z5mVgcJDoHMfLw4Kbfa1o1jjUa2BPgZgmrRYyl2+EZvVDYeWmeSCVSsudp9XqYOc3h2F69BKI+/4H+H7vSUHx3xnYFVzlMjjx9T5wf60hSAP9hQeH/TABr1QC5+4GutOXpX7+dX56lv0ghTUxA4N5Aok9as6hmtc3cdDerUt7MBEhDUYoPH0BJJnZMHthtCjJCepiDez69gjIkNQcutoF+Sr4eOZKuHguASLfewfaNm8AGVv3AIcK7xBM+BCS8CAPq0WeQZBJp/+QNS8DgwNEFzwADgbyHm7g1uV3AslNej0UHTwBfSPDIbR2kM0T9XoD3LubDBIJb/EMiOxFsGr5FnBxVcL4Se9BQWIKqBNuAWfjYVEp142o6vjZlG+0lLpLPVq2bBjOWpiBwQGi88jQPyjQxQYklZBlz8gCyM2HLt1+V4nLz4E7ktBUpivNBFkZOXABVb1+wzCoGxYEhZeuCvG2Y0w3AeeiBEWjepTF98QtLVkTMzA4RvSW8jqh5r5vInpyGkjlUmjXoXmFJ8oVMniza1tB2cvE7hodxP98S3gIdO7SCoofZwDH8w7/QRzPgcTbE6ShQW4mg/F11sQMDPYS3US5OD5Y8WpD5LhRcJX1KY8hJDSw0lPd3Fxg/rLJMHrCUPDx8QQjnsvhP8rEU1cbZxnDrk99LAyCcRgUq6PrL/UVbtKxJr60Pn36yNEzaYc2FW0r2lm002ixaCvRInbt2uVRE/eOiYlxweu/iTYRbTPaf9FOoR1H24Q2asmSJbXtve6iRYvq47k90bqWsu50rylTpvhXdv66deukeGwLtHCra7yF1mD48OGVumn4ncnw2NZoPazOr9uvXz/emd/jhQsXAvG6ndC6lbpXz1atWrm/aBKmp6d3tvrOG3p7ezv1761yMMxzEq5T86i6RqNB1CWvqtq6e7haue+lY2wjGIuKqzVWnq7Nofcgqx0MpnjnDsft3bu3JDY2tivxAq29rcOIjxEREQVExJ07dy4fMmRIanXvHR0dXfeLL76Yji/fRfOu4ND3Z8yYoUOLXbx48d9nz54dX8VbvIn2BVq5B9Snn366xGg0zlqxYkVF51NRkbVor4nsm4S2sgqfwQftX5ZrlcYnaEvQip3YnN3R6A+yTiy1Rot/gSRvGRAQcAhfepXajPEw1EfLfxmKTuyrSySUBPiYlZPc5LAQSLz9sNKTi4vUsOTjdfDpok2Qm1uAos3hJUyCm+7h7mq+gVwG8iYNHO9Lr0H07NnTH0n+Ob48XgHJS4MIExMVFfWf7du393T0vuPGjePwgfEXJPlP+HZ8JSQvgQyt/6xZsy7guZMWLFhQlVttQfvWxr7h9BXYOnHNmjUwZsyYsTZIfnDEiBH7t2zZwvxncfwVqOpSWfjl5OQM8vT0lL4Mootl2EDq7wtGdLkfpVY8l0St1sKRg2eEgTFlYnckd6u2TaGwQAX/PRMPLrUCzN12vy6Su8TFxY21NIq9KERzaL48kkeGJCI124zm78AlqK9y6Zw5cyZ98sknFR6Iyg/oAWy2oWa1Pv/888hJkybZcmvHofUT2Z41cuTIVUjyJMbn8nj69KkXqvkgy4O5XJSGpngZRDcKPwIq85SRY9Z3JLq8bm0wenrAzm2HK3WpicxcGbecg4AgX+jeqyPcT0yBpJQn4Nq00a9R0duizXfgvPvous8YOnToNXtP/PDDD2UY987Fl3Or+dnvL1y48Mq8efMqPRDJfmHp0qUbwVy00xpRFnfXWs3D0OugmoBi8Ru58qcYpW1igoial6BNXl5eW1R1/oUS3WgywLlrO3N53iqnIpGAokNrOLTnBOTlFdpOBkgl0LBxHeSw8Tnx3d1d4P2xUaDVaGHLl/vAo1EdcO3YBkw6fTWcDAwJNDrQPXqq5ySSasc44eHhfqjm79rYnYu23aJoRIStaKqS8AtJPh/j8zgHSA4bNmygiTkVsZPm3q+zxOwRxDm0O9ZuM5K8/9y5c+0pqrnR8jdZwxtV/f2YmJjniT4MJyi0iBZ7ABDBUc23ff3113rGZ1E1h6CgoBFgroJsC05TdfueFhwl241PNbfvUfrdvAkJ7PF2V9AplTBn0jLbPiS66F26tQO9Xi+Q3MVFCcM/HAQ9UM3/Z8v3cPr8VQgQJrZoq/1HCUm9YnURfsgbTviO/NDEBgncO3jw4AB8sPwJbR3aLrThgwcPpn7GNbt3716MJP+3g/ekWHeEjX15aDNXrFhRH+83Du07tD1o0dOnT2+F+/4GQgYFNqErHoUkv2fPjWfOnKlDVV+NLxNEdg9YuXJlXyR7yfsuNlx2zQcffPAZkvwOo7RN9BNJBFojAlU9wMOj+h049gb79ANKMhYVB5cRdR8v8P3rSLi+fD2sWLIZoqcME4a6lobSRSFsr1MvFFSqYug3uDt4eLjBvh3HYMPGveDfpxsoXm8M+vQs0D9JB3n9MOAUCvvnqpOiF6tBm/hQz8klzshakmsVar3x0KFDd/r3719uhtzevXsfEukcvdmoUaNIzbviyz+I7H60atWqmIkTJ+4VO3f58uVqiUSybMmSJWuR5Cp0xR2aDohk/xGv8+W0adM+F/mNDEtLSzv98ccf34qOjh6D75uKXOJTtFjG5QpBIVlVGDwRbRaa9kUS3YjES9Amp3Wgck5g+IVcikZ1weMvkbDnq51w9/ZDmLMgutyQWLlCDoOH9hJeZyChVyzdDNu/iwP/gW+Bz4hIMOQVgOrUecjdtg+ULV4F/4/GAO/iYtckF4ua02eihR+u11Qr9enTx+fAgQNuSHaVky9dC62rjX0UGuyt6GRUYw2ZEz7HerSOltCgNDrv2rXr92DujhNT89Oo5ls3bdrEXHYbePz4cXN02xtB+WniFI6FWXnawy0hXLWIbn+gbzLlGTKzy39GCQ9undqB/4yxcD0tE97tNxH+MWsVnDhyDpIeppkD2px8OH/2CiyatwaGvDMR9sddgOBRQ8B72CAwqtXCQBlpcABIawWC9n4KFHx/EniFHZNcSM21WozPn1DugAiY5IR20YF4f2anfv36HUeyt3Xy74AaWmyY4X9Xr179b1TzF/JjxDBAhx4C9atfFRN9MPdte1q77KNHj/4MSX6b0blCzBFR82MWlbceK+Cfn58/Et33anW12XuyAYl+Sp+R/ZFoyQpUeXmT+hCydCYq84/ww6VrEDf1U+AkkjLHyEICwbVfD3AL7wwSL0+h4ITm9n3I2xUrlJ5yfaM1uPfoBOqbiTYH19gkukYL+rR0KNTk6K+lnXVK3gTtJFoTkX0dkOzn8TNewtf70W2Pwxi9uoMtPG3EbrdFkm01jfNo+9BaWG2va+N4cvUPMx5XqOaeISEh3UW49x3aTssDtJ5IUu4rEO8NqakYnUuiCS2aW/dBju66mFtNQ1Ddw98UjPbrktLMii2VgLxObeCU5kQikbLg8ElQnbmEx6SConkTCF4yQziGikwqmjayu+oMlaQyZudo0Ds454yGOX78eFavXr3+HRcX92d8K9aPLLO4uB0HDRq0GEl/H19/sXv37nWRkZGOuNCvoFlX7dCjmt+aMGHCC/1Roqrj18h/PmXKFCL6wEoOv4Rq/j8bN25kLrv9ag4BAQH7MzMzNVlZWft9fX2joWzfeiNU9e7u7u6HVSqVQ4NM7HLdjUaD6dy1nUk8x4Oe3PeqjFSlddbqhwmklTeoIyyvlL//GGQsXgNpY2ZD0Y5D0NQX+ePtBcELp4OsdojDlWQ5i6JrU59q0ItIdWLjXEabXIUnKn0jDdFWRERE3NuxY0eEk+6PT0lQvYxf5dSpU3M/++wzysInVnIodfXFMx7bxqNHjwDVnNYgtO5S22JpY8K/Sr0Gq1hd9qIUnX7KlJC7qEtJa891bgumX54CUHzlBmT8cz3IwoJB4uvzPGNOxNWiB0BxPLnxktBgkOblw3vD3hG62LZ+uQ8up6YDVHe9B87sJWCMXoT3uemsBjp69KgOVf1LVHVy0Smj3L0Kp9WOiopajWR3r0Y3268FNOyX+tb/ZmP/2rFjx25HNWdsrhiU2Kwlsv2Lktjcz8/vQU5OzmVvb+8uVkIcVVhY+A9U9Zuo6nYzxZFRN0aT0RivTU4rO/kElduldTNBlWkxRcBYe1TvN2BEj3ZQePsBeEW9AyHL50DYthUQNPevwDd4BX46ewV+PBsP33wbC96d2ghFLKoDmk1nVBWRu1+EpHdqxh3JTh5D/Ntvv90DzF1KpHLPKjktCMn+wfbt2wOqeXsKGQJf1q8TVR1WrFjxGb48IJY7GD9+/Lb169erGI8rRbRI+JcQGBh4F9320uRdZUPVRzgkzg4S3YRKnawTiM6XT8Y1rAOeA3uBEfcl3X8Ebdu/jq85cPldC5ojLqg7r5SDW3gXuJOYAvNmrBQSeN5/7CeoseNqXibjTl1rSTXRUkeOHCHC30Kb0L9/f8qQv4G2Ac3WOu60DnyUHbegOnfZ5X4h0dGNaSTay8LkyZNzkewPRHZlgHkQD0PFbnvn0NDQ16B8wLtVhNQHLN+rNWJQ1QNcqMv5RSg6Uj2BlFOflS06pVTq5wM+00dD7PdnYMyIeeDVvDEohKWSjc/Vnyq+hq5dAMGLPoKAGeOeF7KoFtGLNaC7lwIqXd7DhHvHa7zxDh48qEPCX0QbM3DgwMZgzpqKqXGIHZfFGAbECEWj3rowyvyfUnMC9WqUSdr6+Pjoc3NzabvO6ljKYlNSVFLjRDcaDcZz13ee4jkJGDLEiU7KTuWmQlZ/AoFzJoD/5FFgtM6e43m8hzvG8yEOVn0Vic/R9TdQxp3jU190K+7fvz9t8ODBS/HlfZE8SCM7LkWfXWwSzOuo6sNWrlzJKPMbQ2pqqjuqeXeRZNpBdNvTMzLExFtIyom5uH93JCnn4MwYDoNhYzp1sXG2ikTQvHUksuLVBsA7MpTVbp6T666jjHsBJ+XPO/v6NFXVZDL9MTY2drIDp1d5muqmTZuyR48efcTG7pExMTGzKiL7jBkz6uLnPIa2b9GiRT6MZr8KzIayhSVKu+2ixTRQ1e/n5+f/DOZZo6URWFRU1A3dd7u46+hoGwP+kOK1KWk9ywyFfZmwxOj6R09UoJBcdzLJIS4ujgovbO/du3cx/u21Dh06NLtv377PXasBAwYE7NmzhwpDNLA6vQjsn49OI312oA2x2k5P8oVI9oZGo3EGxs3P15ibNm0aLFu2rBO+XA7mfn2YNWvWCTxu7Ny5cy/+xolS58CBA7+3kMLWD1zRo0ePiydPnsypzo2uXLnSDsxTbmW2fUcoatKkSfzdu3crHSeBag61a9cWm6WWFxwc/B9U84oy0JSUowlV1kE5DY88AXYMi3WU6EYwmhJ0RPSaXiK5iiSnATm0WgxIpUgsvdOIHh4eTiSnutElJVLoS5/Wp0+fcUj4HyxudlNL/Cz21E62ELfK2Lhx42P876sNGzbQfX1FfmjvT5o06U9o1N13BsxVZ94C84iq0m3aes6cOUfRPpo/f/6GqsxJ/5ViBNiezVca1CNyspr3qkofIY0p6IaWVoVjqWCJ2OSVbVB5aSxKytHDPMxqey9U9Qao6rfVanWVXGWHXHfOPBT2tB5jdGECyUsnOghz0Gnoq0qbm5GQeEzvLJIfO3aMfjy7ofy4bnrqv432EVpfGyQn0GAbR0bp0Tx2Gvpo6wt2sTxcyC0cb8kDiD246XNRzbbfMw/6pYDqCogl4baA7Z4ac8N5eenQfaeknN5GrF71mo8OKzqNgqLhrdTNxvMvnekWt10DvFPddpqO+xcRklcVF3fu3Dlv6NCh9svKxo0wduzYb/Dl6ArIXhWQe0fdf2zRyReM5OTk3ui2N4XyXWpn0W2/8+zZs6qo8SobLvqA4uJiX6VSWXNENxj1cO76rhwe+AwhIce/XPddGPpKiTgaESflnUb048ePP33rrbcmWb5se/EfJPl7Q4YMeeDo/devXw/jx4+nhA3lBy45cInbCxcu7Infz4rfsNv+W8Z7NtS8Km57iarfKygouAzlk3JKiwhJaozov8TpxiRtisjAmZfhupOipz4pBonkhjMvbZnUQskPGviyq5LD6QlN3Wvjdu/e3R1Jfq+691+7di09yM5MmDCBEm00//tYZS6fJXactXjx4q52lpFicJ6a13rllVcox2Kd1MuvVavWHlRze0aH2VL1iVV13x2WYp6Xyjq3iFrM1wqYGvLZ34Shp4UnzoFnn27CDLKSSi852/aC3/jhAhEt8gvG/ELIXLUZ/Ea/C5KgUqunGoygvnkXVGcvQcCUD36J/zE0MGTlQP7+o+A37s/m7UgpmlijfZgCrh1aQ+Gxs5D9xdZ7RRJ1B4zRs2qqAXv37u0WGxtLo+FozjgNbTVYLG3v3r1nBg8efLemf0QxMTG+K1eupPu/ZknUUPafJu5T4u/k0qVLH86cOZPNImN4Docns3PCmHdT/POEHJK78MgpcGnVFKQhAQIRTTodFJ39CfxjRiLRrbXPJCzWIKUHQokq0zZVsfCAKJPNNxhAl/YU1Am38fmIH1nNCdemOezqhJvC/HVzIi6v6OqjH7Jq8gs7cuSIChWWMrsnX1ajrVq1KhuNlJqpNUPNxegl9ENynn6ekJPwIPH1Bm3yo+eFI4msnFwOmlv3hP2V+98iK7XQgwCJbswrABmt+UbDaOlQtQZ0D5KFijQmjUZIxHESyTnWpAwMTiQ6JeTOX9uVTQk5LSorFZugVUw1NxJ/ITXNRQ8LEdx6rgpRArn8tJabdRafyj9rU5+UelhYJrA8yQBZoL8wvJYScbj/OmtSBgbnKrpZ1UumrCI5qXJM2emrpMbiXXBUxFGPcTdUJWNPMTwSm1aFodclWXZ9eibI6tYWJrPoU58UMkVnYKgZolMRiqu6lDShvjupty7p0fNlj6nbTervAwZUdCi7QItAWKHIZGUj6yxVYzT3U0AW5C/E8bSSqyG/UDDew02I1c0j4oApOgNDTSi6ySgUiwQjkpFiaIqndSWqjoSnmu9aJw+qMWn1oEt9DLyLEqTouuuSH1MiLiM+8aiONSkDQ0247hwkmCwJOYm7m1CemfrWS1S9RLk5R8fEW8pDaR+goterTbl+cyLuYSq+DxPGuOvThEQcU3MGhpog+vOEnInP1JrdZ5DWDgEtuu8Ue5M7TwUn9M8yqxaL6ynp9hg4kQw9PTiExRyowA3G5yWJOCK9FuNzkPAsPmdgqCFFN6u60XhafesecDIJyGsHC/XYy7jqQkKuVDadut1kMlDT8NmSmu+cOXFHq7XIKQSgBBxtQyJT0UlK9En8zQUnhVFw6Zl4XC0wZOWC/tHTYqboDAw1S3S9QPTrd6DoQjy4tGsB2jsPoGD/MYGcitcbAeeigKyN35qXQ0aiEkkpaae+ehsKT54DTi4TBskUxJ4SYm81egeGXPPiKOQd0Hb5K7WEElX6zBzI3mRe7JNG1eVuP4DXV9KQzyusORkYbEbA1YdEInPp1CxyK0p7hJB5x/iZFmsQusNQpfUl2XVUb1loEJHcgOpOc3qpRE0f3s1ViO31GdmF6OLvQe/8j5xCppBjDK6+kSiEAEKZaF8vMOSrBEXnXV2Ea6Pi31apc6PjE4+eZM3JwFCDRLeQXYJkD8e4nRbfo8obNLmkDZinWFKlRprFNQpNgY77LbVOdeDKnSOGN1sO7aU3aDtxHJdXrCncnZB49B5uC9PpNVSwnvx6KuxAJKbVRTug0SLstExSXY7jk1TFOfuR5FmsKRkYGBgY/l/jfwUYAPw0FqsWp2FrAAAAAElFTkSuQmCC\" style=\"margin-top:-20px\" height=\"55\">\n<span style=\"font-size:40px\">  [[cluster]]</span><span style=\"padding-top: 25px;float:right\"><a href=\"https://github.com/scylladb/scylla-monitoring/issues/new?body=scylla-version%3D[[scylla_dash_version]]%0Amonitoring-version%3D[[monitoring_version]]\" target=\"_blank\"><input title=\"Report an issue with Scylla Monitoring\" type=\"button\" style=\"background-color:#57d1e5;color:black;font-size:20px\" value=\"Report an issue\"></a></span><hr style=\"border-top: 3px solid #5780c1;\"></div>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 4,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 1,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue Information</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 4
+            },
+            "id": 2,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 6
+            },
+            "id": 3,
+            "panels": [],
+            "repeat": "classes",
+            "title": "$classes",
+            "type": "row"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 7
+            },
+            "hiddenSeries": false,
+            "id": 4,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "1000000*max(scylla_io_queue_delay{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "seastar_io_queue_delay",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "$classes I/O Queue delay by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 7
+            },
+            "hiddenSeries": false,
+            "id": 5,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_io_queue_total_bytes{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "seastar_io_queue_delay",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "$classes I/O Queue bandwidth by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "Bps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "iops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 7
+            },
+            "hiddenSeries": false,
+            "id": 6,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_io_queue_total_operations{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "seastar_io_queue_delay",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "$classes I/O Queue IOPS by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "iops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        }
+    ],
+    "refresh": "30s",
+    "schemaVersion": 16,
+    "style": "dark",
+    "tags": [
+        "master"
+    ],
+    "templating": {
+        "list": [
+            {
+                "allValue": null,
+                "class": "by_template_var",
+                "current": {
+                    "tags": [],
+                    "text": "Instance",
+                    "value": "instance"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": "by",
+                "multi": false,
+                "name": "by",
+                "options": [
+                    {
+                        "selected": false,
+                        "text": "Cluster",
+                        "value": "cluster"
+                    },
+                    {
+                        "selected": false,
+                        "text": "DC",
+                        "value": "dc"
+                    },
+                    {
+                        "selected": true,
+                        "text": "Instance",
+                        "value": "instance"
+                    },
+                    {
+                        "selected": false,
+                        "text": "instance,shard",
+                        "value": "instance,shard"
+                    }
+                ],
+                "query": "Cluster,DC,Instance,Shard",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_single",
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": false,
+                "label": "cluster",
+                "multi": false,
+                "name": "cluster",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "dc",
+                "multi": true,
+                "name": "dc",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster\"}, dc)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "node",
+                "multi": true,
+                "name": "node",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster|$^\", dc=~\"$dc\"}, instance)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "shard",
+                "multi": true,
+                "name": "shard",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization,shard)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 3,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 2,
+                "includeAll": true,
+                "label": "classes",
+                "multi": true,
+                "name": "classes",
+                "options": [],
+                "query": "label_values(scylla_io_queue_delay,class)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 3,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
+                    "text": "master",
+                    "value": "master"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "scylla_dash_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "master",
+                        "value": "master"
+                    }
+                ],
+                "query": "master",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "monitor_version_var",
+                "current": {
+                    "text": "master",
+                    "value": "master"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "monitoring_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "master",
+                        "value": "master"
+                    }
+                ],
+                "query": "master",
+                "skipUrlSync": false,
+                "type": "custom"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-3h",
+        "to": "now"
+    },
+    "timepicker": {
+        "now": true,
+        "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+        ],
+        "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+        ]
+    },
+    "timezone": "browser",
+    "title": "I/O",
+    "uid": "io-master",
+    "version": 0
+}

--- a/grafana/build/alternator_master/scylla-os.master.json
+++ b/grafana/build/alternator_master/scylla-os.master.json
@@ -1,0 +1,1441 @@
+{
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            },
+            {
+                "class": "annotation_restart",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "resets(scylla_gossip_heart_beat[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "node_restart",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "restart",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_stall",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_stall_detector_reported[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "stall detector",
+                "showIn": 0,
+                "tagKeys": "dc,instance,shard",
+                "tags": [],
+                "titleFormat": "Stall found",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_schema_changed",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_database_schema_changed[30s])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "Schema Changed",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "schema changed",
+                "type": "tags"
+            }
+        ]
+    },
+    "class": "dashboard",
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 1,
+    "hideControls": true,
+    "id": null,
+    "links": [],
+    "overwrite": true,
+    "panels": [
+        {
+            "class": "text_panel",
+            "content": "<div id=\"amnon\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPoAAAA6CAYAAACZBESJAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAGm9JREFUeNrsXQd8VFXWP+9NTe+NEOmgSIdFiuxSIqB0krCssrCI0sKGLnVZV/qCCqx0ERdQ+ehFCKEtCAuCCAkdQkkhlPQ2yfT5znkzwWTyJslMJqDfd//8zo+ZVydz5//+55x777kADAwMDAwMDL99cC/yZjKpUtqxWUQbvUFbD982Q9OjKdE6oz1Gu4HGo6VzHPdzsabw+uU7h4tYMzEw/IqJLpUouE7NIwL1Bl0kvh1gIbQr8DzIgvyA9/EGMJnKnGPSG0CXnAYmjQY/HWfATTeR9HuL1Pknr9w9cpo1GQPDr4ToUomc79g88jWDQTcf3w7ipFJwad8SFE0agLxuKMgb1wcwGGxfAMlvKCgE3b1kKLp0DTR37oP+cboBJPx1juPXFKnzNiHpDaz5GBheAtGlEhnXsVnkqwajfgGq8WBZaBB4Rb4DyhavAaeQl1PvKgPP0yY9grxdh0FzIxEdfsP9Ik3eR1fuxu1hTcjA8AKJLpHIZJ2aRY4zmAxLkeBKIrhrh9aCK+5M6NMzIe+7g6A6+5OeVypjVcU5Y+ITjz5hTcnAUMNER5K7IMm3GnlThHuPzuD1p/7AyWSOK3iFn5gjRQd1wk3I+moHmLLzbqi0+SOQ7D+z5mRgsMHRal+Alyo7NY/aZpRyEX7Rw8Gzbw8zGWsSPAfSkEBwaf066J88C+TS8/v5+YRdepp9P5k1KQODk4lOJO/YPHKLScpH+o4bBm4d2oDJ8OJyZBIvD1A2awLa1DQPPr2gB5L9FJL9KWtWBgYnue5IchmSfIZJws33Hf9nJDnG4wajeSf+r752G1RnLoLm7gMwZOc9V3lOKgEFktO1fStw7dSm+i4+z+P1cyFr9RbQXL3zs8pQ0Dsh8Vgma1oGhmoSHUnOd2wW2dEkgbNeUX3Bc0C4OemGhNU9fgZZa78BQ1IqNG3RGP7Qoz00a9UEDKj0RqMRUpOfwMXzV+H44bPgEhoM5AkomzasXtIOHyLahymQuWyjIf/xw+0JD04OY03LwFBNovMUl7eIOi1t+Er74E+mgkmnE0iuufMAMpeshXp1Q2DuognQ+NV6Nq/x9EkGfLpwE5z+4TL49Q8H7+ERYFJrHCY69csX/XgFMv+5Ia1IqnkXVf0H1rwMDA7G6Dwv4Ts1i+ppkvDT/SeMAImPF6BUo4v+ELKWroMWLRrB+q0LICDQt9y5pOp3bj2EtNRn4O3jCX0GdgM3pRxObN4HMpkUlM2bVDyQpiJgSMC7uYLhyTNPVVJyg2d5SV+z5mVgcJDoHMfLw4Kbfa1o1jjUa2BPgZgmrRYyl2+EZvVDYeWmeSCVSsudp9XqYOc3h2F69BKI+/4H+H7vSUHx3xnYFVzlMjjx9T5wf60hSAP9hQeH/TABr1QC5+4GutOXpX7+dX56lv0ghTUxA4N5Aok9as6hmtc3cdDerUt7MBEhDUYoPH0BJJnZMHthtCjJCepiDez69gjIkNQcutoF+Sr4eOZKuHguASLfewfaNm8AGVv3AIcK7xBM+BCS8CAPq0WeQZBJp/+QNS8DgwNEFzwADgbyHm7g1uV3AslNej0UHTwBfSPDIbR2kM0T9XoD3LubDBIJb/EMiOxFsGr5FnBxVcL4Se9BQWIKqBNuAWfjYVEp142o6vjZlG+0lLpLPVq2bBjOWpiBwQGi88jQPyjQxQYklZBlz8gCyM2HLt1+V4nLz4E7ktBUpivNBFkZOXABVb1+wzCoGxYEhZeuCvG2Y0w3AeeiBEWjepTF98QtLVkTMzA4RvSW8jqh5r5vInpyGkjlUmjXoXmFJ8oVMniza1tB2cvE7hodxP98S3gIdO7SCoofZwDH8w7/QRzPgcTbE6ShQW4mg/F11sQMDPYS3US5OD5Y8WpD5LhRcJX1KY8hJDSw0lPd3Fxg/rLJMHrCUPDx8QQjnsvhP8rEU1cbZxnDrk99LAyCcRgUq6PrL/UVbtKxJr60Pn36yNEzaYc2FW0r2lm002ixaCvRInbt2uVRE/eOiYlxweu/iTYRbTPaf9FOoR1H24Q2asmSJbXtve6iRYvq47k90bqWsu50rylTpvhXdv66deukeGwLtHCra7yF1mD48OGVumn4ncnw2NZoPazOr9uvXz/emd/jhQsXAvG6ndC6lbpXz1atWrm/aBKmp6d3tvrOG3p7ezv1761yMMxzEq5T86i6RqNB1CWvqtq6e7haue+lY2wjGIuKqzVWnq7Nofcgqx0MpnjnDsft3bu3JDY2tivxAq29rcOIjxEREQVExJ07dy4fMmRIanXvHR0dXfeLL76Yji/fRfOu4ND3Z8yYoUOLXbx48d9nz54dX8VbvIn2BVq5B9Snn366xGg0zlqxYkVF51NRkbVor4nsm4S2sgqfwQftX5ZrlcYnaEvQip3YnN3R6A+yTiy1Rot/gSRvGRAQcAhfepXajPEw1EfLfxmKTuyrSySUBPiYlZPc5LAQSLz9sNKTi4vUsOTjdfDpok2Qm1uAos3hJUyCm+7h7mq+gVwG8iYNHO9Lr0H07NnTH0n+Ob48XgHJS4MIExMVFfWf7du393T0vuPGjePwgfEXJPlP+HZ8JSQvgQyt/6xZsy7guZMWLFhQlVttQfvWxr7h9BXYOnHNmjUwZsyYsTZIfnDEiBH7t2zZwvxncfwVqOpSWfjl5OQM8vT0lL4Mootl2EDq7wtGdLkfpVY8l0St1sKRg2eEgTFlYnckd6u2TaGwQAX/PRMPLrUCzN12vy6Su8TFxY21NIq9KERzaL48kkeGJCI124zm78AlqK9y6Zw5cyZ98sknFR6Iyg/oAWy2oWa1Pv/888hJkybZcmvHofUT2Z41cuTIVUjyJMbn8nj69KkXqvkgy4O5XJSGpngZRDcKPwIq85SRY9Z3JLq8bm0wenrAzm2HK3WpicxcGbecg4AgX+jeqyPcT0yBpJQn4Nq00a9R0duizXfgvPvous8YOnToNXtP/PDDD2UY987Fl3Or+dnvL1y48Mq8efMqPRDJfmHp0qUbwVy00xpRFnfXWs3D0OugmoBi8Ru58qcYpW1igoial6BNXl5eW1R1/oUS3WgywLlrO3N53iqnIpGAokNrOLTnBOTlFdpOBkgl0LBxHeSw8Tnx3d1d4P2xUaDVaGHLl/vAo1EdcO3YBkw6fTWcDAwJNDrQPXqq5ySSasc44eHhfqjm79rYnYu23aJoRIStaKqS8AtJPh/j8zgHSA4bNmygiTkVsZPm3q+zxOwRxDm0O9ZuM5K8/9y5c+0pqrnR8jdZwxtV/f2YmJjniT4MJyi0iBZ7ABDBUc23ff3113rGZ1E1h6CgoBFgroJsC05TdfueFhwl241PNbfvUfrdvAkJ7PF2V9AplTBn0jLbPiS66F26tQO9Xi+Q3MVFCcM/HAQ9UM3/Z8v3cPr8VQgQJrZoq/1HCUm9YnURfsgbTviO/NDEBgncO3jw4AB8sPwJbR3aLrThgwcPpn7GNbt3716MJP+3g/ekWHeEjX15aDNXrFhRH+83Du07tD1o0dOnT2+F+/4GQgYFNqErHoUkv2fPjWfOnKlDVV+NLxNEdg9YuXJlXyR7yfsuNlx2zQcffPAZkvwOo7RN9BNJBFojAlU9wMOj+h049gb79ANKMhYVB5cRdR8v8P3rSLi+fD2sWLIZoqcME4a6lobSRSFsr1MvFFSqYug3uDt4eLjBvh3HYMPGveDfpxsoXm8M+vQs0D9JB3n9MOAUCvvnqpOiF6tBm/hQz8klzshakmsVar3x0KFDd/r3719uhtzevXsfEukcvdmoUaNIzbviyz+I7H60atWqmIkTJ+4VO3f58uVqiUSybMmSJWuR5Cp0xR2aDohk/xGv8+W0adM+F/mNDEtLSzv98ccf34qOjh6D75uKXOJTtFjG5QpBIVlVGDwRbRaa9kUS3YjES9Amp3Wgck5g+IVcikZ1weMvkbDnq51w9/ZDmLMgutyQWLlCDoOH9hJeZyChVyzdDNu/iwP/gW+Bz4hIMOQVgOrUecjdtg+ULV4F/4/GAO/iYtckF4ua02eihR+u11Qr9enTx+fAgQNuSHaVky9dC62rjX0UGuyt6GRUYw2ZEz7HerSOltCgNDrv2rXr92DujhNT89Oo5ls3bdrEXHYbePz4cXN02xtB+WniFI6FWXnawy0hXLWIbn+gbzLlGTKzy39GCQ9undqB/4yxcD0tE97tNxH+MWsVnDhyDpIeppkD2px8OH/2CiyatwaGvDMR9sddgOBRQ8B72CAwqtXCQBlpcABIawWC9n4KFHx/EniFHZNcSM21WozPn1DugAiY5IR20YF4f2anfv36HUeyt3Xy74AaWmyY4X9Xr179b1TzF/JjxDBAhx4C9atfFRN9MPdte1q77KNHj/4MSX6b0blCzBFR82MWlbceK+Cfn58/Et33anW12XuyAYl+Sp+R/ZFoyQpUeXmT+hCydCYq84/ww6VrEDf1U+AkkjLHyEICwbVfD3AL7wwSL0+h4ITm9n3I2xUrlJ5yfaM1uPfoBOqbiTYH19gkukYL+rR0KNTk6K+lnXVK3gTtJFoTkX0dkOzn8TNewtf70W2Pwxi9uoMtPG3EbrdFkm01jfNo+9BaWG2va+N4cvUPMx5XqOaeISEh3UW49x3aTssDtJ5IUu4rEO8NqakYnUuiCS2aW/dBju66mFtNQ1Ddw98UjPbrktLMii2VgLxObeCU5kQikbLg8ElQnbmEx6SConkTCF4yQziGikwqmjayu+oMlaQyZudo0Ds454yGOX78eFavXr3+HRcX92d8K9aPLLO4uB0HDRq0GEl/H19/sXv37nWRkZGOuNCvoFlX7dCjmt+aMGHCC/1Roqrj18h/PmXKFCL6wEoOv4Rq/j8bN25kLrv9ag4BAQH7MzMzNVlZWft9fX2joWzfeiNU9e7u7u6HVSqVQ4NM7HLdjUaD6dy1nUk8x4Oe3PeqjFSlddbqhwmklTeoIyyvlL//GGQsXgNpY2ZD0Y5D0NQX+ePtBcELp4OsdojDlWQ5i6JrU59q0ItIdWLjXEabXIUnKn0jDdFWRERE3NuxY0eEk+6PT0lQvYxf5dSpU3M/++wzysInVnIodfXFMx7bxqNHjwDVnNYgtO5S22JpY8K/Sr0Gq1hd9qIUnX7KlJC7qEtJa891bgumX54CUHzlBmT8cz3IwoJB4uvzPGNOxNWiB0BxPLnxktBgkOblw3vD3hG62LZ+uQ8up6YDVHe9B87sJWCMXoT3uemsBjp69KgOVf1LVHVy0Smj3L0Kp9WOiopajWR3r0Y3268FNOyX+tb/ZmP/2rFjx25HNWdsrhiU2Kwlsv2Lktjcz8/vQU5OzmVvb+8uVkIcVVhY+A9U9Zuo6nYzxZFRN0aT0RivTU4rO/kElduldTNBlWkxRcBYe1TvN2BEj3ZQePsBeEW9AyHL50DYthUQNPevwDd4BX46ewV+PBsP33wbC96d2ghFLKoDmk1nVBWRu1+EpHdqxh3JTh5D/Ntvv90DzF1KpHLPKjktCMn+wfbt2wOqeXsKGQJf1q8TVR1WrFjxGb48IJY7GD9+/Lb169erGI8rRbRI+JcQGBh4F9320uRdZUPVRzgkzg4S3YRKnawTiM6XT8Y1rAOeA3uBEfcl3X8Ebdu/jq85cPldC5ojLqg7r5SDW3gXuJOYAvNmrBQSeN5/7CeoseNqXibjTl1rSTXRUkeOHCHC30Kb0L9/f8qQv4G2Ac3WOu60DnyUHbegOnfZ5X4h0dGNaSTay8LkyZNzkewPRHZlgHkQD0PFbnvn0NDQ16B8wLtVhNQHLN+rNWJQ1QNcqMv5RSg6Uj2BlFOflS06pVTq5wM+00dD7PdnYMyIeeDVvDEohKWSjc/Vnyq+hq5dAMGLPoKAGeOeF7KoFtGLNaC7lwIqXd7DhHvHa7zxDh48qEPCX0QbM3DgwMZgzpqKqXGIHZfFGAbECEWj3rowyvyfUnMC9WqUSdr6+Pjoc3NzabvO6ljKYlNSVFLjRDcaDcZz13ee4jkJGDLEiU7KTuWmQlZ/AoFzJoD/5FFgtM6e43m8hzvG8yEOVn0Vic/R9TdQxp3jU190K+7fvz9t8ODBS/HlfZE8SCM7LkWfXWwSzOuo6sNWrlzJKPMbQ2pqqjuqeXeRZNpBdNvTMzLExFtIyom5uH93JCnn4MwYDoNhYzp1sXG2ikTQvHUksuLVBsA7MpTVbp6T666jjHsBJ+XPO/v6NFXVZDL9MTY2drIDp1d5muqmTZuyR48efcTG7pExMTGzKiL7jBkz6uLnPIa2b9GiRT6MZr8KzIayhSVKu+2ixTRQ1e/n5+f/DOZZo6URWFRU1A3dd7u46+hoGwP+kOK1KWk9ywyFfZmwxOj6R09UoJBcdzLJIS4ujgovbO/du3cx/u21Dh06NLtv377PXasBAwYE7NmzhwpDNLA6vQjsn49OI312oA2x2k5P8oVI9oZGo3EGxs3P15ibNm0aLFu2rBO+XA7mfn2YNWvWCTxu7Ny5cy/+xolS58CBA7+3kMLWD1zRo0ePiydPnsypzo2uXLnSDsxTbmW2fUcoatKkSfzdu3crHSeBag61a9cWm6WWFxwc/B9U84oy0JSUowlV1kE5DY88AXYMi3WU6EYwmhJ0RPSaXiK5iiSnATm0WgxIpUgsvdOIHh4eTiSnutElJVLoS5/Wp0+fcUj4HyxudlNL/Cz21E62ELfK2Lhx42P876sNGzbQfX1FfmjvT5o06U9o1N13BsxVZ94C84iq0m3aes6cOUfRPpo/f/6GqsxJ/5ViBNiezVca1CNyspr3qkofIY0p6IaWVoVjqWCJ2OSVbVB5aSxKytHDPMxqey9U9Qao6rfVanWVXGWHXHfOPBT2tB5jdGECyUsnOghz0Gnoq0qbm5GQeEzvLJIfO3aMfjy7ofy4bnrqv432EVpfGyQn0GAbR0bp0Tx2Gvpo6wt2sTxcyC0cb8kDiD246XNRzbbfMw/6pYDqCogl4baA7Z4ac8N5eenQfaeknN5GrF71mo8OKzqNgqLhrdTNxvMvnekWt10DvFPddpqO+xcRklcVF3fu3Dlv6NCh9svKxo0wduzYb/Dl6ArIXhWQe0fdf2zRyReM5OTk3ui2N4XyXWpn0W2/8+zZs6qo8SobLvqA4uJiX6VSWXNENxj1cO76rhwe+AwhIce/XPddGPpKiTgaESflnUb048ePP33rrbcmWb5se/EfJPl7Q4YMeeDo/devXw/jx4+nhA3lBy45cInbCxcu7Infz4rfsNv+W8Z7NtS8Km57iarfKygouAzlk3JKiwhJaozov8TpxiRtisjAmZfhupOipz4pBonkhjMvbZnUQskPGviyq5LD6QlN3Wvjdu/e3R1Jfq+691+7di09yM5MmDCBEm00//tYZS6fJXactXjx4q52lpFicJ6a13rllVcox2Kd1MuvVavWHlRze0aH2VL1iVV13x2WYp6Xyjq3iFrM1wqYGvLZ34Shp4UnzoFnn27CDLKSSi852/aC3/jhAhEt8gvG/ELIXLUZ/Ea/C5KgUqunGoygvnkXVGcvQcCUD36J/zE0MGTlQP7+o+A37s/m7UgpmlijfZgCrh1aQ+Gxs5D9xdZ7RRJ1B4zRs2qqAXv37u0WGxtLo+FozjgNbTVYLG3v3r1nBg8efLemf0QxMTG+K1eupPu/ZknUUPafJu5T4u/k0qVLH86cOZPNImN4Docns3PCmHdT/POEHJK78MgpcGnVFKQhAQIRTTodFJ39CfxjRiLRrbXPJCzWIKUHQokq0zZVsfCAKJPNNxhAl/YU1Am38fmIH1nNCdemOezqhJvC/HVzIi6v6OqjH7Jq8gs7cuSIChWWMrsnX1ajrVq1KhuNlJqpNUPNxegl9ENynn6ekJPwIPH1Bm3yo+eFI4msnFwOmlv3hP2V+98iK7XQgwCJbswrABmt+UbDaOlQtQZ0D5KFijQmjUZIxHESyTnWpAwMTiQ6JeTOX9uVTQk5LSorFZugVUw1NxJ/ITXNRQ8LEdx6rgpRArn8tJabdRafyj9rU5+UelhYJrA8yQBZoL8wvJYScbj/OmtSBgbnKrpZ1UumrCI5qXJM2emrpMbiXXBUxFGPcTdUJWNPMTwSm1aFodclWXZ9eibI6tYWJrPoU58UMkVnYKgZolMRiqu6lDShvjupty7p0fNlj6nbTervAwZUdCi7QItAWKHIZGUj6yxVYzT3U0AW5C/E8bSSqyG/UDDew02I1c0j4oApOgNDTSi6ySgUiwQjkpFiaIqndSWqjoSnmu9aJw+qMWn1oEt9DLyLEqTouuuSH1MiLiM+8aiONSkDQ0247hwkmCwJOYm7m1CemfrWS1S9RLk5R8fEW8pDaR+goterTbl+cyLuYSq+DxPGuOvThEQcU3MGhpog+vOEnInP1JrdZ5DWDgEtuu8Ue5M7TwUn9M8yqxaL6ynp9hg4kQw9PTiExRyowA3G5yWJOCK9FuNzkPAsPmdgqCFFN6u60XhafesecDIJyGsHC/XYy7jqQkKuVDadut1kMlDT8NmSmu+cOXFHq7XIKQSgBBxtQyJT0UlK9En8zQUnhVFw6Zl4XC0wZOWC/tHTYqboDAw1S3S9QPTrd6DoQjy4tGsB2jsPoGD/MYGcitcbAeeigKyN35qXQ0aiEkkpaae+ehsKT54DTi4TBskUxJ4SYm81egeGXPPiKOQd0Hb5K7WEElX6zBzI3mRe7JNG1eVuP4DXV9KQzyusORkYbEbA1YdEInPp1CxyK0p7hJB5x/iZFmsQusNQpfUl2XVUb1loEJHcgOpOc3qpRE0f3s1ViO31GdmF6OLvQe/8j5xCppBjDK6+kSiEAEKZaF8vMOSrBEXnXV2Ea6Pi31apc6PjE4+eZM3JwFCDRLeQXYJkD8e4nRbfo8obNLmkDZinWFKlRprFNQpNgY77LbVOdeDKnSOGN1sO7aU3aDtxHJdXrCncnZB49B5uC9PpNVSwnvx6KuxAJKbVRTug0SLstExSXY7jk1TFOfuR5FmsKRkYGBgY/l/jfwUYAPw0FqsWp2FrAAAAAElFTkSuQmCC\" style=\"margin-top:-20px\" height=\"55\">\n<span style=\"font-size:40px\">  [[cluster]]</span><span style=\"padding-top: 25px;float:right\"><a href=\"https://github.com/scylladb/scylla-monitoring/issues/new?body=scylla-version%3D[[scylla_dash_version]]%0Amonitoring-version%3D[[monitoring_version]]\" target=\"_blank\"><input title=\"Report an issue with Scylla Monitoring\" type=\"button\" style=\"background-color:#57d1e5;color:black;font-size:20px\" value=\"Report an issue\"></a></span><hr style=\"border-top: 3px solid #5780c1;\"></div>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 4,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 1,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "cacheTimeout": null,
+            "class": "pie_chart_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fontSize": "80%",
+            "format": "bytes",
+            "gridPos": {
+                "h": 8,
+                "w": 4,
+                "x": 0,
+                "y": 4
+            },
+            "height": "250px",
+            "id": 2,
+            "interval": null,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": true
+            },
+            "legendType": "On graph",
+            "links": [],
+            "maxDataPoints": 3,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "options": {},
+            "pieType": "pie",
+            "repeat": "node",
+            "span": 2,
+            "strokeWidth": 1,
+            "targets": [
+                {
+                    "expr": "sum(node_filesystem_avail_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"})",
+                    "instant": true,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "Free",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 7200
+                },
+                {
+                    "expr": "(sum(node_filesystem_size_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"})-sum(node_filesystem_avail_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}))",
+                    "instant": true,
+                    "intervalFactor": 1,
+                    "legendFormat": "Used",
+                    "refId": "B",
+                    "step": 7200
+                }
+            ],
+            "title": "Total Storage $node",
+            "type": "grafana-piechart-panel",
+            "valueName": "current"
+        },
+        {
+            "class": "text_panel",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Disk $monitor_disk</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 12
+            },
+            "id": 3,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bytes_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 14
+            },
+            "hiddenSeries": false,
+            "id": 4,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(node_filesystem_size_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])-sum(node_filesystem_avail_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                },
+                {
+                    "expr": "sum(node_filesystem_size{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])-sum(node_filesystem_avail{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "B",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Disk Size by $by",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "bytes",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 14
+            },
+            "hiddenSeries": false,
+            "id": 5,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                },
+                {
+                    "expr": "sum(irate(node_disk_writes_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "B",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Disk Writes per $by",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 14
+            },
+            "hiddenSeries": false,
+            "id": 6,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                },
+                {
+                    "expr": "sum(irate(node_disk_reads_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "B",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Disk Reads per $by",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "text_panel",
+            "content": "",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 20
+            },
+            "id": 7,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 3,
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 20
+            },
+            "hiddenSeries": false,
+            "id": 8,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                },
+                {
+                    "expr": "sum(irate(node_disk_bytes_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "B",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Disk Writes Bps per $by",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "Bps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 20
+            },
+            "hiddenSeries": false,
+            "id": 9,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                },
+                {
+                    "expr": "sum(irate(node_disk_bytes_read{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "B",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Disk Read Bps per $by",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "Bps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "text_panel",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Network $monitor_network_interface</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 26
+            },
+            "id": 10,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "pps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 0,
+                "y": 28
+            },
+            "hiddenSeries": false,
+            "id": 11,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(node_network_receive_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                },
+                {
+                    "expr": "sum(irate(node_network_receive_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "B",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Interface Rx Packets",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "pps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "pps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 12,
+                "y": 28
+            },
+            "hiddenSeries": false,
+            "id": 12,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(node_network_transmit_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                },
+                {
+                    "expr": "sum(irate(node_network_transmit_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "B",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Interface Tx Packets",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "pps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 0,
+                "y": 34
+            },
+            "hiddenSeries": false,
+            "id": 13,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(node_network_receive_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                },
+                {
+                    "expr": "sum(irate(node_network_receive_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "B",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Interface Rx Bps",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "Bps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 12,
+                "y": 34
+            },
+            "hiddenSeries": false,
+            "id": 14,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(node_network_transmit_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                },
+                {
+                    "expr": "sum(irate(node_network_transmit_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "B",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Interface Tx Bps",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "Bps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        }
+    ],
+    "refresh": "30s",
+    "schemaVersion": 16,
+    "style": "dark",
+    "tags": [
+        "master"
+    ],
+    "templating": {
+        "list": [
+            {
+                "allValue": null,
+                "class": "template_variable_single",
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": false,
+                "label": "cluster",
+                "multi": false,
+                "name": "cluster",
+                "options": [],
+                "query": "label_values(node_filesystem_avail_bytes, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "dc",
+                "multi": true,
+                "name": "dc",
+                "options": [],
+                "query": "label_values(node_filesystem_avail_bytes{cluster=~\"$cluster\"}, dc)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "node",
+                "multi": true,
+                "name": "node",
+                "options": [],
+                "query": "label_values(node_filesystem_avail_bytes{cluster=~\"$cluster|$^\", dc=~\"$dc\"}, instance)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "current": {
+                    "tags": [],
+                    "text": "Instance",
+                    "value": "instance"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": "by",
+                "multi": false,
+                "name": "by",
+                "options": [
+                    {
+                        "selected": false,
+                        "text": "Cluster",
+                        "value": "cluster"
+                    },
+                    {
+                        "selected": false,
+                        "text": "DC",
+                        "value": "dc"
+                    },
+                    {
+                        "selected": true,
+                        "text": "Instance",
+                        "value": "instance"
+                    }
+                ],
+                "query": "Cluster,DC,Instance",
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "current": {
+                    "isNone": true,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": "prometheus",
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "monitor_disk",
+                "options": [],
+                "query": "node_disk_read_bytes_total",
+                "refresh": 2,
+                "regex": "/.*device=\"([^\\\"]*)\".*/",
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "current": {
+                    "isNone": true,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": "prometheus",
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "monitor_network_interface",
+                "options": [],
+                "query": "node_network_receive_packets_total",
+                "refresh": 2,
+                "regex": "/.*device=\"([^\\\"]*)\".*/",
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "current": {
+                    "text": "/var/lib/scylla",
+                    "value": "/var/lib/scylla"
+                },
+                "datasource": "prometheus",
+                "hide": 0,
+                "includeAll": false,
+                "label": "Mount path",
+                "multi": false,
+                "name": "mount_point",
+                "options": [],
+                "query": "node_filesystem_avail_bytes",
+                "refresh": 2,
+                "regex": "/mountpoint=\"([^\"]*)\".*/",
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
+                    "text": "master",
+                    "value": "master"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "scylla_dash_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "master",
+                        "value": "master"
+                    }
+                ],
+                "query": "master",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "monitor_version_var",
+                "current": {
+                    "text": "master",
+                    "value": "master"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "monitoring_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "master",
+                        "value": "master"
+                    }
+                ],
+                "query": "master",
+                "skipUrlSync": false,
+                "type": "custom"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-30m",
+        "to": "now"
+    },
+    "timepicker": {
+        "now": true,
+        "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+        ],
+        "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+        ]
+    },
+    "timezone": "browser",
+    "title": "OS Metrics",
+    "uid": "OS-master",
+    "version": 5
+}

--- a/grafana/build/ver_4.0/alternator.4.0.json
+++ b/grafana/build/ver_4.0/alternator.4.0.json
@@ -4050,6 +4050,6 @@
     },
     "timezone": "browser",
     "title": "Alternator",
-    "uid": "alternator-4.0",
+    "uid": "alternator-4-0",
     "version": 1
 }

--- a/start-all.sh
+++ b/start-all.sh
@@ -28,7 +28,7 @@ else
 fi
 PROMETHEUS_RULES="$PWD/prometheus/prometheus.rules.yml"
 VERSIONS=$DEFAULT_VERSION
-usage="$(basename "$0") [-h] [--version] [-e] [-d Prometheus data-dir] [-L resolve the servers from the manger running on the given address] [-G path to grafana data-dir] [-s scylla-target-file] [-n node-target-file] [-l] [-v comma separated versions] [-j additional dashboard to load to Grafana, multiple params are supported] [-c grafana environment variable, multiple params are supported] [-b Prometheus command line options] [-g grafana port ] [ -p prometheus port ] [-a admin password] [-m alertmanager port] [ -M scylla-manager version ] [-D encapsulate docker param] [-r alert-manager-config] [-R prometheus-alert-file] [-N manager target file] [-A bind-to-ip-address] [-C alertmanager commands] [-Q Grafana anonymous role (Admin/Editor/Viewer)] -- starts Grafana and Prometheus Docker instances"
+usage="$(basename "$0") [-h] [--version] [-e] [-d Prometheus data-dir] [-L resolve the servers from the manger running on the given address] [-G path to grafana data-dir] [-s scylla-target-file] [-n node-target-file] [-l] [-v comma separated versions] [-j additional dashboard to load to Grafana, multiple params are supported] [-c grafana environment variable, multiple params are supported] [-b Prometheus command line options] [-g grafana port ] [ -p prometheus port ] [-a admin password] [-m alertmanager port] [ -M scylla-manager version ] [-D encapsulate docker param] [-r alert-manager-config] [-R prometheus-alert-file] [-N manager target file] [-A bind-to-ip-address] [-C alertmanager commands] [-Q Grafana anonymous role (Admin/Editor/Viewer)] [-S start with a system specific dashboard set] -- starts Grafana and Prometheus Docker instances"
 PROMETHEUS_VERSION=v2.15.2
 
 SCYLLA_TARGET_FILES=($PWD/prometheus/scylla_servers.yml $PWD/scylla_servers.yml)
@@ -41,8 +41,9 @@ CONSUL_ADDRESS=""
 BIND_ADDRESS=""
 BIND_ADDRESS_CONFIG=""
 GRAFNA_ANONYMOUS_ROLE=""
+SPECIFIC_SOLUTION=""
 
-while getopts ':hled:g:p:v:s:n:a:c:j:b:m:r:R:M:G:D:L:N:C:Q:A:' option; do
+while getopts ':hled:g:p:v:s:n:a:c:j:b:m:r:R:M:G:D:L:N:C:Q:A:S:' option; do
   case "$option" in
     h) echo "$usage"
        exit
@@ -91,6 +92,8 @@ while getopts ':hled:g:p:v:s:n:a:c:j:b:m:r:R:M:G:D:L:N:C:Q:A:' option; do
     b) PROMETHEUS_COMMAND_LINE_OPTIONS_ARRAY+=("$OPTARG")
        ;;
     N) SCYLLA_MANGER_TARGET_FILE="$OPTARG"
+       ;;
+    S) SPECIFIC_SOLUTION="-S $OPTARG"
        ;;
     :) printf "missing argument for -%s\n" "$OPTARG" >&2
        echo "$usage" >&2
@@ -272,4 +275,4 @@ for val in "${GRAFANA_DASHBOARD_ARRAY[@]}"; do
         GRAFANA_DASHBOARD_COMMAND="$GRAFANA_DASHBOARD_COMMAND -j $val"
 done
 
-./start-grafana.sh $BIND_ADDRESS_CONFIG -p $DB_ADDRESS $GRAFNA_ANONYMOUS_ROLE -D "$DOCKER_PARAM" $GRAFANA_PORT $EXTERNAL_VOLUME -m $AM_ADDRESS -M $MANAGER_VERSION -v $VERSIONS $GRAFANA_ENV_COMMAND $GRAFANA_DASHBOARD_COMMAND $GRAFANA_ADMIN_PASSWORD
+./start-grafana.sh $BIND_ADDRESS_CONFIG $SPECIFIC_SOLUTION -p $DB_ADDRESS $GRAFNA_ANONYMOUS_ROLE -D "$DOCKER_PARAM" $GRAFANA_PORT $EXTERNAL_VOLUME -m $AM_ADDRESS -M $MANAGER_VERSION -v $VERSIONS $GRAFANA_ENV_COMMAND $GRAFANA_DASHBOARD_COMMAND $GRAFANA_ADMIN_PASSWORD

--- a/start-grafana.sh
+++ b/start-grafana.sh
@@ -18,10 +18,11 @@ DOCKER_PARAM=""
 EXTERNAL_VOLUME=""
 BIND_ADDRESS=""
 ANONYMOUS_ROLE="Admin"
+SPECIFIC_SOLUTION=""
 
-usage="$(basename "$0") [-h] [-v comma separated versions ] [-g grafana port ] [-G path to external dir] [-n grafana container name ] [-p ip:port address of prometheus ] [-j additional dashboard to load to Grafana, multiple params are supported] [-c grafana enviroment variable, multiple params are supported] [-x http_proxy_host:port] [-m alert_manager address] [-a admin password] [ -M scylla-manager version ] [-D encapsulate docker param] [-Q Grafana anonymous role (Admin/Editor/Viewer)] -- loads the prometheus datasource and the Scylla dashboards into an existing grafana installation"
+usage="$(basename "$0") [-h] [-v comma separated versions ] [-g grafana port ] [-G path to external dir] [-n grafana container name ] [-p ip:port address of prometheus ] [-j additional dashboard to load to Grafana, multiple params are supported] [-c grafana enviroment variable, multiple params are supported] [-x http_proxy_host:port] [-m alert_manager address] [-a admin password] [ -M scylla-manager version ] [-D encapsulate docker param] [-Q Grafana anonymous role (Admin/Editor/Viewer)] [-S start with a system specific dashboard set] -- loads the prometheus datasource and the Scylla dashboards into an existing grafana installation"
 
-while getopts ':hlg:n:p:v:a:x:c:j:m:G:M:D:A:Q:' option; do
+while getopts ':hlg:n:p:v:a:x:c:j:m:G:M:D:A:S:Q:' option; do
   case "$option" in
     h) echo "$usage"
        exit
@@ -58,6 +59,8 @@ while getopts ':hlg:n:p:v:a:x:c:j:m:G:M:D:A:Q:' option; do
     j) GRAFANA_DASHBOARD_ARRAY+=("$OPTARG")
        ;;
     A) BIND_ADDRESS="$OPTARG:"
+       ;;
+    S) SPECIFIC_SOLUTION="-S $OPTARG"
        ;;
     :) printf "missing argument for -%s\n" "$OPTARG" >&2
        echo "$usage" >&2
@@ -106,7 +109,7 @@ for val in "${GRAFANA_DASHBOARD_ARRAY[@]}"; do
         GRAFANA_DASHBOARD_COMMAND="$GRAFANA_DASHBOARD_COMMAND -j $val"
 done
 
-./generate-dashboards.sh -t -v $VERSIONS -M $MANAGER_VERSION $GRAFANA_DASHBOARD_COMMAND
+./generate-dashboards.sh -t $SPECIFIC_SOLUTION -v $VERSIONS -M $MANAGER_VERSION $GRAFANA_DASHBOARD_COMMAND
 mkdir -p grafana/provisioning/datasources
 sed "s/DB_ADDRESS/$DB_ADDRESS/" grafana/datasource.yml | sed "s/AM_ADDRESS/$ALERT_MANAGER_ADDRESS/" > grafana/provisioning/datasources/datasource.yaml
 


### PR DESCRIPTION
This series adds an option to run alternator only dashboards.
you can start the stack with:
alternator-start-all.sh
and it will not include the scylla specific dashboards.

The list of dashboards:
![image](https://user-images.githubusercontent.com/2118079/79692275-dc296280-826c-11ea-9f7e-f044ed4df011.png)

Fixes #858 