### PR TITLE
scylla-cql.master: Add large partition, rows, and cells table

### DIFF
--- a/grafana/build/ver_master/scylla-cql.master.json
+++ b/grafana/build/ver_master/scylla-cql.master.json
@@ -1005,6 +1005,273 @@
             "id": 15,
             "panels": [],
             "repeat": "",
+            "title": "Large Rows",
+            "type": "row"
+        },
+        {
+            "class": "single_value_table",
+            "columns": [
+                {
+                    "text": "Avg",
+                    "value": "avg"
+                }
+            ],
+            "datasource": "scylla-datasource",
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {
+                        "align": null
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": [
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "row_size"
+                        },
+                        "properties": [
+                            {
+                                "id": "unit",
+                                "value": "bytes"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "fontSize": "100%",
+            "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 27
+            },
+            "id": 16,
+            "links": [],
+            "options": {},
+            "pageSize": null,
+            "scroll": true,
+            "showHeader": true,
+            "sort": {
+                "col": 0,
+                "desc": true
+            },
+            "span": 12,
+            "targets": [
+                {
+                    "queryHost": "$node",
+                    "queryText": "select keyspace_name, table_name,partition_key, clustering_key, row_size  from system.large_rows",
+                    "refId": "A"
+                }
+            ],
+            "title": "Large Rows",
+            "transform": "table",
+            "type": "table"
+        },
+        {
+            "class": "collapsible_row_panel",
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 33
+            },
+            "id": 17,
+            "panels": [],
+            "repeat": "",
+            "title": "Large Cells",
+            "type": "row"
+        },
+        {
+            "class": "single_value_table",
+            "columns": [
+                {
+                    "text": "Avg",
+                    "value": "avg"
+                }
+            ],
+            "datasource": "scylla-datasource",
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {
+                        "align": null
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": [
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "cell_size"
+                        },
+                        "properties": [
+                            {
+                                "id": "unit",
+                                "value": "bytes"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "fontSize": "100%",
+            "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 34
+            },
+            "id": 18,
+            "links": [],
+            "options": {},
+            "pageSize": null,
+            "scroll": true,
+            "showHeader": true,
+            "sort": {
+                "col": 0,
+                "desc": true
+            },
+            "span": 12,
+            "targets": [
+                {
+                    "queryHost": "$node",
+                    "queryText": "select keyspace_name, table_name,partition_key, clustering_key,  column_name,cell_size  from system.large_cells",
+                    "refId": "A"
+                }
+            ],
+            "title": "Large Cells",
+            "transform": "table",
+            "type": "table"
+        },
+        {
+            "class": "collapsible_row_panel",
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 40
+            },
+            "id": 19,
+            "panels": [],
+            "repeat": "",
+            "title": "Large Partitions",
+            "type": "row"
+        },
+        {
+            "class": "single_value_table",
+            "columns": [
+                {
+                    "text": "Avg",
+                    "value": "avg"
+                }
+            ],
+            "datasource": "scylla-datasource",
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {
+                        "align": null
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": [
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "partition_size"
+                        },
+                        "properties": [
+                            {
+                                "id": "unit",
+                                "value": "bytes"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "fontSize": "100%",
+            "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 41
+            },
+            "id": 20,
+            "links": [],
+            "options": {},
+            "pageSize": null,
+            "scroll": true,
+            "showHeader": true,
+            "sort": {
+                "col": 0,
+                "desc": true
+            },
+            "span": 12,
+            "targets": [
+                {
+                    "queryHost": "$node",
+                    "queryText": "select keyspace_name, table_name,partition_key, partition_size  from system.large_partitions",
+                    "refId": "A"
+                }
+            ],
+            "title": "Large Partitions",
+            "transform": "table",
+            "type": "table"
+        },
+        {
+            "class": "collapsible_row_panel",
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 47
+            },
+            "id": 21,
+            "panels": [],
+            "repeat": "",
             "title": "CQL Internal",
             "type": "row"
         },
@@ -1018,9 +1285,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 27
+                "y": 48
             },
-            "id": 16,
+            "id": 22,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -1048,10 +1315,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 29
+                "y": 50
             },
             "hiddenSeries": false,
-            "id": 17,
+            "id": 23,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1147,10 +1414,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 29
+                "y": 50
             },
             "hiddenSeries": false,
