### PR TITLE
Cql connections table

### DIFF
--- a/grafana/build/ver_2019.1/scylla-cql.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-cql.2019.1.json
@@ -47,6 +47,22 @@
     "overwrite": true,
     "panels": [
         {
+            "class": "collapsible_row_panel",
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 1,
+            "panels": [],
+            "repeat": "",
+            "title": "",
+            "type": "row"
+        },
+        {
             "class": "text_panel",
             "content": "<div id=\"amnon\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPoAAAA6CAYAAACZBESJAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAGm9JREFUeNrsXQd8VFXWP+9NTe+NEOmgSIdFiuxSIqB0krCssrCI0sKGLnVZV/qCCqx0ERdQ+ehFCKEtCAuCCAkdQkkhlPQ2yfT5znkzwWTyJslMJqDfd//8zo+ZVydz5//+55x777kADAwMDAwMDL99cC/yZjKpUtqxWUQbvUFbD982Q9OjKdE6oz1Gu4HGo6VzHPdzsabw+uU7h4tYMzEw/IqJLpUouE7NIwL1Bl0kvh1gIbQr8DzIgvyA9/EGMJnKnGPSG0CXnAYmjQY/HWfATTeR9HuL1Pknr9w9cpo1GQPDr4ToUomc79g88jWDQTcf3w7ipFJwad8SFE0agLxuKMgb1wcwGGxfAMlvKCgE3b1kKLp0DTR37oP+cboBJPx1juPXFKnzNiHpDaz5GBheAtGlEhnXsVnkqwajfgGq8WBZaBB4Rb4DyhavAaeQl1PvKgPP0yY9grxdh0FzIxEdfsP9Ik3eR1fuxu1hTcjA8AKJLpHIZJ2aRY4zmAxLkeBKIrhrh9aCK+5M6NMzIe+7g6A6+5OeVypjVcU5Y+ITjz5hTcnAUMNER5K7IMm3GnlThHuPzuD1p/7AyWSOK3iFn5gjRQd1wk3I+moHmLLzbqi0+SOQ7D+z5mRgsMHRal+Alyo7NY/aZpRyEX7Rw8Gzbw8zGWsSPAfSkEBwaf066J88C+TS8/v5+YRdepp9P5k1KQODk4lOJO/YPHKLScpH+o4bBm4d2oDJ8OJyZBIvD1A2awLa1DQPPr2gB5L9FJL9KWtWBgYnue5IchmSfIZJws33Hf9nJDnG4wajeSf+r752G1RnLoLm7gMwZOc9V3lOKgEFktO1fStw7dSm+i4+z+P1cyFr9RbQXL3zs8pQ0Dsh8Vgma1oGhmoSHUnOd2wW2dEkgbNeUX3Bc0C4OemGhNU9fgZZa78BQ1IqNG3RGP7Qoz00a9UEDKj0RqMRUpOfwMXzV+H44bPgEhoM5AkomzasXtIOHyLahymQuWyjIf/xw+0JD04OY03LwFBNovMUl7eIOi1t+Er74E+mgkmnE0iuufMAMpeshXp1Q2DuognQ+NV6Nq/x9EkGfLpwE5z+4TL49Q8H7+ERYFJrHCY69csX/XgFMv+5Ia1IqnkXVf0H1rwMDA7G6Dwv4Ts1i+ppkvDT/SeMAImPF6BUo4v+ELKWroMWLRrB+q0LICDQt9y5pOp3bj2EtNRn4O3jCX0GdgM3pRxObN4HMpkUlM2bVDyQpiJgSMC7uYLhyTNPVVJyg2d5SV+z5mVgcJDoHMfLw4Kbfa1o1jjUa2BPgZgmrRYyl2+EZvVDYeWmeSCVSsudp9XqYOc3h2F69BKI+/4H+H7vSUHx3xnYFVzlMjjx9T5wf60hSAP9hQeH/TABr1QC5+4GutOXpX7+dX56lv0ghTUxA4N5Aok9as6hmtc3cdDerUt7MBEhDUYoPH0BJJnZMHthtCjJCepiDez69gjIkNQcutoF+Sr4eOZKuHguASLfewfaNm8AGVv3AIcK7xBM+BCS8CAPq0WeQZBJp/+QNS8DgwNEFzwADgbyHm7g1uV3AslNej0UHTwBfSPDIbR2kM0T9XoD3LubDBIJb/EMiOxFsGr5FnBxVcL4Se9BQWIKqBNuAWfjYVEp142o6vjZlG+0lLpLPVq2bBjOWpiBwQGi88jQPyjQxQYklZBlz8gCyM2HLt1+V4nLz4E7ktBUpivNBFkZOXABVb1+wzCoGxYEhZeuCvG2Y0w3AeeiBEWjepTF98QtLVkTMzA4RvSW8jqh5r5vInpyGkjlUmjXoXmFJ8oVMniza1tB2cvE7hodxP98S3gIdO7SCoofZwDH8w7/QRzPgcTbE6ShQW4mg/F11sQMDPYS3US5OD5Y8WpD5LhRcJX1KY8hJDSw0lPd3Fxg/rLJMHrCUPDx8QQjnsvhP8rEU1cbZxnDrk99LAyCcRgUq6PrL/UVbtKxJr60Pn36yNEzaYc2FW0r2lm002ixaCvRInbt2uVRE/eOiYlxweu/iTYRbTPaf9FOoR1H24Q2asmSJbXtve6iRYvq47k90bqWsu50rylTpvhXdv66deukeGwLtHCra7yF1mD48OGVumn4ncnw2NZoPazOr9uvXz/emd/jhQsXAvG6ndC6lbpXz1atWrm/aBKmp6d3tvrOG3p7ezv1761yMMxzEq5T86i6RqNB1CWvqtq6e7haue+lY2wjGIuKqzVWnq7Nofcgqx0MpnjnDsft3bu3JDY2tivxAq29rcOIjxEREQVExJ07dy4fMmRIanXvHR0dXfeLL76Yji/fRfOu4ND3Z8yYoUOLXbx48d9nz54dX8VbvIn2BVq5B9Snn366xGg0zlqxYkVF51NRkbVor4nsm4S2sgqfwQftX5ZrlcYnaEvQip3YnN3R6A+yTiy1Rot/gSRvGRAQcAhfepXajPEw1EfLfxmKTuyrSySUBPiYlZPc5LAQSLz9sNKTi4vUsOTjdfDpok2Qm1uAos3hJUyCm+7h7mq+gVwG8iYNHO9Lr0H07NnTH0n+Ob48XgHJS4MIExMVFfWf7du393T0vuPGjePwgfEXJPlP+HZ8JSQvgQyt/6xZsy7guZMWLFhQlVttQfvWxr7h9BXYOnHNmjUwZsyYsTZIfnDEiBH7t2zZwvxncfwVqOpSWfjl5OQM8vT0lL4Mootl2EDq7wtGdLkfpVY8l0St1sKRg2eEgTFlYnckd6u2TaGwQAX/PRMPLrUCzN12vy6Su8TFxY21NIq9KERzaL48kkeGJCI124zm78AlqK9y6Zw5cyZ98sknFR6Iyg/oAWy2oWa1Pv/888hJkybZcmvHofUT2Z41cuTIVUjyJMbn8nj69KkXqvkgy4O5XJSGpngZRDcKPwIq85SRY9Z3JLq8bm0wenrAzm2HK3WpicxcGbecg4AgX+jeqyPcT0yBpJQn4Nq00a9R0duizXfgvPvous8YOnToNXtP/PDDD2UY987Fl3Or+dnvL1y48Mq8efMqPRDJfmHp0qUbwVy00xpRFnfXWs3D0OugmoBi8Ru58qcYpW1igoial6BNXl5eW1R1/oUS3WgywLlrO3N53iqnIpGAokNrOLTnBOTlFdpOBkgl0LBxHeSw8Tnx3d1d4P2xUaDVaGHLl/vAo1EdcO3YBkw6fTWcDAwJNDrQPXqq5ySSasc44eHhfqjm79rYnYu23aJoRIStaKqS8AtJPh/j8zgHSA4bNmygiTkVsZPm3q+zxOwRxDm0O9ZuM5K8/9y5c+0pqrnR8jdZwxtV/f2YmJjniT4MJyi0iBZ7ABDBUc23ff3113rGZ1E1h6CgoBFgroJsC05TdfueFhwl241PNbfvUfrdvAkJ7PF2V9AplTBn0jLbPiS66F26tQO9Xi+Q3MVFCcM/HAQ9UM3/Z8v3cPr8VQgQJrZoq/1HCUm9YnURfsgbTviO/NDEBgncO3jw4AB8sPwJbR3aLrThgwcPpn7GNbt3716MJP+3g/ekWHeEjX15aDNXrFhRH+83Du07tD1o0dOnT2+F+/4GQgYFNqErHoUkv2fPjWfOnKlDVV+NLxNEdg9YuXJlXyR7yfsuNlx2zQcffPAZkvwOo7RN9BNJBFojAlU9wMOj+h049gb79ANKMhYVB5cRdR8v8P3rSLi+fD2sWLIZoqcME4a6lobSRSFsr1MvFFSqYug3uDt4eLjBvh3HYMPGveDfpxsoXm8M+vQs0D9JB3n9MOAUCvvnqpOiF6tBm/hQz8klzshakmsVar3x0KFDd/r3719uhtzevXsfEukcvdmoUaNIzbviyz+I7H60atWqmIkTJ+4VO3f58uVqiUSybMmSJWuR5Cp0xR2aDohk/xGv8+W0adM+F/mNDEtLSzv98ccf34qOjh6D75uKXOJTtFjG5QpBIVlVGDwRbRaa9kUS3YjES9Amp3Wgck5g+IVcikZ1weMvkbDnq51w9/ZDmLMgutyQWLlCDoOH9hJeZyChVyzdDNu/iwP/gW+Bz4hIMOQVgOrUecjdtg+ULV4F/4/GAO/iYtckF4ua02eihR+u11Qr9enTx+fAgQNuSHaVky9dC62rjX0UGuyt6GRUYw2ZEz7HerSOltCgNDrv2rXr92DujhNT89Oo5ls3bdrEXHYbePz4cXN02xtB+WniFI6FWXnawy0hXLWIbn+gbzLlGTKzy39GCQ9undqB/4yxcD0tE97tNxH+MWsVnDhyDpIeppkD2px8OH/2CiyatwaGvDMR9sddgOBRQ8B72CAwqtXCQBlpcABIawWC9n4KFHx/EniFHZNcSM21WozPn1DugAiY5IR20YF4f2anfv36HUeyt3Xy74AaWmyY4X9Xr179b1TzF/JjxDBAhx4C9atfFRN9MPdte1q77KNHj/4MSX6b0blCzBFR82MWlbceK+Cfn58/Et33anW12XuyAYl+Sp+R/ZFoyQpUeXmT+hCydCYq84/ww6VrEDf1U+AkkjLHyEICwbVfD3AL7wwSL0+h4ITm9n3I2xUrlJ5yfaM1uPfoBOqbiTYH19gkukYL+rR0KNTk6K+lnXVK3gTtJFoTkX0dkOzn8TNewtf70W2Pwxi9uoMtPG3EbrdFkm01jfNo+9BaWG2va+N4cvUPMx5XqOaeISEh3UW49x3aTssDtJ5IUu4rEO8NqakYnUuiCS2aW/dBju66mFtNQ1Ddw98UjPbrktLMii2VgLxObeCU5kQikbLg8ElQnbmEx6SConkTCF4yQziGikwqmjayu+oMlaQyZudo0Ds454yGOX78eFavXr3+HRcX92d8K9aPLLO4uB0HDRq0GEl/H19/sXv37nWRkZGOuNCvoFlX7dCjmt+aMGHCC/1Roqrj18h/PmXKFCL6wEoOv4Rq/j8bN25kLrv9ag4BAQH7MzMzNVlZWft9fX2joWzfeiNU9e7u7u6HVSqVQ4NM7HLdjUaD6dy1nUk8x4Oe3PeqjFSlddbqhwmklTeoIyyvlL//GGQsXgNpY2ZD0Y5D0NQX+ePtBcELp4OsdojDlWQ5i6JrU59q0ItIdWLjXEabXIUnKn0jDdFWRERE3NuxY0eEk+6PT0lQvYxf5dSpU3M/++wzysInVnIodfXFMx7bxqNHjwDVnNYgtO5S22JpY8K/Sr0Gq1hd9qIUnX7KlJC7qEtJa891bgumX54CUHzlBmT8cz3IwoJB4uvzPGNOxNWiB0BxPLnxktBgkOblw3vD3hG62LZ+uQ8up6YDVHe9B87sJWCMXoT3uemsBjp69KgOVf1LVHVy0Smj3L0Kp9WOiopajWR3r0Y3268FNOyX+tb/ZmP/2rFjx25HNWdsrhiU2Kwlsv2Lktjcz8/vQU5OzmVvb+8uVkIcVVhY+A9U9Zuo6nYzxZFRN0aT0RivTU4rO/kElduldTNBlWkxRcBYe1TvN2BEj3ZQePsBeEW9AyHL50DYthUQNPevwDd4BX46ewV+PBsP33wbC96d2ghFLKoDmk1nVBWRu1+EpHdqxh3JTh5D/Ntvv90DzF1KpHLPKjktCMn+wfbt2wOqeXsKGQJf1q8TVR1WrFjxGb48IJY7GD9+/Lb169erGI8rRbRI+JcQGBh4F9320uRdZUPVRzgkzg4S3YRKnawTiM6XT8Y1rAOeA3uBEfcl3X8Ebdu/jq85cPldC5ojLqg7r5SDW3gXuJOYAvNmrBQSeN5/7CeoseNqXibjTl1rSTXRUkeOHCHC30Kb0L9/f8qQv4G2Ac3WOu60DnyUHbegOnfZ5X4h0dGNaSTay8LkyZNzkewPRHZlgHkQD0PFbnvn0NDQ16B8wLtVhNQHLN+rNWJQ1QNcqMv5RSg6Uj2BlFOflS06pVTq5wM+00dD7PdnYMyIeeDVvDEohKWSjc/Vnyq+hq5dAMGLPoKAGeOeF7KoFtGLNaC7lwIqXd7DhHvHa7zxDh48qEPCX0QbM3DgwMZgzpqKqXGIHZfFGAbECEWj3rowyvyfUnMC9WqUSdr6+Pjoc3NzabvO6ljKYlNSVFLjRDcaDcZz13ee4jkJGDLEiU7KTuWmQlZ/AoFzJoD/5FFgtM6e43m8hzvG8yEOVn0Vic/R9TdQxp3jU190K+7fvz9t8ODBS/HlfZE8SCM7LkWfXWwSzOuo6sNWrlzJKPMbQ2pqqjuqeXeRZNpBdNvTMzLExFtIyom5uH93JCnn4MwYDoNhYzp1sXG2ikTQvHUksuLVBsA7MpTVbp6T666jjHsBJ+XPO/v6NFXVZDL9MTY2drIDp1d5muqmTZuyR48efcTG7pExMTGzKiL7jBkz6uLnPIa2b9GiRT6MZr8KzIayhSVKu+2ixTRQ1e/n5+f/DOZZo6URWFRU1A3dd7u46+hoGwP+kOK1KWk9ywyFfZmwxOj6R09UoJBcdzLJIS4ujgovbO/du3cx/u21Dh06NLtv377PXasBAwYE7NmzhwpDNLA6vQjsn49OI312oA2x2k5P8oVI9oZGo3EGxs3P15ibNm0aLFu2rBO+XA7mfn2YNWvWCTxu7Ny5cy/+xolS58CBA7+3kMLWD1zRo0ePiydPnsypzo2uXLnSDsxTbmW2fUcoatKkSfzdu3crHSeBag61a9cWm6WWFxwc/B9U84oy0JSUowlV1kE5DY88AXYMi3WU6EYwmhJ0RPSaXiK5iiSnATm0WgxIpUgsvdOIHh4eTiSnutElJVLoS5/Wp0+fcUj4HyxudlNL/Cz21E62ELfK2Lhx42P876sNGzbQfX1FfmjvT5o06U9o1N13BsxVZ94C84iq0m3aes6cOUfRPpo/f/6GqsxJ/5ViBNiezVca1CNyspr3qkofIY0p6IaWVoVjqWCJ2OSVbVB5aSxKytHDPMxqey9U9Qao6rfVanWVXGWHXHfOPBT2tB5jdGECyUsnOghz0Gnoq0qbm5GQeEzvLJIfO3aMfjy7ofy4bnrqv432EVpfGyQn0GAbR0bp0Tx2Gvpo6wt2sTxcyC0cb8kDiD246XNRzbbfMw/6pYDqCogl4baA7Z4ac8N5eenQfaeknN5GrF71mo8OKzqNgqLhrdTNxvMvnekWt10DvFPddpqO+xcRklcVF3fu3Dlv6NCh9svKxo0wduzYb/Dl6ArIXhWQe0fdf2zRyReM5OTk3ui2N4XyXWpn0W2/8+zZs6qo8SobLvqA4uJiX6VSWXNENxj1cO76rhwe+AwhIce/XPddGPpKiTgaESflnUb048ePP33rrbcmWb5se/EfJPl7Q4YMeeDo/devXw/jx4+nhA3lBy45cInbCxcu7Infz4rfsNv+W8Z7NtS8Km57iarfKygouAzlk3JKiwhJaozov8TpxiRtisjAmZfhupOipz4pBonkhjMvbZnUQskPGviyq5LD6QlN3Wvjdu/e3R1Jfq+691+7di09yM5MmDCBEm00//tYZS6fJXactXjx4q52lpFicJ6a13rllVcox2Kd1MuvVavWHlRze0aH2VL1iVV13x2WYp6Xyjq3iFrM1wqYGvLZ34Shp4UnzoFnn27CDLKSSi852/aC3/jhAhEt8gvG/ELIXLUZ/Ea/C5KgUqunGoygvnkXVGcvQcCUD36J/zE0MGTlQP7+o+A37s/m7UgpmlijfZgCrh1aQ+Gxs5D9xdZ7RRJ1B4zRs2qqAXv37u0WGxtLo+FozjgNbTVYLG3v3r1nBg8efLemf0QxMTG+K1eupPu/ZknUUPafJu5T4u/k0qVLH86cOZPNImN4Docns3PCmHdT/POEHJK78MgpcGnVFKQhAQIRTTodFJ39CfxjRiLRrbXPJCzWIKUHQokq0zZVsfCAKJPNNxhAl/YU1Am38fmIH1nNCdemOezqhJvC/HVzIi6v6OqjH7Jq8gs7cuSIChWWMrsnX1ajrVq1KhuNlJqpNUPNxegl9ENynn6ekJPwIPH1Bm3yo+eFI4msnFwOmlv3hP2V+98iK7XQgwCJbswrABmt+UbDaOlQtQZ0D5KFijQmjUZIxHESyTnWpAwMTiQ6JeTOX9uVTQk5LSorFZugVUw1NxJ/ITXNRQ8LEdx6rgpRArn8tJabdRafyj9rU5+UelhYJrA8yQBZoL8wvJYScbj/OmtSBgbnKrpZ1UumrCI5qXJM2emrpMbiXXBUxFGPcTdUJWNPMTwSm1aFodclWXZ9eibI6tYWJrPoU58UMkVnYKgZolMRiqu6lDShvjupty7p0fNlj6nbTervAwZUdCi7QItAWKHIZGUj6yxVYzT3U0AW5C/E8bSSqyG/UDDew02I1c0j4oApOgNDTSi6ySgUiwQjkpFiaIqndSWqjoSnmu9aJw+qMWn1oEt9DLyLEqTouuuSH1MiLiM+8aiONSkDQ0247hwkmCwJOYm7m1CemfrWS1S9RLk5R8fEW8pDaR+goterTbl+cyLuYSq+DxPGuOvThEQcU3MGhpog+vOEnInP1JrdZ5DWDgEtuu8Ue5M7TwUn9M8yqxaL6ynp9hg4kQw9PTiExRyowA3G5yWJOCK9FuNzkPAsPmdgqCFFN6u60XhafesecDIJyGsHC/XYy7jqQkKuVDadut1kMlDT8NmSmu+cOXFHq7XIKQSgBBxtQyJT0UlK9En8zQUnhVFw6Zl4XC0wZOWC/tHTYqboDAw1S3S9QPTrd6DoQjy4tGsB2jsPoGD/MYGcitcbAeeigKyN35qXQ0aiEkkpaae+ehsKT54DTi4TBskUxJ4SYm81egeGXPPiKOQd0Hb5K7WEElX6zBzI3mRe7JNG1eVuP4DXV9KQzyusORkYbEbA1YdEInPp1CxyK0p7hJB5x/iZFmsQusNQpfUl2XVUb1loEJHcgOpOc3qpRE0f3s1ViO31GdmF6OLvQe/8j5xCppBjDK6+kSiEAEKZaF8vMOSrBEXnXV2Ea6Pi31apc6PjE4+eZM3JwFCDRLeQXYJkD8e4nRbfo8obNLmkDZinWFKlRprFNQpNgY77LbVOdeDKnSOGN1sO7aU3aDtxHJdXrCncnZB49B5uC9PpNVSwnvx6KuxAJKbVRTug0SLstExSXY7jk1TFOfuR5FmsKRkYGBgY/l/jfwUYAPw0FqsWp2FrAAAAAElFTkSuQmCC\" style=\"margin-top:-20px\" height=\"55\">\n<span style=\"font-size:40px\">  [[cluster]]</span><span style=\"padding-top: 25px;float:right\"><a href=\"https://github.com/scylladb/scylla-monitoring/issues/new?body=scylla-version%3D[[scylla_dash_version]]%0Amonitoring-version%3D[[monitoring_version]]\" target=\"_blank\"><input title=\"Report an issue with Scylla Monitoring\" type=\"button\" style=\"background-color:#57d1e5;color:black;font-size:20px\" value=\"Report an issue\"></a></span><hr style=\"border-top: 3px solid #5780c1;\"></div>",
             "datasource": null,
@@ -58,7 +74,7 @@
                 "x": 0,
                 "y": 0
             },
-            "id": 1,
+            "id": 2,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -67,6 +83,22 @@
             "title": "",
             "transparent": true,
             "type": "text"
+        },
+        {
+            "class": "collapsible_row_panel",
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 4
+            },
+            "id": 3,
+            "panels": [],
+            "repeat": "",
+            "title": "CQL Coordinator",
+            "type": "row"
         },
         {
             "class": "text_panel",
@@ -78,9 +110,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 3
+                "y": 5
             },
