### PR TITLE
matrix.rst: remove os 3.0 from monitoring 3.2

### DIFF
--- a/docs/source/matrix.rst
+++ b/docs/source/matrix.rst
@@ -15,13 +15,13 @@ The following table shows which version of Scylla Monitor supports dashboards fo
      - Node_exporter[1] Version
      - Scylla Manager Version
    * - 3.5
-     - 4.0, 4.1, 4.2
+     - 3.3, 4.0, 4.1, 4.2
      - 2019.1, 2020.1
      - 0.17
      - 2.0, 2.1, 2.2
    * - 3.4.3
      - 3.3, 4.0, 4.1, 4.2
-     - 2018.1, 2019.1, 2020.1
+     - 2019.1, 2020.1
      - 0.17
      - 2.0, 2.1
    * - 3.4
@@ -35,7 +35,7 @@ The following table shows which version of Scylla Monitor supports dashboards fo
      - 0.17
      - 1.4, 2.0, 2.1
    * - 3.2
-     - 3.0, 3.1, 3.2, 3.3
+     - 3.1, 3.2, 3.3
      - 2018.1, 2019.1
      - 0.17
      - 1.4, 2.0  


### PR DESCRIPTION
This patch addresses multiple issues with the supported matrix:
1. remove Scylla OS 3.0 from scylla-monitoring 3.2
2. remove Scylla enterprise 2018.1 from scylla-monitoring 3.4.3
3. add Scylla OS 3.3 to scylla-monitoring 3.5

Fixes #1078