### PR TITLE
prometheus.rules.yml Add alerts for backup and repair failure

### DIFF
--- a/prometheus/prometheus.rules.yml
+++ b/prometheus/prometheus.rules.yml
@@ -101,3 +101,19 @@ groups:
     annotations:
       description: '{{ $labels.instance }} has average high latency for more than 5 minutes.'
       summary: Instance {{ $labels.instance }} Hight Read  Latency
+  - alert: BackupFailed
+    expr: (sum(scylla_manager_task_run_total{type=~"backup", status="ERROR"}) or vector(0)) - (sum(scylla_manager_task_run_total{type=~"backup", status="ERROR"} offset 3m) or vector(0)) > 0
+    for: 10s
+    labels:
+      severity: "1"
+    annotations:
+      description: 'Backup failed'
+      summary: Backup task failed
+  - alert: RepairFailed
+    expr: (sum(scylla_manager_task_run_total{type=~"repair", status="ERROR"}) or vector(0)) - (sum(scylla_manager_task_run_total{type=~"repair", status="ERROR"} offset 3m) or vector(0)) > 0
+    for: 10s
+    labels:
+      severity: "1"
+    annotations:
+      description: 'Repair failed'
+      summary: Repair task failed


### PR DESCRIPTION
This patch adds an alert when a Manager backup or Repair task fails.

There are two issues with such rules:
1. Typically, an alert is for an on-going condition, and not a single change.
    To overcome this, the rules look at a change over a 3 minutes period, this gives enough
    time for the alert to propagate.
2. the progress metrics are not created with zero value.
    To overcome this, there is a separate rule for backup and for repair and a missing value
     is calculate as zero.

Fixes #933