### PR TITLE
Remove avg from the overview panel

### DIFF
--- a/grafana/build/ver_2019.1/scylla-overview.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-overview.2019.1.json
@@ -1664,13 +1664,6 @@
                     "legendFormat": "99% {{[[by]]}}",
                     "refId": "B",
                     "step": 1
-                },
-                {
-                    "expr": "sum(rate(scylla_storage_proxy_coordinator_write_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])/(sum(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])+ 1)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Avg {{[[by]]}}",
-                    "refId": "C",
-                    "step": 1
                 }
             ],
             "thresholds": [],
@@ -1871,13 +1864,6 @@
                     "intervalFactor": 1,
                     "legendFormat": "99% {{[[by]]}}",
                     "refId": "B",
-                    "step": 1
-                },
-                {
-                    "expr": "sum(rate(scylla_storage_proxy_coordinator_read_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])/(sum(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])+ 1)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Avg {{[[by]]}}",
-                    "refId": "C",
                     "step": 1
                 }
             ],

--- a/grafana/build/ver_2020.1/scylla-overview.2020.1.json
+++ b/grafana/build/ver_2020.1/scylla-overview.2020.1.json
@@ -1664,13 +1664,6 @@
                     "legendFormat": "99% {{[[by]]}}",
                     "refId": "B",
                     "step": 1
-                },
-                {
-                    "expr": "sum(rate(scylla_storage_proxy_coordinator_write_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])/(sum(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])+ 1)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Avg {{[[by]]}}",
-                    "refId": "C",
-                    "step": 1
                 }
             ],
             "thresholds": [],
@@ -1871,13 +1864,6 @@
                     "intervalFactor": 1,
                     "legendFormat": "99% {{[[by]]}}",
                     "refId": "B",
-                    "step": 1
-                },
-                {
-                    "expr": "sum(rate(scylla_storage_proxy_coordinator_read_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])/(sum(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])+ 1)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Avg {{[[by]]}}",
-                    "refId": "C",
                     "step": 1
                 }
             ],

--- a/grafana/build/ver_4.1/scylla-overview.4.1.json
+++ b/grafana/build/ver_4.1/scylla-overview.4.1.json
@@ -1648,13 +1648,6 @@
                     "legendFormat": "99% {{[[by]]}}",
                     "refId": "B",
                     "step": 1
-                },
-                {
-                    "expr": "sum(rate(scylla_storage_proxy_coordinator_write_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])/(sum(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])+ 1)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Avg {{[[by]]}}",
-                    "refId": "C",
-                    "step": 1
                 }
             ],
             "thresholds": [],
@@ -1855,13 +1848,6 @@
                     "intervalFactor": 1,
                     "legendFormat": "99% {{[[by]]}}",
                     "refId": "B",
-                    "step": 1
-                },
-                {
-                    "expr": "sum(rate(scylla_storage_proxy_coordinator_read_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])/(sum(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])+ 1)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Avg {{[[by]]}}",
-                    "refId": "C",
                     "step": 1
                 }
             ],

--- a/grafana/build/ver_4.2/scylla-overview.4.2.json
+++ b/grafana/build/ver_4.2/scylla-overview.4.2.json
@@ -1664,13 +1664,6 @@
                     "legendFormat": "99% {{[[by]]}}",
                     "refId": "B",
                     "step": 1
-                },
-                {
-                    "expr": "sum(rate(scylla_storage_proxy_coordinator_write_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])/(sum(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])+ 1)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Avg {{[[by]]}}",
-                    "refId": "C",
-                    "step": 1
                 }
             ],
             "thresholds": [],
@@ -1871,13 +1864,6 @@
                     "intervalFactor": 1,
                     "legendFormat": "99% {{[[by]]}}",
                     "refId": "B",
-                    "step": 1
-                },
-                {
-                    "expr": "sum(rate(scylla_storage_proxy_coordinator_read_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])/(sum(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])+ 1)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Avg {{[[by]]}}",
-                    "refId": "C",
                     "step": 1
                 }
             ],

--- a/grafana/build/ver_master/scylla-overview.master.json
+++ b/grafana/build/ver_master/scylla-overview.master.json
@@ -1664,13 +1664,6 @@
                     "legendFormat": "99% {{[[by]]}}",
                     "refId": "B",
                     "step": 1
-                },
-                {
-                    "expr": "sum(rate(scylla_storage_proxy_coordinator_write_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])/(sum(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])+ 1)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Avg {{[[by]]}}",
-                    "refId": "C",
-                    "step": 1
                 }
             ],
             "thresholds": [],
@@ -1871,13 +1864,6 @@
                     "intervalFactor": 1,
                     "legendFormat": "99% {{[[by]]}}",
                     "refId": "B",
-                    "step": 1
-                },
-                {
-                    "expr": "sum(rate(scylla_storage_proxy_coordinator_read_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])/(sum(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])+ 1)",
-                    "intervalFactor": 1,
-                    "legendFormat": "Avg {{[[by]]}}",
-                    "refId": "C",
                     "step": 1
                 }
             ],