-            "id": 2,
+            "id": 4,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -107,10 +139,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 5
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 3,
+            "id": 5,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -205,10 +237,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 5
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 4,
+            "id": 6,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -303,10 +335,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 5
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 5,
+            "id": 7,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -401,10 +433,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 5
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 6,
+            "id": 8,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -500,10 +532,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 11
+                "y": 13
             },
             "hiddenSeries": false,
-            "id": 7,
+            "id": 9,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -597,10 +629,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 11
+                "y": 13
             },
             "hiddenSeries": false,
-            "id": 8,
+            "id": 10,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -694,10 +726,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 11
+                "y": 13
             },
             "hiddenSeries": false,
-            "id": 9,
+            "id": 11,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -784,9 +816,9 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 11
+                "y": 13
             },
-            "id": 10,
+            "id": 12,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -798,6 +830,76 @@
             "type": "text"
         },
         {
+            "class": "collapsible_row_panel",
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 19
+            },
+            "id": 13,
+            "panels": [],
+            "repeat": "",
+            "title": "Connection",
+            "type": "row"
+        },
+        {
+            "class": "single_value_table",
+            "columns": [
+                {
+                    "text": "Avg",
+                    "value": "avg"
+                }
+            ],
+            "datasource": "scylla-datasource",
+            "fontSize": "100%",
+            "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 20
+            },
+            "id": 14,
+            "links": [],
+            "options": {},
+            "pageSize": null,
+            "scroll": true,
+            "showHeader": true,
+            "sort": {
+                "col": 0,
+                "desc": true
+            },
+            "span": 12,
+            "targets": [
+                {
+                    "queryHost": "$node",
+                    "queryText": "select address, port, shard_id, ssl_enabled, username from system.clients",
+                    "refId": "A"
+                }
+            ],
+            "title": "Connection Table",
+            "transform": "table",
+            "type": "table"
+        },
+        {
+            "class": "collapsible_row_panel",
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 26
+            },
+            "id": 15,
+            "panels": [],
+            "repeat": "",
+            "title": "CQL Optimization",
+            "type": "row"
+        },
+        {
             "class": "text_panel",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Optimization</h1>",
             "datasource": null,
@@ -807,9 +909,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 17
+                "y": 27
             },
-            "id": 11,
+            "id": 16,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -829,9 +931,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 19
+                "y": 29
             },
-            "id": 12,
+            "id": 17,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -909,10 +1011,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 19
+                "y": 29
             },
             "hiddenSeries": false,
-            "id": 13,
+            "id": 18,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -999,9 +1101,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 19
+                "y": 29
             },
-            "id": 14,
+            "id": 19,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -1079,10 +1181,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 19
+                "y": 29
             },
             "hiddenSeries": false,
-            "id": 15,
+            "id": 20,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1169,9 +1271,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 16,
-                "y": 19
+                "y": 29
             },
-            "id": 16,
+            "id": 21,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -1247,10 +1349,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 19
+                "y": 29
             },
             "hiddenSeries": false,
-            "id": 17,
+            "id": 22,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1337,9 +1439,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 25
+                "y": 35
             },
-            "id": 18,
+            "id": 23,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -1417,10 +1519,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 25
+                "y": 35
             },
             "hiddenSeries": false,
-            "id": 19,
+            "id": 24,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1507,9 +1609,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 25
+                "y": 35
             },
-            "id": 20,
+            "id": 25,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -1585,10 +1687,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 25
+                "y": 35
             },
             "hiddenSeries": false,
-            "id": 21,
+            "id": 26,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1673,9 +1775,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 16,
-                "y": 25
+                "y": 35
             },
-            "id": 22,
+            "id": 27,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -1753,10 +1855,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 25
+                "y": 35
             },
             "hiddenSeries": false,
-            "id": 23,
+            "id": 28,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1858,9 +1960,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 31
+                "y": 41
             },
-            "id": 24,
+            "id": 29,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -1938,10 +2040,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 31
+                "y": 41
             },
             "hiddenSeries": false,
-            "id": 25,
+            "id": 30,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2028,9 +2130,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 31
+                "y": 41
             },
-            "id": 26,
+            "id": 31,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2108,10 +2210,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 31
+                "y": 41
             },
             "hiddenSeries": false,
-            "id": 27,
+            "id": 32,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2199,9 +2301,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 37
+                "y": 47
             },
-            "id": 28,
+            "id": 33,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -2221,9 +2323,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 39
+                "y": 49
             },
-            "id": 29,
+            "id": 34,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2301,10 +2403,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 39
+                "y": 49
             },
             "hiddenSeries": false,
-            "id": 30,
+            "id": 35,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2391,9 +2493,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 39
+                "y": 49
             },
-            "id": 31,
+            "id": 36,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2471,10 +2573,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 39
+                "y": 49
             },
             "hiddenSeries": false,
-            "id": 32,
+            "id": 37,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2561,9 +2663,9 @@
                 "h": 6,
                 "w": 4,
                 "x": 0,
-                "y": 45
+                "y": 55
             },
-            "id": 33,
+            "id": 38,
             "links": [],
             "options": {
                 "fieldOptions": {

--- a/grafana/build/ver_2020.1/scylla-cql.2020.1.json
+++ b/grafana/build/ver_2020.1/scylla-cql.2020.1.json
@@ -77,6 +77,22 @@
     "overwrite": true,
     "panels": [
         {
+            "class": "collapsible_row_panel",
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 1,
+            "panels": [],
+            "repeat": "",
+            "title": "",
+            "type": "row"
+        },
+        {
             "class": "text_panel",
             "content": "<div id=\"amnon\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPoAAAA6CAYAAACZBESJAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAGm9JREFUeNrsXQd8VFXWP+9NTe+NEOmgSIdFiuxSIqB0krCssrCI0sKGLnVZV/qCCqx0ERdQ+ehFCKEtCAuCCAkdQkkhlPQ2yfT5znkzwWTyJslMJqDfd//8zo+ZVydz5//+55x777kADAwMDAwMDL99cC/yZjKpUtqxWUQbvUFbD982Q9OjKdE6oz1Gu4HGo6VzHPdzsabw+uU7h4tYMzEw/IqJLpUouE7NIwL1Bl0kvh1gIbQr8DzIgvyA9/EGMJnKnGPSG0CXnAYmjQY/HWfATTeR9HuL1Pknr9w9cpo1GQPDr4ToUomc79g88jWDQTcf3w7ipFJwad8SFE0agLxuKMgb1wcwGGxfAMlvKCgE3b1kKLp0DTR37oP+cboBJPx1juPXFKnzNiHpDaz5GBheAtGlEhnXsVnkqwajfgGq8WBZaBB4Rb4DyhavAaeQl1PvKgPP0yY9grxdh0FzIxEdfsP9Ik3eR1fuxu1hTcjA8AKJLpHIZJ2aRY4zmAxLkeBKIrhrh9aCK+5M6NMzIe+7g6A6+5OeVypjVcU5Y+ITjz5hTcnAUMNER5K7IMm3GnlThHuPzuD1p/7AyWSOK3iFn5gjRQd1wk3I+moHmLLzbqi0+SOQ7D+z5mRgsMHRal+Alyo7NY/aZpRyEX7Rw8Gzbw8zGWsSPAfSkEBwaf066J88C+TS8/v5+YRdepp9P5k1KQODk4lOJO/YPHKLScpH+o4bBm4d2oDJ8OJyZBIvD1A2awLa1DQPPr2gB5L9FJL9KWtWBgYnue5IchmSfIZJws33Hf9nJDnG4wajeSf+r752G1RnLoLm7gMwZOc9V3lOKgEFktO1fStw7dSm+i4+z+P1cyFr9RbQXL3zs8pQ0Dsh8Vgma1oGhmoSHUnOd2wW2dEkgbNeUX3Bc0C4OemGhNU9fgZZa78BQ1IqNG3RGP7Qoz00a9UEDKj0RqMRUpOfwMXzV+H44bPgEhoM5AkomzasXtIOHyLahymQuWyjIf/xw+0JD04OY03LwFBNovMUl7eIOi1t+Er74E+mgkmnE0iuufMAMpeshXp1Q2DuognQ+NV6Nq/x9EkGfLpwE5z+4TL49Q8H7+ERYFJrHCY69csX/XgFMv+5Ia1IqnkXVf0H1rwMDA7G6Dwv4Ts1i+ppkvDT/SeMAImPF6BUo4v+ELKWroMWLRrB+q0LICDQt9y5pOp3bj2EtNRn4O3jCX0GdgM3pRxObN4HMpkUlM2bVDyQpiJgSMC7uYLhyTNPVVJyg2d5SV+z5mVgcJDoHMfLw4Kbfa1o1jjUa2BPgZgmrRYyl2+EZvVDYeWmeSCVSsudp9XqYOc3h2F69BKI+/4H+H7vSUHx3xnYFVzlMjjx9T5wf60hSAP9hQeH/TABr1QC5+4GutOXpX7+dX56lv0ghTUxA4N5Aok9as6hmtc3cdDerUt7MBEhDUYoPH0BJJnZMHthtCjJCepiDez69gjIkNQcutoF+Sr4eOZKuHguASLfewfaNm8AGVv3AIcK7xBM+BCS8CAPq0WeQZBJp/+QNS8DgwNEFzwADgbyHm7g1uV3AslNej0UHTwBfSPDIbR2kM0T9XoD3LubDBIJb/EMiOxFsGr5FnBxVcL4Se9BQWIKqBNuAWfjYVEp142o6vjZlG+0lLpLPVq2bBjOWpiBwQGi88jQPyjQxQYklZBlz8gCyM2HLt1+V4nLz4E7ktBUpivNBFkZOXABVb1+wzCoGxYEhZeuCvG2Y0w3AeeiBEWjepTF98QtLVkTMzA4RvSW8jqh5r5vInpyGkjlUmjXoXmFJ8oVMniza1tB2cvE7hodxP98S3gIdO7SCoofZwDH8w7/QRzPgcTbE6ShQW4mg/F11sQMDPYS3US5OD5Y8WpD5LhRcJX1KY8hJDSw0lPd3Fxg/rLJMHrCUPDx8QQjnsvhP8rEU1cbZxnDrk99LAyCcRgUq6PrL/UVbtKxJr60Pn36yNEzaYc2FW0r2lm002ixaCvRInbt2uVRE/eOiYlxweu/iTYRbTPaf9FOoR1H24Q2asmSJbXtve6iRYvq47k90bqWsu50rylTpvhXdv66deukeGwLtHCra7yF1mD48OGVumn4ncnw2NZoPazOr9uvXz/emd/jhQsXAvG6ndC6lbpXz1atWrm/aBKmp6d3tvrOG3p7ezv1761yMMxzEq5T86i6RqNB1CWvqtq6e7haue+lY2wjGIuKqzVWnq7Nofcgqx0MpnjnDsft3bu3JDY2tivxAq29rcOIjxEREQVExJ07dy4fMmRIanXvHR0dXfeLL76Yji/fRfOu4ND3Z8yYoUOLXbx48d9nz54dX8VbvIn2BVq5B9Snn366xGg0zlqxYkVF51NRkbVor4nsm4S2sgqfwQftX5ZrlcYnaEvQip3YnN3R6A+yTiy1Rot/gSRvGRAQcAhfepXajPEw1EfLfxmKTuyrSySUBPiYlZPc5LAQSLz9sNKTi4vUsOTjdfDpok2Qm1uAos3hJUyCm+7h7mq+gVwG8iYNHO9Lr0H07NnTH0n+Ob48XgHJS4MIExMVFfWf7du393T0vuPGjePwgfEXJPlP+HZ8JSQvgQyt/6xZsy7guZMWLFhQlVttQfvWxr7h9BXYOnHNmjUwZsyYsTZIfnDEiBH7t2zZwvxncfwVqOpSWfjl5OQM8vT0lL4Mootl2EDq7wtGdLkfpVY8l0St1sKRg2eEgTFlYnckd6u2TaGwQAX/PRMPLrUCzN12vy6Su8TFxY21NIq9KERzaL48kkeGJCI124zm78AlqK9y6Zw5cyZ98sknFR6Iyg/oAWy2oWa1Pv/888hJkybZcmvHofUT2Z41cuTIVUjyJMbn8nj69KkXqvkgy4O5XJSGpngZRDcKPwIq85SRY9Z3JLq8bm0wenrAzm2HK3WpicxcGbecg4AgX+jeqyPcT0yBpJQn4Nq00a9R0duizXfgvPvous8YOnToNXtP/PDDD2UY987Fl3Or+dnvL1y48Mq8efMqPRDJfmHp0qUbwVy00xpRFnfXWs3D0OugmoBi8Ru58qcYpW1igoial6BNXl5eW1R1/oUS3WgywLlrO3N53iqnIpGAokNrOLTnBOTlFdpOBkgl0LBxHeSw8Tnx3d1d4P2xUaDVaGHLl/vAo1EdcO3YBkw6fTWcDAwJNDrQPXqq5ySSasc44eHhfqjm79rYnYu23aJoRIStaKqS8AtJPh/j8zgHSA4bNmygiTkVsZPm3q+zxOwRxDm0O9ZuM5K8/9y5c+0pqrnR8jdZwxtV/f2YmJjniT4MJyi0iBZ7ABDBUc23ff3113rGZ1E1h6CgoBFgroJsC05TdfueFhwl241PNbfvUfrdvAkJ7PF2V9AplTBn0jLbPiS66F26tQO9Xi+Q3MVFCcM/HAQ9UM3/Z8v3cPr8VQgQJrZoq/1HCUm9YnURfsgbTviO/NDEBgncO3jw4AB8sPwJbR3aLrThgwcPpn7GNbt3716MJP+3g/ekWHeEjX15aDNXrFhRH+83Du07tD1o0dOnT2+F+/4GQgYFNqErHoUkv2fPjWfOnKlDVV+NLxNEdg9YuXJlXyR7yfsuNlx2zQcffPAZkvwOo7RN9BNJBFojAlU9wMOj+h049gb79ANKMhYVB5cRdR8v8P3rSLi+fD2sWLIZoqcME4a6lobSRSFsr1MvFFSqYug3uDt4eLjBvh3HYMPGveDfpxsoXm8M+vQs0D9JB3n9MOAUCvvnqpOiF6tBm/hQz8klzshakmsVar3x0KFDd/r3719uhtzevXsfEukcvdmoUaNIzbviyz+I7H60atWqmIkTJ+4VO3f58uVqiUSybMmSJWuR5Cp0xR2aDohk/xGv8+W0adM+F/mNDEtLSzv98ccf34qOjh6D75uKXOJTtFjG5QpBIVlVGDwRbRaa9kUS3YjES9Amp3Wgck5g+IVcikZ1weMvkbDnq51w9/ZDmLMgutyQWLlCDoOH9hJeZyChVyzdDNu/iwP/gW+Bz4hIMOQVgOrUecjdtg+ULV4F/4/GAO/iYtckF4ua02eihR+u11Qr9enTx+fAgQNuSHaVky9dC62rjX0UGuyt6GRUYw2ZEz7HerSOltCgNDrv2rXr92DujhNT89Oo5ls3bdrEXHYbePz4cXN02xtB+WniFI6FWXnawy0hXLWIbn+gbzLlGTKzy39GCQ9undqB/4yxcD0tE97tNxH+MWsVnDhyDpIeppkD2px8OH/2CiyatwaGvDMR9sddgOBRQ8B72CAwqtXCQBlpcABIawWC9n4KFHx/EniFHZNcSM21WozPn1DugAiY5IR20YF4f2anfv36HUeyt3Xy74AaWmyY4X9Xr179b1TzF/JjxDBAhx4C9atfFRN9MPdte1q77KNHj/4MSX6b0blCzBFR82MWlbceK+Cfn58/Et33anW12XuyAYl+Sp+R/ZFoyQpUeXmT+hCydCYq84/ww6VrEDf1U+AkkjLHyEICwbVfD3AL7wwSL0+h4ITm9n3I2xUrlJ5yfaM1uPfoBOqbiTYH19gkukYL+rR0KNTk6K+lnXVK3gTtJFoTkX0dkOzn8TNewtf70W2Pwxi9uoMtPG3EbrdFkm01jfNo+9BaWG2va+N4cvUPMx5XqOaeISEh3UW49x3aTssDtJ5IUu4rEO8NqakYnUuiCS2aW/dBju66mFtNQ1Ddw98UjPbrktLMii2VgLxObeCU5kQikbLg8ElQnbmEx6SConkTCF4yQziGikwqmjayu+oMlaQyZudo0Ds454yGOX78eFavXr3+HRcX92d8K9aPLLO4uB0HDRq0GEl/H19/sXv37nWRkZGOuNCvoFlX7dCjmt+aMGHCC/1Roqrj18h/PmXKFCL6wEoOv4Rq/j8bN25kLrv9ag4BAQH7MzMzNVlZWft9fX2joWzfeiNU9e7u7u6HVSqVQ4NM7HLdjUaD6dy1nUk8x4Oe3PeqjFSlddbqhwmklTeoIyyvlL//GGQsXgNpY2ZD0Y5D0NQX+ePtBcELp4OsdojDlWQ5i6JrU59q0ItIdWLjXEabXIUnKn0jDdFWRERE3NuxY0eEk+6PT0lQvYxf5dSpU3M/++wzysInVnIodfXFMx7bxqNHjwDVnNYgtO5S22JpY8K/Sr0Gq1hd9qIUnX7KlJC7qEtJa891bgumX54CUHzlBmT8cz3IwoJB4uvzPGNOxNWiB0BxPLnxktBgkOblw3vD3hG62LZ+uQ8up6YDVHe9B87sJWCMXoT3uemsBjp69KgOVf1LVHVy0Smj3L0Kp9WOiopajWR3r0Y3268FNOyX+tb/ZmP/2rFjx25HNWdsrhiU2Kwlsv2Lktjcz8/vQU5OzmVvb+8uVkIcVVhY+A9U9Zuo6nYzxZFRN0aT0RivTU4rO/kElduldTNBlWkxRcBYe1TvN2BEj3ZQePsBeEW9AyHL50DYthUQNPevwDd4BX46ewV+PBsP33wbC96d2ghFLKoDmk1nVBWRu1+EpHdqxh3JTh5D/Ntvv90DzF1KpHLPKjktCMn+wfbt2wOqeXsKGQJf1q8TVR1WrFjxGb48IJY7GD9+/Lb169erGI8rRbRI+JcQGBh4F9320uRdZUPVRzgkzg4S3YRKnawTiM6XT8Y1rAOeA3uBEfcl3X8Ebdu/jq85cPldC5ojLqg7r5SDW3gXuJOYAvNmrBQSeN5/7CeoseNqXibjTl1rSTXRUkeOHCHC30Kb0L9/f8qQv4G2Ac3WOu60DnyUHbegOnfZ5X4h0dGNaSTay8LkyZNzkewPRHZlgHkQD0PFbnvn0NDQ16B8wLtVhNQHLN+rNWJQ1QNcqMv5RSg6Uj2BlFOflS06pVTq5wM+00dD7PdnYMyIeeDVvDEohKWSjc/Vnyq+hq5dAMGLPoKAGeOeF7KoFtGLNaC7lwIqXd7DhHvHa7zxDh48qEPCX0QbM3DgwMZgzpqKqXGIHZfFGAbECEWj3rowyvyfUnMC9WqUSdr6+Pjoc3NzabvO6ljKYlNSVFLjRDcaDcZz13ee4jkJGDLEiU7KTuWmQlZ/AoFzJoD/5FFgtM6e43m8hzvG8yEOVn0Vic/R9TdQxp3jU190K+7fvz9t8ODBS/HlfZE8SCM7LkWfXWwSzOuo6sNWrlzJKPMbQ2pqqjuqeXeRZNpBdNvTMzLExFtIyom5uH93JCnn4MwYDoNhYzp1sXG2ikTQvHUksuLVBsA7MpTVbp6T666jjHsBJ+XPO/v6NFXVZDL9MTY2drIDp1d5muqmTZuyR48efcTG7pExMTGzKiL7jBkz6uLnPIa2b9GiRT6MZr8KzIayhSVKu+2ixTRQ1e/n5+f/DOZZo6URWFRU1A3dd7u46+hoGwP+kOK1KWk9ywyFfZmwxOj6R09UoJBcdzLJIS4ujgovbO/du3cx/u21Dh06NLtv377PXasBAwYE7NmzhwpDNLA6vQjsn49OI312oA2x2k5P8oVI9oZGo3EGxs3P15ibNm0aLFu2rBO+XA7mfn2YNWvWCTxu7Ny5cy/+xolS58CBA7+3kMLWD1zRo0ePiydPnsypzo2uXLnSDsxTbmW2fUcoatKkSfzdu3crHSeBag61a9cWm6WWFxwc/B9U84oy0JSUowlV1kE5DY88AXYMi3WU6EYwmhJ0RPSaXiK5iiSnATm0WgxIpUgsvdOIHh4eTiSnutElJVLoS5/Wp0+fcUj4HyxudlNL/Cz21E62ELfK2Lhx42P876sNGzbQfX1FfmjvT5o06U9o1N13BsxVZ94C84iq0m3aes6cOUfRPpo/f/6GqsxJ/5ViBNiezVca1CNyspr3qkofIY0p6IaWVoVjqWCJ2OSVbVB5aSxKytHDPMxqey9U9Qao6rfVanWVXGWHXHfOPBT2tB5jdGECyUsnOghz0Gnoq0qbm5GQeEzvLJIfO3aMfjy7ofy4bnrqv432EVpfGyQn0GAbR0bp0Tx2Gvpo6wt2sTxcyC0cb8kDiD246XNRzbbfMw/6pYDqCogl4baA7Z4ac8N5eenQfaeknN5GrF71mo8OKzqNgqLhrdTNxvMvnekWt10DvFPddpqO+xcRklcVF3fu3Dlv6NCh9svKxo0wduzYb/Dl6ArIXhWQe0fdf2zRyReM5OTk3ui2N4XyXWpn0W2/8+zZs6qo8SobLvqA4uJiX6VSWXNENxj1cO76rhwe+AwhIce/XPddGPpKiTgaESflnUb048ePP33rrbcmWb5se/EfJPl7Q4YMeeDo/devXw/jx4+nhA3lBy45cInbCxcu7Infz4rfsNv+W8Z7NtS8Km57iarfKygouAzlk3JKiwhJaozov8TpxiRtisjAmZfhupOipz4pBonkhjMvbZnUQskPGviyq5LD6QlN3Wvjdu/e3R1Jfq+691+7di09yM5MmDCBEm00//tYZS6fJXactXjx4q52lpFicJ6a13rllVcox2Kd1MuvVavWHlRze0aH2VL1iVV13x2WYp6Xyjq3iFrM1wqYGvLZ34Shp4UnzoFnn27CDLKSSi852/aC3/jhAhEt8gvG/ELIXLUZ/Ea/C5KgUqunGoygvnkXVGcvQcCUD36J/zE0MGTlQP7+o+A37s/m7UgpmlijfZgCrh1aQ+Gxs5D9xdZ7RRJ1B4zRs2qqAXv37u0WGxtLo+FozjgNbTVYLG3v3r1nBg8efLemf0QxMTG+K1eupPu/ZknUUPafJu5T4u/k0qVLH86cOZPNImN4Docns3PCmHdT/POEHJK78MgpcGnVFKQhAQIRTTodFJ39CfxjRiLRrbXPJCzWIKUHQokq0zZVsfCAKJPNNxhAl/YU1Am38fmIH1nNCdemOezqhJvC/HVzIi6v6OqjH7Jq8gs7cuSIChWWMrsnX1ajrVq1KhuNlJqpNUPNxegl9ENynn6ekJPwIPH1Bm3yo+eFI4msnFwOmlv3hP2V+98iK7XQgwCJbswrABmt+UbDaOlQtQZ0D5KFijQmjUZIxHESyTnWpAwMTiQ6JeTOX9uVTQk5LSorFZugVUw1NxJ/ITXNRQ8LEdx6rgpRArn8tJabdRafyj9rU5+UelhYJrA8yQBZoL8wvJYScbj/OmtSBgbnKrpZ1UumrCI5qXJM2emrpMbiXXBUxFGPcTdUJWNPMTwSm1aFodclWXZ9eibI6tYWJrPoU58UMkVnYKgZolMRiqu6lDShvjupty7p0fNlj6nbTervAwZUdCi7QItAWKHIZGUj6yxVYzT3U0AW5C/E8bSSqyG/UDDew02I1c0j4oApOgNDTSi6ySgUiwQjkpFiaIqndSWqjoSnmu9aJw+qMWn1oEt9DLyLEqTouuuSH1MiLiM+8aiONSkDQ0247hwkmCwJOYm7m1CemfrWS1S9RLk5R8fEW8pDaR+goterTbl+cyLuYSq+DxPGuOvThEQcU3MGhpog+vOEnInP1JrdZ5DWDgEtuu8Ue5M7TwUn9M8yqxaL6ynp9hg4kQw9PTiExRyowA3G5yWJOCK9FuNzkPAsPmdgqCFFN6u60XhafesecDIJyGsHC/XYy7jqQkKuVDadut1kMlDT8NmSmu+cOXFHq7XIKQSgBBxtQyJT0UlK9En8zQUnhVFw6Zl4XC0wZOWC/tHTYqboDAw1S3S9QPTrd6DoQjy4tGsB2jsPoGD/MYGcitcbAeeigKyN35qXQ0aiEkkpaae+ehsKT54DTi4TBskUxJ4SYm81egeGXPPiKOQd0Hb5K7WEElX6zBzI3mRe7JNG1eVuP4DXV9KQzyusORkYbEbA1YdEInPp1CxyK0p7hJB5x/iZFmsQusNQpfUl2XVUb1loEJHcgOpOc3qpRE0f3s1ViO31GdmF6OLvQe/8j5xCppBjDK6+kSiEAEKZaF8vMOSrBEXnXV2Ea6Pi31apc6PjE4+eZM3JwFCDRLeQXYJkD8e4nRbfo8obNLmkDZinWFKlRprFNQpNgY77LbVOdeDKnSOGN1sO7aU3aDtxHJdXrCncnZB49B5uC9PpNVSwnvx6KuxAJKbVRTug0SLstExSXY7jk1TFOfuR5FmsKRkYGBgY/l/jfwUYAPw0FqsWp2FrAAAAAElFTkSuQmCC\" style=\"margin-top:-20px\" height=\"55\">\n<span style=\"font-size:40px\">  [[cluster]]</span><span style=\"padding-top: 25px;float:right\"><a href=\"https://github.com/scylladb/scylla-monitoring/issues/new?body=scylla-version%3D[[scylla_dash_version]]%0Amonitoring-version%3D[[monitoring_version]]\" target=\"_blank\"><input title=\"Report an issue with Scylla Monitoring\" type=\"button\" style=\"background-color:#57d1e5;color:black;font-size:20px\" value=\"Report an issue\"></a></span><hr style=\"border-top: 3px solid #5780c1;\"></div>",
             "datasource": null,
@@ -88,7 +104,7 @@
                 "x": 0,
                 "y": 0
             },
-            "id": 1,
+            "id": 2,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -97,6 +113,22 @@
             "title": "",
             "transparent": true,
             "type": "text"
+        },
+        {
+            "class": "collapsible_row_panel",
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 4
+            },
+            "id": 3,
+            "panels": [],
+            "repeat": "",
+            "title": "CQL By User",
+            "type": "row"
         },
         {
             "class": "text_panel",
@@ -108,9 +140,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 3
+                "y": 5
             },
-            "id": 2,
+            "id": 4,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -138,10 +170,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 5
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 3,
+            "id": 5,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -237,10 +269,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 5
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 4,
+            "id": 6,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -336,10 +368,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 5
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 5,
+            "id": 7,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -435,10 +467,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 5
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 6,
+            "id": 8,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -534,10 +566,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 11
+                "y": 13
             },
             "hiddenSeries": false,
