### PR TITLE
Grafana renderer

### DIFF
--- a/kill-all.sh
+++ b/kill-all.sh
@@ -48,6 +48,7 @@ sleep 2
 ./kill-container.sh $PROMETHEUS_PORT -b aprom
 ./kill-container.sh $GRAFANA_PORT -b agraf
 ./kill-container.sh $ALERTMANAGER_PORT -b aalert
+./kill-container.sh -b agrafrender
 
 
 

--- a/start-all.sh
+++ b/start-all.sh
@@ -51,8 +51,9 @@ BIND_ADDRESS_CONFIG=""
 GRAFNA_ANONYMOUS_ROLE=""
 SPECIFIC_SOLUTION=""
 LDAP_FILE=""
+RUN_RENDERER=""
 
-while getopts ':hled:g:p:v:s:n:a:c:j:b:m:r:R:M:G:D:L:N:C:Q:A:P:S:' option; do
+while getopts ':hleEd:g:p:v:s:n:a:c:j:b:m:r:R:M:G:D:L:N:C:Q:A:P:S:' option; do
   case "$option" in
     h) echo "$usage"
        exit
@@ -105,6 +106,8 @@ while getopts ':hled:g:p:v:s:n:a:c:j:b:m:r:R:M:G:D:L:N:C:Q:A:P:S:' option; do
     N) SCYLLA_MANGER_TARGET_FILE="$OPTARG"
        ;;
     S) SPECIFIC_SOLUTION="-S $OPTARG"
+       ;;
+    E) RUN_RENDERER="-E"
        ;;
     :) printf "missing argument for -%s\n" "$OPTARG" >&2
        echo "$usage" >&2
@@ -291,4 +294,4 @@ for val in "${GRAFANA_DASHBOARD_ARRAY[@]}"; do
         GRAFANA_DASHBOARD_COMMAND="$GRAFANA_DASHBOARD_COMMAND -j $val"
 done
 
-./start-grafana.sh $LDAP_FILE $BIND_ADDRESS_CONFIG $SPECIFIC_SOLUTION -p $DB_ADDRESS $GRAFNA_ANONYMOUS_ROLE -D "$DOCKER_PARAM" $GRAFANA_PORT $EXTERNAL_VOLUME -m $AM_ADDRESS -M $MANAGER_VERSION -v $VERSIONS $GRAFANA_ENV_COMMAND $GRAFANA_DASHBOARD_COMMAND $GRAFANA_ADMIN_PASSWORD
+./start-grafana.sh $LDAP_FILE $BIND_ADDRESS_CONFIG $RUN_RENDERER $SPECIFIC_SOLUTION -p $DB_ADDRESS $GRAFNA_ANONYMOUS_ROLE -D "$DOCKER_PARAM" $GRAFANA_PORT $EXTERNAL_VOLUME -m $AM_ADDRESS -M $MANAGER_VERSION -v $VERSIONS $GRAFANA_ENV_COMMAND $GRAFANA_DASHBOARD_COMMAND $GRAFANA_ADMIN_PASSWORD

--- a/start-grafana-renderer.sh
+++ b/start-grafana-renderer.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+VERSION="2.0.0"
+DOCKER_PARAM=""
+GRAFANA_NAME="agrafrender"
+BIND_ADDRESS=""
+GRAFANA_RENDPORT="8081"
+
+usage="$(basename "$0") [-h] [-D encapsulate docker param] -- Start the grafana render container"
+
+while getopts ':hlg:D:' option; do
+  case "$option" in
+    h) echo "$usage"
+       exit
+       ;;
+    l) DOCKER_PARAM="$DOCKER_PARAM --net=host"
+       ;;
+    D) DOCKER_PARAM="$DOCKER_PARAM $OPTARG"
+       ;;
+    :) printf "missing argument for -%s\n" "$OPTARG" >&2
+       echo "$usage" >&2
+       exit 1
+       ;;
+   \?) printf "illegal option: -%s\n" "$OPTARG" >&2
+       echo "$usage" >&2
+       exit 1
+       ;;
+  esac
+done
+
+if [ "`id -u`" -ne 0 ]; then
+    GROUPID=`id -g`
+    USER_PERMISSIONS="-u $UID:$GROUPID"
+fi
+
+if [[ ! $DOCKER_PARAM = *"--net=host"* ]]; then
+    PORT_MAPPING="-p $GRAFANA_RENDPORT:8081"
+fi
+
+docker run -d $DOCKER_PARAM -i $USER_PERMISSIONS $PORT_MAPPING \
+     --name $GRAFANA_NAME grafana/grafana-image-renderer:$VERSION


### PR DESCRIPTION
The grafana renderer is an extension that allows a user to download capture of a dashboard.
When I tested it, it run very slow, so I'm not sure how useful it will be.

This series adds it as an optional, by running `start-all.sh` with `-E`.

Fixes #904