-            "id": 18,
+            "id": 24,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1246,10 +1513,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 29
+                "y": 50
             },
             "hiddenSeries": false,
-            "id": 19,
+            "id": 25,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1345,10 +1612,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 29
+                "y": 50
             },
             "hiddenSeries": false,
-            "id": 20,
+            "id": 26,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1435,9 +1702,9 @@
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 35
+                "y": 56
             },
-            "id": 21,
+            "id": 27,
             "panels": [],
             "repeat": "",
             "title": "LWT",
@@ -1453,9 +1720,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 36
+                "y": 57
             },
-            "id": 22,
+            "id": 28,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -1482,10 +1749,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 38
+                "y": 59
             },
             "hiddenSeries": false,
-            "id": 23,
+            "id": 29,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1580,10 +1847,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 38
+                "y": 59
             },
             "hiddenSeries": false,
-            "id": 24,
+            "id": 30,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1678,10 +1945,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 38
+                "y": 59
             },
             "hiddenSeries": false,
-            "id": 25,
+            "id": 31,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1777,10 +2044,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 38
+                "y": 59
             },
             "hiddenSeries": false,
-            "id": 26,
+            "id": 32,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -1865,9 +2132,9 @@
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 44
+                "y": 65
             },
-            "id": 27,
+            "id": 33,
             "panels": [],
             "repeat": "",
             "title": "Optimization",
@@ -1883,9 +2150,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 45
+                "y": 66
             },
-            "id": 28,
+            "id": 34,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -1905,9 +2172,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 47
+                "y": 68
             },
-            "id": 29,
+            "id": 35,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -1985,10 +2252,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 47
+                "y": 68
             },
             "hiddenSeries": false,
-            "id": 30,
+            "id": 36,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2075,9 +2342,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 47
+                "y": 68
             },
-            "id": 31,
+            "id": 37,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2155,10 +2422,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 47
+                "y": 68
             },
             "hiddenSeries": false,
-            "id": 32,
+            "id": 38,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2245,9 +2512,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 16,
-                "y": 47
+                "y": 68
             },
-            "id": 33,
+            "id": 39,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2323,10 +2590,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 47
+                "y": 68
             },
             "hiddenSeries": false,
-            "id": 34,
+            "id": 40,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2413,9 +2680,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 53
+                "y": 74
             },
-            "id": 35,
+            "id": 41,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2493,10 +2760,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 53
+                "y": 74
             },
             "hiddenSeries": false,
-            "id": 36,
+            "id": 42,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2583,9 +2850,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 53
+                "y": 74
             },
-            "id": 37,
+            "id": 43,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2661,10 +2928,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 53
+                "y": 74
             },
             "hiddenSeries": false,
-            "id": 38,
+            "id": 44,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2749,9 +3016,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 16,
-                "y": 53
+                "y": 74
             },
-            "id": 39,
+            "id": 45,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -2829,10 +3096,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 53
+                "y": 74
             },
             "hiddenSeries": false,
-            "id": 40,
+            "id": 46,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2934,9 +3201,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 59
+                "y": 80
             },
-            "id": 41,
+            "id": 47,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -3014,10 +3281,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 59
+                "y": 80
             },
             "hiddenSeries": false,
-            "id": 42,
+            "id": 48,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3104,9 +3371,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 59
+                "y": 80
             },
-            "id": 43,
+            "id": 49,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -3184,10 +3451,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 59
+                "y": 80
             },
             "hiddenSeries": false,
-            "id": 44,
+            "id": 50,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3275,9 +3542,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 65
+                "y": 86
             },
-            "id": 45,
+            "id": 51,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -3297,9 +3564,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 67
+                "y": 88
             },
-            "id": 46,
+            "id": 52,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -3377,10 +3644,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 67
+                "y": 88
             },
             "hiddenSeries": false,
-            "id": 47,
+            "id": 53,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3467,9 +3734,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 67
+                "y": 88
             },
-            "id": 48,
+            "id": 54,
             "links": [],
             "options": {
                 "fieldOptions": {
@@ -3547,10 +3814,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 67
+                "y": 88
             },
             "hiddenSeries": false,
-            "id": 49,
+            "id": 55,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3637,9 +3904,9 @@
                 "h": 6,
                 "w": 4,
                 "x": 0,
-                "y": 73
+                "y": 94
             },