-            "id": 7,
+            "id": 9,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -631,10 +663,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 11
+                "y": 13
             },
             "hiddenSeries": false,
-            "id": 8,
+            "id": 10,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -728,10 +760,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 11
+                "y": 13
             },
             "hiddenSeries": false,
-            "id": 9,
+            "id": 11,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -825,10 +857,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 11
+                "y": 13
             },
             "hiddenSeries": false,
-            "id": 10,
+            "id": 12,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -907,6 +939,76 @@
             }
         },
         {
+            "class": "collapsible_row_panel",
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 19
+            },
+            "id": 13,
+            "panels": [],
+            "repeat": "",
+            "title": "Connection",
+            "type": "row"
+        },
+        {
+            "class": "single_value_table",
+            "columns": [
+                {
+                    "text": "Avg",
+                    "value": "avg"
+                }
+            ],
+            "datasource": "scylla-datasource",
+            "fontSize": "100%",
+            "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 20
+            },
+            "id": 14,
+            "links": [],
+            "options": {},
+            "pageSize": null,
+            "scroll": true,
+            "showHeader": true,
+            "sort": {
+                "col": 0,
+                "desc": true
+            },
+            "span": 12,
+            "targets": [
+                {
+                    "queryHost": "$node",
+                    "queryText": "select address, port, shard_id, ssl_enabled, username from system.clients",
+                    "refId": "A"
+                }
+            ],
+            "title": "Connection Table",
+            "transform": "table",
+            "type": "table"
+        },
+        {
+            "class": "collapsible_row_panel",
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 26
+            },
+            "id": 15,
+            "panels": [],
+            "repeat": "",
+            "title": "CQL Internal",
+            "type": "row"
+        },
+        {
             "class": "text_panel",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">CQL Internal - Coordinator</h1>",
             "datasource": null,
@@ -916,9 +1018,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 17
+                "y": 27
             },
-            "id": 11,
+            "id": 16,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -946,10 +1048,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 19
+                "y": 29
             },
             "hiddenSeries": false,
-            "id": 12,
+            "id": 17,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1045,10 +1147,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 19
+                "y": 29
             },
             "hiddenSeries": false,
-            "id": 13,
+            "id": 18,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1144,10 +1246,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 19
+                "y": 29
             },
             "hiddenSeries": false,
-            "id": 14,
+            "id": 19,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1243,10 +1345,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 19
+                "y": 29
             },
             "hiddenSeries": false,
-            "id": 15,
+            "id": 20,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1326,6 +1428,22 @@
             }
         },
         {
+            "class": "collapsible_row_panel",
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 35
+            },
+            "id": 21,
+            "panels": [],
+            "repeat": "",
+            "title": "LWT",
+            "type": "row"
+        },
+        {
             "class": "text_panel",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">LWT</h1>",
             "datasource": null,
@@ -1335,9 +1453,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 25
+                "y": 36
             },
-            "id": 16,
+            "id": 22,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -1364,10 +1482,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 27
+                "y": 38
             },
             "hiddenSeries": false,
-            "id": 17,
+            "id": 23,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1462,10 +1580,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 27
+                "y": 38
             },
             "hiddenSeries": false,
-            "id": 18,
+            "id": 24,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1560,10 +1678,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 27
+                "y": 38
             },
             "hiddenSeries": false,
-            "id": 19,
+            "id": 25,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1659,10 +1777,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 27
+                "y": 38
             },
             "hiddenSeries": false,
-            "id": 20,
+            "id": 26,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1740,6 +1858,22 @@
             }
         },
         {
+            "class": "collapsible_row_panel",
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 44
+            },
+            "id": 27,
+            "panels": [],
+            "repeat": "",
+            "title": "Optimization",
+            "type": "row"
+        },
+        {
             "class": "text_panel",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Optimization</h1>",
             "datasource": null,
@@ -1749,9 +1883,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 33
+                "y": 45
             },
-            "id": 21,
+            "id": 28,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -1771,9 +1905,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 35
+                "y": 47
             },
-            "id": 22,
+            "id": 29,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -1851,10 +1985,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 35
+                "y": 47
             },
             "hiddenSeries": false,
-            "id": 23,
+            "id": 30,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1941,9 +2075,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 35
+                "y": 47
             },
-            "id": 24,
+            "id": 31,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2021,10 +2155,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 35
+                "y": 47
             },
             "hiddenSeries": false,
-            "id": 25,
+            "id": 32,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2111,9 +2245,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 16,
-                "y": 35
+                "y": 47
             },
-            "id": 26,
+            "id": 33,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2189,10 +2323,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 35
+                "y": 47
             },
             "hiddenSeries": false,
-            "id": 27,
+            "id": 34,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2279,9 +2413,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 41
+                "y": 53
             },
-            "id": 28,
+            "id": 35,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2359,10 +2493,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 41
+                "y": 53
             },
             "hiddenSeries": false,
-            "id": 29,
+            "id": 36,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2449,9 +2583,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 41
+                "y": 53
             },
-            "id": 30,
+            "id": 37,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2527,10 +2661,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 41
+                "y": 53
             },
             "hiddenSeries": false,
-            "id": 31,
+            "id": 38,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2615,9 +2749,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 16,
-                "y": 41
+                "y": 53
             },
-            "id": 32,
+            "id": 39,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2695,10 +2829,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 41
+                "y": 53
             },
             "hiddenSeries": false,
-            "id": 33,
+            "id": 40,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2800,9 +2934,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 47
+                "y": 59
             },
-            "id": 34,
+            "id": 41,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2880,10 +3014,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 47
+                "y": 59
             },
             "hiddenSeries": false,
-            "id": 35,
+            "id": 42,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2970,9 +3104,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 47
+                "y": 59
             },
-            "id": 36,
+            "id": 43,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -3050,10 +3184,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 47
+                "y": 59
             },
             "hiddenSeries": false,
-            "id": 37,
+            "id": 44,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3141,9 +3275,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 53
+                "y": 65
             },
-            "id": 38,
+            "id": 45,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -3163,9 +3297,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 55
+                "y": 67
             },
-            "id": 39,
+            "id": 46,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -3243,10 +3377,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 55
+                "y": 67
             },
             "hiddenSeries": false,
-            "id": 40,
+            "id": 47,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3333,9 +3467,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 55
+                "y": 67
             },
-            "id": 41,
+            "id": 48,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -3413,10 +3547,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 55
+                "y": 67
             },
             "hiddenSeries": false,
-            "id": 42,
+            "id": 49,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3503,9 +3637,9 @@
                 "h": 6,
                 "w": 4,
                 "x": 0,
-                "y": 61
+                "y": 73
             },
