### PR TITLE
Add Dashboard links to all dashboards

### DIFF
--- a/grafana/build/manager_2.0/scylla-manager.2.0.json
+++ b/grafana/build/manager_2.0/scylla-manager.2.0.json
@@ -51,7 +51,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "originalTitle": "Scylla Manager Metrics",
     "overwrite": true,
     "panels": [

--- a/grafana/build/manager_2.1/scylla-manager.2.1.json
+++ b/grafana/build/manager_2.1/scylla-manager.2.1.json
@@ -63,7 +63,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "originalTitle": "Scylla Manager Metrics",
     "overwrite": true,
     "panels": [

--- a/grafana/build/manager_master/scylla-manager.master.json
+++ b/grafana/build/manager_master/scylla-manager.master.json
@@ -63,7 +63,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "originalTitle": "Scylla Manager Metrics",
     "overwrite": true,
     "panels": [

--- a/grafana/build/ver_2019.1/scylla-cpu.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-cpu.2019.1.json
@@ -33,7 +33,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "overwrite": true,
     "panels": [
         {

--- a/grafana/build/ver_2019.1/scylla-cql.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-cql.2019.1.json
@@ -33,7 +33,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "originalTitle": "CQL",
     "overwrite": true,
     "panels": [

--- a/grafana/build/ver_2019.1/scylla-detailed.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-detailed.2019.1.json
@@ -33,7 +33,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "overwrite": true,
     "panels": [
         {

--- a/grafana/build/ver_2019.1/scylla-errors.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-errors.2019.1.json
@@ -33,7 +33,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "overwrite": true,
     "panels": [
         {

--- a/grafana/build/ver_2019.1/scylla-io.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-io.2019.1.json
@@ -33,7 +33,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "overwrite": true,
     "panels": [
         {

--- a/grafana/build/ver_2019.1/scylla-os.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-os.2019.1.json
@@ -33,7 +33,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "overwrite": true,
     "panels": [
         {

--- a/grafana/build/ver_2019.1/scylla-overview.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-overview.2019.1.json
@@ -33,7 +33,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "originalTitle": "Scylla Cluster Metrics",
     "overwrite": true,
     "panels": [

--- a/grafana/build/ver_3.1/scylla-cpu.3.1.json
+++ b/grafana/build/ver_3.1/scylla-cpu.3.1.json
@@ -33,7 +33,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "overwrite": true,
     "panels": [
         {

--- a/grafana/build/ver_3.1/scylla-cql.3.1.json
+++ b/grafana/build/ver_3.1/scylla-cql.3.1.json
@@ -33,7 +33,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "originalTitle": "CQL",
     "overwrite": true,
     "panels": [

--- a/grafana/build/ver_3.1/scylla-detailed.3.1.json
+++ b/grafana/build/ver_3.1/scylla-detailed.3.1.json
@@ -33,7 +33,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "overwrite": true,
     "panels": [
         {

--- a/grafana/build/ver_3.1/scylla-errors.3.1.json
+++ b/grafana/build/ver_3.1/scylla-errors.3.1.json
@@ -33,7 +33,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "overwrite": true,
     "panels": [
         {

--- a/grafana/build/ver_3.1/scylla-io.3.1.json
+++ b/grafana/build/ver_3.1/scylla-io.3.1.json
@@ -33,7 +33,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "overwrite": true,
     "panels": [
         {

--- a/grafana/build/ver_3.1/scylla-os.3.1.json
+++ b/grafana/build/ver_3.1/scylla-os.3.1.json
@@ -33,7 +33,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "overwrite": true,
     "panels": [
         {

--- a/grafana/build/ver_3.1/scylla-overview.3.1.json
+++ b/grafana/build/ver_3.1/scylla-overview.3.1.json
@@ -33,7 +33,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "originalTitle": "Scylla Cluster Metrics",
     "overwrite": true,
     "panels": [

--- a/grafana/build/ver_3.2/alternator.3.2.json
+++ b/grafana/build/ver_3.2/alternator.3.2.json
@@ -33,7 +33,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "originalTitle": "Scylla Cluster Metrics",
     "overwrite": true,
     "panels": [

--- a/grafana/build/ver_3.2/scylla-cpu.3.2.json
+++ b/grafana/build/ver_3.2/scylla-cpu.3.2.json
@@ -33,7 +33,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "overwrite": true,
     "panels": [
         {

--- a/grafana/build/ver_3.2/scylla-cql.3.2.json
+++ b/grafana/build/ver_3.2/scylla-cql.3.2.json
@@ -33,7 +33,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "originalTitle": "CQL",
     "overwrite": true,
     "panels": [

--- a/grafana/build/ver_3.2/scylla-detailed.3.2.json
+++ b/grafana/build/ver_3.2/scylla-detailed.3.2.json
@@ -33,7 +33,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "overwrite": true,
     "panels": [
         {

--- a/grafana/build/ver_3.2/scylla-errors.3.2.json
+++ b/grafana/build/ver_3.2/scylla-errors.3.2.json
@@ -33,7 +33,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "overwrite": true,
     "panels": [
         {

--- a/grafana/build/ver_3.2/scylla-io.3.2.json
+++ b/grafana/build/ver_3.2/scylla-io.3.2.json
@@ -33,7 +33,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "overwrite": true,
     "panels": [
         {

--- a/grafana/build/ver_3.2/scylla-os.3.2.json
+++ b/grafana/build/ver_3.2/scylla-os.3.2.json
@@ -33,7 +33,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "overwrite": true,
     "panels": [
         {

--- a/grafana/build/ver_3.2/scylla-overview.3.2.json
+++ b/grafana/build/ver_3.2/scylla-overview.3.2.json
@@ -33,7 +33,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "originalTitle": "Scylla Cluster Metrics",
     "overwrite": true,
     "panels": [

--- a/grafana/build/ver_3.3/alternator.3.3.json
+++ b/grafana/build/ver_3.3/alternator.3.3.json
@@ -63,7 +63,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "originalTitle": "Scylla Cluster Metrics",
     "overwrite": true,
     "panels": [

--- a/grafana/build/ver_3.3/scylla-cpu.3.3.json
+++ b/grafana/build/ver_3.3/scylla-cpu.3.3.json
@@ -63,7 +63,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "overwrite": true,
     "panels": [
         {

--- a/grafana/build/ver_3.3/scylla-cql.3.3.json
+++ b/grafana/build/ver_3.3/scylla-cql.3.3.json
@@ -63,7 +63,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "originalTitle": "CQL",
     "overwrite": true,
     "panels": [

--- a/grafana/build/ver_3.3/scylla-detailed.3.3.json
+++ b/grafana/build/ver_3.3/scylla-detailed.3.3.json
@@ -63,7 +63,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "overwrite": true,
     "panels": [
         {

--- a/grafana/build/ver_3.3/scylla-errors.3.3.json
+++ b/grafana/build/ver_3.3/scylla-errors.3.3.json
@@ -63,7 +63,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "overwrite": true,
     "panels": [
         {

--- a/grafana/build/ver_3.3/scylla-io.3.3.json
+++ b/grafana/build/ver_3.3/scylla-io.3.3.json
@@ -63,7 +63,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "overwrite": true,
     "panels": [
         {

--- a/grafana/build/ver_3.3/scylla-os.3.3.json
+++ b/grafana/build/ver_3.3/scylla-os.3.3.json
@@ -63,7 +63,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "overwrite": true,
     "panels": [
         {

--- a/grafana/build/ver_3.3/scylla-overview.3.3.json
+++ b/grafana/build/ver_3.3/scylla-overview.3.3.json
@@ -63,7 +63,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "originalTitle": "Scylla Cluster Metrics",
     "overwrite": true,
     "panels": [

--- a/grafana/build/ver_4.0/alternator.4.0.json
+++ b/grafana/build/ver_4.0/alternator.4.0.json
@@ -63,7 +63,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "originalTitle": "Scylla Cluster Metrics",
     "overwrite": true,
     "panels": [

--- a/grafana/build/ver_4.0/scylla-cpu.4.0.json
+++ b/grafana/build/ver_4.0/scylla-cpu.4.0.json
@@ -63,7 +63,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "overwrite": true,
     "panels": [
         {

--- a/grafana/build/ver_4.0/scylla-cql.4.0.json
+++ b/grafana/build/ver_4.0/scylla-cql.4.0.json
@@ -63,7 +63,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "originalTitle": "CQL",
     "overwrite": true,
     "panels": [

--- a/grafana/build/ver_4.0/scylla-detailed.4.0.json
+++ b/grafana/build/ver_4.0/scylla-detailed.4.0.json
@@ -63,7 +63,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "overwrite": true,
     "panels": [
         {

--- a/grafana/build/ver_4.0/scylla-errors.4.0.json
+++ b/grafana/build/ver_4.0/scylla-errors.4.0.json
@@ -63,7 +63,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "overwrite": true,
     "panels": [
         {

--- a/grafana/build/ver_4.0/scylla-io.4.0.json
+++ b/grafana/build/ver_4.0/scylla-io.4.0.json
@@ -63,7 +63,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "overwrite": true,
     "panels": [
         {

--- a/grafana/build/ver_4.0/scylla-os.4.0.json
+++ b/grafana/build/ver_4.0/scylla-os.4.0.json
@@ -63,7 +63,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "overwrite": true,
     "panels": [
         {

--- a/grafana/build/ver_4.0/scylla-overview.4.0.json
+++ b/grafana/build/ver_4.0/scylla-overview.4.0.json
@@ -63,7 +63,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "originalTitle": "Scylla Cluster Metrics",
     "overwrite": true,
     "panels": [

--- a/grafana/build/ver_master/alternator.master.json
+++ b/grafana/build/ver_master/alternator.master.json
@@ -63,7 +63,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "originalTitle": "Scylla Cluster Metrics",
     "overwrite": true,
     "panels": [

--- a/grafana/build/ver_master/scylla-cpu.master.json
+++ b/grafana/build/ver_master/scylla-cpu.master.json
@@ -63,7 +63,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "overwrite": true,
     "panels": [
         {

--- a/grafana/build/ver_master/scylla-cql.master.json
+++ b/grafana/build/ver_master/scylla-cql.master.json
@@ -63,7 +63,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "originalTitle": "CQL",
     "overwrite": true,
     "panels": [

--- a/grafana/build/ver_master/scylla-detailed.master.json
+++ b/grafana/build/ver_master/scylla-detailed.master.json
@@ -63,7 +63,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "overwrite": true,
     "panels": [
         {

--- a/grafana/build/ver_master/scylla-errors.master.json
+++ b/grafana/build/ver_master/scylla-errors.master.json
@@ -63,7 +63,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "overwrite": true,
     "panels": [
         {

--- a/grafana/build/ver_master/scylla-io.master.json
+++ b/grafana/build/ver_master/scylla-io.master.json
@@ -63,7 +63,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "overwrite": true,
     "panels": [
         {

--- a/grafana/build/ver_master/scylla-os.master.json
+++ b/grafana/build/ver_master/scylla-os.master.json
@@ -63,7 +63,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "overwrite": true,
     "panels": [
         {

--- a/grafana/build/ver_master/scylla-overview.master.json
+++ b/grafana/build/ver_master/scylla-overview.master.json
@@ -63,7 +63,16 @@
     "graphTooltip": 1,
     "hideControls": true,
     "id": null,
-    "links": [],
+    "links": [
+        {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [],
+            "type": "dashboards"
+        }
+    ],
     "originalTitle": "Scylla Cluster Metrics",
     "overwrite": true,
     "panels": [

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -720,7 +720,16 @@
 		"refresh": "30s",
 		"schemaVersion": 16,
 		"version": 0,
-		"links": [],
+		"links": [
+            {
+              "icon": "external link",
+              "asDropdown": true,
+              "includeVars": true,
+              "keepTime": true,
+              "tags": [],
+              "type": "dashboards"
+            }
+          ],
 		"gnetId": null
 	},
 	"plain_text": {


### PR DESCRIPTION
This patch series adds a dropdown dashboards links to all the dashboards.
Using the link has the advantage of keeping all the parameters value (e.g. specific node or dc) and the current time.

![image](https://user-images.githubusercontent.com/2118079/82865419-582f5e00-9f2f-11ea-9022-825eed769285.png)

Fixes #946