### PR TITLE
prometheus.yml.template: Look for manager metrics in both 5090 and 56090

### DIFF
--- a/prometheus/prometheus.yml.template
+++ b/prometheus/prometheus.yml.template
@@ -101,6 +101,25 @@ scrape_configs:
       target_label: __address__
       replacement: '${1}:56090'
 
+- job_name: manager_agent1
+  honor_labels: false
+  file_sd_configs:
+    - files:
+      - /etc/scylla.d/prometheus/node_exporter_servers.yml
+  relabel_configs:
+    - source_labels: [__address__]
+      regex:  '(.*):\d+'
+      target_label: instance
+      replacement: '${1}'
+    - source_labels: [__address__]
+      regex:  '([^:]+)'
+      target_label: instance
+      replacement: '${1}'
+    - source_labels: [instance]
+      regex:  '(.*)'
+      target_label: __address__
+      replacement: '${1}:5090'
+
 - job_name: scylla_manager
   honor_labels: false
   file_sd_configs:
@@ -110,6 +129,27 @@ scrape_configs:
     - source_labels: [host]
       target_label: instance
 
+- job_name: scylla_manager1
+  honor_labels: false
+  file_sd_configs:
+    - files:
+      - /etc/scylla.d/prometheus/scylla_manager_servers.yml
+  relabel_configs:
+    - source_labels: [__address__]
+      regex:  '(.*):\d+'
+      target_label: instance
+      replacement: '${1}'
+    - source_labels: [__address__]
+      regex:  '([^:]+)'
+      target_label: instance
+      replacement: '${1}'
+    - source_labels: [instance]
+      regex:  '(.*)'
+      target_label: __address__
+      replacement: '${1}:5090'
+  metric_relabel_configs:
+    - source_labels: [host]
+      target_label: instance
 - job_name: 'prometheus'
   # Override the global default and scrape targets from this job every 5 seconds.
   scrape_interval: 5s


### PR DESCRIPTION
Manager 2.2 uses 5090 port to export its and the agent metrics.
This patch change prometheus to try and read from both ports

Fixes #1010