-            "id": 43,
+            "id": 50,
             "links": [],
             "options": {
                 "fieldOptions": {

--- a/grafana/build/ver_4.1/scylla-cql.4.1.json
+++ b/grafana/build/ver_4.1/scylla-cql.4.1.json
@@ -77,6 +77,22 @@
     "overwrite": true,
     "panels": [
         {
+            "class": "collapsible_row_panel",
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 1,
+            "panels": [],
+            "repeat": "",
+            "title": "",
+            "type": "row"
+        },
+        {
             "class": "text_panel",
             "content": "<div id=\"amnon\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPoAAAA6CAYAAACZBESJAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAGm9JREFUeNrsXQd8VFXWP+9NTe+NEOmgSIdFiuxSIqB0krCssrCI0sKGLnVZV/qCCqx0ERdQ+ehFCKEtCAuCCAkdQkkhlPQ2yfT5znkzwWTyJslMJqDfd//8zo+ZVydz5//+55x777kADAwMDAwMDL99cC/yZjKpUtqxWUQbvUFbD982Q9OjKdE6oz1Gu4HGo6VzHPdzsabw+uU7h4tYMzEw/IqJLpUouE7NIwL1Bl0kvh1gIbQr8DzIgvyA9/EGMJnKnGPSG0CXnAYmjQY/HWfATTeR9HuL1Pknr9w9cpo1GQPDr4ToUomc79g88jWDQTcf3w7ipFJwad8SFE0agLxuKMgb1wcwGGxfAMlvKCgE3b1kKLp0DTR37oP+cboBJPx1juPXFKnzNiHpDaz5GBheAtGlEhnXsVnkqwajfgGq8WBZaBB4Rb4DyhavAaeQl1PvKgPP0yY9grxdh0FzIxEdfsP9Ik3eR1fuxu1hTcjA8AKJLpHIZJ2aRY4zmAxLkeBKIrhrh9aCK+5M6NMzIe+7g6A6+5OeVypjVcU5Y+ITjz5hTcnAUMNER5K7IMm3GnlThHuPzuD1p/7AyWSOK3iFn5gjRQd1wk3I+moHmLLzbqi0+SOQ7D+z5mRgsMHRal+Alyo7NY/aZpRyEX7Rw8Gzbw8zGWsSPAfSkEBwaf066J88C+TS8/v5+YRdepp9P5k1KQODk4lOJO/YPHKLScpH+o4bBm4d2oDJ8OJyZBIvD1A2awLa1DQPPr2gB5L9FJL9KWtWBgYnue5IchmSfIZJws33Hf9nJDnG4wajeSf+r752G1RnLoLm7gMwZOc9V3lOKgEFktO1fStw7dSm+i4+z+P1cyFr9RbQXL3zs8pQ0Dsh8Vgma1oGhmoSHUnOd2wW2dEkgbNeUX3Bc0C4OemGhNU9fgZZa78BQ1IqNG3RGP7Qoz00a9UEDKj0RqMRUpOfwMXzV+H44bPgEhoM5AkomzasXtIOHyLahymQuWyjIf/xw+0JD04OY03LwFBNovMUl7eIOi1t+Er74E+mgkmnE0iuufMAMpeshXp1Q2DuognQ+NV6Nq/x9EkGfLpwE5z+4TL49Q8H7+ERYFJrHCY69csX/XgFMv+5Ia1IqnkXVf0H1rwMDA7G6Dwv4Ts1i+ppkvDT/SeMAImPF6BUo4v+ELKWroMWLRrB+q0LICDQt9y5pOp3bj2EtNRn4O3jCX0GdgM3pRxObN4HMpkUlM2bVDyQpiJgSMC7uYLhyTNPVVJyg2d5SV+z5mVgcJDoHMfLw4Kbfa1o1jjUa2BPgZgmrRYyl2+EZvVDYeWmeSCVSsudp9XqYOc3h2F69BKI+/4H+H7vSUHx3xnYFVzlMjjx9T5wf60hSAP9hQeH/TABr1QC5+4GutOXpX7+dX56lv0ghTUxA4N5Aok9as6hmtc3cdDerUt7MBEhDUYoPH0BJJnZMHthtCjJCepiDez69gjIkNQcutoF+Sr4eOZKuHguASLfewfaNm8AGVv3AIcK7xBM+BCS8CAPq0WeQZBJp/+QNS8DgwNEFzwADgbyHm7g1uV3AslNej0UHTwBfSPDIbR2kM0T9XoD3LubDBIJb/EMiOxFsGr5FnBxVcL4Se9BQWIKqBNuAWfjYVEp142o6vjZlG+0lLpLPVq2bBjOWpiBwQGi88jQPyjQxQYklZBlz8gCyM2HLt1+V4nLz4E7ktBUpivNBFkZOXABVb1+wzCoGxYEhZeuCvG2Y0w3AeeiBEWjepTF98QtLVkTMzA4RvSW8jqh5r5vInpyGkjlUmjXoXmFJ8oVMniza1tB2cvE7hodxP98S3gIdO7SCoofZwDH8w7/QRzPgcTbE6ShQW4mg/F11sQMDPYS3US5OD5Y8WpD5LhRcJX1KY8hJDSw0lPd3Fxg/rLJMHrCUPDx8QQjnsvhP8rEU1cbZxnDrk99LAyCcRgUq6PrL/UVbtKxJr60Pn36yNEzaYc2FW0r2lm002ixaCvRInbt2uVRE/eOiYlxweu/iTYRbTPaf9FOoR1H24Q2asmSJbXtve6iRYvq47k90bqWsu50rylTpvhXdv66deukeGwLtHCra7yF1mD48OGVumn4ncnw2NZoPazOr9uvXz/emd/jhQsXAvG6ndC6lbpXz1atWrm/aBKmp6d3tvrOG3p7ezv1761yMMxzEq5T86i6RqNB1CWvqtq6e7haue+lY2wjGIuKqzVWnq7Nofcgqx0MpnjnDsft3bu3JDY2tivxAq29rcOIjxEREQVExJ07dy4fMmRIanXvHR0dXfeLL76Yji/fRfOu4ND3Z8yYoUOLXbx48d9nz54dX8VbvIn2BVq5B9Snn366xGg0zlqxYkVF51NRkbVor4nsm4S2sgqfwQftX5ZrlcYnaEvQip3YnN3R6A+yTiy1Rot/gSRvGRAQcAhfepXajPEw1EfLfxmKTuyrSySUBPiYlZPc5LAQSLz9sNKTi4vUsOTjdfDpok2Qm1uAos3hJUyCm+7h7mq+gVwG8iYNHO9Lr0H07NnTH0n+Ob48XgHJS4MIExMVFfWf7du393T0vuPGjePwgfEXJPlP+HZ8JSQvgQyt/6xZsy7guZMWLFhQlVttQfvWxr7h9BXYOnHNmjUwZsyYsTZIfnDEiBH7t2zZwvxncfwVqOpSWfjl5OQM8vT0lL4Mootl2EDq7wtGdLkfpVY8l0St1sKRg2eEgTFlYnckd6u2TaGwQAX/PRMPLrUCzN12vy6Su8TFxY21NIq9KERzaL48kkeGJCI124zm78AlqK9y6Zw5cyZ98sknFR6Iyg/oAWy2oWa1Pv/888hJkybZcmvHofUT2Z41cuTIVUjyJMbn8nj69KkXqvkgy4O5XJSGpngZRDcKPwIq85SRY9Z3JLq8bm0wenrAzm2HK3WpicxcGbecg4AgX+jeqyPcT0yBpJQn4Nq00a9R0duizXfgvPvous8YOnToNXtP/PDDD2UY987Fl3Or+dnvL1y48Mq8efMqPRDJfmHp0qUbwVy00xpRFnfXWs3D0OugmoBi8Ru58qcYpW1igoial6BNXl5eW1R1/oUS3WgywLlrO3N53iqnIpGAokNrOLTnBOTlFdpOBkgl0LBxHeSw8Tnx3d1d4P2xUaDVaGHLl/vAo1EdcO3YBkw6fTWcDAwJNDrQPXqq5ySSasc44eHhfqjm79rYnYu23aJoRIStaKqS8AtJPh/j8zgHSA4bNmygiTkVsZPm3q+zxOwRxDm0O9ZuM5K8/9y5c+0pqrnR8jdZwxtV/f2YmJjniT4MJyi0iBZ7ABDBUc23ff3113rGZ1E1h6CgoBFgroJsC05TdfueFhwl241PNbfvUfrdvAkJ7PF2V9AplTBn0jLbPiS66F26tQO9Xi+Q3MVFCcM/HAQ9UM3/Z8v3cPr8VQgQJrZoq/1HCUm9YnURfsgbTviO/NDEBgncO3jw4AB8sPwJbR3aLrThgwcPpn7GNbt3716MJP+3g/ekWHeEjX15aDNXrFhRH+83Du07tD1o0dOnT2+F+/4GQgYFNqErHoUkv2fPjWfOnKlDVV+NLxNEdg9YuXJlXyR7yfsuNlx2zQcffPAZkvwOo7RN9BNJBFojAlU9wMOj+h049gb79ANKMhYVB5cRdR8v8P3rSLi+fD2sWLIZoqcME4a6lobSRSFsr1MvFFSqYug3uDt4eLjBvh3HYMPGveDfpxsoXm8M+vQs0D9JB3n9MOAUCvvnqpOiF6tBm/hQz8klzshakmsVar3x0KFDd/r3719uhtzevXsfEukcvdmoUaNIzbviyz+I7H60atWqmIkTJ+4VO3f58uVqiUSybMmSJWuR5Cp0xR2aDohk/xGv8+W0adM+F/mNDEtLSzv98ccf34qOjh6D75uKXOJTtFjG5QpBIVlVGDwRbRaa9kUS3YjES9Amp3Wgck5g+IVcikZ1weMvkbDnq51w9/ZDmLMgutyQWLlCDoOH9hJeZyChVyzdDNu/iwP/gW+Bz4hIMOQVgOrUecjdtg+ULV4F/4/GAO/iYtckF4ua02eihR+u11Qr9enTx+fAgQNuSHaVky9dC62rjX0UGuyt6GRUYw2ZEz7HerSOltCgNDrv2rXr92DujhNT89Oo5ls3bdrEXHYbePz4cXN02xtB+WniFI6FWXnawy0hXLWIbn+gbzLlGTKzy39GCQ9undqB/4yxcD0tE97tNxH+MWsVnDhyDpIeppkD2px8OH/2CiyatwaGvDMR9sddgOBRQ8B72CAwqtXCQBlpcABIawWC9n4KFHx/EniFHZNcSM21WozPn1DugAiY5IR20YF4f2anfv36HUeyt3Xy74AaWmyY4X9Xr179b1TzF/JjxDBAhx4C9atfFRN9MPdte1q77KNHj/4MSX6b0blCzBFR82MWlbceK+Cfn58/Et33anW12XuyAYl+Sp+R/ZFoyQpUeXmT+hCydCYq84/ww6VrEDf1U+AkkjLHyEICwbVfD3AL7wwSL0+h4ITm9n3I2xUrlJ5yfaM1uPfoBOqbiTYH19gkukYL+rR0KNTk6K+lnXVK3gTtJFoTkX0dkOzn8TNewtf70W2Pwxi9uoMtPG3EbrdFkm01jfNo+9BaWG2va+N4cvUPMx5XqOaeISEh3UW49x3aTssDtJ5IUu4rEO8NqakYnUuiCS2aW/dBju66mFtNQ1Ddw98UjPbrktLMii2VgLxObeCU5kQikbLg8ElQnbmEx6SConkTCF4yQziGikwqmjayu+oMlaQyZudo0Ds454yGOX78eFavXr3+HRcX92d8K9aPLLO4uB0HDRq0GEl/H19/sXv37nWRkZGOuNCvoFlX7dCjmt+aMGHCC/1Roqrj18h/PmXKFCL6wEoOv4Rq/j8bN25kLrv9ag4BAQH7MzMzNVlZWft9fX2joWzfeiNU9e7u7u6HVSqVQ4NM7HLdjUaD6dy1nUk8x4Oe3PeqjFSlddbqhwmklTeoIyyvlL//GGQsXgNpY2ZD0Y5D0NQX+ePtBcELp4OsdojDlWQ5i6JrU59q0ItIdWLjXEabXIUnKn0jDdFWRERE3NuxY0eEk+6PT0lQvYxf5dSpU3M/++wzysInVnIodfXFMx7bxqNHjwDVnNYgtO5S22JpY8K/Sr0Gq1hd9qIUnX7KlJC7qEtJa891bgumX54CUHzlBmT8cz3IwoJB4uvzPGNOxNWiB0BxPLnxktBgkOblw3vD3hG62LZ+uQ8up6YDVHe9B87sJWCMXoT3uemsBjp69KgOVf1LVHVy0Smj3L0Kp9WOiopajWR3r0Y3268FNOyX+tb/ZmP/2rFjx25HNWdsrhiU2Kwlsv2Lktjcz8/vQU5OzmVvb+8uVkIcVVhY+A9U9Zuo6nYzxZFRN0aT0RivTU4rO/kElduldTNBlWkxRcBYe1TvN2BEj3ZQePsBeEW9AyHL50DYthUQNPevwDd4BX46ewV+PBsP33wbC96d2ghFLKoDmk1nVBWRu1+EpHdqxh3JTh5D/Ntvv90DzF1KpHLPKjktCMn+wfbt2wOqeXsKGQJf1q8TVR1WrFjxGb48IJY7GD9+/Lb169erGI8rRbRI+JcQGBh4F9320uRdZUPVRzgkzg4S3YRKnawTiM6XT8Y1rAOeA3uBEfcl3X8Ebdu/jq85cPldC5ojLqg7r5SDW3gXuJOYAvNmrBQSeN5/7CeoseNqXibjTl1rSTXRUkeOHCHC30Kb0L9/f8qQv4G2Ac3WOu60DnyUHbegOnfZ5X4h0dGNaSTay8LkyZNzkewPRHZlgHkQD0PFbnvn0NDQ16B8wLtVhNQHLN+rNWJQ1QNcqMv5RSg6Uj2BlFOflS06pVTq5wM+00dD7PdnYMyIeeDVvDEohKWSjc/Vnyq+hq5dAMGLPoKAGeOeF7KoFtGLNaC7lwIqXd7DhHvHa7zxDh48qEPCX0QbM3DgwMZgzpqKqXGIHZfFGAbECEWj3rowyvyfUnMC9WqUSdr6+Pjoc3NzabvO6ljKYlNSVFLjRDcaDcZz13ee4jkJGDLEiU7KTuWmQlZ/AoFzJoD/5FFgtM6e43m8hzvG8yEOVn0Vic/R9TdQxp3jU190K+7fvz9t8ODBS/HlfZE8SCM7LkWfXWwSzOuo6sNWrlzJKPMbQ2pqqjuqeXeRZNpBdNvTMzLExFtIyom5uH93JCnn4MwYDoNhYzp1sXG2ikTQvHUksuLVBsA7MpTVbp6T666jjHsBJ+XPO/v6NFXVZDL9MTY2drIDp1d5muqmTZuyR48efcTG7pExMTGzKiL7jBkz6uLnPIa2b9GiRT6MZr8KzIayhSVKu+2ixTRQ1e/n5+f/DOZZo6URWFRU1A3dd7u46+hoGwP+kOK1KWk9ywyFfZmwxOj6R09UoJBcdzLJIS4ujgovbO/du3cx/u21Dh06NLtv377PXasBAwYE7NmzhwpDNLA6vQjsn49OI312oA2x2k5P8oVI9oZGo3EGxs3P15ibNm0aLFu2rBO+XA7mfn2YNWvWCTxu7Ny5cy/+xolS58CBA7+3kMLWD1zRo0ePiydPnsypzo2uXLnSDsxTbmW2fUcoatKkSfzdu3crHSeBag61a9cWm6WWFxwc/B9U84oy0JSUowlV1kE5DY88AXYMi3WU6EYwmhJ0RPSaXiK5iiSnATm0WgxIpUgsvdOIHh4eTiSnutElJVLoS5/Wp0+fcUj4HyxudlNL/Cz21E62ELfK2Lhx42P876sNGzbQfX1FfmjvT5o06U9o1N13BsxVZ94C84iq0m3aes6cOUfRPpo/f/6GqsxJ/5ViBNiezVca1CNyspr3qkofIY0p6IaWVoVjqWCJ2OSVbVB5aSxKytHDPMxqey9U9Qao6rfVanWVXGWHXHfOPBT2tB5jdGECyUsnOghz0Gnoq0qbm5GQeEzvLJIfO3aMfjy7ofy4bnrqv432EVpfGyQn0GAbR0bp0Tx2Gvpo6wt2sTxcyC0cb8kDiD246XNRzbbfMw/6pYDqCogl4baA7Z4ac8N5eenQfaeknN5GrF71mo8OKzqNgqLhrdTNxvMvnekWt10DvFPddpqO+xcRklcVF3fu3Dlv6NCh9svKxo0wduzYb/Dl6ArIXhWQe0fdf2zRyReM5OTk3ui2N4XyXWpn0W2/8+zZs6qo8SobLvqA4uJiX6VSWXNENxj1cO76rhwe+AwhIce/XPddGPpKiTgaESflnUb048ePP33rrbcmWb5se/EfJPl7Q4YMeeDo/devXw/jx4+nhA3lBy45cInbCxcu7Infz4rfsNv+W8Z7NtS8Km57iarfKygouAzlk3JKiwhJaozov8TpxiRtisjAmZfhupOipz4pBonkhjMvbZnUQskPGviyq5LD6QlN3Wvjdu/e3R1Jfq+691+7di09yM5MmDCBEm00//tYZS6fJXactXjx4q52lpFicJ6a13rllVcox2Kd1MuvVavWHlRze0aH2VL1iVV13x2WYp6Xyjq3iFrM1wqYGvLZ34Shp4UnzoFnn27CDLKSSi852/aC3/jhAhEt8gvG/ELIXLUZ/Ea/C5KgUqunGoygvnkXVGcvQcCUD36J/zE0MGTlQP7+o+A37s/m7UgpmlijfZgCrh1aQ+Gxs5D9xdZ7RRJ1B4zRs2qqAXv37u0WGxtLo+FozjgNbTVYLG3v3r1nBg8efLemf0QxMTG+K1eupPu/ZknUUPafJu5T4u/k0qVLH86cOZPNImN4Docns3PCmHdT/POEHJK78MgpcGnVFKQhAQIRTTodFJ39CfxjRiLRrbXPJCzWIKUHQokq0zZVsfCAKJPNNxhAl/YU1Am38fmIH1nNCdemOezqhJvC/HVzIi6v6OqjH7Jq8gs7cuSIChWWMrsnX1ajrVq1KhuNlJqpNUPNxegl9ENynn6ekJPwIPH1Bm3yo+eFI4msnFwOmlv3hP2V+98iK7XQgwCJbswrABmt+UbDaOlQtQZ0D5KFijQmjUZIxHESyTnWpAwMTiQ6JeTOX9uVTQk5LSorFZugVUw1NxJ/ITXNRQ8LEdx6rgpRArn8tJabdRafyj9rU5+UelhYJrA8yQBZoL8wvJYScbj/OmtSBgbnKrpZ1UumrCI5qXJM2emrpMbiXXBUxFGPcTdUJWNPMTwSm1aFodclWXZ9eibI6tYWJrPoU58UMkVnYKgZolMRiqu6lDShvjupty7p0fNlj6nbTervAwZUdCi7QItAWKHIZGUj6yxVYzT3U0AW5C/E8bSSqyG/UDDew02I1c0j4oApOgNDTSi6ySgUiwQjkpFiaIqndSWqjoSnmu9aJw+qMWn1oEt9DLyLEqTouuuSH1MiLiM+8aiONSkDQ0247hwkmCwJOYm7m1CemfrWS1S9RLk5R8fEW8pDaR+goterTbl+cyLuYSq+DxPGuOvThEQcU3MGhpog+vOEnInP1JrdZ5DWDgEtuu8Ue5M7TwUn9M8yqxaL6ynp9hg4kQw9PTiExRyowA3G5yWJOCK9FuNzkPAsPmdgqCFFN6u60XhafesecDIJyGsHC/XYy7jqQkKuVDadut1kMlDT8NmSmu+cOXFHq7XIKQSgBBxtQyJT0UlK9En8zQUnhVFw6Zl4XC0wZOWC/tHTYqboDAw1S3S9QPTrd6DoQjy4tGsB2jsPoGD/MYGcitcbAeeigKyN35qXQ0aiEkkpaae+ehsKT54DTi4TBskUxJ4SYm81egeGXPPiKOQd0Hb5K7WEElX6zBzI3mRe7JNG1eVuP4DXV9KQzyusORkYbEbA1YdEInPp1CxyK0p7hJB5x/iZFmsQusNQpfUl2XVUb1loEJHcgOpOc3qpRE0f3s1ViO31GdmF6OLvQe/8j5xCppBjDK6+kSiEAEKZaF8vMOSrBEXnXV2Ea6Pi31apc6PjE4+eZM3JwFCDRLeQXYJkD8e4nRbfo8obNLmkDZinWFKlRprFNQpNgY77LbVOdeDKnSOGN1sO7aU3aDtxHJdXrCncnZB49B5uC9PpNVSwnvx6KuxAJKbVRTug0SLstExSXY7jk1TFOfuR5FmsKRkYGBgY/l/jfwUYAPw0FqsWp2FrAAAAAElFTkSuQmCC\" style=\"margin-top:-20px\" height=\"55\">\n<span style=\"font-size:40px\">  [[cluster]]</span><span style=\"padding-top: 25px;float:right\"><a href=\"https://github.com/scylladb/scylla-monitoring/issues/new?body=scylla-version%3D[[scylla_dash_version]]%0Amonitoring-version%3D[[monitoring_version]]\" target=\"_blank\"><input title=\"Report an issue with Scylla Monitoring\" type=\"button\" style=\"background-color:#57d1e5;color:black;font-size:20px\" value=\"Report an issue\"></a></span><hr style=\"border-top: 3px solid #5780c1;\"></div>",
             "datasource": null,
@@ -88,7 +104,7 @@
                 "x": 0,
                 "y": 0
             },
-            "id": 1,
+            "id": 2,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -97,6 +113,22 @@
             "title": "",
             "transparent": true,
             "type": "text"
+        },
+        {
+            "class": "collapsible_row_panel",
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 4
+            },
+            "id": 3,
+            "panels": [],
+            "repeat": "",
+            "title": "CQL By User",
+            "type": "row"
         },
         {
             "class": "text_panel",
@@ -108,9 +140,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 3
+                "y": 5
             },
-            "id": 2,
+            "id": 4,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -138,10 +170,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 5
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 3,
+            "id": 5,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -237,10 +269,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 5
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 4,
+            "id": 6,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -336,10 +368,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 5
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 5,
+            "id": 7,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -435,10 +467,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 5
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 6,
+            "id": 8,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -534,10 +566,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 11
+                "y": 13
             },
             "hiddenSeries": false,
-            "id": 7,
+            "id": 9,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -631,10 +663,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 11
+                "y": 13
             },
             "hiddenSeries": false,
-            "id": 8,
+            "id": 10,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -728,10 +760,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 11
+                "y": 13
             },
             "hiddenSeries": false,
-            "id": 9,
+            "id": 11,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -825,10 +857,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 11
+                "y": 13
             },
             "hiddenSeries": false,
-            "id": 10,
+            "id": 12,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -907,6 +939,76 @@
             }
         },
         {
+            "class": "collapsible_row_panel",
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 19
+            },
+            "id": 13,
+            "panels": [],
+            "repeat": "",
+            "title": "Connection",
+            "type": "row"
+        },
+        {
+            "class": "single_value_table",
+            "columns": [
+                {
+                    "text": "Avg",
+                    "value": "avg"
+                }
+            ],
+            "datasource": "scylla-datasource",
+            "fontSize": "100%",
+            "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 20
+            },
+            "id": 14,
+            "links": [],
+            "options": {},
+            "pageSize": null,
+            "scroll": true,
+            "showHeader": true,
+            "sort": {
+                "col": 0,
+                "desc": true
+            },
+            "span": 12,
+            "targets": [
+                {
+                    "queryHost": "$node",
+                    "queryText": "select address, port, shard_id, ssl_enabled, username from system.clients",
+                    "refId": "A"
+                }
+            ],
+            "title": "Connection Table",
+            "transform": "table",
+            "type": "table"
+        },
+        {
+            "class": "collapsible_row_panel",
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 26
+            },
+            "id": 15,
+            "panels": [],
+            "repeat": "",
+            "title": "CQL Internal",
+            "type": "row"
+        },
+        {
             "class": "text_panel",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">CQL Internal - Coordinator</h1>",
             "datasource": null,
@@ -916,9 +1018,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 17
+                "y": 27
             },
-            "id": 11,
+            "id": 16,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -946,10 +1048,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 19
+                "y": 29
             },
             "hiddenSeries": false,
-            "id": 12,
+            "id": 17,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1045,10 +1147,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 19
+                "y": 29
             },
             "hiddenSeries": false,
-            "id": 13,
+            "id": 18,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1144,10 +1246,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 19
+                "y": 29
             },
             "hiddenSeries": false,
-            "id": 14,
+            "id": 19,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1243,10 +1345,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 19
+                "y": 29
             },
             "hiddenSeries": false,
-            "id": 15,
+            "id": 20,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1326,6 +1428,22 @@
             }
         },
         {
+            "class": "collapsible_row_panel",
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 35
+            },
+            "id": 21,
+            "panels": [],
+            "repeat": "",
+            "title": "LWT",
+            "type": "row"
+        },
+        {
             "class": "text_panel",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">LWT</h1>",
             "datasource": null,
@@ -1335,9 +1453,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 25
+                "y": 36
             },
