### PR TITLE
Manager task range annotations

### DIFF
--- a/grafana/build/manager_2.1/scylla-manager.2.1.json
+++ b/grafana/build/manager_2.1/scylla-manager.2.1.json
@@ -29,7 +29,7 @@
                 "class": "annotation_manager_task",
                 "datasource": "prometheus",
                 "enable": true,
-                "expr": "changes(scylla_manager_task_active_count[1m])",
+                "expr": "scylla_manager_task_active_count{type=~\"repair|backup\",cluster=~\"$cluster|$^\"}>0",
                 "hide": false,
                 "iconColor": "#73BF69",
                 "limit": 100,
@@ -37,22 +37,22 @@
                 "showIn": 0,
                 "tagKeys": "type",
                 "tags": [],
-                "titleFormat": "Started",
+                "titleFormat": "Running",
                 "type": "tags"
             },
             {
-                "class": "annotation_manager_task_completed",
+                "class": "annotation_manager_task_failed",
                 "datasource": "prometheus",
                 "enable": true,
-                "expr": "changes(scylla_manager_task_run_total{}[1m])>0",
+                "expr": "sum(changes(scylla_manager_task_run_total{status=\"ERROR\", cluster=~\"$cluster|$^\"}[1m])) by(type)>0",
                 "hide": false,
                 "iconColor": "#73BF69",
                 "limit": 100,
-                "name": "Done",
+                "name": "Failed",
                 "showIn": 0,
-                "tagKeys": "type,status",
+                "tagKeys": "type",
                 "tags": [],
-                "titleFormat": "Task Completed",
+                "titleFormat": "Task Failed",
                 "type": "tags"
             }
         ]

--- a/grafana/build/manager_master/scylla-manager.master.json
+++ b/grafana/build/manager_master/scylla-manager.master.json
@@ -29,7 +29,7 @@
                 "class": "annotation_manager_task",
                 "datasource": "prometheus",
                 "enable": true,
-                "expr": "changes(scylla_manager_task_active_count[1m])",
+                "expr": "scylla_manager_task_active_count{type=~\"repair|backup\",cluster=~\"$cluster|$^\"}>0",
                 "hide": false,
                 "iconColor": "#73BF69",
                 "limit": 100,
@@ -37,22 +37,22 @@
                 "showIn": 0,
                 "tagKeys": "type",
                 "tags": [],
-                "titleFormat": "Started",
+                "titleFormat": "Running",
                 "type": "tags"
             },
             {
-                "class": "annotation_manager_task_completed",
+                "class": "annotation_manager_task_failed",
                 "datasource": "prometheus",
                 "enable": true,
-                "expr": "changes(scylla_manager_task_run_total{}[1m])>0",
+                "expr": "sum(changes(scylla_manager_task_run_total{status=\"ERROR\", cluster=~\"$cluster|$^\"}[1m])) by(type)>0",
                 "hide": false,
                 "iconColor": "#73BF69",
                 "limit": 100,
-                "name": "Done",
+                "name": "Failed",
                 "showIn": 0,
-                "tagKeys": "type,status",
+                "tagKeys": "type",
                 "tags": [],
-                "titleFormat": "Task Completed",
+                "titleFormat": "Task Failed",
                 "type": "tags"
             }
         ]

--- a/grafana/scylla-manager.2.1.template.json
+++ b/grafana/scylla-manager.2.1.template.json
@@ -264,7 +264,7 @@
               "class" : "annotation_manager_task"
               },
               {
-              "class" : "annotation_manager_task_completed"
+              "class" : "annotation_manager_task_failed"
               }
           ]
         },

--- a/grafana/scylla-manager.master.template.json
+++ b/grafana/scylla-manager.master.template.json
@@ -264,7 +264,7 @@
               "class" : "annotation_manager_task"
               },
               {
-              "class" : "annotation_manager_task_completed"
+              "class" : "annotation_manager_task_failed"
               }
           ]
         },

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -1055,7 +1055,7 @@
       "annotation_manager_task": {
         "datasource": "prometheus",
         "enable": true,
-        "expr": "changes(scylla_manager_task_active_count[1m])",
+        "expr": "scylla_manager_task_active_count{type=~\"repair|backup\",cluster=~\"$cluster|$^\"}>0",
         "hide": false,
         "iconColor": "#73BF69",
         "limit": 100,
@@ -1063,21 +1063,21 @@
         "showIn": 0,
         "tagKeys": "type",
         "tags": [],
-        "titleFormat": "Started",
+        "titleFormat": "Running",
         "type": "tags"
       },
-      "annotation_manager_task_completed": {
+      "annotation_manager_task_failed": {
         "datasource": "prometheus",
         "enable": true,
-        "expr": "changes(scylla_manager_task_run_total{}[1m])>0",
+        "expr": "sum(changes(scylla_manager_task_run_total{status=\"ERROR\", cluster=~\"$cluster|$^\"}[1m])) by(type)>0",
         "hide": false,
         "iconColor": "#73BF69",
         "limit": 100,
-        "name": "Done",
+        "name": "Failed",
         "showIn": 0,
-        "tagKeys": "type,status",
+        "tagKeys": "type",
         "tags": [],
-        "titleFormat": "Task Completed",
+        "titleFormat": "Task Failed",
         "type": "tags"
       },
       "adhoc_filter" : {


### PR DESCRIPTION
Grafana now supports range annotations based on metrics.

This patch tasks use of that. 

Instead of start and stop annotations we have an annotation for a running task and an annotation for a failed task
![Screenshot from 2020-05-18 13-35-13](https://user-images.githubusercontent.com/2118079/82207991-666bf180-9913-11ea-8ed3-65c3938969d4.png)

Fixes #852

Relates to #933 