-            "id": 50,
+            "id": 56,
             "links": [],
             "options": {
                 "fieldOptions": {

--- a/grafana/scylla-cql.master.template.json
+++ b/grafana/scylla-cql.master.template.json
@@ -206,6 +206,192 @@
                 "panels": [
                     {
                         "class": "collapsible_row_panel",
+                        "title": "Large Rows"
+                    }
+                ]
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "single_value_table",
+                        "datasource": "scylla-datasource",
+                        "span":12,
+                        "targets": [
+                            {
+                              "refId": "A",
+                              "queryText": "select keyspace_name, table_name,partition_key, clustering_key, row_size  from system.large_rows",
+                              "queryHost": "$node"
+                            }
+                          ],
+                        "fieldConfig": {
+                            "defaults": {
+                              "custom": {
+                                "align": null
+                              },
+                              "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                  {
+                                    "value": null,
+                                    "color": "green"
+                                  },
+                                  {
+                                    "value": 80,
+                                    "color": "red"
+                                  }
+                                ]
+                              },
+                              "mappings": []
+                            },
+                            "overrides": [
+                              {
+                                "matcher": {
+                                  "id": "byName",
+                                  "options": "row_size"
+                                },
+                                "properties": [
+                                  {
+                                    "id": "unit",
+                                    "value": "bytes"
+                                  }
+                                ]
+                              }
+                              ]
+                        },
+                        "title": "Large Rows"
+                     }
+                ]
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
+                        "title": "Large Cells"
+                    }
+                ]
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "single_value_table",
+                        "datasource": "scylla-datasource",
+                        "span":12,
+                        "targets": [
+                            {
+                              "refId": "A",
+                              "queryText": "select keyspace_name, table_name,partition_key, clustering_key,  column_name,cell_size  from system.large_cells",
+                              "queryHost": "$node"
+                            }
+                          ],
+                        "fieldConfig": {
+                            "defaults": {
+                              "custom": {
+                                "align": null
+                              },
+                              "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                  {
+                                    "value": null,
+                                    "color": "green"
+                                  },
+                                  {
+                                    "value": 80,
+                                    "color": "red"
+                                  }
+                                ]
+                              },
+                              "mappings": []
+                            },
+                            "overrides": [
+                              {
+                                "matcher": {
+                                  "id": "byName",
+                                  "options": "cell_size"
+                                },
+                                "properties": [
+                                  {
+                                    "id": "unit",
+                                    "value": "bytes"
+                                  }
+                                ]
+                              }
+                              ]
+                        },
+                        "title": "Large Cells"
+                     }
+                ]
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
+                        "title": "Large Partitions"
+                    }
+                ]
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "single_value_table",
+                        "datasource": "scylla-datasource",
+                        "span":12,
+                        "targets": [
+                            {
+                              "refId": "A",
+                              "queryText": "select keyspace_name, table_name,partition_key, partition_size  from system.large_partitions",
+                              "queryHost": "$node"
+                            }
+                          ],
+                        "fieldConfig": {
+                            "defaults": {
+                              "custom": {
+                                "align": null
+                              },
+                              "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                  {
+                                    "value": null,
+                                    "color": "green"
+                                  },
+                                  {
+                                    "value": 80,
+                                    "color": "red"
+                                  }
+                                ]
+                              },
+                              "mappings": []
+                            },
+                            "overrides": [
+                              {
+                                "matcher": {
+                                  "id": "byName",
+                                  "options": "partition_size"
+                                },
+                                "properties": [
+                                  {
+                                    "id": "unit",
+                                    "value": "bytes"
+                                  }
+                                ]
+                              }
+                              ]
+                        },
+                        "title": "Large Partitions"
+                     }
+                ]
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
                         "title": "CQL Internal"
                     }
                 ]


### PR DESCRIPTION
This patch adds 3 tables to the cql dashboard: large partition, large rows, and large cells:
![image](https://user-images.githubusercontent.com/2118079/95202955-b2e49a80-07ea-11eb-8656-6cced47895fb.png)

This is how it looks like as an entire page:
![image](https://user-images.githubusercontent.com/2118079/95202996-c6900100-07ea-11eb-9b32-13f50779b143.png)