-            "id": 16,
+            "id": 22,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -1364,10 +1482,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 27
+                "y": 38
             },
             "hiddenSeries": false,
-            "id": 17,
+            "id": 23,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1462,10 +1580,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 27
+                "y": 38
             },
             "hiddenSeries": false,
-            "id": 18,
+            "id": 24,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1560,10 +1678,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 27
+                "y": 38
             },
             "hiddenSeries": false,
-            "id": 19,
+            "id": 25,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1659,10 +1777,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 27
+                "y": 38
             },
             "hiddenSeries": false,
-            "id": 20,
+            "id": 26,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1740,6 +1858,22 @@
             }
         },
         {
+            "class": "collapsible_row_panel",
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 44
+            },
+            "id": 27,
+            "panels": [],
+            "repeat": "",
+            "title": "Optimization",
+            "type": "row"
+        },
+        {
             "class": "text_panel",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Optimization</h1>",
             "datasource": null,
@@ -1749,9 +1883,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 33
+                "y": 45
             },
-            "id": 21,
+            "id": 28,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -1771,9 +1905,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 35
+                "y": 47
             },
-            "id": 22,
+            "id": 29,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -1851,10 +1985,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 35
+                "y": 47
             },
             "hiddenSeries": false,
-            "id": 23,
+            "id": 30,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1941,9 +2075,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 35
+                "y": 47
             },
-            "id": 24,
+            "id": 31,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2021,10 +2155,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 35
+                "y": 47
             },
             "hiddenSeries": false,
-            "id": 25,
+            "id": 32,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2111,9 +2245,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 16,
-                "y": 35
+                "y": 47
             },
-            "id": 26,
+            "id": 33,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2189,10 +2323,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 35
+                "y": 47
             },
             "hiddenSeries": false,
-            "id": 27,
+            "id": 34,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2279,9 +2413,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 41
+                "y": 53
             },
-            "id": 28,
+            "id": 35,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2359,10 +2493,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 41
+                "y": 53
             },
             "hiddenSeries": false,
-            "id": 29,
+            "id": 36,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2449,9 +2583,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 41
+                "y": 53
             },
-            "id": 30,
+            "id": 37,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2527,10 +2661,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 41
+                "y": 53
             },
             "hiddenSeries": false,
-            "id": 31,
+            "id": 38,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2615,9 +2749,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 16,
-                "y": 41
+                "y": 53
             },
-            "id": 32,
+            "id": 39,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2695,10 +2829,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 41
+                "y": 53
             },
             "hiddenSeries": false,
-            "id": 33,
+            "id": 40,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2800,9 +2934,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 47
+                "y": 59
             },
-            "id": 34,
+            "id": 41,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2880,10 +3014,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 47
+                "y": 59
             },
             "hiddenSeries": false,
-            "id": 35,
+            "id": 42,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2970,9 +3104,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 47
+                "y": 59
             },
-            "id": 36,
+            "id": 43,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -3050,10 +3184,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 47
+                "y": 59
             },
             "hiddenSeries": false,
-            "id": 37,
+            "id": 44,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3141,9 +3275,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 53
+                "y": 65
             },
-            "id": 38,
+            "id": 45,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -3163,9 +3297,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 55
+                "y": 67
             },
-            "id": 39,
+            "id": 46,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -3243,10 +3377,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 55
+                "y": 67
             },
             "hiddenSeries": false,
-            "id": 40,
+            "id": 47,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3333,9 +3467,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 55
+                "y": 67
             },
-            "id": 41,
+            "id": 48,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -3413,10 +3547,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 55
+                "y": 67
             },
             "hiddenSeries": false,
-            "id": 42,
+            "id": 49,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3503,9 +3637,9 @@
                 "h": 6,
                 "w": 4,
                 "x": 0,
-                "y": 61
+                "y": 73
             },
-            "id": 43,
+            "id": 50,
             "links": [],
             "options": {
                 "fieldOptions": {

--- a/grafana/build/ver_4.2/scylla-cql.4.2.json
+++ b/grafana/build/ver_4.2/scylla-cql.4.2.json
@@ -77,6 +77,22 @@
     "overwrite": true,
     "panels": [
         {
+            "class": "collapsible_row_panel",
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 1,
+            "panels": [],
+            "repeat": "",
+            "title": "",
+            "type": "row"
+        },
+        {
             "class": "text_panel",
             "content": "<div id=\"amnon\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPoAAAA6CAYAAACZBESJAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAGm9JREFUeNrsXQd8VFXWP+9NTe+NEOmgSIdFiuxSIqB0krCssrCI0sKGLnVZV/qCCqx0ERdQ+ehFCKEtCAuCCAkdQkkhlPQ2yfT5znkzwWTyJslMJqDfd//8zo+ZVydz5//+55x777kADAwMDAwMDL99cC/yZjKpUtqxWUQbvUFbD982Q9OjKdE6oz1Gu4HGo6VzHPdzsabw+uU7h4tYMzEw/IqJLpUouE7NIwL1Bl0kvh1gIbQr8DzIgvyA9/EGMJnKnGPSG0CXnAYmjQY/HWfATTeR9HuL1Pknr9w9cpo1GQPDr4ToUomc79g88jWDQTcf3w7ipFJwad8SFE0agLxuKMgb1wcwGGxfAMlvKCgE3b1kKLp0DTR37oP+cboBJPx1juPXFKnzNiHpDaz5GBheAtGlEhnXsVnkqwajfgGq8WBZaBB4Rb4DyhavAaeQl1PvKgPP0yY9grxdh0FzIxEdfsP9Ik3eR1fuxu1hTcjA8AKJLpHIZJ2aRY4zmAxLkeBKIrhrh9aCK+5M6NMzIe+7g6A6+5OeVypjVcU5Y+ITjz5hTcnAUMNER5K7IMm3GnlThHuPzuD1p/7AyWSOK3iFn5gjRQd1wk3I+moHmLLzbqi0+SOQ7D+z5mRgsMHRal+Alyo7NY/aZpRyEX7Rw8Gzbw8zGWsSPAfSkEBwaf066J88C+TS8/v5+YRdepp9P5k1KQODk4lOJO/YPHKLScpH+o4bBm4d2oDJ8OJyZBIvD1A2awLa1DQPPr2gB5L9FJL9KWtWBgYnue5IchmSfIZJws33Hf9nJDnG4wajeSf+r752G1RnLoLm7gMwZOc9V3lOKgEFktO1fStw7dSm+i4+z+P1cyFr9RbQXL3zs8pQ0Dsh8Vgma1oGhmoSHUnOd2wW2dEkgbNeUX3Bc0C4OemGhNU9fgZZa78BQ1IqNG3RGP7Qoz00a9UEDKj0RqMRUpOfwMXzV+H44bPgEhoM5AkomzasXtIOHyLahymQuWyjIf/xw+0JD04OY03LwFBNovMUl7eIOi1t+Er74E+mgkmnE0iuufMAMpeshXp1Q2DuognQ+NV6Nq/x9EkGfLpwE5z+4TL49Q8H7+ERYFJrHCY69csX/XgFMv+5Ia1IqnkXVf0H1rwMDA7G6Dwv4Ts1i+ppkvDT/SeMAImPF6BUo4v+ELKWroMWLRrB+q0LICDQt9y5pOp3bj2EtNRn4O3jCX0GdgM3pRxObN4HMpkUlM2bVDyQpiJgSMC7uYLhyTNPVVJyg2d5SV+z5mVgcJDoHMfLw4Kbfa1o1jjUa2BPgZgmrRYyl2+EZvVDYeWmeSCVSsudp9XqYOc3h2F69BKI+/4H+H7vSUHx3xnYFVzlMjjx9T5wf60hSAP9hQeH/TABr1QC5+4GutOXpX7+dX56lv0ghTUxA4N5Aok9as6hmtc3cdDerUt7MBEhDUYoPH0BJJnZMHthtCjJCepiDez69gjIkNQcutoF+Sr4eOZKuHguASLfewfaNm8AGVv3AIcK7xBM+BCS8CAPq0WeQZBJp/+QNS8DgwNEFzwADgbyHm7g1uV3AslNej0UHTwBfSPDIbR2kM0T9XoD3LubDBIJb/EMiOxFsGr5FnBxVcL4Se9BQWIKqBNuAWfjYVEp142o6vjZlG+0lLpLPVq2bBjOWpiBwQGi88jQPyjQxQYklZBlz8gCyM2HLt1+V4nLz4E7ktBUpivNBFkZOXABVb1+wzCoGxYEhZeuCvG2Y0w3AeeiBEWjepTF98QtLVkTMzA4RvSW8jqh5r5vInpyGkjlUmjXoXmFJ8oVMniza1tB2cvE7hodxP98S3gIdO7SCoofZwDH8w7/QRzPgcTbE6ShQW4mg/F11sQMDPYS3US5OD5Y8WpD5LhRcJX1KY8hJDSw0lPd3Fxg/rLJMHrCUPDx8QQjnsvhP8rEU1cbZxnDrk99LAyCcRgUq6PrL/UVbtKxJr60Pn36yNEzaYc2FW0r2lm002ixaCvRInbt2uVRE/eOiYlxweu/iTYRbTPaf9FOoR1H24Q2asmSJbXtve6iRYvq47k90bqWsu50rylTpvhXdv66deukeGwLtHCra7yF1mD48OGVumn4ncnw2NZoPazOr9uvXz/emd/jhQsXAvG6ndC6lbpXz1atWrm/aBKmp6d3tvrOG3p7ezv1761yMMxzEq5T86i6RqNB1CWvqtq6e7haue+lY2wjGIuKqzVWnq7Nofcgqx0MpnjnDsft3bu3JDY2tivxAq29rcOIjxEREQVExJ07dy4fMmRIanXvHR0dXfeLL76Yji/fRfOu4ND3Z8yYoUOLXbx48d9nz54dX8VbvIn2BVq5B9Snn366xGg0zlqxYkVF51NRkbVor4nsm4S2sgqfwQftX5ZrlcYnaEvQip3YnN3R6A+yTiy1Rot/gSRvGRAQcAhfepXajPEw1EfLfxmKTuyrSySUBPiYlZPc5LAQSLz9sNKTi4vUsOTjdfDpok2Qm1uAos3hJUyCm+7h7mq+gVwG8iYNHO9Lr0H07NnTH0n+Ob48XgHJS4MIExMVFfWf7du393T0vuPGjePwgfEXJPlP+HZ8JSQvgQyt/6xZsy7guZMWLFhQlVttQfvWxr7h9BXYOnHNmjUwZsyYsTZIfnDEiBH7t2zZwvxncfwVqOpSWfjl5OQM8vT0lL4Mootl2EDq7wtGdLkfpVY8l0St1sKRg2eEgTFlYnckd6u2TaGwQAX/PRMPLrUCzN12vy6Su8TFxY21NIq9KERzaL48kkeGJCI124zm78AlqK9y6Zw5cyZ98sknFR6Iyg/oAWy2oWa1Pv/888hJkybZcmvHofUT2Z41cuTIVUjyJMbn8nj69KkXqvkgy4O5XJSGpngZRDcKPwIq85SRY9Z3JLq8bm0wenrAzm2HK3WpicxcGbecg4AgX+jeqyPcT0yBpJQn4Nq00a9R0duizXfgvPvous8YOnToNXtP/PDDD2UY987Fl3Or+dnvL1y48Mq8efMqPRDJfmHp0qUbwVy00xpRFnfXWs3D0OugmoBi8Ru58qcYpW1igoial6BNXl5eW1R1/oUS3WgywLlrO3N53iqnIpGAokNrOLTnBOTlFdpOBkgl0LBxHeSw8Tnx3d1d4P2xUaDVaGHLl/vAo1EdcO3YBkw6fTWcDAwJNDrQPXqq5ySSasc44eHhfqjm79rYnYu23aJoRIStaKqS8AtJPh/j8zgHSA4bNmygiTkVsZPm3q+zxOwRxDm0O9ZuM5K8/9y5c+0pqrnR8jdZwxtV/f2YmJjniT4MJyi0iBZ7ABDBUc23ff3113rGZ1E1h6CgoBFgroJsC05TdfueFhwl241PNbfvUfrdvAkJ7PF2V9AplTBn0jLbPiS66F26tQO9Xi+Q3MVFCcM/HAQ9UM3/Z8v3cPr8VQgQJrZoq/1HCUm9YnURfsgbTviO/NDEBgncO3jw4AB8sPwJbR3aLrThgwcPpn7GNbt3716MJP+3g/ekWHeEjX15aDNXrFhRH+83Du07tD1o0dOnT2+F+/4GQgYFNqErHoUkv2fPjWfOnKlDVV+NLxNEdg9YuXJlXyR7yfsuNlx2zQcffPAZkvwOo7RN9BNJBFojAlU9wMOj+h049gb79ANKMhYVB5cRdR8v8P3rSLi+fD2sWLIZoqcME4a6lobSRSFsr1MvFFSqYug3uDt4eLjBvh3HYMPGveDfpxsoXm8M+vQs0D9JB3n9MOAUCvvnqpOiF6tBm/hQz8klzshakmsVar3x0KFDd/r3719uhtzevXsfEukcvdmoUaNIzbviyz+I7H60atWqmIkTJ+4VO3f58uVqiUSybMmSJWuR5Cp0xR2aDohk/xGv8+W0adM+F/mNDEtLSzv98ccf34qOjh6D75uKXOJTtFjG5QpBIVlVGDwRbRaa9kUS3YjES9Amp3Wgck5g+IVcikZ1weMvkbDnq51w9/ZDmLMgutyQWLlCDoOH9hJeZyChVyzdDNu/iwP/gW+Bz4hIMOQVgOrUecjdtg+ULV4F/4/GAO/iYtckF4ua02eihR+u11Qr9enTx+fAgQNuSHaVky9dC62rjX0UGuyt6GRUYw2ZEz7HerSOltCgNDrv2rXr92DujhNT89Oo5ls3bdrEXHYbePz4cXN02xtB+WniFI6FWXnawy0hXLWIbn+gbzLlGTKzy39GCQ9undqB/4yxcD0tE97tNxH+MWsVnDhyDpIeppkD2px8OH/2CiyatwaGvDMR9sddgOBRQ8B72CAwqtXCQBlpcABIawWC9n4KFHx/EniFHZNcSM21WozPn1DugAiY5IR20YF4f2anfv36HUeyt3Xy74AaWmyY4X9Xr179b1TzF/JjxDBAhx4C9atfFRN9MPdte1q77KNHj/4MSX6b0blCzBFR82MWlbceK+Cfn58/Et33anW12XuyAYl+Sp+R/ZFoyQpUeXmT+hCydCYq84/ww6VrEDf1U+AkkjLHyEICwbVfD3AL7wwSL0+h4ITm9n3I2xUrlJ5yfaM1uPfoBOqbiTYH19gkukYL+rR0KNTk6K+lnXVK3gTtJFoTkX0dkOzn8TNewtf70W2Pwxi9uoMtPG3EbrdFkm01jfNo+9BaWG2va+N4cvUPMx5XqOaeISEh3UW49x3aTssDtJ5IUu4rEO8NqakYnUuiCS2aW/dBju66mFtNQ1Ddw98UjPbrktLMii2VgLxObeCU5kQikbLg8ElQnbmEx6SConkTCF4yQziGikwqmjayu+oMlaQyZudo0Ds454yGOX78eFavXr3+HRcX92d8K9aPLLO4uB0HDRq0GEl/H19/sXv37nWRkZGOuNCvoFlX7dCjmt+aMGHCC/1Roqrj18h/PmXKFCL6wEoOv4Rq/j8bN25kLrv9ag4BAQH7MzMzNVlZWft9fX2joWzfeiNU9e7u7u6HVSqVQ4NM7HLdjUaD6dy1nUk8x4Oe3PeqjFSlddbqhwmklTeoIyyvlL//GGQsXgNpY2ZD0Y5D0NQX+ePtBcELp4OsdojDlWQ5i6JrU59q0ItIdWLjXEabXIUnKn0jDdFWRERE3NuxY0eEk+6PT0lQvYxf5dSpU3M/++wzysInVnIodfXFMx7bxqNHjwDVnNYgtO5S22JpY8K/Sr0Gq1hd9qIUnX7KlJC7qEtJa891bgumX54CUHzlBmT8cz3IwoJB4uvzPGNOxNWiB0BxPLnxktBgkOblw3vD3hG62LZ+uQ8up6YDVHe9B87sJWCMXoT3uemsBjp69KgOVf1LVHVy0Smj3L0Kp9WOiopajWR3r0Y3268FNOyX+tb/ZmP/2rFjx25HNWdsrhiU2Kwlsv2Lktjcz8/vQU5OzmVvb+8uVkIcVVhY+A9U9Zuo6nYzxZFRN0aT0RivTU4rO/kElduldTNBlWkxRcBYe1TvN2BEj3ZQePsBeEW9AyHL50DYthUQNPevwDd4BX46ewV+PBsP33wbC96d2ghFLKoDmk1nVBWRu1+EpHdqxh3JTh5D/Ntvv90DzF1KpHLPKjktCMn+wfbt2wOqeXsKGQJf1q8TVR1WrFjxGb48IJY7GD9+/Lb169erGI8rRbRI+JcQGBh4F9320uRdZUPVRzgkzg4S3YRKnawTiM6XT8Y1rAOeA3uBEfcl3X8Ebdu/jq85cPldC5ojLqg7r5SDW3gXuJOYAvNmrBQSeN5/7CeoseNqXibjTl1rSTXRUkeOHCHC30Kb0L9/f8qQv4G2Ac3WOu60DnyUHbegOnfZ5X4h0dGNaSTay8LkyZNzkewPRHZlgHkQD0PFbnvn0NDQ16B8wLtVhNQHLN+rNWJQ1QNcqMv5RSg6Uj2BlFOflS06pVTq5wM+00dD7PdnYMyIeeDVvDEohKWSjc/Vnyq+hq5dAMGLPoKAGeOeF7KoFtGLNaC7lwIqXd7DhHvHa7zxDh48qEPCX0QbM3DgwMZgzpqKqXGIHZfFGAbECEWj3rowyvyfUnMC9WqUSdr6+Pjoc3NzabvO6ljKYlNSVFLjRDcaDcZz13ee4jkJGDLEiU7KTuWmQlZ/AoFzJoD/5FFgtM6e43m8hzvG8yEOVn0Vic/R9TdQxp3jU190K+7fvz9t8ODBS/HlfZE8SCM7LkWfXWwSzOuo6sNWrlzJKPMbQ2pqqjuqeXeRZNpBdNvTMzLExFtIyom5uH93JCnn4MwYDoNhYzp1sXG2ikTQvHUksuLVBsA7MpTVbp6T666jjHsBJ+XPO/v6NFXVZDL9MTY2drIDp1d5muqmTZuyR48efcTG7pExMTGzKiL7jBkz6uLnPIa2b9GiRT6MZr8KzIayhSVKu+2ixTRQ1e/n5+f/DOZZo6URWFRU1A3dd7u46+hoGwP+kOK1KWk9ywyFfZmwxOj6R09UoJBcdzLJIS4ujgovbO/du3cx/u21Dh06NLtv377PXasBAwYE7NmzhwpDNLA6vQjsn49OI312oA2x2k5P8oVI9oZGo3EGxs3P15ibNm0aLFu2rBO+XA7mfn2YNWvWCTxu7Ny5cy/+xolS58CBA7+3kMLWD1zRo0ePiydPnsypzo2uXLnSDsxTbmW2fUcoatKkSfzdu3crHSeBag61a9cWm6WWFxwc/B9U84oy0JSUowlV1kE5DY88AXYMi3WU6EYwmhJ0RPSaXiK5iiSnATm0WgxIpUgsvdOIHh4eTiSnutElJVLoS5/Wp0+fcUj4HyxudlNL/Cz21E62ELfK2Lhx42P876sNGzbQfX1FfmjvT5o06U9o1N13BsxVZ94C84iq0m3aes6cOUfRPpo/f/6GqsxJ/5ViBNiezVca1CNyspr3qkofIY0p6IaWVoVjqWCJ2OSVbVB5aSxKytHDPMxqey9U9Qao6rfVanWVXGWHXHfOPBT2tB5jdGECyUsnOghz0Gnoq0qbm5GQeEzvLJIfO3aMfjy7ofy4bnrqv432EVpfGyQn0GAbR0bp0Tx2Gvpo6wt2sTxcyC0cb8kDiD246XNRzbbfMw/6pYDqCogl4baA7Z4ac8N5eenQfaeknN5GrF71mo8OKzqNgqLhrdTNxvMvnekWt10DvFPddpqO+xcRklcVF3fu3Dlv6NCh9svKxo0wduzYb/Dl6ArIXhWQe0fdf2zRyReM5OTk3ui2N4XyXWpn0W2/8+zZs6qo8SobLvqA4uJiX6VSWXNENxj1cO76rhwe+AwhIce/XPddGPpKiTgaESflnUb048ePP33rrbcmWb5se/EfJPl7Q4YMeeDo/devXw/jx4+nhA3lBy45cInbCxcu7Infz4rfsNv+W8Z7NtS8Km57iarfKygouAzlk3JKiwhJaozov8TpxiRtisjAmZfhupOipz4pBonkhjMvbZnUQskPGviyq5LD6QlN3Wvjdu/e3R1Jfq+691+7di09yM5MmDCBEm00//tYZS6fJXactXjx4q52lpFicJ6a13rllVcox2Kd1MuvVavWHlRze0aH2VL1iVV13x2WYp6Xyjq3iFrM1wqYGvLZ34Shp4UnzoFnn27CDLKSSi852/aC3/jhAhEt8gvG/ELIXLUZ/Ea/C5KgUqunGoygvnkXVGcvQcCUD36J/zE0MGTlQP7+o+A37s/m7UgpmlijfZgCrh1aQ+Gxs5D9xdZ7RRJ1B4zRs2qqAXv37u0WGxtLo+FozjgNbTVYLG3v3r1nBg8efLemf0QxMTG+K1eupPu/ZknUUPafJu5T4u/k0qVLH86cOZPNImN4Docns3PCmHdT/POEHJK78MgpcGnVFKQhAQIRTTodFJ39CfxjRiLRrbXPJCzWIKUHQokq0zZVsfCAKJPNNxhAl/YU1Am38fmIH1nNCdemOezqhJvC/HVzIi6v6OqjH7Jq8gs7cuSIChWWMrsnX1ajrVq1KhuNlJqpNUPNxegl9ENynn6ekJPwIPH1Bm3yo+eFI4msnFwOmlv3hP2V+98iK7XQgwCJbswrABmt+UbDaOlQtQZ0D5KFijQmjUZIxHESyTnWpAwMTiQ6JeTOX9uVTQk5LSorFZugVUw1NxJ/ITXNRQ8LEdx6rgpRArn8tJabdRafyj9rU5+UelhYJrA8yQBZoL8wvJYScbj/OmtSBgbnKrpZ1UumrCI5qXJM2emrpMbiXXBUxFGPcTdUJWNPMTwSm1aFodclWXZ9eibI6tYWJrPoU58UMkVnYKgZolMRiqu6lDShvjupty7p0fNlj6nbTervAwZUdCi7QItAWKHIZGUj6yxVYzT3U0AW5C/E8bSSqyG/UDDew02I1c0j4oApOgNDTSi6ySgUiwQjkpFiaIqndSWqjoSnmu9aJw+qMWn1oEt9DLyLEqTouuuSH1MiLiM+8aiONSkDQ0247hwkmCwJOYm7m1CemfrWS1S9RLk5R8fEW8pDaR+goterTbl+cyLuYSq+DxPGuOvThEQcU3MGhpog+vOEnInP1JrdZ5DWDgEtuu8Ue5M7TwUn9M8yqxaL6ynp9hg4kQw9PTiExRyowA3G5yWJOCK9FuNzkPAsPmdgqCFFN6u60XhafesecDIJyGsHC/XYy7jqQkKuVDadut1kMlDT8NmSmu+cOXFHq7XIKQSgBBxtQyJT0UlK9En8zQUnhVFw6Zl4XC0wZOWC/tHTYqboDAw1S3S9QPTrd6DoQjy4tGsB2jsPoGD/MYGcitcbAeeigKyN35qXQ0aiEkkpaae+ehsKT54DTi4TBskUxJ4SYm81egeGXPPiKOQd0Hb5K7WEElX6zBzI3mRe7JNG1eVuP4DXV9KQzyusORkYbEbA1YdEInPp1CxyK0p7hJB5x/iZFmsQusNQpfUl2XVUb1loEJHcgOpOc3qpRE0f3s1ViO31GdmF6OLvQe/8j5xCppBjDK6+kSiEAEKZaF8vMOSrBEXnXV2Ea6Pi31apc6PjE4+eZM3JwFCDRLeQXYJkD8e4nRbfo8obNLmkDZinWFKlRprFNQpNgY77LbVOdeDKnSOGN1sO7aU3aDtxHJdXrCncnZB49B5uC9PpNVSwnvx6KuxAJKbVRTug0SLstExSXY7jk1TFOfuR5FmsKRkYGBgY/l/jfwUYAPw0FqsWp2FrAAAAAElFTkSuQmCC\" style=\"margin-top:-20px\" height=\"55\">\n<span style=\"font-size:40px\">  [[cluster]]</span><span style=\"padding-top: 25px;float:right\"><a href=\"https://github.com/scylladb/scylla-monitoring/issues/new?body=scylla-version%3D[[scylla_dash_version]]%0Amonitoring-version%3D[[monitoring_version]]\" target=\"_blank\"><input title=\"Report an issue with Scylla Monitoring\" type=\"button\" style=\"background-color:#57d1e5;color:black;font-size:20px\" value=\"Report an issue\"></a></span><hr style=\"border-top: 3px solid #5780c1;\"></div>",
             "datasource": null,
@@ -88,7 +104,7 @@
                 "x": 0,
                 "y": 0
             },
-            "id": 1,
+            "id": 2,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -97,6 +113,22 @@
             "title": "",
             "transparent": true,
             "type": "text"
+        },
+        {
+            "class": "collapsible_row_panel",
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 4
+            },
+            "id": 3,
+            "panels": [],
+            "repeat": "",
+            "title": "CQL By User",
+            "type": "row"
         },
         {
             "class": "text_panel",
@@ -108,9 +140,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 3
+                "y": 5
             },
-            "id": 2,
+            "id": 4,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -138,10 +170,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 5
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 3,
+            "id": 5,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -237,10 +269,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 5
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 4,
+            "id": 6,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -336,10 +368,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 5
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 5,
+            "id": 7,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -435,10 +467,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 5
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 6,
+            "id": 8,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -534,10 +566,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 11
+                "y": 13
             },
             "hiddenSeries": false,
