### PR TITLE
Update units in panels

### DIFF
--- a/grafana/build/manager_2.0/scylla-manager.2.0.json
+++ b/grafana/build/manager_2.0/scylla-manager.2.0.json
@@ -805,7 +805,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -901,7 +901,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/manager_2.1/scylla-manager.2.1.json
+++ b/grafana/build/manager_2.1/scylla-manager.2.1.json
@@ -805,7 +805,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -901,7 +901,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/manager_master/scylla-manager.master.json
+++ b/grafana/build/manager_master/scylla-manager.master.json
@@ -805,7 +805,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -901,7 +901,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_2019.1/scylla-cql.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-cql.2019.1.json
@@ -161,7 +161,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -259,7 +259,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -357,7 +357,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -455,7 +455,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -962,7 +962,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1132,7 +1132,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1300,7 +1300,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1470,7 +1470,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1636,7 +1636,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1821,7 +1821,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1991,7 +1991,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2161,7 +2161,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2354,7 +2354,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2524,7 +2524,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_2019.1/scylla-detailed.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-detailed.2019.1.json
@@ -236,7 +236,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -331,7 +331,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -427,7 +427,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -569,7 +569,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -666,7 +666,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -762,7 +762,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -858,7 +858,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -954,7 +954,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1050,7 +1050,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1146,7 +1146,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1243,7 +1243,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1338,7 +1338,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1435,7 +1435,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1531,7 +1531,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1627,7 +1627,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1745,7 +1745,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1840,7 +1840,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1935,7 +1935,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2030,7 +2030,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2147,7 +2147,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2242,7 +2242,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2337,7 +2337,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2476,7 +2476,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2571,7 +2571,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2689,7 +2689,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2784,7 +2784,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2879,7 +2879,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2974,7 +2974,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3069,7 +3069,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3164,7 +3164,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3259,7 +3259,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3354,7 +3354,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3451,7 +3451,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3548,7 +3548,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3645,7 +3645,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3742,7 +3742,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3839,7 +3839,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3936,7 +3936,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4435,7 +4435,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4531,7 +4531,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4725,7 +4725,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4821,7 +4821,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4917,7 +4917,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -5557,7 +5557,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -5646,7 +5646,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_2019.1/scylla-errors.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-errors.2019.1.json
@@ -136,7 +136,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -233,7 +233,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -353,7 +353,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -450,7 +450,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -549,7 +549,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -648,7 +648,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -770,7 +770,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_2019.1/scylla-os.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-os.2019.1.json
@@ -332,7 +332,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -434,7 +434,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_2019.1/scylla-overview.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-overview.2019.1.json
@@ -981,7 +981,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1206,7 +1206,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1596,7 +1596,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2033,7 +2033,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2131,7 +2131,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2227,7 +2227,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2323,7 +2323,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2435,7 +2435,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2524,7 +2524,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_3.2/alternator.3.2.json
+++ b/grafana/build/ver_3.2/alternator.3.2.json
@@ -962,7 +962,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1187,7 +1187,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1284,7 +1284,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1381,7 +1381,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1478,7 +1478,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1575,7 +1575,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1672,7 +1672,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1769,7 +1769,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1889,7 +1889,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2279,7 +2279,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2669,7 +2669,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3059,7 +3059,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3472,7 +3472,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3569,7 +3569,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3666,7 +3666,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3763,7 +3763,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3860,7 +3860,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4027,7 +4027,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4125,7 +4125,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4222,7 +4222,7 @@
             "yaxes": [
                 {
                     "decimals": 0,
-                    "format": "wpm",
+                    "format": "si:writes/m",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4319,7 +4319,7 @@
             "yaxes": [
                 {
                     "decimals": 0,
-                    "format": "rpm",
+                    "format": "si:reads/m",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4431,7 +4431,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4520,7 +4520,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_3.2/scylla-cql.3.2.json
+++ b/grafana/build/ver_3.2/scylla-cql.3.2.json
@@ -161,7 +161,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -259,7 +259,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -357,7 +357,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -455,7 +455,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -962,7 +962,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1132,7 +1132,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1300,7 +1300,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1470,7 +1470,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1636,7 +1636,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1821,7 +1821,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1991,7 +1991,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2161,7 +2161,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2354,7 +2354,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2524,7 +2524,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_3.2/scylla-detailed.3.2.json
+++ b/grafana/build/ver_3.2/scylla-detailed.3.2.json
@@ -236,7 +236,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -331,7 +331,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -427,7 +427,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -569,7 +569,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -666,7 +666,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -762,7 +762,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -858,7 +858,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -954,7 +954,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1050,7 +1050,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1146,7 +1146,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1243,7 +1243,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1338,7 +1338,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1435,7 +1435,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1531,7 +1531,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1627,7 +1627,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1745,7 +1745,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1840,7 +1840,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1935,7 +1935,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2030,7 +2030,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2147,7 +2147,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2242,7 +2242,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2337,7 +2337,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2476,7 +2476,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2571,7 +2571,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2689,7 +2689,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2784,7 +2784,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2879,7 +2879,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2974,7 +2974,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3069,7 +3069,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3164,7 +3164,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3259,7 +3259,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3354,7 +3354,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3451,7 +3451,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3548,7 +3548,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3645,7 +3645,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3742,7 +3742,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3839,7 +3839,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3936,7 +3936,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4435,7 +4435,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4531,7 +4531,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4725,7 +4725,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4821,7 +4821,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4917,7 +4917,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -5557,7 +5557,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -5646,7 +5646,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_3.2/scylla-errors.3.2.json
+++ b/grafana/build/ver_3.2/scylla-errors.3.2.json
@@ -136,7 +136,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -233,7 +233,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -353,7 +353,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -450,7 +450,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -549,7 +549,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -648,7 +648,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -770,7 +770,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_3.2/scylla-os.3.2.json
+++ b/grafana/build/ver_3.2/scylla-os.3.2.json
@@ -332,7 +332,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -434,7 +434,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_3.2/scylla-overview.3.2.json
+++ b/grafana/build/ver_3.2/scylla-overview.3.2.json
@@ -981,7 +981,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1206,7 +1206,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1596,7 +1596,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2033,7 +2033,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2131,7 +2131,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2227,7 +2227,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2323,7 +2323,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2435,7 +2435,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2524,7 +2524,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_3.3/alternator.3.3.json
+++ b/grafana/build/ver_3.3/alternator.3.3.json
@@ -992,7 +992,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1217,7 +1217,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1314,7 +1314,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1411,7 +1411,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1508,7 +1508,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1605,7 +1605,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1702,7 +1702,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1799,7 +1799,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1919,7 +1919,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2309,7 +2309,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2699,7 +2699,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3089,7 +3089,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3502,7 +3502,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3599,7 +3599,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3696,7 +3696,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3793,7 +3793,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3890,7 +3890,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4057,7 +4057,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4155,7 +4155,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4252,7 +4252,7 @@
             "yaxes": [
                 {
                     "decimals": 0,
-                    "format": "wpm",
+                    "format": "si:writes/m",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4349,7 +4349,7 @@
             "yaxes": [
                 {
                     "decimals": 0,
-                    "format": "rpm",
+                    "format": "si:reads/m",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4461,7 +4461,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4550,7 +4550,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_3.3/scylla-cql.3.3.json
+++ b/grafana/build/ver_3.3/scylla-cql.3.3.json
@@ -191,7 +191,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -289,7 +289,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -387,7 +387,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -485,7 +485,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -874,7 +874,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1067,7 +1067,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1237,7 +1237,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1405,7 +1405,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1575,7 +1575,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1741,7 +1741,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1926,7 +1926,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2096,7 +2096,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2266,7 +2266,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2459,7 +2459,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2629,7 +2629,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_3.3/scylla-detailed.3.3.json
+++ b/grafana/build/ver_3.3/scylla-detailed.3.3.json
@@ -266,7 +266,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -361,7 +361,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -457,7 +457,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -599,7 +599,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -696,7 +696,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -792,7 +792,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -888,7 +888,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -984,7 +984,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1080,7 +1080,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1176,7 +1176,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1273,7 +1273,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1368,7 +1368,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1465,7 +1465,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1561,7 +1561,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1657,7 +1657,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1775,7 +1775,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1870,7 +1870,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1965,7 +1965,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2060,7 +2060,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2177,7 +2177,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2272,7 +2272,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2367,7 +2367,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2506,7 +2506,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2601,7 +2601,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2719,7 +2719,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2814,7 +2814,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2909,7 +2909,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3004,7 +3004,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3099,7 +3099,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3194,7 +3194,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3289,7 +3289,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3384,7 +3384,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3481,7 +3481,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3578,7 +3578,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3675,7 +3675,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3772,7 +3772,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3869,7 +3869,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3966,7 +3966,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4465,7 +4465,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4561,7 +4561,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4755,7 +4755,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4851,7 +4851,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4947,7 +4947,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -5066,7 +5066,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -5358,7 +5358,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -5454,7 +5454,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -5746,7 +5746,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -6386,7 +6386,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -6475,7 +6475,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_3.3/scylla-errors.3.3.json
+++ b/grafana/build/ver_3.3/scylla-errors.3.3.json
@@ -166,7 +166,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -263,7 +263,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -383,7 +383,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -480,7 +480,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -579,7 +579,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -678,7 +678,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -777,7 +777,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -876,7 +876,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_3.3/scylla-os.3.3.json
+++ b/grafana/build/ver_3.3/scylla-os.3.3.json
@@ -362,7 +362,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -464,7 +464,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_3.3/scylla-overview.3.3.json
+++ b/grafana/build/ver_3.3/scylla-overview.3.3.json
@@ -1011,7 +1011,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1236,7 +1236,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1626,7 +1626,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2063,7 +2063,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2161,7 +2161,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2257,7 +2257,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2353,7 +2353,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2465,7 +2465,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2554,7 +2554,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_4.0/alternator.4.0.json
+++ b/grafana/build/ver_4.0/alternator.4.0.json
@@ -992,7 +992,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1217,7 +1217,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1314,7 +1314,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1411,7 +1411,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1508,7 +1508,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1605,7 +1605,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1702,7 +1702,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1799,7 +1799,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1919,7 +1919,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2309,7 +2309,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2699,7 +2699,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3089,7 +3089,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3502,7 +3502,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3599,7 +3599,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3696,7 +3696,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3793,7 +3793,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3890,7 +3890,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4057,7 +4057,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4155,7 +4155,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4252,7 +4252,7 @@
             "yaxes": [
                 {
                     "decimals": 0,
-                    "format": "wpm",
+                    "format": "si:writes/m",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4349,7 +4349,7 @@
             "yaxes": [
                 {
                     "decimals": 0,
-                    "format": "rpm",
+                    "format": "si:reads/m",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4461,7 +4461,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4550,7 +4550,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_4.0/scylla-cql.4.0.json
+++ b/grafana/build/ver_4.0/scylla-cql.4.0.json
@@ -192,7 +192,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -291,7 +291,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -390,7 +390,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -489,7 +489,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -878,7 +878,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1000,7 +1000,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1099,7 +1099,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1198,7 +1198,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1297,7 +1297,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1418,7 +1418,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1516,7 +1516,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1614,7 +1614,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1904,7 +1904,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2074,7 +2074,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2242,7 +2242,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2412,7 +2412,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2578,7 +2578,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2763,7 +2763,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2933,7 +2933,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3103,7 +3103,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3296,7 +3296,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3466,7 +3466,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_4.0/scylla-detailed.4.0.json
+++ b/grafana/build/ver_4.0/scylla-detailed.4.0.json
@@ -266,7 +266,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -361,7 +361,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -457,7 +457,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -599,7 +599,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -696,7 +696,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -792,7 +792,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -888,7 +888,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -984,7 +984,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1080,7 +1080,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1176,7 +1176,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1273,7 +1273,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1368,7 +1368,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1465,7 +1465,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1561,7 +1561,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1657,7 +1657,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1775,7 +1775,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1870,7 +1870,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1965,7 +1965,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2060,7 +2060,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2177,7 +2177,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2272,7 +2272,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2367,7 +2367,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2506,7 +2506,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2601,7 +2601,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2719,7 +2719,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2814,7 +2814,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2909,7 +2909,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3004,7 +3004,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3099,7 +3099,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3194,7 +3194,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3289,7 +3289,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3384,7 +3384,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3481,7 +3481,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3578,7 +3578,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3675,7 +3675,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3772,7 +3772,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3869,7 +3869,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3966,7 +3966,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4465,7 +4465,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4561,7 +4561,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4755,7 +4755,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4851,7 +4851,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4947,7 +4947,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -5066,7 +5066,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -5358,7 +5358,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -5454,7 +5454,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -5746,7 +5746,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -5842,7 +5842,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -5938,7 +5938,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -6034,7 +6034,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -6130,7 +6130,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -6226,7 +6226,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -6322,7 +6322,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -6418,7 +6418,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -6514,7 +6514,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -6610,7 +6610,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -6708,7 +6708,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -6806,7 +6806,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -6927,7 +6927,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -7025,7 +7025,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -7665,7 +7665,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -7754,7 +7754,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_4.0/scylla-errors.4.0.json
+++ b/grafana/build/ver_4.0/scylla-errors.4.0.json
@@ -166,7 +166,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -263,7 +263,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -383,7 +383,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -480,7 +480,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -579,7 +579,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -678,7 +678,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -777,7 +777,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -876,7 +876,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_4.0/scylla-os.4.0.json
+++ b/grafana/build/ver_4.0/scylla-os.4.0.json
@@ -362,7 +362,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -464,7 +464,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_4.0/scylla-overview.4.0.json
+++ b/grafana/build/ver_4.0/scylla-overview.4.0.json
@@ -1011,7 +1011,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1236,7 +1236,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1626,7 +1626,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2063,7 +2063,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2161,7 +2161,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2257,7 +2257,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2353,7 +2353,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2465,7 +2465,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2554,7 +2554,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_master/alternator.master.json
+++ b/grafana/build/ver_master/alternator.master.json
@@ -992,7 +992,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1217,7 +1217,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1314,7 +1314,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1411,7 +1411,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1508,7 +1508,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1605,7 +1605,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1702,7 +1702,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1799,7 +1799,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1919,7 +1919,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2309,7 +2309,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2699,7 +2699,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3089,7 +3089,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3502,7 +3502,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3599,7 +3599,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3696,7 +3696,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3793,7 +3793,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3890,7 +3890,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4057,7 +4057,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4155,7 +4155,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4252,7 +4252,7 @@
             "yaxes": [
                 {
                     "decimals": 0,
-                    "format": "wpm",
+                    "format": "si:writes/m",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4349,7 +4349,7 @@
             "yaxes": [
                 {
                     "decimals": 0,
-                    "format": "rpm",
+                    "format": "si:reads/m",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4461,7 +4461,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4550,7 +4550,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_master/scylla-cql.master.json
+++ b/grafana/build/ver_master/scylla-cql.master.json
@@ -192,7 +192,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -291,7 +291,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -390,7 +390,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -489,7 +489,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -878,7 +878,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1000,7 +1000,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1099,7 +1099,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1198,7 +1198,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1297,7 +1297,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1418,7 +1418,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1516,7 +1516,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1614,7 +1614,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1904,7 +1904,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2074,7 +2074,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2242,7 +2242,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2412,7 +2412,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2578,7 +2578,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2763,7 +2763,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2933,7 +2933,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3103,7 +3103,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3296,7 +3296,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3466,7 +3466,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_master/scylla-detailed.master.json
+++ b/grafana/build/ver_master/scylla-detailed.master.json
@@ -266,7 +266,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -361,7 +361,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -457,7 +457,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -599,7 +599,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -696,7 +696,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -792,7 +792,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -888,7 +888,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -984,7 +984,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1080,7 +1080,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1176,7 +1176,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1273,7 +1273,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1368,7 +1368,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1465,7 +1465,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1561,7 +1561,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1657,7 +1657,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1775,7 +1775,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1870,7 +1870,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1965,7 +1965,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2060,7 +2060,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2177,7 +2177,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2272,7 +2272,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2367,7 +2367,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2506,7 +2506,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2601,7 +2601,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2719,7 +2719,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2814,7 +2814,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2909,7 +2909,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3004,7 +3004,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3099,7 +3099,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3194,7 +3194,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3289,7 +3289,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3384,7 +3384,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3481,7 +3481,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3578,7 +3578,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3675,7 +3675,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3772,7 +3772,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3869,7 +3869,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -3966,7 +3966,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4465,7 +4465,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4561,7 +4561,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4755,7 +4755,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4851,7 +4851,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -4947,7 +4947,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -5066,7 +5066,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -5358,7 +5358,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -5454,7 +5454,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -5746,7 +5746,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -5842,7 +5842,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -5938,7 +5938,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -6034,7 +6034,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -6130,7 +6130,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -6226,7 +6226,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -6322,7 +6322,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -6418,7 +6418,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -6514,7 +6514,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -6610,7 +6610,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -6708,7 +6708,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -6806,7 +6806,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -6927,7 +6927,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -7025,7 +7025,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -7665,7 +7665,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -7754,7 +7754,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_master/scylla-errors.master.json
+++ b/grafana/build/ver_master/scylla-errors.master.json
@@ -166,7 +166,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -263,7 +263,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -383,7 +383,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -480,7 +480,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -579,7 +579,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -678,7 +678,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -777,7 +777,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -876,7 +876,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_master/scylla-os.master.json
+++ b/grafana/build/ver_master/scylla-os.master.json
@@ -362,7 +362,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -464,7 +464,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_master/scylla-overview.master.json
+++ b/grafana/build/ver_master/scylla-overview.master.json
@@ -1011,7 +1011,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1236,7 +1236,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1626,7 +1626,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2063,7 +2063,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2161,7 +2161,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2257,7 +2257,7 @@
             },
             "yaxes": [
                 {
-                    "format": "wps",
+                    "format": "si:writes/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2353,7 +2353,7 @@
             },
             "yaxes": [
                 {
-                    "format": "rps",
+                    "format": "si:reads/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2465,7 +2465,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2554,7 +2554,7 @@
             },
             "yaxes": [
                 {
-                    "format": "ops",
+                    "format": "si:ops/s",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -323,7 +323,7 @@
         ],
         "yaxes": [
             {
-                "format": "ops",
+                "format": "si:ops/s",
                 "logBase": 1,
                 "max": null,
                 "min": 0,
@@ -479,7 +479,7 @@
         "class": "iops_panel",
         "yaxes": [
             {
-                "format": "wps",
+                "format": "si:writes/s",
                 "logBase": 1,
                 "max": null,
                 "min": 0,
@@ -498,7 +498,7 @@
         "class": "iops_panel",
         "yaxes": [
             {
-                "format": "rps",
+                "format": "si:reads/s",
                 "logBase": 1,
                 "max": null,
                 "min": 0,
@@ -517,7 +517,7 @@
         "class": "iops_panel",
         "yaxes": [
             {
-                "format": "wpm",
+                "format": "si:writes/m",
                 "logBase": 1,
                 "max": null,
                 "min": 0,
@@ -537,7 +537,7 @@
         "class": "iops_panel",
         "yaxes": [
             {
-                "format": "rpm",
+                "format": "si:reads/m",
                 "logBase": 1,
                 "max": null,
                 "min": 0,


### PR DESCRIPTION
This patch updates the ops, wps, rps, rpm and wpm panels to:
ops/s, writes/s, reads/s write/m and read/m.
For example:

![image](https://user-images.githubusercontent.com/2118079/82231218-87453e80-9935-11ea-8fb4-b422af3e9ba6.png)

Fixes #737 