--- a/grafana/scylla-overview.2019.1.template.json
+++ b/grafana/scylla-overview.2019.1.template.json
@@ -256,13 +256,6 @@
                                 "legendFormat": "99% {{[[by]]}}",
                                 "refId": "B",
                                 "step": 1
-                            },
-                            {
-                                "expr": "sum(rate(scylla_storage_proxy_coordinator_write_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])/(sum(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])+ 1)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Avg {{[[by]]}}",
-                                "refId": "C",
-                                "step": 1
                             }
                         ],
                         "title": "Write Latencies"
@@ -297,13 +290,6 @@
                                 "intervalFactor": 1,
                                 "legendFormat": "99% {{[[by]]}}",
                                 "refId": "B",
-                                "step": 1
-                            },
-                            {
-                                "expr": "sum(rate(scylla_storage_proxy_coordinator_read_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])/(sum(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])+ 1)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Avg {{[[by]]}}",
-                                "refId": "C",
                                 "step": 1
                             }
                         ],

--- a/grafana/scylla-overview.2020.1.template.json
+++ b/grafana/scylla-overview.2020.1.template.json
@@ -256,13 +256,6 @@
                                 "legendFormat": "99% {{[[by]]}}",
                                 "refId": "B",
                                 "step": 1
-                            },
-                            {
-                                "expr": "sum(rate(scylla_storage_proxy_coordinator_write_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])/(sum(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])+ 1)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Avg {{[[by]]}}",
-                                "refId": "C",
-                                "step": 1
                             }
                         ],
                         "title": "Write Latencies"
@@ -297,13 +290,6 @@
                                 "intervalFactor": 1,
                                 "legendFormat": "99% {{[[by]]}}",
                                 "refId": "B",
-                                "step": 1
-                            },
-                            {
-                                "expr": "sum(rate(scylla_storage_proxy_coordinator_read_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])/(sum(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])+ 1)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Avg {{[[by]]}}",
-                                "refId": "C",
                                 "step": 1
                             }
                         ],

--- a/grafana/scylla-overview.4.1.template.json
+++ b/grafana/scylla-overview.4.1.template.json
@@ -256,13 +256,6 @@
                                 "legendFormat": "99% {{[[by]]}}",
                                 "refId": "B",
                                 "step": 1
-                            },
-                            {
-                                "expr": "sum(rate(scylla_storage_proxy_coordinator_write_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])/(sum(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])+ 1)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Avg {{[[by]]}}",
-                                "refId": "C",
-                                "step": 1
                             }
                         ],
                         "title": "Write Latencies"
@@ -297,13 +290,6 @@
                                 "intervalFactor": 1,
                                 "legendFormat": "99% {{[[by]]}}",
                                 "refId": "B",
-                                "step": 1
-                            },
-                            {
-                                "expr": "sum(rate(scylla_storage_proxy_coordinator_read_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])/(sum(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])+ 1)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Avg {{[[by]]}}",
-                                "refId": "C",
                                 "step": 1
                             }
                         ],

--- a/grafana/scylla-overview.4.2.template.json
+++ b/grafana/scylla-overview.4.2.template.json
@@ -256,13 +256,6 @@
                                 "legendFormat": "99% {{[[by]]}}",
                                 "refId": "B",
                                 "step": 1
-                            },
-                            {
-                                "expr": "sum(rate(scylla_storage_proxy_coordinator_write_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])/(sum(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])+ 1)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Avg {{[[by]]}}",
-                                "refId": "C",
-                                "step": 1
                             }
                         ],
                         "title": "Write Latencies"
@@ -297,13 +290,6 @@
                                 "intervalFactor": 1,
                                 "legendFormat": "99% {{[[by]]}}",
                                 "refId": "B",
-                                "step": 1
-                            },
-                            {
-                                "expr": "sum(rate(scylla_storage_proxy_coordinator_read_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])/(sum(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])+ 1)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Avg {{[[by]]}}",
-                                "refId": "C",
                                 "step": 1
                             }
                         ],

--- a/grafana/scylla-overview.master.template.json
+++ b/grafana/scylla-overview.master.template.json
@@ -256,13 +256,6 @@
                                 "legendFormat": "99% {{[[by]]}}",
                                 "refId": "B",
                                 "step": 1
-                            },
-                            {
-                                "expr": "sum(rate(scylla_storage_proxy_coordinator_write_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])/(sum(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])+ 1)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Avg {{[[by]]}}",
-                                "refId": "C",
-                                "step": 1
                             }
                         ],
                         "title": "Write Latencies"
@@ -297,13 +290,6 @@
                                 "intervalFactor": 1,
                                 "legendFormat": "99% {{[[by]]}}",
                                 "refId": "B",
-                                "step": 1
-                            },
-                            {
-                                "expr": "sum(rate(scylla_storage_proxy_coordinator_read_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])/(sum(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])+ 1)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Avg {{[[by]]}}",
-                                "refId": "C",
                                 "step": 1
                             }
                         ],


### PR DESCRIPTION
this series removes the avg line from the overview latencies panel, in practice the difference between avg and 95/99 % is too big for a single graph.

Fixes #1115