-            "id": 7,
+            "id": 9,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -631,10 +663,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 11
+                "y": 13
             },
             "hiddenSeries": false,
-            "id": 8,
+            "id": 10,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -728,10 +760,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 11
+                "y": 13
             },
             "hiddenSeries": false,
-            "id": 9,
+            "id": 11,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -825,10 +857,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 11
+                "y": 13
             },
             "hiddenSeries": false,
-            "id": 10,
+            "id": 12,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -907,6 +939,76 @@
             }
         },
         {
+            "class": "collapsible_row_panel",
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 19
+            },
+            "id": 13,
+            "panels": [],
+            "repeat": "",
+            "title": "Connection",
+            "type": "row"
+        },
+        {
+            "class": "single_value_table",
+            "columns": [
+                {
+                    "text": "Avg",
+                    "value": "avg"
+                }
+            ],
+            "datasource": "scylla-datasource",
+            "fontSize": "100%",
+            "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 20
+            },
+            "id": 14,
+            "links": [],
+            "options": {},
+            "pageSize": null,
+            "scroll": true,
+            "showHeader": true,
+            "sort": {
+                "col": 0,
+                "desc": true
+            },
+            "span": 12,
+            "targets": [
+                {
+                    "queryHost": "$node",
+                    "queryText": "select address, port, shard_id, ssl_enabled, username from system.clients",
+                    "refId": "A"
+                }
+            ],
+            "title": "Connection Table",
+            "transform": "table",
+            "type": "table"
+        },
+        {
+            "class": "collapsible_row_panel",
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 26
+            },
+            "id": 15,
+            "panels": [],
+            "repeat": "",
+            "title": "CQL Internal",
+            "type": "row"
+        },
+        {
             "class": "text_panel",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">CQL Internal - Coordinator</h1>",
             "datasource": null,
@@ -916,9 +1018,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 17
+                "y": 27
             },
-            "id": 11,
+            "id": 16,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -946,10 +1048,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 19
+                "y": 29
             },
             "hiddenSeries": false,
-            "id": 12,
+            "id": 17,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1045,10 +1147,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 19
+                "y": 29
             },
             "hiddenSeries": false,
-            "id": 13,
+            "id": 18,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1144,10 +1246,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 19
+                "y": 29
             },
             "hiddenSeries": false,
-            "id": 14,
+            "id": 19,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1243,10 +1345,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 19
+                "y": 29
             },
             "hiddenSeries": false,
-            "id": 15,
+            "id": 20,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1326,6 +1428,22 @@
             }
         },
         {
+            "class": "collapsible_row_panel",
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 35
+            },
+            "id": 21,
+            "panels": [],
+            "repeat": "",
+            "title": "LWT",
+            "type": "row"
+        },
+        {
             "class": "text_panel",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">LWT</h1>",
             "datasource": null,
@@ -1335,9 +1453,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 25
+                "y": 36
             },
-            "id": 16,
+            "id": 22,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -1364,10 +1482,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 27
+                "y": 38
             },
             "hiddenSeries": false,
-            "id": 17,
+            "id": 23,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1462,10 +1580,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 27
+                "y": 38
             },
             "hiddenSeries": false,
-            "id": 18,
+            "id": 24,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1560,10 +1678,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 27
+                "y": 38
             },
             "hiddenSeries": false,
-            "id": 19,
+            "id": 25,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1659,10 +1777,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 27
+                "y": 38
             },
             "hiddenSeries": false,
-            "id": 20,
+            "id": 26,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1740,6 +1858,22 @@
             }
         },
         {
+            "class": "collapsible_row_panel",
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 44
+            },
+            "id": 27,
+            "panels": [],
+            "repeat": "",
+            "title": "Optimization",
+            "type": "row"
+        },
+        {
             "class": "text_panel",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Optimization</h1>",
             "datasource": null,
@@ -1749,9 +1883,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 33
+                "y": 45
             },
-            "id": 21,
+            "id": 28,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -1771,9 +1905,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 35
+                "y": 47
             },
-            "id": 22,
+            "id": 29,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -1851,10 +1985,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 35
+                "y": 47
             },
             "hiddenSeries": false,
-            "id": 23,
+            "id": 30,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1941,9 +2075,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 35
+                "y": 47
             },
-            "id": 24,
+            "id": 31,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2021,10 +2155,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 35
+                "y": 47
             },
             "hiddenSeries": false,
-            "id": 25,
+            "id": 32,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2111,9 +2245,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 16,
-                "y": 35
+                "y": 47
             },
-            "id": 26,
+            "id": 33,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2189,10 +2323,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 35
+                "y": 47
             },
             "hiddenSeries": false,
-            "id": 27,
+            "id": 34,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2279,9 +2413,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 41
+                "y": 53
             },
-            "id": 28,
+            "id": 35,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2359,10 +2493,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 41
+                "y": 53
             },
             "hiddenSeries": false,
-            "id": 29,
+            "id": 36,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2449,9 +2583,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 41
+                "y": 53
             },
-            "id": 30,
+            "id": 37,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2527,10 +2661,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 41
+                "y": 53
             },
             "hiddenSeries": false,
-            "id": 31,
+            "id": 38,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2615,9 +2749,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 16,
-                "y": 41
+                "y": 53
             },
-            "id": 32,
+            "id": 39,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2695,10 +2829,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 41
+                "y": 53
             },
             "hiddenSeries": false,
-            "id": 33,
+            "id": 40,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2800,9 +2934,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 47
+                "y": 59
             },
-            "id": 34,
+            "id": 41,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2880,10 +3014,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 47
+                "y": 59
             },
             "hiddenSeries": false,
-            "id": 35,
+            "id": 42,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2970,9 +3104,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 47
+                "y": 59
             },
-            "id": 36,
+            "id": 43,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -3050,10 +3184,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 47
+                "y": 59
             },
             "hiddenSeries": false,
-            "id": 37,
+            "id": 44,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3141,9 +3275,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 53
+                "y": 65
             },
-            "id": 38,
+            "id": 45,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -3163,9 +3297,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 55
+                "y": 67
             },
-            "id": 39,
+            "id": 46,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -3243,10 +3377,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 55
+                "y": 67
             },
             "hiddenSeries": false,
-            "id": 40,
+            "id": 47,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3333,9 +3467,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 55
+                "y": 67
             },
-            "id": 41,
+            "id": 48,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -3413,10 +3547,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 55
+                "y": 67
             },
             "hiddenSeries": false,
-            "id": 42,
+            "id": 49,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3503,9 +3637,9 @@
                 "h": 6,
                 "w": 4,
                 "x": 0,
-                "y": 61
+                "y": 73
             },
