### PR TITLE
Fixed build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,4 +29,4 @@ jobs:
       run : ./docs/_utils/deploy.sh
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        LATEST_VERSION: scylla-monitoring-3.4
+        LATEST_VERSION: scylla-monitoring-3.4.2

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -537,7 +537,7 @@ sitemap_url_scheme = "{link}"
 # -- Options for multiversion --------------------------------------------
 # Whitelist pattern for tags (set to None to ignore all tags)
 # smv_tag_whitelist = r'^.*$'
-smv_tag_whitelist = r'\b(scylla-monitoring-3.4)\b'
+smv_tag_whitelist = r'\b(scylla-monitoring-3.4.2)\b(?!\S)'
 # Whitelist pattern for branches (set to None to ignore all branches)
 smv_branch_whitelist = "None"
 # Whitelist pattern for remotes (set to None to use local branches only)


### PR DESCRIPTION
@amnonh  Noticed the previous fix https://github.com/scylladb/scylla-monitoring/pull/1048 didn't work. This is because the tag ``scylla-monitoring-3.4.`` doesn't have a docs folder, so the script can't build them: https://github.com/scylladb/scylla-monitoring/tree/scylla-monitoring-3.4

The first version tagged with docs seems to be ``scylla-monitoring-3.4.2``: https://github.com/scylladb/scylla-monitoring/tree/scylla-monitoring-3.4.2