### PR TITLE
Node exporter longer scrap interval

### DIFF
--- a/grafana/build/ver_2019.1/scylla-os.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-os.2019.1.json
@@ -295,7 +295,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -303,7 +303,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_disk_writes_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_writes_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -399,14 +399,14 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_disk_reads_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_reads_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "B",
@@ -523,7 +523,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -531,7 +531,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_disk_bytes_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_bytes_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -627,14 +627,14 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_disk_bytes_read{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_bytes_read{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "B",
@@ -752,7 +752,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_network_receive_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_receive_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -760,7 +760,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_network_receive_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_receive_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -856,7 +856,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_network_transmit_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_transmit_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -864,7 +864,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_network_transmit_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_transmit_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -960,7 +960,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_network_receive_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_receive_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -968,7 +968,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_network_receive_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_receive_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -1064,7 +1064,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_network_transmit_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_transmit_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -1072,7 +1072,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_network_transmit_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_transmit_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",

--- a/grafana/build/ver_3.2/scylla-os.3.2.json
+++ b/grafana/build/ver_3.2/scylla-os.3.2.json
@@ -295,7 +295,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -303,7 +303,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_disk_writes_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_writes_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -399,14 +399,14 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_disk_reads_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_reads_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "B",
@@ -523,7 +523,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -531,7 +531,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_disk_bytes_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_bytes_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -627,14 +627,14 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_disk_bytes_read{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_bytes_read{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "B",
@@ -752,7 +752,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_network_receive_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_receive_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -760,7 +760,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_network_receive_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_receive_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -856,7 +856,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_network_transmit_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_transmit_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -864,7 +864,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_network_transmit_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_transmit_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -960,7 +960,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_network_receive_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_receive_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -968,7 +968,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_network_receive_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_receive_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -1064,7 +1064,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_network_transmit_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_transmit_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -1072,7 +1072,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_network_transmit_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_transmit_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",

--- a/grafana/build/ver_3.3/scylla-os.3.3.json
+++ b/grafana/build/ver_3.3/scylla-os.3.3.json
@@ -325,7 +325,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -333,7 +333,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_disk_writes_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_writes_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -429,14 +429,14 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_disk_reads_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_reads_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "B",
@@ -553,7 +553,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -561,7 +561,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_disk_bytes_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_bytes_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -657,14 +657,14 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_disk_bytes_read{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_bytes_read{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "B",
@@ -782,7 +782,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_network_receive_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_receive_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -790,7 +790,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_network_receive_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_receive_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -886,7 +886,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_network_transmit_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_transmit_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -894,7 +894,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_network_transmit_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_transmit_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -990,7 +990,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_network_receive_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_receive_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -998,7 +998,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_network_receive_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_receive_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -1094,7 +1094,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_network_transmit_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_transmit_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -1102,7 +1102,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_network_transmit_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_transmit_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",

--- a/grafana/build/ver_4.0/scylla-os.4.0.json
+++ b/grafana/build/ver_4.0/scylla-os.4.0.json
@@ -325,7 +325,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -333,7 +333,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_disk_writes_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_writes_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -429,14 +429,14 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_disk_reads_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_reads_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "B",
@@ -553,7 +553,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -561,7 +561,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_disk_bytes_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_bytes_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -657,14 +657,14 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_disk_bytes_read{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_bytes_read{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "B",
@@ -782,7 +782,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_network_receive_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_receive_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -790,7 +790,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_network_receive_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_receive_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -886,7 +886,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_network_transmit_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_transmit_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -894,7 +894,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_network_transmit_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_transmit_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -990,7 +990,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_network_receive_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_receive_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -998,7 +998,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_network_receive_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_receive_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -1094,7 +1094,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_network_transmit_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_transmit_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -1102,7 +1102,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_network_transmit_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_transmit_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",

--- a/grafana/build/ver_master/scylla-os.master.json
+++ b/grafana/build/ver_master/scylla-os.master.json
@@ -325,7 +325,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -333,7 +333,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_disk_writes_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_writes_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -429,14 +429,14 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_disk_reads_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_reads_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "B",
@@ -553,7 +553,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -561,7 +561,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_disk_bytes_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_bytes_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -657,14 +657,14 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_disk_bytes_read{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_disk_bytes_read{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "B",
@@ -782,7 +782,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_network_receive_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_receive_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -790,7 +790,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_network_receive_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_receive_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -886,7 +886,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_network_transmit_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_transmit_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -894,7 +894,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_network_transmit_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_transmit_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -990,7 +990,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_network_receive_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_receive_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -998,7 +998,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_network_receive_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_receive_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -1094,7 +1094,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_network_transmit_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_transmit_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -1102,7 +1102,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_network_transmit_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "expr": "sum(irate(node_network_transmit_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",

--- a/grafana/scylla-os.2019.1.template.json
+++ b/grafana/scylla-os.2019.1.template.json
@@ -85,7 +85,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -93,7 +93,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_disk_writes_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_writes_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -108,14 +108,14 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_disk_reads_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_reads_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "B",
@@ -140,7 +140,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -148,7 +148,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_disk_bytes_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_bytes_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -163,14 +163,14 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_disk_bytes_read{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_bytes_read{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "B",
@@ -205,7 +205,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_network_receive_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_receive_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -213,7 +213,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_network_receive_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_receive_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -228,7 +228,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_network_transmit_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_transmit_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -236,7 +236,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_network_transmit_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_transmit_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -257,7 +257,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_network_receive_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_receive_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -265,7 +265,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_network_receive_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_receive_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -280,7 +280,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_network_transmit_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_transmit_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -288,7 +288,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_network_transmit_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_transmit_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",

--- a/grafana/scylla-os.3.2.template.json
+++ b/grafana/scylla-os.3.2.template.json
@@ -85,7 +85,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -93,7 +93,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_disk_writes_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_writes_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -108,14 +108,14 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_disk_reads_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_reads_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "B",
@@ -140,7 +140,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -148,7 +148,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_disk_bytes_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_bytes_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -163,14 +163,14 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_disk_bytes_read{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_bytes_read{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "B",
@@ -205,7 +205,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_network_receive_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_receive_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -213,7 +213,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_network_receive_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_receive_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -228,7 +228,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_network_transmit_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_transmit_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -236,7 +236,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_network_transmit_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_transmit_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -257,7 +257,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_network_receive_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_receive_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -265,7 +265,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_network_receive_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_receive_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -280,7 +280,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_network_transmit_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_transmit_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -288,7 +288,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_network_transmit_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_transmit_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",

--- a/grafana/scylla-os.3.3.template.json
+++ b/grafana/scylla-os.3.3.template.json
@@ -85,7 +85,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -93,7 +93,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_disk_writes_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_writes_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -108,14 +108,14 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_disk_reads_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_reads_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "B",
@@ -140,7 +140,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -148,7 +148,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_disk_bytes_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_bytes_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -163,14 +163,14 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_disk_bytes_read{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_bytes_read{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "B",
@@ -205,7 +205,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_network_receive_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_receive_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -213,7 +213,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_network_receive_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_receive_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -228,7 +228,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_network_transmit_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_transmit_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -236,7 +236,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_network_transmit_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_transmit_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -257,7 +257,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_network_receive_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_receive_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -265,7 +265,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_network_receive_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_receive_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -280,7 +280,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_network_transmit_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_transmit_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -288,7 +288,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_network_transmit_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_transmit_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",

--- a/grafana/scylla-os.4.0.template.json
+++ b/grafana/scylla-os.4.0.template.json
@@ -85,7 +85,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -93,7 +93,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_disk_writes_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_writes_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -108,14 +108,14 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_disk_reads_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_reads_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "B",
@@ -140,7 +140,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -148,7 +148,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_disk_bytes_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_bytes_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -163,14 +163,14 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_disk_bytes_read{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_bytes_read{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "B",
@@ -205,7 +205,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_network_receive_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_receive_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -213,7 +213,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_network_receive_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_receive_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -228,7 +228,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_network_transmit_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_transmit_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -236,7 +236,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_network_transmit_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_transmit_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -257,7 +257,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_network_receive_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_receive_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -265,7 +265,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_network_receive_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_receive_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -280,7 +280,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_network_transmit_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_transmit_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -288,7 +288,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_network_transmit_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_transmit_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",

--- a/grafana/scylla-os.master.template.json
+++ b/grafana/scylla-os.master.template.json
@@ -85,7 +85,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -93,7 +93,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_disk_writes_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_writes_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -108,14 +108,14 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_disk_reads_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_reads_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "B",
@@ -140,7 +140,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -148,7 +148,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_disk_bytes_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_bytes_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -163,14 +163,14 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_disk_bytes_read{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_disk_bytes_read{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "B",
@@ -205,7 +205,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_network_receive_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_receive_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -213,7 +213,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_network_receive_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_receive_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -228,7 +228,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_network_transmit_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_transmit_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -236,7 +236,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_network_transmit_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_transmit_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -257,7 +257,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_network_receive_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_receive_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -265,7 +265,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_network_receive_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_receive_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -280,7 +280,7 @@
                         "span": 6,
                         "targets": [
                             {
-                                "expr": "sum(irate(node_network_transmit_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_transmit_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -288,7 +288,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "sum(irate(node_network_transmit_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(node_network_transmit_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",

--- a/prometheus/prometheus.consul.yml.template
+++ b/prometheus/prometheus.consul.yml.template
@@ -1,6 +1,6 @@
 global:
-  scrape_interval: 5s # By default, scrape targets every 5 second.
-  scrape_timeout: 4s # Timeout before trying to scape a target again
+  scrape_interval: 20s # By default, scrape targets every 20 second.
+  scrape_timeout: 15s # Timeout before trying to scape a target again
 
   # Attach these labels to any time series or alerts when communicating with
   # external systems (federation, remote storage, Alertmanager).
@@ -71,6 +71,8 @@ scrape_configs:
 
 - job_name: node_exporter
   honor_labels: false
+  scrape_interval: 1m # By default, scrape targets every 20 second.
+  scrape_timeout: 20s # Timeout before trying to scape a target again
   consul_sd_configs:
   - server: 'MANAGER_ADDRESS'
     services:

--- a/prometheus/prometheus.yml.template
+++ b/prometheus/prometheus.yml.template
@@ -64,6 +64,8 @@ scrape_configs:
 
 - job_name: node_exporter
   honor_labels: false
+  scrape_interval: 1m # By default, scrape targets every 20 second.
+  scrape_timeout: 20s # Timeout before trying to scape a target again
   file_sd_configs:
     - files:
       - /etc/scylla.d/prometheus/node_exporter_servers.yml


### PR DESCRIPTION
The node_exporter scrap interval can be set to 1m, it will reduce load from the nodes and is safer for situations such as timeouts and longer network delays.

Fixes #919