### PR TITLE
Manager gauge progress should use percent

### DIFF
--- a/grafana/build/manager_2.1/scylla-manager.2.1.json
+++ b/grafana/build/manager_2.1/scylla-manager.2.1.json
@@ -440,7 +440,7 @@
                 }
             ],
             "thresholds": "",
-            "title": "Active Repair Tasks",
+            "title": "Active Repair",
             "transparent": true,
             "type": "singlestat",
             "valueFontSize": "150%",
@@ -527,7 +527,7 @@
                 }
             ],
             "thresholds": "",
-            "title": "Active Backup Tasks",
+            "title": "Active Backup",
             "transparent": true,
             "type": "singlestat",
             "valueFontSize": "150%",
@@ -542,25 +542,8 @@
         },
         {
             "cacheTimeout": null,
-            "class": "single_stat_panel",
-            "colorBackground": false,
-            "colorValue": false,
-            "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-            ],
+            "class": "gauge_percent_panel",
             "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": true,
-                "thresholdLabels": false,
-                "thresholdMarkers": false
-            },
             "gridPos": {
                 "h": 6,
                 "w": 2,
@@ -568,43 +551,49 @@
                 "y": 4
             },
             "id": 7,
-            "interval": null,
-            "isNew": true,
             "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
+            "options": {
+                "fieldOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "defaults": {
+                        "mappings": [
+                            {
+                                "id": 0,
+                                "op": "=",
+                                "text": "N/A",
+                                "type": 1,
+                                "value": "null"
+                            }
+                        ],
+                        "max": 100,
+                        "min": 0,
+                        "nullValueMode": "connected",
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "rgba(50, 172, 45, 0.97)",
+                                    "value": 0
+                                }
+                            ]
+                        },
+                        "unit": "percent"
+                    },
+                    "overrides": [],
+                    "values": false
                 },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "options": {},
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
+                "orientation": "horizontal",
+                "showThresholdLabels": false,
+                "showThresholdMarkers": false
             },
-            "tableColumn": "",
+            "pluginVersion": "6.7.3",
+            "span": 1,
             "targets": [
                 {
                     "expr": "sum(avg(scylla_manager_repair_progress{cluster=~\"[[cluster]]\", instance=~\"$instance\", keyspace=~\"$keyspace\"}) by (task) * sum(scylla_manager_task_active_count{cluster=~\"[[cluster]]\", type=\"repair\"}) by (task))",
@@ -613,41 +602,14 @@
                     "refId": "A"
                 }
             ],
-            "thresholds": "0,0",
-            "title": "Repair progress",
+            "title": "Repair",
             "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
+            "type": "gauge"
         },
         {
             "cacheTimeout": null,
-            "class": "single_stat_panel",
-            "colorBackground": false,
-            "colorValue": false,
-            "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-            ],
+            "class": "gauge_percent_panel",
             "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": true,
-                "thresholdLabels": false,
-                "thresholdMarkers": false
-            },
             "gridPos": {
                 "h": 6,
                 "w": 2,
@@ -655,43 +617,49 @@
                 "y": 4
             },
             "id": 8,
-            "interval": null,
-            "isNew": true,
             "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
+            "options": {
+                "fieldOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "defaults": {
+                        "mappings": [
+                            {
+                                "id": 0,
+                                "op": "=",
+                                "text": "N/A",
+                                "type": 1,
+                                "value": "null"
+                            }
+                        ],
+                        "max": 100,
+                        "min": 0,
+                        "nullValueMode": "connected",
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "rgba(50, 172, 45, 0.97)",
+                                    "value": 0
+                                }
+                            ]
+                        },
+                        "unit": "percent"
+                    },
+                    "overrides": [],
+                    "values": false
                 },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "options": {},
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
+                "orientation": "horizontal",
+                "showThresholdLabels": false,
+                "showThresholdMarkers": false
             },
-            "tableColumn": "",
+            "pluginVersion": "6.7.3",
+            "span": 1,
             "targets": [
                 {
                     "expr": "sum(avg(scylla_manager_backup_percent_progress{cluster=~\"[[cluster]]\", instance=~\"$instance\", keyspace=~\"$keyspace\"}) by (task) * sum(scylla_manager_task_active_count{cluster=~\"[[cluster]]\", type=\"backup\"}) by (task))",
@@ -700,19 +668,9 @@
                     "refId": "A"
                 }
             ],
-            "thresholds": "0,0",
-            "title": "Backup progress",
+            "title": "Backup",
             "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
+            "type": "gauge"
         },
         {
             "class": "text_panel",

--- a/grafana/build/manager_master/scylla-manager.master.json
+++ b/grafana/build/manager_master/scylla-manager.master.json
@@ -440,7 +440,7 @@
                 }
             ],
             "thresholds": "",
-            "title": "Active Repair Tasks",
+            "title": "Active Repair",
             "transparent": true,
             "type": "singlestat",
             "valueFontSize": "150%",
@@ -527,7 +527,7 @@
                 }
             ],
             "thresholds": "",
