### PR TITLE
Manager annotations

### DIFF
--- a/grafana/build/ver_2019.1/scylla-cpu.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-cpu.2019.1.json
@@ -1,5 +1,6 @@
 {
     "annotations": {
+        "class": "default_annotations",
         "list": [
             {
                 "builtIn": 1,
@@ -23,6 +24,51 @@
                 "tagKeys": "instance,dc,cluster",
                 "tags": [],
                 "titleFormat": "restart",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_stall",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_stall_detector_reported[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "stall detector",
+                "showIn": 0,
+                "tagKeys": "dc,instance,shard",
+                "tags": [],
+                "titleFormat": "Stall found",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_schema_changed",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_database_schema_changed[30s])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "Schema Changed",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "schema changed",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_manager_task",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "scylla_manager_task_active_count{type=~\"repair|backup\",cluster=~\"$cluster|$^\"}>0",
+                "hide": false,
+                "iconColor": "#73BF69",
+                "limit": 100,
+                "name": "Task",
+                "showIn": 0,
+                "tagKeys": "type",
+                "tags": [],
+                "titleFormat": "Running",
                 "type": "tags"
             }
         ]

--- a/grafana/build/ver_2019.1/scylla-cql.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-cql.2019.1.json
@@ -1,5 +1,6 @@
 {
     "annotations": {
+        "class": "default_annotations",
         "list": [
             {
                 "builtIn": 1,
@@ -23,6 +24,51 @@
                 "tagKeys": "instance,dc,cluster",
                 "tags": [],
                 "titleFormat": "restart",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_stall",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_stall_detector_reported[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "stall detector",
+                "showIn": 0,
+                "tagKeys": "dc,instance,shard",
+                "tags": [],
+                "titleFormat": "Stall found",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_schema_changed",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_database_schema_changed[30s])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "Schema Changed",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "schema changed",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_manager_task",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "scylla_manager_task_active_count{type=~\"repair|backup\",cluster=~\"$cluster|$^\"}>0",
+                "hide": false,
+                "iconColor": "#73BF69",
+                "limit": 100,
+                "name": "Task",
+                "showIn": 0,
+                "tagKeys": "type",
+                "tags": [],
+                "titleFormat": "Running",
                 "type": "tags"
             }
         ]

--- a/grafana/build/ver_2019.1/scylla-detailed.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-detailed.2019.1.json
@@ -1,5 +1,6 @@
 {
     "annotations": {
+        "class": "default_annotations",
         "list": [
             {
                 "builtIn": 1,
@@ -23,6 +24,51 @@
                 "tagKeys": "instance,dc,cluster",
                 "tags": [],
                 "titleFormat": "restart",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_stall",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_stall_detector_reported[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "stall detector",
+                "showIn": 0,
+                "tagKeys": "dc,instance,shard",
+                "tags": [],
+                "titleFormat": "Stall found",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_schema_changed",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_database_schema_changed[30s])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "Schema Changed",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "schema changed",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_manager_task",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "scylla_manager_task_active_count{type=~\"repair|backup\",cluster=~\"$cluster|$^\"}>0",
+                "hide": false,
+                "iconColor": "#73BF69",
+                "limit": 100,
+                "name": "Task",
+                "showIn": 0,
+                "tagKeys": "type",
+                "tags": [],
+                "titleFormat": "Running",
                 "type": "tags"
             }
         ]

--- a/grafana/build/ver_2019.1/scylla-errors.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-errors.2019.1.json
@@ -1,5 +1,6 @@
 {
     "annotations": {
+        "class": "default_annotations",
         "list": [
             {
                 "builtIn": 1,
@@ -23,6 +24,51 @@
                 "tagKeys": "instance,dc,cluster",
                 "tags": [],
                 "titleFormat": "restart",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_stall",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_stall_detector_reported[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "stall detector",
+                "showIn": 0,
+                "tagKeys": "dc,instance,shard",
+                "tags": [],
+                "titleFormat": "Stall found",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_schema_changed",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_database_schema_changed[30s])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "Schema Changed",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "schema changed",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_manager_task",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "scylla_manager_task_active_count{type=~\"repair|backup\",cluster=~\"$cluster|$^\"}>0",
+                "hide": false,
+                "iconColor": "#73BF69",
+                "limit": 100,
+                "name": "Task",
+                "showIn": 0,
+                "tagKeys": "type",
+                "tags": [],
+                "titleFormat": "Running",
                 "type": "tags"
             }
         ]

--- a/grafana/build/ver_2019.1/scylla-io.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-io.2019.1.json
@@ -1,5 +1,6 @@
 {
     "annotations": {
+        "class": "default_annotations",
         "list": [
             {
                 "builtIn": 1,
@@ -23,6 +24,51 @@
                 "tagKeys": "instance,dc,cluster",
                 "tags": [],
                 "titleFormat": "restart",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_stall",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_stall_detector_reported[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "stall detector",
+                "showIn": 0,
+                "tagKeys": "dc,instance,shard",
+                "tags": [],
+                "titleFormat": "Stall found",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_schema_changed",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_database_schema_changed[30s])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "Schema Changed",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "schema changed",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_manager_task",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "scylla_manager_task_active_count{type=~\"repair|backup\",cluster=~\"$cluster|$^\"}>0",
+                "hide": false,
+                "iconColor": "#73BF69",
+                "limit": 100,
+                "name": "Task",
+                "showIn": 0,
+                "tagKeys": "type",
+                "tags": [],
+                "titleFormat": "Running",
                 "type": "tags"
             }
         ]

--- a/grafana/build/ver_2019.1/scylla-os.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-os.2019.1.json
@@ -1,5 +1,6 @@
 {
     "annotations": {
+        "class": "default_annotations",
         "list": [
             {
                 "builtIn": 1,
@@ -23,6 +24,51 @@
                 "tagKeys": "instance,dc,cluster",
                 "tags": [],
                 "titleFormat": "restart",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_stall",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_stall_detector_reported[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "stall detector",
+                "showIn": 0,
+                "tagKeys": "dc,instance,shard",
+                "tags": [],
+                "titleFormat": "Stall found",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_schema_changed",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_database_schema_changed[30s])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "Schema Changed",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "schema changed",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_manager_task",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "scylla_manager_task_active_count{type=~\"repair|backup\",cluster=~\"$cluster|$^\"}>0",
+                "hide": false,
+                "iconColor": "#73BF69",
+                "limit": 100,
+                "name": "Task",
+                "showIn": 0,
+                "tagKeys": "type",
+                "tags": [],
+                "titleFormat": "Running",
                 "type": "tags"
             }
         ]

--- a/grafana/build/ver_2019.1/scylla-overview.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-overview.2019.1.json
@@ -1,5 +1,6 @@
 {
     "annotations": {
+        "class": "default_annotations",
         "list": [
             {
                 "builtIn": 1,
@@ -23,6 +24,51 @@
                 "tagKeys": "instance,dc,cluster",
                 "tags": [],
                 "titleFormat": "restart",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_stall",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_stall_detector_reported[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "stall detector",
+                "showIn": 0,
+                "tagKeys": "dc,instance,shard",
+                "tags": [],
+                "titleFormat": "Stall found",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_schema_changed",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_database_schema_changed[30s])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "Schema Changed",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "schema changed",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_manager_task",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "scylla_manager_task_active_count{type=~\"repair|backup\",cluster=~\"$cluster|$^\"}>0",
+                "hide": false,
+                "iconColor": "#73BF69",
+                "limit": 100,
+                "name": "Task",
+                "showIn": 0,
+                "tagKeys": "type",
+                "tags": [],
+                "titleFormat": "Running",
                 "type": "tags"
             }
         ]

--- a/grafana/build/ver_2020.1/scylla-detailed.2020.1.json
+++ b/grafana/build/ver_2020.1/scylla-detailed.2020.1.json
@@ -1,5 +1,6 @@
 {
     "annotations": {
+        "class": "default_annotations",
         "list": [
             {
                 "builtIn": 1,
@@ -53,6 +54,21 @@
                 "tagKeys": "instance,dc,cluster",
                 "tags": [],
                 "titleFormat": "schema changed",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_manager_task",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "scylla_manager_task_active_count{type=~\"repair|backup\",cluster=~\"$cluster|$^\"}>0",
+                "hide": false,
+                "iconColor": "#73BF69",
+                "limit": 100,
+                "name": "Task",
+                "showIn": 0,
+                "tagKeys": "type",
+                "tags": [],
+                "titleFormat": "Running",
                 "type": "tags"
             }
         ]

--- a/grafana/build/ver_2020.1/scylla-overview.2020.1.json
+++ b/grafana/build/ver_2020.1/scylla-overview.2020.1.json
@@ -1,5 +1,6 @@
 {
     "annotations": {
+        "class": "default_annotations",
         "list": [
             {
                 "builtIn": 1,
@@ -53,6 +54,21 @@
                 "tagKeys": "instance,dc,cluster",
                 "tags": [],
                 "titleFormat": "schema changed",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_manager_task",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "scylla_manager_task_active_count{type=~\"repair|backup\",cluster=~\"$cluster|$^\"}>0",
+                "hide": false,
+                "iconColor": "#73BF69",
+                "limit": 100,
+                "name": "Task",
+                "showIn": 0,
+                "tagKeys": "type",
+                "tags": [],
+                "titleFormat": "Running",
                 "type": "tags"
             }
         ]

--- a/grafana/build/ver_4.2/scylla-detailed.4.2.json
+++ b/grafana/build/ver_4.2/scylla-detailed.4.2.json
@@ -1,5 +1,6 @@
 {
     "annotations": {
+        "class": "default_annotations",
         "list": [
             {
                 "builtIn": 1,
@@ -53,6 +54,21 @@
                 "tagKeys": "instance,dc,cluster",
                 "tags": [],
                 "titleFormat": "schema changed",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_manager_task",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "scylla_manager_task_active_count{type=~\"repair|backup\",cluster=~\"$cluster|$^\"}>0",
+                "hide": false,
+                "iconColor": "#73BF69",
+                "limit": 100,
+                "name": "Task",
+                "showIn": 0,
+                "tagKeys": "type",
+                "tags": [],
+                "titleFormat": "Running",
                 "type": "tags"
             }
         ]

--- a/grafana/build/ver_4.2/scylla-overview.4.2.json
+++ b/grafana/build/ver_4.2/scylla-overview.4.2.json
@@ -1,5 +1,6 @@
 {
     "annotations": {
+        "class": "default_annotations",
         "list": [
             {
                 "builtIn": 1,
@@ -53,6 +54,21 @@
                 "tagKeys": "instance,dc,cluster",
                 "tags": [],
                 "titleFormat": "schema changed",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_manager_task",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "scylla_manager_task_active_count{type=~\"repair|backup\",cluster=~\"$cluster|$^\"}>0",
+                "hide": false,
+                "iconColor": "#73BF69",
+                "limit": 100,
+                "name": "Task",
+                "showIn": 0,
+                "tagKeys": "type",
+                "tags": [],
+                "titleFormat": "Running",
                 "type": "tags"
             }
         ]

--- a/grafana/build/ver_master/scylla-detailed.master.json
+++ b/grafana/build/ver_master/scylla-detailed.master.json
@@ -1,5 +1,6 @@
 {
     "annotations": {
+        "class": "default_annotations",
         "list": [
             {
                 "builtIn": 1,
@@ -53,6 +54,21 @@
                 "tagKeys": "instance,dc,cluster",
                 "tags": [],
                 "titleFormat": "schema changed",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_manager_task",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "scylla_manager_task_active_count{type=~\"repair|backup\",cluster=~\"$cluster|$^\"}>0",
+                "hide": false,
+                "iconColor": "#73BF69",
+                "limit": 100,
+                "name": "Task",
+                "showIn": 0,
+                "tagKeys": "type",
+                "tags": [],
+                "titleFormat": "Running",
                 "type": "tags"
             }
         ]

--- a/grafana/build/ver_master/scylla-overview.master.json
+++ b/grafana/build/ver_master/scylla-overview.master.json
@@ -1,5 +1,6 @@
 {
     "annotations": {
+        "class": "default_annotations",
         "list": [
             {
                 "builtIn": 1,
@@ -53,6 +54,21 @@
                 "tagKeys": "instance,dc,cluster",
                 "tags": [],
                 "titleFormat": "schema changed",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_manager_task",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "scylla_manager_task_active_count{type=~\"repair|backup\",cluster=~\"$cluster|$^\"}>0",
+                "hide": false,
+                "iconColor": "#73BF69",
+                "limit": 100,
+                "name": "Task",
+                "showIn": 0,
+                "tagKeys": "type",
+                "tags": [],
+                "titleFormat": "Running",
                 "type": "tags"
             }
         ]

--- a/grafana/scylla-detailed.2020.1.template.json
+++ b/grafana/scylla-detailed.2020.1.template.json
@@ -1425,28 +1425,6 @@
             "from": "now-30m",
             "to": "now"
         },
-        "annotations" :{
-            "list": [
-              {
-                "builtIn": 1,
-                "datasource": "-- Grafana --",
-                "enable": true,
-                "hide": true,
-                "iconColor": "rgba(0, 211, 255, 1)",
-                "name": "Annotations & Alerts",
-                "type": "dashboard"
-              },
-              {
-                "class" : "annotation_restart"
-              },
-              {
-                "class" : "annotation_stall"
-              },
-              {
-              "class" : "annotation_schema_changed"
-              }
-            ]
-        },
         "title": "Detailed",
         "overwrite": true,
         "version": 5

--- a/grafana/scylla-detailed.4.2.template.json
+++ b/grafana/scylla-detailed.4.2.template.json
@@ -1425,28 +1425,6 @@
             "from": "now-30m",
             "to": "now"
         },
-        "annotations" :{
-            "list": [
-              {
-                "builtIn": 1,
-                "datasource": "-- Grafana --",
-                "enable": true,
-                "hide": true,
-                "iconColor": "rgba(0, 211, 255, 1)",
-                "name": "Annotations & Alerts",
-                "type": "dashboard"
-              },
-              {
-                "class" : "annotation_restart"
-              },
-              {
-                "class" : "annotation_stall"
-              },
-              {
-              "class" : "annotation_schema_changed"
-              }
-            ]
-        },
         "title": "Detailed",
         "overwrite": true,
         "version": 5

--- a/grafana/scylla-detailed.master.template.json
+++ b/grafana/scylla-detailed.master.template.json
@@ -1425,28 +1425,6 @@
             "from": "now-30m",
             "to": "now"
         },
-        "annotations" :{
-            "list": [
-              {
-                "builtIn": 1,
-                "datasource": "-- Grafana --",
-                "enable": true,
-                "hide": true,
-                "iconColor": "rgba(0, 211, 255, 1)",
-                "name": "Annotations & Alerts",
-                "type": "dashboard"
-              },
-              {
-                "class" : "annotation_restart"
-              },
-              {
-                "class" : "annotation_stall"
-              },
-              {
-              "class" : "annotation_schema_changed"
-              }
-            ]
-        },
         "title": "Detailed",
         "overwrite": true,
         "version": 5

--- a/grafana/scylla-overview.2020.1.template.json
+++ b/grafana/scylla-overview.2020.1.template.json
@@ -525,28 +525,6 @@
                 
             ]
         },
-        "annotations" :{
-            "list": [
-              {
-                "builtIn": 1,
-                "datasource": "-- Grafana --",
-                "enable": true,
-                "hide": true,
-                "iconColor": "rgba(0, 211, 255, 1)",
-                "name": "Annotations & Alerts",
-                "type": "dashboard"
-              },
-              {
-                "class" : "annotation_restart"
-              },
-              {
-                "class" : "annotation_stall"
-              },
-              {
-              "class" : "annotation_schema_changed"
-              }
-            ]
-        },
         "time": {
             "from": "now-30m",
             "to": "now"

--- a/grafana/scylla-overview.4.2.template.json
+++ b/grafana/scylla-overview.4.2.template.json
@@ -525,28 +525,6 @@
                 
             ]
         },
-        "annotations" :{
-            "list": [
-              {
-                "builtIn": 1,
-                "datasource": "-- Grafana --",
-                "enable": true,
-                "hide": true,
-                "iconColor": "rgba(0, 211, 255, 1)",
-                "name": "Annotations & Alerts",
-                "type": "dashboard"
-              },
-              {
-                "class" : "annotation_restart"
-              },
-              {
-                "class" : "annotation_stall"
-              },
-              {
-              "class" : "annotation_schema_changed"
-              }
-            ]
-        },
         "time": {
             "from": "now-30m",
             "to": "now"

--- a/grafana/scylla-overview.master.template.json
+++ b/grafana/scylla-overview.master.template.json
@@ -525,28 +525,6 @@
                 
             ]
         },
-        "annotations" :{
-            "list": [
-              {
-                "builtIn": 1,
-                "datasource": "-- Grafana --",
-                "enable": true,
-                "hide": true,
-                "iconColor": "rgba(0, 211, 255, 1)",
-                "name": "Annotations & Alerts",
-                "type": "dashboard"
-              },
-              {
-                "class" : "annotation_restart"
-              },
-              {
-                "class" : "annotation_stall"
-              },
-              {
-              "class" : "annotation_schema_changed"
-              }
-            ]
-        },
         "time": {
             "from": "now-30m",
             "to": "now"

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -764,21 +764,8 @@
 			]
 		},
 		"annotations": {
-			"list": [
-              {
-                "builtIn": 1,
-                "datasource": "-- Grafana --",
-                "enable": true,
-                "hide": true,
-                "iconColor": "rgba(0, 211, 255, 1)",
-                "name": "Annotations & Alerts",
-                "type": "dashboard"
-              },
-              {
-                "class" : "annotation_restart"
-              }
-			]
-		},
+            "class": "default_annotations"
+        },
 		"refresh": "30s",
 		"schemaVersion": 16,
 		"version": 0,
@@ -1413,6 +1400,31 @@
         "skipUrlSync": false,
         "type": "adhoc"
       },
+      "default_annotations" :{
+            "list": [
+              {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+              },
+              {
+                "class" : "annotation_restart"
+              },
+              {
+                "class" : "annotation_stall"
+              },
+              {
+              "class" : "annotation_schema_changed"
+              },
+              {
+              "class" : "annotation_manager_task"
+              }
+            ]
+        },
         "by_template_var": {
                     "allValue": null,
                     "current": {


### PR DESCRIPTION
This series adds Manager task annotations to the overview and detailed dashboard.
It uses default annotations in the dashboard definition, so it can be updated easily.
![image](https://user-images.githubusercontent.com/2118079/91835356-f418e600-ec51-11ea-893d-92d3c7aad27e.png)

Fixes #925