### PR TITLE
Podman support

### DIFF
--- a/start-alertmanager.sh
+++ b/start-alertmanager.sh
@@ -5,6 +5,7 @@ if [ "$1" = "-e" ]; then
 else
 . versions.sh
 fi
+is_podman="$(docker --help | grep -o podman)"
 VERSIONS=$DEFAULT_VERSION
 RULE_FILE=$PWD/prometheus/rule_config.yml
 ALERT_MANAGER_VERSION="v0.20.0"
@@ -85,4 +86,8 @@ then
 fi
 
 AM_ADDRESS="$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' $ALERTMANAGER_NAME):9093"
+if [ ! -z "$is_podman" ] && [ "$AM_ADDRESS" = ":9093" ]; then
+    HOST_IP=`hostname -I | awk '{print $1}'`
+    AM_ADDRESS="$HOST_IP:9093"
+fi
 echo $AM_ADDRESS

--- a/start-all.sh
+++ b/start-all.sh
@@ -26,6 +26,14 @@ else
     GROUPID=`id -g`
     USER_PERMISSIONS="-u $UID:$GROUPID"
 fi
+
+group_args=()
+is_podman="$(docker --help | grep -o podman)"
+if [ ! -z "$is_podman" ]; then
+    group_args+=(--userns=keep-id)
+fi
+
+
 PROMETHEUS_RULES="$PWD/prometheus/prometheus.rules.yml"
 VERSIONS=$DEFAULT_VERSION
 usage="$(basename "$0") [-h] [--version] [-e] [-d Prometheus data-dir] [-L resolve the servers from the manger running on the given address] [-G path to grafana data-dir] [-s scylla-target-file] [-n node-target-file] [-l] [-v comma separated versions] [-j additional dashboard to load to Grafana, multiple params are supported] [-c grafana environment variable, multiple params are supported] [-b Prometheus command line options] [-g grafana port ] [ -p prometheus port ] [-a admin password] [-m alertmanager port] [ -M scylla-manager version ] [-D encapsulate docker param] [-r alert-manager-config] [-R prometheus-alert-file] [-N manager target file] [-A bind-to-ip-address] [-C alertmanager commands] [-Q Grafana anonymous role (Admin/Editor/Viewer)] [-S start with a system specific dashboard set] -- starts Grafana and Prometheus Docker instances"
@@ -223,6 +231,7 @@ fi
 
 docker run -d $DOCKER_PARAM $USER_PERMISSIONS \
      $DATA_DIR \
+     "${group_args[@]}" \
      -v $PWD/prometheus/build/prometheus.yml:/etc/prometheus/prometheus.yml:Z \
      -v $PROMETHEUS_RULES:/etc/prometheus/prometheus.rules.yml:Z \
      $SCYLLA_TARGET_FILE \

--- a/start-all.sh
+++ b/start-all.sh
@@ -275,6 +275,10 @@ fi
 # Can't use localhost here, because the monitoring may be running remotely.
 # Also note that the port to which we need to connect is 9090, regardless of which port we bind to at localhost.
 DB_ADDRESS="$(docker inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $PROMETHEUS_NAME):9090"
+if [ ! -z "$is_podman" ] && [ "$DB_ADDRESS" = ":9090" ]; then
+    HOST_IP=`hostname -I | awk '{print $1}'`
+    DB_ADDRESS="$HOST_IP:9090"
+fi
 
 for val in "${GRAFANA_ENV_ARRAY[@]}"; do
         GRAFANA_ENV_COMMAND="$GRAFANA_ENV_COMMAND -c $val"

--- a/start-grafana.sh
+++ b/start-grafana.sh
@@ -90,6 +90,12 @@ if [ $? -eq 0 ]; then
     exit 1
 fi
 
+group_args=()
+is_podman="$(docker --help | grep -o podman)"
+if [ ! -z "$is_podman" ]; then
+    group_args+=(--userns=keep-id)
+fi
+
 if [ "`id -u`" -ne 0 ]; then
     GROUPID=`id -g`
     USER_PERMISSIONS="-u $UID:$GROUPID"
@@ -127,6 +133,7 @@ docker run -d $DOCKER_PARAM -i $USER_PERMISSIONS $PORT_MAPPING \
      -e "GF_AUTH_ANONYMOUS_ENABLED=$GRAFANA_AUTH_ANONYMOUS" \
      -e "GF_AUTH_ANONYMOUS_ORG_ROLE=$ANONYMOUS_ROLE" \
      -e "GF_PANELS_DISABLE_SANITIZE_HTML=true" \
+     "${group_args[@]}" \
      -v $PWD/grafana/build:/var/lib/grafana/dashboards:z \
      -v $PWD/grafana/plugins:/var/lib/grafana/plugins:z \
      -v $PWD/grafana/provisioning:/var/lib/grafana/provisioning:z $EXTERNAL_VOLUME \


### PR DESCRIPTION
podman should be a docker drop-in replacement, so technically, it should be enough to alias podman to docker
and the monitoring stack should work.

This is almost true.
We do not use root users inside or outside the containers, so for the monitoring solution to work fine it should use the same user id and group.

In docker, it's enough to add the running user group to Docker and change the running user roll, in podman it's different, you need to add the groups to the podman command and tell it to keep the user id.

There is also a bug in podman https://github.com/containers/podman/issues/7087 that prevents rootless container to communicate using a pod.
As a workaround, the containers will use a host address

Fixes #994