-            "title": "Active Backup Tasks",
+            "title": "Active Backup",
             "transparent": true,
             "type": "singlestat",
             "valueFontSize": "150%",
@@ -542,25 +542,8 @@
         },
         {
             "cacheTimeout": null,
-            "class": "single_stat_panel",
-            "colorBackground": false,
-            "colorValue": false,
-            "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-            ],
+            "class": "gauge_percent_panel",
             "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": true,
-                "thresholdLabels": false,
-                "thresholdMarkers": false
-            },
             "gridPos": {
                 "h": 6,
                 "w": 2,
@@ -568,43 +551,49 @@
                 "y": 4
             },
             "id": 7,
-            "interval": null,
-            "isNew": true,
             "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
+            "options": {
+                "fieldOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "defaults": {
+                        "mappings": [
+                            {
+                                "id": 0,
+                                "op": "=",
+                                "text": "N/A",
+                                "type": 1,
+                                "value": "null"
+                            }
+                        ],
+                        "max": 100,
+                        "min": 0,
+                        "nullValueMode": "connected",
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "rgba(50, 172, 45, 0.97)",
+                                    "value": 0
+                                }
+                            ]
+                        },
+                        "unit": "percent"
+                    },
+                    "overrides": [],
+                    "values": false
                 },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "options": {},
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
+                "orientation": "horizontal",
+                "showThresholdLabels": false,
+                "showThresholdMarkers": false
             },
-            "tableColumn": "",
+            "pluginVersion": "6.7.3",
+            "span": 1,
             "targets": [
                 {
                     "expr": "sum(avg(scylla_manager_repair_progress{cluster=~\"[[cluster]]\", instance=~\"$instance\", keyspace=~\"$keyspace\"}) by (task) * sum(scylla_manager_task_active_count{cluster=~\"[[cluster]]\", type=\"repair\"}) by (task))",
@@ -613,41 +602,14 @@
                     "refId": "A"
                 }
             ],
-            "thresholds": "0,0",
-            "title": "Repair progress",
+            "title": "Repair",
             "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
+            "type": "gauge"
         },
         {
             "cacheTimeout": null,
-            "class": "single_stat_panel",
-            "colorBackground": false,
-            "colorValue": false,
-            "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-            ],
+            "class": "gauge_percent_panel",
             "datasource": "prometheus",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": true,
-                "thresholdLabels": false,
-                "thresholdMarkers": false
-            },
             "gridPos": {
                 "h": 6,
                 "w": 2,
@@ -655,43 +617,49 @@
                 "y": 4
             },
             "id": 8,
-            "interval": null,
-            "isNew": true,
             "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                    "name": "value to text",
-                    "value": 1
+            "options": {
+                "fieldOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "defaults": {
+                        "mappings": [
+                            {
+                                "id": 0,
+                                "op": "=",
+                                "text": "N/A",
+                                "type": 1,
+                                "value": "null"
+                            }
+                        ],
+                        "max": 100,
+                        "min": 0,
+                        "nullValueMode": "connected",
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "rgba(50, 172, 45, 0.97)",
+                                    "value": 0
+                                }
+                            ]
+                        },
+                        "unit": "percent"
+                    },
+                    "overrides": [],
+                    "values": false
                 },
-                {
-                    "name": "range to text",
-                    "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "options": {},
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                    "from": "null",
-                    "text": "N/A",
-                    "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
+                "orientation": "horizontal",
+                "showThresholdLabels": false,
+                "showThresholdMarkers": false
             },
-            "tableColumn": "",
+            "pluginVersion": "6.7.3",
+            "span": 1,
             "targets": [
                 {
                     "expr": "sum(avg(scylla_manager_backup_percent_progress{cluster=~\"[[cluster]]\", instance=~\"$instance\", keyspace=~\"$keyspace\"}) by (task) * sum(scylla_manager_task_active_count{cluster=~\"[[cluster]]\", type=\"backup\"}) by (task))",
@@ -700,19 +668,9 @@
                     "refId": "A"
                 }
             ],
-            "thresholds": "0,0",
-            "title": "Backup progress",
+            "title": "Backup",
             "transparent": true,
-            "type": "singlestat",
-            "valueFontSize": "150%",
-            "valueMaps": [
-                {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null"
-                }
-            ],
-            "valueName": "current"
+            "type": "gauge"
         },
         {
             "class": "text_panel",

--- a/grafana/scylla-manager.2.1.template.json
+++ b/grafana/scylla-manager.2.1.template.json
@@ -73,7 +73,7 @@
                                 "step": 40
                             }
                         ],
-                        "title": "Active Repair Tasks"
+                        "title": "Active Repair"
                     },
                     {
                         "class": "single_stat_panel",
@@ -85,19 +85,11 @@
                                 "step": 40
                             }
                         ],