-            "id": 43,
+            "id": 50,
             "links": [],
             "options": {
                 "fieldOptions": {

--- a/grafana/build/ver_master/alternator.master.json
+++ b/grafana/build/ver_master/alternator.master.json
@@ -972,7 +972,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_alternator_total_operations{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_alternator_total_operations{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -4038,7 +4038,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_cache_row_hits{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_cache_row_hits{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -4136,7 +4136,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_cache_row_misses{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_cache_row_misses{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",

--- a/grafana/build/ver_master/scylla-cpu.master.json
+++ b/grafana/build/ver_master/scylla-cpu.master.json
@@ -184,7 +184,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_scheduler_runtime_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_scheduler_runtime_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -281,7 +281,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_scheduler_time_spent_on_task_quota_violations_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_scheduler_time_spent_on_task_quota_violations_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",

--- a/grafana/build/ver_master/scylla-cql.master.json
+++ b/grafana/build/ver_master/scylla-cql.master.json
@@ -77,6 +77,22 @@
     "overwrite": true,
     "panels": [
         {
+            "class": "collapsible_row_panel",
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 1,
+            "panels": [],
+            "repeat": "",
+            "title": "",
+            "type": "row"
+        },
+        {
             "class": "text_panel",
             "content": "<div id=\"amnon\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPoAAAA6CAYAAACZBESJAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAGm9JREFUeNrsXQd8VFXWP+9NTe+NEOmgSIdFiuxSIqB0krCssrCI0sKGLnVZV/qCCqx0ERdQ+ehFCKEtCAuCCAkdQkkhlPQ2yfT5znkzwWTyJslMJqDfd//8zo+ZVydz5//+55x777kADAwMDAwMDL99cC/yZjKpUtqxWUQbvUFbD982Q9OjKdE6oz1Gu4HGo6VzHPdzsabw+uU7h4tYMzEw/IqJLpUouE7NIwL1Bl0kvh1gIbQr8DzIgvyA9/EGMJnKnGPSG0CXnAYmjQY/HWfATTeR9HuL1Pknr9w9cpo1GQPDr4ToUomc79g88jWDQTcf3w7ipFJwad8SFE0agLxuKMgb1wcwGGxfAMlvKCgE3b1kKLp0DTR37oP+cboBJPx1juPXFKnzNiHpDaz5GBheAtGlEhnXsVnkqwajfgGq8WBZaBB4Rb4DyhavAaeQl1PvKgPP0yY9grxdh0FzIxEdfsP9Ik3eR1fuxu1hTcjA8AKJLpHIZJ2aRY4zmAxLkeBKIrhrh9aCK+5M6NMzIe+7g6A6+5OeVypjVcU5Y+ITjz5hTcnAUMNER5K7IMm3GnlThHuPzuD1p/7AyWSOK3iFn5gjRQd1wk3I+moHmLLzbqi0+SOQ7D+z5mRgsMHRal+Alyo7NY/aZpRyEX7Rw8Gzbw8zGWsSPAfSkEBwaf066J88C+TS8/v5+YRdepp9P5k1KQODk4lOJO/YPHKLScpH+o4bBm4d2oDJ8OJyZBIvD1A2awLa1DQPPr2gB5L9FJL9KWtWBgYnue5IchmSfIZJws33Hf9nJDnG4wajeSf+r752G1RnLoLm7gMwZOc9V3lOKgEFktO1fStw7dSm+i4+z+P1cyFr9RbQXL3zs8pQ0Dsh8Vgma1oGhmoSHUnOd2wW2dEkgbNeUX3Bc0C4OemGhNU9fgZZa78BQ1IqNG3RGP7Qoz00a9UEDKj0RqMRUpOfwMXzV+H44bPgEhoM5AkomzasXtIOHyLahymQuWyjIf/xw+0JD04OY03LwFBNovMUl7eIOi1t+Er74E+mgkmnE0iuufMAMpeshXp1Q2DuognQ+NV6Nq/x9EkGfLpwE5z+4TL49Q8H7+ERYFJrHCY69csX/XgFMv+5Ia1IqnkXVf0H1rwMDA7G6Dwv4Ts1i+ppkvDT/SeMAImPF6BUo4v+ELKWroMWLRrB+q0LICDQt9y5pOp3bj2EtNRn4O3jCX0GdgM3pRxObN4HMpkUlM2bVDyQpiJgSMC7uYLhyTNPVVJyg2d5SV+z5mVgcJDoHMfLw4Kbfa1o1jjUa2BPgZgmrRYyl2+EZvVDYeWmeSCVSsudp9XqYOc3h2F69BKI+/4H+H7vSUHx3xnYFVzlMjjx9T5wf60hSAP9hQeH/TABr1QC5+4GutOXpX7+dX56lv0ghTUxA4N5Aok9as6hmtc3cdDerUt7MBEhDUYoPH0BJJnZMHthtCjJCepiDez69gjIkNQcutoF+Sr4eOZKuHguASLfewfaNm8AGVv3AIcK7xBM+BCS8CAPq0WeQZBJp/+QNS8DgwNEFzwADgbyHm7g1uV3AslNej0UHTwBfSPDIbR2kM0T9XoD3LubDBIJb/EMiOxFsGr5FnBxVcL4Se9BQWIKqBNuAWfjYVEp142o6vjZlG+0lLpLPVq2bBjOWpiBwQGi88jQPyjQxQYklZBlz8gCyM2HLt1+V4nLz4E7ktBUpivNBFkZOXABVb1+wzCoGxYEhZeuCvG2Y0w3AeeiBEWjepTF98QtLVkTMzA4RvSW8jqh5r5vInpyGkjlUmjXoXmFJ8oVMniza1tB2cvE7hodxP98S3gIdO7SCoofZwDH8w7/QRzPgcTbE6ShQW4mg/F11sQMDPYS3US5OD5Y8WpD5LhRcJX1KY8hJDSw0lPd3Fxg/rLJMHrCUPDx8QQjnsvhP8rEU1cbZxnDrk99LAyCcRgUq6PrL/UVbtKxJr60Pn36yNEzaYc2FW0r2lm002ixaCvRInbt2uVRE/eOiYlxweu/iTYRbTPaf9FOoR1H24Q2asmSJbXtve6iRYvq47k90bqWsu50rylTpvhXdv66deukeGwLtHCra7yF1mD48OGVumn4ncnw2NZoPazOr9uvXz/emd/jhQsXAvG6ndC6lbpXz1atWrm/aBKmp6d3tvrOG3p7ezv1761yMMxzEq5T86i6RqNB1CWvqtq6e7haue+lY2wjGIuKqzVWnq7Nofcgqx0MpnjnDsft3bu3JDY2tivxAq29rcOIjxEREQVExJ07dy4fMmRIanXvHR0dXfeLL76Yji/fRfOu4ND3Z8yYoUOLXbx48d9nz54dX8VbvIn2BVq5B9Snn366xGg0zlqxYkVF51NRkbVor4nsm4S2sgqfwQftX5ZrlcYnaEvQip3YnN3R6A+yTiy1Rot/gSRvGRAQcAhfepXajPEw1EfLfxmKTuyrSySUBPiYlZPc5LAQSLz9sNKTi4vUsOTjdfDpok2Qm1uAos3hJUyCm+7h7mq+gVwG8iYNHO9Lr0H07NnTH0n+Ob48XgHJS4MIExMVFfWf7du393T0vuPGjePwgfEXJPlP+HZ8JSQvgQyt/6xZsy7guZMWLFhQlVttQfvWxr7h9BXYOnHNmjUwZsyYsTZIfnDEiBH7t2zZwvxncfwVqOpSWfjl5OQM8vT0lL4Mootl2EDq7wtGdLkfpVY8l0St1sKRg2eEgTFlYnckd6u2TaGwQAX/PRMPLrUCzN12vy6Su8TFxY21NIq9KERzaL48kkeGJCI124zm78AlqK9y6Zw5cyZ98sknFR6Iyg/oAWy2oWa1Pv/888hJkybZcmvHofUT2Z41cuTIVUjyJMbn8nj69KkXqvkgy4O5XJSGpngZRDcKPwIq85SRY9Z3JLq8bm0wenrAzm2HK3WpicxcGbecg4AgX+jeqyPcT0yBpJQn4Nq00a9R0duizXfgvPvous8YOnToNXtP/PDDD2UY987Fl3Or+dnvL1y48Mq8efMqPRDJfmHp0qUbwVy00xpRFnfXWs3D0OugmoBi8Ru58qcYpW1igoial6BNXl5eW1R1/oUS3WgywLlrO3N53iqnIpGAokNrOLTnBOTlFdpOBkgl0LBxHeSw8Tnx3d1d4P2xUaDVaGHLl/vAo1EdcO3YBkw6fTWcDAwJNDrQPXqq5ySSasc44eHhfqjm79rYnYu23aJoRIStaKqS8AtJPh/j8zgHSA4bNmygiTkVsZPm3q+zxOwRxDm0O9ZuM5K8/9y5c+0pqrnR8jdZwxtV/f2YmJjniT4MJyi0iBZ7ABDBUc23ff3113rGZ1E1h6CgoBFgroJsC05TdfueFhwl241PNbfvUfrdvAkJ7PF2V9AplTBn0jLbPiS66F26tQO9Xi+Q3MVFCcM/HAQ9UM3/Z8v3cPr8VQgQJrZoq/1HCUm9YnURfsgbTviO/NDEBgncO3jw4AB8sPwJbR3aLrThgwcPpn7GNbt3716MJP+3g/ekWHeEjX15aDNXrFhRH+83Du07tD1o0dOnT2+F+/4GQgYFNqErHoUkv2fPjWfOnKlDVV+NLxNEdg9YuXJlXyR7yfsuNlx2zQcffPAZkvwOo7RN9BNJBFojAlU9wMOj+h049gb79ANKMhYVB5cRdR8v8P3rSLi+fD2sWLIZoqcME4a6lobSRSFsr1MvFFSqYug3uDt4eLjBvh3HYMPGveDfpxsoXm8M+vQs0D9JB3n9MOAUCvvnqpOiF6tBm/hQz8klzshakmsVar3x0KFDd/r3719uhtzevXsfEukcvdmoUaNIzbviyz+I7H60atWqmIkTJ+4VO3f58uVqiUSybMmSJWuR5Cp0xR2aDohk/xGv8+W0adM+F/mNDEtLSzv98ccf34qOjh6D75uKXOJTtFjG5QpBIVlVGDwRbRaa9kUS3YjES9Amp3Wgck5g+IVcikZ1weMvkbDnq51w9/ZDmLMgutyQWLlCDoOH9hJeZyChVyzdDNu/iwP/gW+Bz4hIMOQVgOrUecjdtg+ULV4F/4/GAO/iYtckF4ua02eihR+u11Qr9enTx+fAgQNuSHaVky9dC62rjX0UGuyt6GRUYw2ZEz7HerSOltCgNDrv2rXr92DujhNT89Oo5ls3bdrEXHYbePz4cXN02xtB+WniFI6FWXnawy0hXLWIbn+gbzLlGTKzy39GCQ9undqB/4yxcD0tE97tNxH+MWsVnDhyDpIeppkD2px8OH/2CiyatwaGvDMR9sddgOBRQ8B72CAwqtXCQBlpcABIawWC9n4KFHx/EniFHZNcSM21WozPn1DugAiY5IR20YF4f2anfv36HUeyt3Xy74AaWmyY4X9Xr179b1TzF/JjxDBAhx4C9atfFRN9MPdte1q77KNHj/4MSX6b0blCzBFR82MWlbceK+Cfn58/Et33anW12XuyAYl+Sp+R/ZFoyQpUeXmT+hCydCYq84/ww6VrEDf1U+AkkjLHyEICwbVfD3AL7wwSL0+h4ITm9n3I2xUrlJ5yfaM1uPfoBOqbiTYH19gkukYL+rR0KNTk6K+lnXVK3gTtJFoTkX0dkOzn8TNewtf70W2Pwxi9uoMtPG3EbrdFkm01jfNo+9BaWG2va+N4cvUPMx5XqOaeISEh3UW49x3aTssDtJ5IUu4rEO8NqakYnUuiCS2aW/dBju66mFtNQ1Ddw98UjPbrktLMii2VgLxObeCU5kQikbLg8ElQnbmEx6SConkTCF4yQziGikwqmjayu+oMlaQyZudo0Ds454yGOX78eFavXr3+HRcX92d8K9aPLLO4uB0HDRq0GEl/H19/sXv37nWRkZGOuNCvoFlX7dCjmt+aMGHCC/1Roqrj18h/PmXKFCL6wEoOv4Rq/j8bN25kLrv9ag4BAQH7MzMzNVlZWft9fX2joWzfeiNU9e7u7u6HVSqVQ4NM7HLdjUaD6dy1nUk8x4Oe3PeqjFSlddbqhwmklTeoIyyvlL//GGQsXgNpY2ZD0Y5D0NQX+ePtBcELp4OsdojDlWQ5i6JrU59q0ItIdWLjXEabXIUnKn0jDdFWRERE3NuxY0eEk+6PT0lQvYxf5dSpU3M/++wzysInVnIodfXFMx7bxqNHjwDVnNYgtO5S22JpY8K/Sr0Gq1hd9qIUnX7KlJC7qEtJa891bgumX54CUHzlBmT8cz3IwoJB4uvzPGNOxNWiB0BxPLnxktBgkOblw3vD3hG62LZ+uQ8up6YDVHe9B87sJWCMXoT3uemsBjp69KgOVf1LVHVy0Smj3L0Kp9WOiopajWR3r0Y3268FNOyX+tb/ZmP/2rFjx25HNWdsrhiU2Kwlsv2Lktjcz8/vQU5OzmVvb+8uVkIcVVhY+A9U9Zuo6nYzxZFRN0aT0RivTU4rO/kElduldTNBlWkxRcBYe1TvN2BEj3ZQePsBeEW9AyHL50DYthUQNPevwDd4BX46ewV+PBsP33wbC96d2ghFLKoDmk1nVBWRu1+EpHdqxh3JTh5D/Ntvv90DzF1KpHLPKjktCMn+wfbt2wOqeXsKGQJf1q8TVR1WrFjxGb48IJY7GD9+/Lb169erGI8rRbRI+JcQGBh4F9320uRdZUPVRzgkzg4S3YRKnawTiM6XT8Y1rAOeA3uBEfcl3X8Ebdu/jq85cPldC5ojLqg7r5SDW3gXuJOYAvNmrBQSeN5/7CeoseNqXibjTl1rSTXRUkeOHCHC30Kb0L9/f8qQv4G2Ac3WOu60DnyUHbegOnfZ5X4h0dGNaSTay8LkyZNzkewPRHZlgHkQD0PFbnvn0NDQ16B8wLtVhNQHLN+rNWJQ1QNcqMv5RSg6Uj2BlFOflS06pVTq5wM+00dD7PdnYMyIeeDVvDEohKWSjc/Vnyq+hq5dAMGLPoKAGeOeF7KoFtGLNaC7lwIqXd7DhHvHa7zxDh48qEPCX0QbM3DgwMZgzpqKqXGIHZfFGAbECEWj3rowyvyfUnMC9WqUSdr6+Pjoc3NzabvO6ljKYlNSVFLjRDcaDcZz13ee4jkJGDLEiU7KTuWmQlZ/AoFzJoD/5FFgtM6e43m8hzvG8yEOVn0Vic/R9TdQxp3jU190K+7fvz9t8ODBS/HlfZE8SCM7LkWfXWwSzOuo6sNWrlzJKPMbQ2pqqjuqeXeRZNpBdNvTMzLExFtIyom5uH93JCnn4MwYDoNhYzp1sXG2ikTQvHUksuLVBsA7MpTVbp6T666jjHsBJ+XPO/v6NFXVZDL9MTY2drIDp1d5muqmTZuyR48efcTG7pExMTGzKiL7jBkz6uLnPIa2b9GiRT6MZr8KzIayhSVKu+2ixTRQ1e/n5+f/DOZZo6URWFRU1A3dd7u46+hoGwP+kOK1KWk9ywyFfZmwxOj6R09UoJBcdzLJIS4ujgovbO/du3cx/u21Dh06NLtv377PXasBAwYE7NmzhwpDNLA6vQjsn49OI312oA2x2k5P8oVI9oZGo3EGxs3P15ibNm0aLFu2rBO+XA7mfn2YNWvWCTxu7Ny5cy/+xolS58CBA7+3kMLWD1zRo0ePiydPnsypzo2uXLnSDsxTbmW2fUcoatKkSfzdu3crHSeBag61a9cWm6WWFxwc/B9U84oy0JSUowlV1kE5DY88AXYMi3WU6EYwmhJ0RPSaXiK5iiSnATm0WgxIpUgsvdOIHh4eTiSnutElJVLoS5/Wp0+fcUj4HyxudlNL/Cz21E62ELfK2Lhx42P876sNGzbQfX1FfmjvT5o06U9o1N13BsxVZ94C84iq0m3aes6cOUfRPpo/f/6GqsxJ/5ViBNiezVca1CNyspr3qkofIY0p6IaWVoVjqWCJ2OSVbVB5aSxKytHDPMxqey9U9Qao6rfVanWVXGWHXHfOPBT2tB5jdGECyUsnOghz0Gnoq0qbm5GQeEzvLJIfO3aMfjy7ofy4bnrqv432EVpfGyQn0GAbR0bp0Tx2Gvpo6wt2sTxcyC0cb8kDiD246XNRzbbfMw/6pYDqCogl4baA7Z4ac8N5eenQfaeknN5GrF71mo8OKzqNgqLhrdTNxvMvnekWt10DvFPddpqO+xcRklcVF3fu3Dlv6NCh9svKxo0wduzYb/Dl6ArIXhWQe0fdf2zRyReM5OTk3ui2N4XyXWpn0W2/8+zZs6qo8SobLvqA4uJiX6VSWXNENxj1cO76rhwe+AwhIce/XPddGPpKiTgaESflnUb048ePP33rrbcmWb5se/EfJPl7Q4YMeeDo/devXw/jx4+nhA3lBy45cInbCxcu7Infz4rfsNv+W8Z7NtS8Km57iarfKygouAzlk3JKiwhJaozov8TpxiRtisjAmZfhupOipz4pBonkhjMvbZnUQskPGviyq5LD6QlN3Wvjdu/e3R1Jfq+691+7di09yM5MmDCBEm00//tYZS6fJXactXjx4q52lpFicJ6a13rllVcox2Kd1MuvVavWHlRze0aH2VL1iVV13x2WYp6Xyjq3iFrM1wqYGvLZ34Shp4UnzoFnn27CDLKSSi852/aC3/jhAhEt8gvG/ELIXLUZ/Ea/C5KgUqunGoygvnkXVGcvQcCUD36J/zE0MGTlQP7+o+A37s/m7UgpmlijfZgCrh1aQ+Gxs5D9xdZ7RRJ1B4zRs2qqAXv37u0WGxtLo+FozjgNbTVYLG3v3r1nBg8efLemf0QxMTG+K1eupPu/ZknUUPafJu5T4u/k0qVLH86cOZPNImN4Docns3PCmHdT/POEHJK78MgpcGnVFKQhAQIRTTodFJ39CfxjRiLRrbXPJCzWIKUHQokq0zZVsfCAKJPNNxhAl/YU1Am38fmIH1nNCdemOezqhJvC/HVzIi6v6OqjH7Jq8gs7cuSIChWWMrsnX1ajrVq1KhuNlJqpNUPNxegl9ENynn6ekJPwIPH1Bm3yo+eFI4msnFwOmlv3hP2V+98iK7XQgwCJbswrABmt+UbDaOlQtQZ0D5KFijQmjUZIxHESyTnWpAwMTiQ6JeTOX9uVTQk5LSorFZugVUw1NxJ/ITXNRQ8LEdx6rgpRArn8tJabdRafyj9rU5+UelhYJrA8yQBZoL8wvJYScbj/OmtSBgbnKrpZ1UumrCI5qXJM2emrpMbiXXBUxFGPcTdUJWNPMTwSm1aFodclWXZ9eibI6tYWJrPoU58UMkVnYKgZolMRiqu6lDShvjupty7p0fNlj6nbTervAwZUdCi7QItAWKHIZGUj6yxVYzT3U0AW5C/E8bSSqyG/UDDew02I1c0j4oApOgNDTSi6ySgUiwQjkpFiaIqndSWqjoSnmu9aJw+qMWn1oEt9DLyLEqTouuuSH1MiLiM+8aiONSkDQ0247hwkmCwJOYm7m1CemfrWS1S9RLk5R8fEW8pDaR+goterTbl+cyLuYSq+DxPGuOvThEQcU3MGhpog+vOEnInP1JrdZ5DWDgEtuu8Ue5M7TwUn9M8yqxaL6ynp9hg4kQw9PTiExRyowA3G5yWJOCK9FuNzkPAsPmdgqCFFN6u60XhafesecDIJyGsHC/XYy7jqQkKuVDadut1kMlDT8NmSmu+cOXFHq7XIKQSgBBxtQyJT0UlK9En8zQUnhVFw6Zl4XC0wZOWC/tHTYqboDAw1S3S9QPTrd6DoQjy4tGsB2jsPoGD/MYGcitcbAeeigKyN35qXQ0aiEkkpaae+ehsKT54DTi4TBskUxJ4SYm81egeGXPPiKOQd0Hb5K7WEElX6zBzI3mRe7JNG1eVuP4DXV9KQzyusORkYbEbA1YdEInPp1CxyK0p7hJB5x/iZFmsQusNQpfUl2XVUb1loEJHcgOpOc3qpRE0f3s1ViO31GdmF6OLvQe/8j5xCppBjDK6+kSiEAEKZaF8vMOSrBEXnXV2Ea6Pi31apc6PjE4+eZM3JwFCDRLeQXYJkD8e4nRbfo8obNLmkDZinWFKlRprFNQpNgY77LbVOdeDKnSOGN1sO7aU3aDtxHJdXrCncnZB49B5uC9PpNVSwnvx6KuxAJKbVRTug0SLstExSXY7jk1TFOfuR5FmsKRkYGBgY/l/jfwUYAPw0FqsWp2FrAAAAAElFTkSuQmCC\" style=\"margin-top:-20px\" height=\"55\">\n<span style=\"font-size:40px\">  [[cluster]]</span><span style=\"padding-top: 25px;float:right\"><a href=\"https://github.com/scylladb/scylla-monitoring/issues/new?body=scylla-version%3D[[scylla_dash_version]]%0Amonitoring-version%3D[[monitoring_version]]\" target=\"_blank\"><input title=\"Report an issue with Scylla Monitoring\" type=\"button\" style=\"background-color:#57d1e5;color:black;font-size:20px\" value=\"Report an issue\"></a></span><hr style=\"border-top: 3px solid #5780c1;\"></div>",
             "datasource": null,
@@ -88,7 +104,7 @@
                 "x": 0,
                 "y": 0
             },
-            "id": 1,
+            "id": 2,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -97,6 +113,22 @@
             "title": "",
             "transparent": true,
             "type": "text"
+        },
+        {
+            "class": "collapsible_row_panel",
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 4
+            },
+            "id": 3,
+            "panels": [],
+            "repeat": "",
+            "title": "CQL By User",
+            "type": "row"
         },
         {
             "class": "text_panel",
@@ -108,9 +140,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 3
+                "y": 5
             },
-            "id": 2,
+            "id": 4,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -138,10 +170,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 5
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 3,
+            "id": 5,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -172,7 +204,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]]) - sum(irate(scylla_cql_inserts_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[300s])) by ([[by]])",
+                    "expr": "sum(rate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]]) - sum(rate(scylla_cql_inserts_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[300s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -237,10 +269,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 5
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 4,
+            "id": 6,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -271,7 +303,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]]) - sum(irate(scylla_cql_reads_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[300s])) by ([[by]])",
+                    "expr": "sum(rate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]]) - sum(rate(scylla_cql_reads_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[300s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -336,10 +368,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 5
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 5,
+            "id": 7,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -370,7 +402,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])-sum(irate(scylla_cql_deletes_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[300s])) by ([[by]])",
+                    "expr": "sum(rate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])-sum(rate(scylla_cql_deletes_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[300s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -435,10 +467,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 5
+                "y": 7
             },
             "hiddenSeries": false,
-            "id": 6,
+            "id": 8,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -469,7 +501,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])-sum(irate(scylla_cql_updates_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[300s])) by ([[by]])",
+                    "expr": "sum(rate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])-sum(rate(scylla_cql_updates_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[300s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -534,10 +566,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 11
+                "y": 13
             },
             "hiddenSeries": false,
-            "id": 7,
+            "id": 9,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -631,10 +663,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 11
+                "y": 13
             },
             "hiddenSeries": false,
-            "id": 8,
+            "id": 10,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -728,10 +760,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 11
+                "y": 13
             },
             "hiddenSeries": false,
-            "id": 9,
+            "id": 11,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -760,7 +792,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(scylla_cql_statements_in_batches{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                    "expr": "sum(rate(scylla_cql_statements_in_batches{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -825,10 +857,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 11
+                "y": 13
             },
             "hiddenSeries": false,
-            "id": 10,
+            "id": 12,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -907,6 +939,76 @@
             }
         },
         {
+            "class": "collapsible_row_panel",
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 19
+            },
+            "id": 13,
+            "panels": [],
+            "repeat": "",
+            "title": "Connection",
+            "type": "row"
+        },
+        {
+            "class": "single_value_table",
+            "columns": [
+                {
+                    "text": "Avg",
+                    "value": "avg"
+                }
+            ],
+            "datasource": "scylla-datasource",
+            "fontSize": "100%",
+            "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 20
+            },
+            "id": 14,
+            "links": [],
+            "options": {},
+            "pageSize": null,
+            "scroll": true,
+            "showHeader": true,
+            "sort": {
+                "col": 0,
+                "desc": true
+            },
+            "span": 12,
+            "targets": [
+                {
+                    "queryHost": "$node",
+                    "queryText": "select address, port, shard_id, ssl_enabled, username from system.clients",
+                    "refId": "A"
+                }
+            ],
+            "title": "Connection Table",
+            "transform": "table",
+            "type": "table"
+        },
+        {
+            "class": "collapsible_row_panel",
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 26
+            },
+            "id": 15,
+            "panels": [],
+            "repeat": "",
+            "title": "CQL Internal",
+            "type": "row"
+        },
+        {
             "class": "text_panel",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">CQL Internal - Coordinator</h1>",
             "datasource": null,
@@ -916,9 +1018,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 17
+                "y": 27
             },
-            "id": 11,
+            "id": 16,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -946,10 +1048,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 19
+                "y": 29
             },
             "hiddenSeries": false,
-            "id": 12,
+            "id": 17,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -980,7 +1082,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(scylla_cql_inserts_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[300s])) by ([[by]])",
+                    "expr": "sum(rate(scylla_cql_inserts_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[300s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -1045,10 +1147,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 19
+                "y": 29
             },
             "hiddenSeries": false,
-            "id": 13,
+            "id": 18,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1079,7 +1181,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(scylla_cql_reads_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[300s])) by ([[by]])",
+                    "expr": "sum(rate(scylla_cql_reads_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[300s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -1144,10 +1246,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 19
+                "y": 29
             },
             "hiddenSeries": false,
-            "id": 14,
+            "id": 19,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1178,7 +1280,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(scylla_cql_deletes_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[300s])) by ([[by]])",
+                    "expr": "sum(rate(scylla_cql_deletes_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[300s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -1243,10 +1345,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 19
+                "y": 29
             },
             "hiddenSeries": false,
-            "id": 15,
+            "id": 20,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1277,7 +1379,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(scylla_cql_updates_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[300s])) by ([[by]])",
+                    "expr": "sum(rate(scylla_cql_updates_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[300s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -1326,6 +1428,22 @@
             }
         },
         {
+            "class": "collapsible_row_panel",
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 35
+            },
+            "id": 21,
+            "panels": [],
+            "repeat": "",
+            "title": "LWT",
+            "type": "row"
+        },
+        {
             "class": "text_panel",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">LWT</h1>",
             "datasource": null,
@@ -1335,9 +1453,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 25
+                "y": 36
             },
-            "id": 16,
+            "id": 22,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -1364,10 +1482,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 27
+                "y": 38
             },
             "hiddenSeries": false,
-            "id": 17,
+            "id": 23,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1398,7 +1516,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", conditional=\"yes\"}[300s])) by ([[by]])",
+                    "expr": "sum(rate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", conditional=\"yes\"}[300s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -1462,10 +1580,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 27
+                "y": 38
             },
             "hiddenSeries": false,
-            "id": 18,
+            "id": 24,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1496,7 +1614,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", conditional=\"yes\"}[300s])) by ([[by]])",
+                    "expr": "sum(rate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", conditional=\"yes\"}[300s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -1560,10 +1678,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 27
+                "y": 38
             },
             "hiddenSeries": false,
