### PR TITLE
Use longer scrap interval

### DIFF
--- a/grafana/build/ver_2019.1/scylla-detailed.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-detailed.2019.1.json
@@ -1310,7 +1310,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_hints_manager_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "expr": "$func(irate(scylla_hints_manager_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -1407,7 +1407,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_hints_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "expr": "$func(irate(scylla_hints_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -4793,7 +4793,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_hints_for_views_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s]))  by ([[by]])",
+                    "expr": "$func(irate(scylla_hints_for_views_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s]))  by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",

--- a/grafana/build/ver_3.1/scylla-detailed.3.1.json
+++ b/grafana/build/ver_3.1/scylla-detailed.3.1.json
@@ -1310,7 +1310,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_hints_manager_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "expr": "$func(irate(scylla_hints_manager_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -1407,7 +1407,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_hints_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "expr": "$func(irate(scylla_hints_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -4793,7 +4793,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_hints_for_views_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s]))  by ([[by]])",
+                    "expr": "$func(irate(scylla_hints_for_views_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s]))  by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",

--- a/grafana/build/ver_3.2/scylla-detailed.3.2.json
+++ b/grafana/build/ver_3.2/scylla-detailed.3.2.json
@@ -1310,7 +1310,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_hints_manager_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "expr": "$func(irate(scylla_hints_manager_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -1407,7 +1407,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_hints_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "expr": "$func(irate(scylla_hints_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -4793,7 +4793,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_hints_for_views_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s]))  by ([[by]])",
+                    "expr": "$func(irate(scylla_hints_for_views_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s]))  by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",

--- a/grafana/build/ver_3.3/scylla-detailed.3.3.json
+++ b/grafana/build/ver_3.3/scylla-detailed.3.3.json
@@ -1340,7 +1340,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_hints_manager_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "expr": "$func(irate(scylla_hints_manager_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -1437,7 +1437,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_hints_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "expr": "$func(irate(scylla_hints_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -4823,7 +4823,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_hints_for_views_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s]))  by ([[by]])",
+                    "expr": "$func(irate(scylla_hints_for_views_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s]))  by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",

--- a/grafana/build/ver_4.0/scylla-detailed.4.0.json
+++ b/grafana/build/ver_4.0/scylla-detailed.4.0.json
@@ -1340,7 +1340,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_hints_manager_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "expr": "$func(irate(scylla_hints_manager_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -1437,7 +1437,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_hints_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "expr": "$func(irate(scylla_hints_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -4823,7 +4823,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_hints_for_views_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s]))  by ([[by]])",
+                    "expr": "$func(irate(scylla_hints_for_views_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s]))  by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",

--- a/grafana/build/ver_master/scylla-detailed.master.json
+++ b/grafana/build/ver_master/scylla-detailed.master.json
@@ -1340,7 +1340,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_hints_manager_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "expr": "$func(irate(scylla_hints_manager_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -1437,7 +1437,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_hints_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "expr": "$func(irate(scylla_hints_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -4823,7 +4823,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_hints_for_views_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s]))  by ([[by]])",
+                    "expr": "$func(irate(scylla_hints_for_views_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s]))  by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",

--- a/grafana/scylla-detailed.2019.1.template.json
+++ b/grafana/scylla-detailed.2019.1.template.json
@@ -233,7 +233,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$func(irate(scylla_hints_manager_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "$func(irate(scylla_hints_manager_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -247,7 +247,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$func(irate(scylla_hints_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "$func(irate(scylla_hints_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -827,7 +827,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$func(irate(scylla_hints_for_views_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s]))  by ([[by]])",
+                                "expr": "$func(irate(scylla_hints_for_views_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s]))  by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",

--- a/grafana/scylla-detailed.3.1.template.json
+++ b/grafana/scylla-detailed.3.1.template.json
@@ -233,7 +233,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$func(irate(scylla_hints_manager_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "$func(irate(scylla_hints_manager_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -247,7 +247,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$func(irate(scylla_hints_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "$func(irate(scylla_hints_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -827,7 +827,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$func(irate(scylla_hints_for_views_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s]))  by ([[by]])",
+                                "expr": "$func(irate(scylla_hints_for_views_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s]))  by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",

--- a/grafana/scylla-detailed.3.2.template.json
+++ b/grafana/scylla-detailed.3.2.template.json
@@ -233,7 +233,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$func(irate(scylla_hints_manager_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "$func(irate(scylla_hints_manager_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -247,7 +247,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$func(irate(scylla_hints_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "$func(irate(scylla_hints_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -827,7 +827,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$func(irate(scylla_hints_for_views_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s]))  by ([[by]])",
+                                "expr": "$func(irate(scylla_hints_for_views_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s]))  by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",

--- a/grafana/scylla-detailed.3.3.template.json
+++ b/grafana/scylla-detailed.3.3.template.json
@@ -233,7 +233,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$func(irate(scylla_hints_manager_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "$func(irate(scylla_hints_manager_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -247,7 +247,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$func(irate(scylla_hints_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "$func(irate(scylla_hints_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -827,7 +827,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$func(irate(scylla_hints_for_views_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s]))  by ([[by]])",
+                                "expr": "$func(irate(scylla_hints_for_views_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s]))  by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",

--- a/grafana/scylla-detailed.4.0.template.json
+++ b/grafana/scylla-detailed.4.0.template.json
@@ -233,7 +233,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$func(irate(scylla_hints_manager_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "$func(irate(scylla_hints_manager_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -247,7 +247,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$func(irate(scylla_hints_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "$func(irate(scylla_hints_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -827,7 +827,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$func(irate(scylla_hints_for_views_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s]))  by ([[by]])",
+                                "expr": "$func(irate(scylla_hints_for_views_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s]))  by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",

--- a/grafana/scylla-detailed.master.template.json
+++ b/grafana/scylla-detailed.master.template.json
@@ -233,7 +233,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$func(irate(scylla_hints_manager_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "$func(irate(scylla_hints_manager_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -247,7 +247,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$func(irate(scylla_hints_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                                "expr": "$func(irate(scylla_hints_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -827,7 +827,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$func(irate(scylla_hints_for_views_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s]))  by ([[by]])",
+                                "expr": "$func(irate(scylla_hints_for_views_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s]))  by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",

--- a/prometheus/prometheus.yml.template
+++ b/prometheus/prometheus.yml.template
@@ -1,6 +1,6 @@
 global:
-  scrape_interval: 5s # By default, scrape targets every 5 second.
-  scrape_timeout: 4s # Timeout before trying to scape a target again
+  scrape_interval: 20s # By default, scrape targets every 20 second.
+  scrape_timeout: 15s # Timeout before trying to scape a target again
 
   # Attach these labels to any time series or alerts when communicating with
   # external systems (federation, remote storage, Alertmanager).


### PR DESCRIPTION
In a production system especially cross DC setting the scrap interval too small will cause
timeout.

This patch change the scrap interval to 20s and the timeout to 15s.
It also makes sure the minimal duration in query is set to 1m

Fixes #914