-                        "title": "Active Backup Tasks"
+                        "title": "Active Backup"
                     },
                     {
-                        "class": "single_stat_panel",
+                        "class": "gauge_percent_panel",
                         "span": 1,
-                        "thresholds": "0,0",
-                        "gauge": {
-                            "maxValue": 100,
-                            "minValue": 0,
-                            "show": true,
-                            "thresholdLabels": false,
-                            "thresholdMarkers": false
-                          },
                          "targets": [
                             {
                               "expr": "sum(avg(scylla_manager_repair_progress{cluster=~\"[[cluster]]\", instance=~\"$instance\", keyspace=~\"$keyspace\"}) by (task) * sum(scylla_manager_task_active_count{cluster=~\"[[cluster]]\", type=\"repair\"}) by (task))",
@@ -106,19 +98,11 @@
                               "refId": "A"
                             }
                           ],
-                          "title": "Repair progress"
+                          "title": "Repair"
                     },
                     {
-                        "class": "single_stat_panel",
+                        "class": "gauge_percent_panel",
                         "span": 1,
-                        "thresholds": "0,0",
-                        "gauge": {
-                            "maxValue": 100,
-                            "minValue": 0,
-                            "show": true,
-                            "thresholdLabels": false,
-                            "thresholdMarkers": false
-                          },
                          "targets": [
                             {
                               "expr": "sum(avg(scylla_manager_backup_percent_progress{cluster=~\"[[cluster]]\", instance=~\"$instance\", keyspace=~\"$keyspace\"}) by (task) * sum(scylla_manager_task_active_count{cluster=~\"[[cluster]]\", type=\"backup\"}) by (task))",
@@ -127,7 +111,7 @@
                               "refId": "A"
                             }
                           ],
-                          "title": "Backup progress"
+                          "title": "Backup"
                     },
                     {
                         "class": "text_panel",

--- a/grafana/scylla-manager.master.template.json
+++ b/grafana/scylla-manager.master.template.json
@@ -73,7 +73,7 @@
                                 "step": 40
                             }
                         ],
-                        "title": "Active Repair Tasks"
+                        "title": "Active Repair"
                     },
                     {
                         "class": "single_stat_panel",
@@ -85,19 +85,11 @@
                                 "step": 40
                             }
                         ],
-                        "title": "Active Backup Tasks"
+                        "title": "Active Backup"
                     },
                     {
-                        "class": "single_stat_panel",
+                        "class": "gauge_percent_panel",
                         "span": 1,
-                        "thresholds": "0,0",
-                        "gauge": {
-                            "maxValue": 100,
-                            "minValue": 0,
-                            "show": true,
-                            "thresholdLabels": false,
-                            "thresholdMarkers": false
-                          },
                          "targets": [
                             {
                               "expr": "sum(avg(scylla_manager_repair_progress{cluster=~\"[[cluster]]\", instance=~\"$instance\", keyspace=~\"$keyspace\"}) by (task) * sum(scylla_manager_task_active_count{cluster=~\"[[cluster]]\", type=\"repair\"}) by (task))",
@@ -106,19 +98,11 @@
                               "refId": "A"
                             }
                           ],
-                          "title": "Repair progress"
+                          "title": "Repair"
                     },
                     {
-                        "class": "single_stat_panel",
+                        "class": "gauge_percent_panel",
                         "span": 1,
-                        "thresholds": "0,0",
-                        "gauge": {
-                            "maxValue": 100,
-                            "minValue": 0,
-                            "show": true,
-                            "thresholdLabels": false,
-                            "thresholdMarkers": false
-                          },
                          "targets": [
                             {
                               "expr": "sum(avg(scylla_manager_backup_percent_progress{cluster=~\"[[cluster]]\", instance=~\"$instance\", keyspace=~\"$keyspace\"}) by (task) * sum(scylla_manager_task_active_count{cluster=~\"[[cluster]]\", type=\"backup\"}) by (task))",
@@ -127,7 +111,7 @@
                               "refId": "A"
                             }
                           ],
-                          "title": "Backup progress"
+                          "title": "Backup"
                     },
                     {
                         "class": "text_panel",

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -133,6 +133,55 @@
             "rgba(50, 172, 45, 0.97)"
         ]
 	},
+	"gauge_percent_panel": {
+      "datasource": "prometheus",
+      "cacheTimeout": null,
+      "id": "auto",
+      "links": [],
+      "transparent": true,
+      "type": "gauge",
+      "options": {
+        "showThresholdMarkers": false,
+        "showThresholdLabels": false,
+        "fieldOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "defaults": {
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "rgba(50, 172, 45, 0.97)",
+                  "value": 0
+                }
+              ]
+            },
+            "mappings": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null",
+                "id": 0,
+                "type": 1
+              }
+            ],
+            "unit": "percent",
+            "nullValueMode": "connected",
+            "min": 0,
+            "max": 100
+          },
+          "overrides": []
+        },
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "6.7.3"
+    },
 	"gauge_errors_panel": {
         "span": 1,
         "id": "auto",


### PR DESCRIPTION
This patch switches the gauge to use percent and shorten the panels headers so it will be clearer
![image](https://user-images.githubusercontent.com/2118079/84992637-d78c0800-b150-11ea-9201-5d4c46a53441.png)


Fixes #968