-            "id": 19,
+            "id": 25,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1594,7 +1712,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", conditional=\"yes\"}[300s])) by ([[by]])",
+                    "expr": "sum(rate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", conditional=\"yes\"}[300s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -1659,10 +1777,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 27
+                "y": 38
             },
             "hiddenSeries": false,
-            "id": 20,
+            "id": 26,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1691,7 +1809,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(scylla_cql_batches{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", conditional=\"yes\"}[300s])) by ([[by]])",
+                    "expr": "sum(rate(scylla_cql_batches{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", conditional=\"yes\"}[300s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -1740,6 +1858,22 @@
             }
         },
         {
+            "class": "collapsible_row_panel",
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 44
+            },
+            "id": 27,
+            "panels": [],
+            "repeat": "",
+            "title": "Optimization",
+            "type": "row"
+        },
+        {
             "class": "text_panel",
             "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Optimization</h1>",
             "datasource": null,
@@ -1749,9 +1883,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 33
+                "y": 45
             },
-            "id": 21,
+            "id": 28,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -1771,9 +1905,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 35
+                "y": 47
             },
-            "id": 22,
+            "id": 29,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -1851,10 +1985,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 35
+                "y": 47
             },
             "hiddenSeries": false,
-            "id": 23,
+            "id": 30,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1885,7 +2019,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(scylla_query_processor_statements_prepared{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "sum(rate(scylla_query_processor_statements_prepared{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "format": "time_series",
                     "hide": false,
                     "intervalFactor": 2,
@@ -1941,9 +2075,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 35
+                "y": 47
             },
-            "id": 24,
+            "id": 31,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2021,10 +2155,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 35
+                "y": 47
             },
             "hiddenSeries": false,
-            "id": 25,
+            "id": 32,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2055,7 +2189,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(scylla_cql_unpaged_select_queries{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "sum(rate(scylla_cql_unpaged_select_queries{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "format": "time_series",
                     "hide": false,
                     "intervalFactor": 2,
@@ -2111,9 +2245,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 16,
-                "y": 35
+                "y": 47
             },
-            "id": 26,
+            "id": 33,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2189,10 +2323,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 35
+                "y": 47
             },
             "hiddenSeries": false,
-            "id": 27,
+            "id": 34,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2223,7 +2357,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]]) - sum(irate(scylla_storage_proxy_coordinator_reads_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]]) + sum(irate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s]) + irate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s]) + irate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]]) - sum(irate(scylla_storage_proxy_coordinator_total_write_attempts_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])\n",
+                    "expr": "sum(rate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]]) - sum(rate(scylla_storage_proxy_coordinator_reads_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]]) + sum(rate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s]) + rate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s]) + rate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]]) - sum(rate(scylla_storage_proxy_coordinator_total_write_attempts_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])\n",
                     "format": "time_series",
                     "hide": false,
                     "intervalFactor": 2,
@@ -2279,9 +2413,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 41
+                "y": 53
             },
-            "id": 28,
+            "id": 35,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2359,10 +2493,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 41
+                "y": 53
             },
             "hiddenSeries": false,
-            "id": 29,
+            "id": 36,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2393,7 +2527,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(scylla_cql_reverse_queries{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "sum(rate(scylla_cql_reverse_queries{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "format": "time_series",
                     "hide": false,
                     "intervalFactor": 2,
@@ -2449,9 +2583,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 41
+                "y": 53
             },
-            "id": 30,
+            "id": 37,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2527,10 +2661,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 41
+                "y": 53
             },
             "hiddenSeries": false,
-            "id": 31,
+            "id": 38,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2559,7 +2693,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(scylla_cql_filtered_read_requests{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "sum(rate(scylla_cql_filtered_read_requests{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "format": "time_series",
                     "hide": false,
                     "intervalFactor": 2,
@@ -2615,9 +2749,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 16,
-                "y": 41
+                "y": 53
             },
-            "id": 32,
+            "id": 39,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2695,10 +2829,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 41
+                "y": 53
             },
             "hiddenSeries": false,
-            "id": 33,
+            "id": 40,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2727,7 +2861,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(scylla_cql_filtered_rows_read_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "sum(rate(scylla_cql_filtered_rows_read_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "format": "time_series",
                     "hide": false,
                     "intervalFactor": 2,
@@ -2735,7 +2869,7 @@
                     "refId": "A"
                 },
                 {
-                    "expr": "sum(irate(scylla_cql_filtered_rows_matched_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "sum(rate(scylla_cql_filtered_rows_matched_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "format": "time_series",
                     "hide": false,
                     "interval": "",
@@ -2744,7 +2878,7 @@
                     "refId": "B"
                 },
                 {
-                    "expr": "sum(irate(scylla_cql_filtered_rows_dropped_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "sum(rate(scylla_cql_filtered_rows_dropped_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "format": "time_series",
                     "intervalFactor": 2,
                     "legendFormat": "rows dropped $node $shard",
@@ -2800,9 +2934,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 47
+                "y": 59
             },
-            "id": 34,
+            "id": 41,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2880,10 +3014,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 47
+                "y": 59
             },
             "hiddenSeries": false,
-            "id": 35,
+            "id": 42,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2970,9 +3104,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 47
+                "y": 59
             },
-            "id": 36,
+            "id": 43,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -3050,10 +3184,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 47
+                "y": 59
             },
             "hiddenSeries": false,
-            "id": 37,
+            "id": 44,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3141,9 +3275,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 53
+                "y": 65
             },
-            "id": 38,
+            "id": 45,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -3163,9 +3297,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 55
+                "y": 67
             },
-            "id": 39,
+            "id": 46,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -3243,10 +3377,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 55
+                "y": 67
             },
             "hiddenSeries": false,
-            "id": 40,
+            "id": 47,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3333,9 +3467,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 55
+                "y": 67
             },
-            "id": 41,
+            "id": 48,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -3413,10 +3547,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 55
+                "y": 67
             },
             "hiddenSeries": false,
-            "id": 42,
+            "id": 49,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3503,9 +3637,9 @@
                 "h": 6,
                 "w": 4,
                 "x": 0,
-                "y": 61
+                "y": 73
             },
-            "id": 43,
+            "id": 50,
             "links": [],
             "options": {
                 "fieldOptions": {

--- a/grafana/build/ver_master/scylla-detailed.master.json
+++ b/grafana/build/ver_master/scylla-detailed.master.json
@@ -246,7 +246,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]]) + $func(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]]) + $func(rate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -342,7 +342,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_database_total_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_database_total_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -437,7 +437,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_database_total_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_database_total_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -1349,7 +1349,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_hints_manager_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_hints_manager_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -1446,7 +1446,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_hints_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_hints_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -2158,7 +2158,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_database_total_reads_failed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_database_total_reads_failed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -2253,7 +2253,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_database_requests_blocked_memory{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_database_requests_blocked_memory{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -2348,7 +2348,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_commitlog_requests_blocked_memory{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_commitlog_requests_blocked_memory{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -2487,7 +2487,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_database_total_writes_failed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_database_total_writes_failed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -2582,7 +2582,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_database_total_writes_timedout{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_database_total_writes_timedout{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -2700,7 +2700,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_cache_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s]) - irate(scylla_cache_reads_with_misses{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_cache_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s]) - rate(scylla_cache_reads_with_misses{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -2795,7 +2795,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_cache_reads_with_misses{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_cache_reads_with_misses{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -2890,7 +2890,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_cache_row_hits{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_cache_row_hits{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -2985,7 +2985,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_cache_partition_hits{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_cache_partition_hits{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -3080,7 +3080,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_cache_row_misses{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_cache_row_misses{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -3175,7 +3175,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_cache_partition_misses{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_cache_partition_misses{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -3270,7 +3270,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_cache_row_insertions{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_cache_row_insertions{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -3365,7 +3365,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_cache_partition_insertions{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_cache_partition_insertions{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -3462,7 +3462,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_cache_row_evictions{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_cache_row_evictions{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -3559,7 +3559,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_cache_partition_evictions{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_cache_partition_evictions{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -3656,7 +3656,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_cache_rows_merged_from_memtable{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_cache_rows_merged_from_memtable{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -3753,7 +3753,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_cache_partition_merges{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_cache_partition_merges{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -3850,7 +3850,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_cache_row_removals{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_cache_row_removals{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -3947,7 +3947,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_cache_partition_removals{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_cache_partition_removals{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -4736,7 +4736,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_database_dropped_view_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_database_dropped_view_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -4832,7 +4832,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_hints_for_views_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s]))  by ([[by]])",
+                    "expr": "$func(rate(scylla_hints_for_views_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s]))  by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -6908,7 +6908,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_cdc_operations_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m])) by ([[by]])",
+                    "expr": "$func(rate(scylla_cdc_operations_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -7006,7 +7006,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_cdc_operations_failed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])/($func(rate(scylla_storage_proxy_coordinator_cas_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]]) + 1)",
+                    "expr": "$func(rate(scylla_cdc_operations_failed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])/($func(rate(scylla_storage_proxy_coordinator_cas_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]]) + 1)",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",

--- a/grafana/build/ver_master/scylla-errors.master.json
+++ b/grafana/build/ver_master/scylla-errors.master.json
@@ -146,7 +146,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "avg(irate(scylla_storage_proxy_coordinator_read_errors_local_node{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "avg(rate(scylla_storage_proxy_coordinator_read_errors_local_node{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -243,7 +243,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "avg(irate(scylla_storage_proxy_coordinator_write_errors_local_node{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "avg(rate(scylla_storage_proxy_coordinator_write_errors_local_node{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -363,7 +363,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "avg(irate(scylla_storage_proxy_coordinator_read_unavailable{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "avg(rate(scylla_storage_proxy_coordinator_read_unavailable{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -460,7 +460,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "avg(irate(scylla_storage_proxy_coordinator_write_unavailable{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "avg(rate(scylla_storage_proxy_coordinator_write_unavailable{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -559,7 +559,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "avg(irate(scylla_storage_proxy_coordinator_range_unavailable{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "avg(rate(scylla_storage_proxy_coordinator_range_unavailable{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -658,7 +658,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "avg(irate(scylla_reactor_aio_errors{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "avg(rate(scylla_reactor_aio_errors{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -757,7 +757,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(scylla_reactor_abandoned_failed_futures{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "sum(rate(scylla_reactor_abandoned_failed_futures{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -856,7 +856,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(scylla_reactor_cpp_exceptions{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "sum(rate(scylla_reactor_cpp_exceptions{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",

--- a/grafana/build/ver_master/scylla-io.master.json
+++ b/grafana/build/ver_master/scylla-io.master.json
@@ -281,7 +281,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(scylla_io_queue_total_bytes{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "sum(rate(scylla_io_queue_total_bytes{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "seastar_io_queue_delay",
@@ -377,7 +377,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(scylla_io_queue_total_operations{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "sum(rate(scylla_io_queue_total_operations{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "seastar_io_queue_delay",

--- a/grafana/build/ver_master/scylla-os.master.json
+++ b/grafana/build/ver_master/scylla-os.master.json
@@ -334,7 +334,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
+                    "expr": "sum(rate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -342,7 +342,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_disk_writes_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
+                    "expr": "sum(rate(node_disk_writes_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -438,14 +438,14 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
+                    "expr": "sum(rate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_disk_reads_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
+                    "expr": "sum(rate(node_disk_reads_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "B",
@@ -562,7 +562,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
+                    "expr": "sum(rate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -570,7 +570,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_disk_bytes_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
+                    "expr": "sum(rate(node_disk_bytes_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -666,14 +666,14 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
+                    "expr": "sum(rate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_disk_bytes_read{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
+                    "expr": "sum(rate(node_disk_bytes_read{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "B",
@@ -791,7 +791,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_network_receive_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
+                    "expr": "sum(rate(node_network_receive_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -799,7 +799,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_network_receive_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
+                    "expr": "sum(rate(node_network_receive_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -895,7 +895,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_network_transmit_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
+                    "expr": "sum(rate(node_network_transmit_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -903,7 +903,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_network_transmit_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
+                    "expr": "sum(rate(node_network_transmit_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -999,7 +999,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_network_receive_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
+                    "expr": "sum(rate(node_network_receive_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -1007,7 +1007,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_network_receive_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
+                    "expr": "sum(rate(node_network_receive_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -1103,7 +1103,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(node_network_transmit_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
+                    "expr": "sum(rate(node_network_transmit_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -1111,7 +1111,7 @@
                     "step": 1
                 },
                 {
-                    "expr": "sum(irate(node_network_transmit_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
+                    "expr": "sum(rate(node_network_transmit_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[4m])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",

--- a/grafana/build/ver_master/scylla-overview.master.json
+++ b/grafana/build/ver_master/scylla-overview.master.json
@@ -991,7 +991,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]]) + $func(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]]) + $func(rate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "metric": "",
@@ -2044,7 +2044,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_cache_row_hits{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_cache_row_hits{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",
@@ -2142,7 +2142,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "$func(irate(scylla_cache_row_misses{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "expr": "$func(rate(scylla_cache_row_misses{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                     "intervalFactor": 1,
                     "legendFormat": "",
                     "refId": "A",

--- a/grafana/scylla-cql.2019.1.template.json
+++ b/grafana/scylla-cql.2019.1.template.json
@@ -5,7 +5,25 @@
         "originalTitle": "CQL",
         "rows": [
             {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
+                        "title": ""
+                    }
+                ]
+            },
+            {
                 "class": "logo_row"
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
+                        "title": "CQL Coordinator"
+                    }
+                ]
             },
             {
                 "class": "row",
@@ -141,6 +159,42 @@
                     }
                 ],
                 "title": "New row"
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
+                        "title": "Connection"
+                    }
+                ]
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "single_value_table",
+                        "datasource": "scylla-datasource",
+                        "span":12,
+                        "targets": [
+                            {
+                              "refId": "A",
+                              "queryText": "select address, port, shard_id, ssl_enabled, username from system.clients",
+                              "queryHost": "$node"
+                            }
+                          ],
+                        "title": "Connection Table"
+                     }
+                ]
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
+                        "title": "CQL Optimization"
+                    }
+                ]
             },
             {
                 "class": "row",

--- a/grafana/scylla-cql.2020.1.template.json
+++ b/grafana/scylla-cql.2020.1.template.json
@@ -5,7 +5,25 @@
         "originalTitle": "CQL",
         "rows": [
             {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
+                        "title": ""
+                    }
+                ]
+            },
+            {
                 "class": "logo_row"
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
+                        "title": "CQL By User"
+                    }
+                ]
             },
             {
                 "class": "row",
@@ -158,6 +176,42 @@
             },
             {
                 "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
+                        "title": "Connection"
+                    }
+                ]
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "single_value_table",
+                        "datasource": "scylla-datasource",
+                        "span":12,
+                        "targets": [
+                            {
+                              "refId": "A",
+                              "queryText": "select address, port, shard_id, ssl_enabled, username from system.clients",
+                              "queryHost": "$node"
+                            }
+                          ],
+                        "title": "Connection Table"
+                     }
+                ]
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
+                        "title": "CQL Internal"
+                    }
+                ]
+            },
+            {
+                "class": "row",
                 "height": "25px",
                 "gridPos": {"h": 2},
                 "panels": [
@@ -241,6 +295,15 @@
             },
             {
                 "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
+                        "title": "LWT"
+                    }
+                ]
+            },
+            {
+                "class": "row",
                 "height": "25px",
                 "gridPos": {"h": 2},
                 "panels": [
@@ -319,6 +382,15 @@
                     }
                 ],
                 "title": "New row"
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
+                        "title": "Optimization"
+                    }
+                ]
             },
             {
                 "class": "row",

--- a/grafana/scylla-cql.4.1.template.json
+++ b/grafana/scylla-cql.4.1.template.json
@@ -5,7 +5,25 @@
         "originalTitle": "CQL",
         "rows": [
             {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
+                        "title": ""
+                    }
+                ]
+            },
+            {
                 "class": "logo_row"
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
+                        "title": "CQL By User"
+                    }
+                ]
             },
             {
                 "class": "row",
@@ -158,6 +176,42 @@
             },
             {
                 "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
+                        "title": "Connection"
+                    }
+                ]
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "single_value_table",
+                        "datasource": "scylla-datasource",
+                        "span":12,
+                        "targets": [
+                            {
+                              "refId": "A",
+                              "queryText": "select address, port, shard_id, ssl_enabled, username from system.clients",
+                              "queryHost": "$node"
+                            }
+                          ],
+                        "title": "Connection Table"
+                     }
+                ]
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
+                        "title": "CQL Internal"
+                    }
+                ]
+            },
+            {
+                "class": "row",
                 "height": "25px",
                 "gridPos": {"h": 2},
                 "panels": [
@@ -241,6 +295,15 @@
             },
             {
                 "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
+                        "title": "LWT"
+                    }
+                ]
+            },
+            {
+                "class": "row",
                 "height": "25px",
                 "gridPos": {"h": 2},
                 "panels": [
@@ -319,6 +382,15 @@
                     }
                 ],
                 "title": "New row"
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
+                        "title": "Optimization"
+                    }
+                ]
             },
             {
                 "class": "row",

--- a/grafana/scylla-cql.4.2.template.json
+++ b/grafana/scylla-cql.4.2.template.json
@@ -5,7 +5,25 @@
         "originalTitle": "CQL",
         "rows": [
             {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
+                        "title": ""
+                    }
+                ]
+            },
+            {
                 "class": "logo_row"
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
+                        "title": "CQL By User"
+                    }
+                ]
             },
             {
                 "class": "row",
@@ -158,6 +176,42 @@
             },
             {
                 "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
+                        "title": "Connection"
+                    }
+                ]
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "single_value_table",
+                        "datasource": "scylla-datasource",
+                        "span":12,
+                        "targets": [
+                            {
+                              "refId": "A",
+                              "queryText": "select address, port, shard_id, ssl_enabled, username from system.clients",
+                              "queryHost": "$node"
+                            }
+                          ],
+                        "title": "Connection Table"
+                     }
+                ]
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
+                        "title": "CQL Internal"
+                    }
+                ]
+            },
+            {
+                "class": "row",
                 "height": "25px",
                 "gridPos": {"h": 2},
                 "panels": [
@@ -241,6 +295,15 @@
             },
             {
                 "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
+                        "title": "LWT"
+                    }
+                ]
+            },
+            {
+                "class": "row",
                 "height": "25px",
                 "gridPos": {"h": 2},
                 "panels": [
@@ -319,6 +382,15 @@
                     }
                 ],
                 "title": "New row"
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
+                        "title": "Optimization"
+                    }
+                ]
             },
             {
                 "class": "row",

--- a/grafana/scylla-cql.master.template.json
+++ b/grafana/scylla-cql.master.template.json
@@ -5,7 +5,25 @@
         "originalTitle": "CQL",
         "rows": [
             {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
+                        "title": ""
+                    }
+                ]
+            },
+            {
                 "class": "logo_row"
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
+                        "title": "CQL By User"
+                    }
+                ]
             },
             {
                 "class": "row",
@@ -158,6 +176,42 @@
             },
             {
                 "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
+                        "title": "Connection"
+                    }
+                ]
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "single_value_table",
+                        "datasource": "scylla-datasource",
+                        "span":12,
+                        "targets": [
+                            {
+                              "refId": "A",
+                              "queryText": "select address, port, shard_id, ssl_enabled, username from system.clients",
+                              "queryHost": "$node"
+                            }
+                          ],
+                        "title": "Connection Table"
+                     }
+                ]
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
+                        "title": "CQL Internal"
+                    }
+                ]
+            },
+            {
+                "class": "row",
                 "height": "25px",
                 "gridPos": {"h": 2},
                 "panels": [
@@ -241,6 +295,15 @@
             },
             {
                 "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
+                        "title": "LWT"
+                    }
+                ]
+            },
+            {
+                "class": "row",
                 "height": "25px",
                 "gridPos": {"h": 2},
                 "panels": [
@@ -319,6 +382,15 @@
                     }
                 ],
                 "title": "New row"
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
+                        "title": "Optimization"
+                    }
+                ]
             },
             {
                 "class": "row",

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -25,6 +25,19 @@
                 ],
         "title": "New row"
     },
+    "collapsible_row_panel" : {
+      "collapsed": false,
+      "datasource": null,
+      "id": "auto",
+      "gridPos": {
+        "h": 1,
+        "w": 24
+      },
+      "panels": [],
+      "repeat": "",
+      "title": "",
+      "type": "row"
+    },
     "alternator_logo_row": {
         "collapse": false,
         "editable": true,


### PR DESCRIPTION
This patch adds a client table to the CQL dashboard.
It breaks the dashboard into sections each of them can be collapsed.

![image](https://user-images.githubusercontent.com/2118079/91690856-50efa000-eb6f-11ea-8147-94ac3773aea3.png)

Fixes #1024