### PR TITLE
Bug fix: Dashboard Overview, Stat Joining

### DIFF
--- a/grafana/alternator.3.2.template.json
+++ b/grafana/alternator.3.2.template.json
@@ -43,7 +43,7 @@
                         "description": "Number of nodes that reported their status as Starting or Joining",
                         "targets": [
                             {
-                                "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
+                                "expr": "count(scylla_node_operation_mode<=2)OR vector(0)",
                                 "intervalFactor": 1,
                                 "legendFormat": "Joining",
                                 "refId": "A",

--- a/grafana/alternator.3.3.template.json
+++ b/grafana/alternator.3.3.template.json
@@ -43,7 +43,7 @@
                         "description": "Number of nodes that reported their status as Starting or Joining",
                         "targets": [
                             {
-                                "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
+                                "expr": "count(scylla_node_operation_mode<=2)OR vector(0)",
                                 "intervalFactor": 1,
                                 "legendFormat": "Joining",
                                 "refId": "A",

--- a/grafana/alternator.4.0.template.json
+++ b/grafana/alternator.4.0.template.json
@@ -43,7 +43,7 @@
                         "description": "Number of nodes that reported their status as Starting or Joining",
                         "targets": [
                             {
-                                "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
+                                "expr": "count(scylla_node_operation_mode<=2)OR vector(0)",
                                 "intervalFactor": 1,
                                 "legendFormat": "Joining",
                                 "refId": "A",

--- a/grafana/alternator.4.1.template.json
+++ b/grafana/alternator.4.1.template.json
@@ -43,7 +43,7 @@
                         "description": "Number of nodes that reported their status as Starting or Joining",
                         "targets": [
                             {
-                                "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
+                                "expr": "count(scylla_node_operation_mode<=2)OR vector(0)",
                                 "intervalFactor": 1,
                                 "legendFormat": "Joining",
                                 "refId": "A",

--- a/grafana/alternator.master.template.json
+++ b/grafana/alternator.master.template.json
@@ -43,7 +43,7 @@
                         "description": "Number of nodes that reported their status as Starting or Joining",
                         "targets": [
                             {
-                                "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
+                                "expr": "count(scylla_node_operation_mode<=2)OR vector(0)",
                                 "intervalFactor": 1,
                                 "legendFormat": "Joining",
                                 "refId": "A",

--- a/grafana/build/ver_2019.1/scylla-overview.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-overview.2019.1.json
@@ -312,7 +312,7 @@
             "tableColumn": "",
             "targets": [
                 {
-                    "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
+                    "expr": "count(scylla_node_operation_mode<=2)OR vector(0)",
                     "intervalFactor": 1,
                     "legendFormat": "Joining",
                     "refId": "A",

--- a/grafana/build/ver_3.2/alternator.3.2.json
+++ b/grafana/build/ver_3.2/alternator.3.2.json
@@ -312,7 +312,7 @@
             "tableColumn": "",
             "targets": [
                 {
-                    "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
+                    "expr": "count(scylla_node_operation_mode<=2)OR vector(0)",
                     "intervalFactor": 1,
                     "legendFormat": "Joining",
                     "refId": "A",

--- a/grafana/build/ver_3.2/scylla-overview.3.2.json
+++ b/grafana/build/ver_3.2/scylla-overview.3.2.json
@@ -312,7 +312,7 @@
             "tableColumn": "",
             "targets": [
                 {
-                    "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
+                    "expr": "count(scylla_node_operation_mode<=2)OR vector(0)",
                     "intervalFactor": 1,
                     "legendFormat": "Joining",
                     "refId": "A",

--- a/grafana/build/ver_3.3/alternator.3.3.json
+++ b/grafana/build/ver_3.3/alternator.3.3.json
@@ -342,7 +342,7 @@
             "tableColumn": "",
             "targets": [
                 {
-                    "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
+                    "expr": "count(scylla_node_operation_mode<=2)OR vector(0)",
                     "intervalFactor": 1,
                     "legendFormat": "Joining",
                     "refId": "A",

--- a/grafana/build/ver_3.3/scylla-overview.3.3.json
+++ b/grafana/build/ver_3.3/scylla-overview.3.3.json
@@ -342,7 +342,7 @@
             "tableColumn": "",
             "targets": [
                 {
-                    "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
+                    "expr": "count(scylla_node_operation_mode<=2)OR vector(0)",
                     "intervalFactor": 1,
                     "legendFormat": "Joining",
                     "refId": "A",

--- a/grafana/build/ver_4.0/alternator.4.0.json
+++ b/grafana/build/ver_4.0/alternator.4.0.json
@@ -342,7 +342,7 @@
             "tableColumn": "",
             "targets": [
                 {
-                    "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
+                    "expr": "count(scylla_node_operation_mode<=2)OR vector(0)",
                     "intervalFactor": 1,
                     "legendFormat": "Joining",
                     "refId": "A",

--- a/grafana/build/ver_4.0/scylla-overview.4.0.json
+++ b/grafana/build/ver_4.0/scylla-overview.4.0.json
@@ -342,7 +342,7 @@
             "tableColumn": "",
             "targets": [
                 {
-                    "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
+                    "expr": "count(scylla_node_operation_mode<=2)OR vector(0)",
                     "intervalFactor": 1,
                     "legendFormat": "Joining",
                     "refId": "A",

--- a/grafana/build/ver_4.1/alternator.4.1.json
+++ b/grafana/build/ver_4.1/alternator.4.1.json
@@ -342,7 +342,7 @@
             "tableColumn": "",
             "targets": [
                 {
-                    "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
+                    "expr": "count(scylla_node_operation_mode<=2)OR vector(0)",
                     "intervalFactor": 1,
                     "legendFormat": "Joining",
                     "refId": "A",

--- a/grafana/build/ver_4.1/scylla-overview.4.1.json
+++ b/grafana/build/ver_4.1/scylla-overview.4.1.json
@@ -342,7 +342,7 @@
             "tableColumn": "",
             "targets": [
                 {
-                    "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
+                    "expr": "count(scylla_node_operation_mode<=2)OR vector(0)",
                     "intervalFactor": 1,
                     "legendFormat": "Joining",
                     "refId": "A",

--- a/grafana/build/ver_master/alternator.master.json
+++ b/grafana/build/ver_master/alternator.master.json
@@ -342,7 +342,7 @@
             "tableColumn": "",
             "targets": [
                 {
-                    "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
+                    "expr": "count(scylla_node_operation_mode<=2)OR vector(0)",
                     "intervalFactor": 1,
                     "legendFormat": "Joining",
                     "refId": "A",

--- a/grafana/build/ver_master/scylla-overview.master.json
+++ b/grafana/build/ver_master/scylla-overview.master.json
@@ -342,7 +342,7 @@
             "tableColumn": "",
             "targets": [
                 {
-                    "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
+                    "expr": "count(scylla_node_operation_mode<=2)OR vector(0)",
                     "intervalFactor": 1,
                     "legendFormat": "Joining",
                     "refId": "A",

--- a/grafana/scylla-overview.2019.1.template.json
+++ b/grafana/scylla-overview.2019.1.template.json
@@ -43,7 +43,7 @@
                         "description": "Number of nodes that reported their status as Starting or Joining",
                         "targets": [
                             {
-                                "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
+                                "expr": "count(scylla_node_operation_mode<=2)OR vector(0)",
                                 "intervalFactor": 1,
                                 "legendFormat": "Joining",
                                 "refId": "A",

--- a/grafana/scylla-overview.3.1.template.json
+++ b/grafana/scylla-overview.3.1.template.json
@@ -43,7 +43,7 @@
                         "description": "Number of nodes that reported their status as Starting or Joining",
                         "targets": [
                             {
-                                "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
+                                "expr": "count(scylla_node_operation_mode<=2)OR vector(0)",
                                 "intervalFactor": 1,
                                 "legendFormat": "Joining",
                                 "refId": "A",

--- a/grafana/scylla-overview.3.2.template.json
+++ b/grafana/scylla-overview.3.2.template.json
@@ -43,7 +43,7 @@
                         "description": "Number of nodes that reported their status as Starting or Joining",
                         "targets": [
                             {
-                                "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
+                                "expr": "count(scylla_node_operation_mode<=2)OR vector(0)",
                                 "intervalFactor": 1,
                                 "legendFormat": "Joining",
                                 "refId": "A",

--- a/grafana/scylla-overview.3.3.template.json
+++ b/grafana/scylla-overview.3.3.template.json
@@ -43,7 +43,7 @@
                         "description": "Number of nodes that reported their status as Starting or Joining",
                         "targets": [
                             {
-                                "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
+                                "expr": "count(scylla_node_operation_mode<=2)OR vector(0)",
                                 "intervalFactor": 1,
                                 "legendFormat": "Joining",
                                 "refId": "A",

--- a/grafana/scylla-overview.4.0.template.json
+++ b/grafana/scylla-overview.4.0.template.json
@@ -43,7 +43,7 @@
                         "description": "Number of nodes that reported their status as Starting or Joining",
                         "targets": [
                             {
-                                "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
+                                "expr": "count(scylla_node_operation_mode<=2)OR vector(0)",
                                 "intervalFactor": 1,
                                 "legendFormat": "Joining",
                                 "refId": "A",

--- a/grafana/scylla-overview.4.1.template.json
+++ b/grafana/scylla-overview.4.1.template.json
@@ -43,7 +43,7 @@
                         "description": "Number of nodes that reported their status as Starting or Joining",
                         "targets": [
                             {
-                                "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
+                                "expr": "count(scylla_node_operation_mode<=2)OR vector(0)",
                                 "intervalFactor": 1,
                                 "legendFormat": "Joining",
                                 "refId": "A",

--- a/grafana/scylla-overview.master.template.json
+++ b/grafana/scylla-overview.master.template.json
@@ -43,7 +43,7 @@
                         "description": "Number of nodes that reported their status as Starting or Joining",
                         "targets": [
                             {
-                                "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
+                                "expr": "count(scylla_node_operation_mode<=2)OR vector(0)",
                                 "intervalFactor": 1,
                                 "legendFormat": "Joining",
                                 "refId": "A",


### PR DESCRIPTION
Problem :
does not show new pod joining

How to simulate:
1. Deploy using scylla operator for 1 pod
2. Add 1 pod

Root cause:
Arithmetic addition in prometheus expr is not working if one condition is empty. Only work when both condition return value.

Fix:

Original code
>count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)

Fixing code
>count(scylla_node_operation_mode<=2)OR vector(0)

Question:
1. Is this fix is acceptable? If yes, I will update the other related dashboard templates
2. Any script to run after updating the templates? I ran 'generate-dashboard.sh', it updated the files in grafana/build