### PR TITLE
read-write Sstable units should be absolute not rate

### DIFF
--- a/grafana/build/ver_2019.1/scylla-detailed.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-detailed.2019.1.json
@@ -1727,10 +1727,11 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "rps_panel",
+            "class": "reads_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
+            "description": "The number of currently active read operations",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -1800,7 +1801,8 @@
             },
             "yaxes": [
                 {
-                    "format": "si:reads/s",
+                    "decimals": 0,
+                    "format": "si:reads",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1822,10 +1824,11 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "rps_panel",
+            "class": "reads_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
+            "description": "number of currently queued read operations",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -1895,7 +1898,8 @@
             },
             "yaxes": [
                 {
-                    "format": "si:reads/s",
+                    "decimals": 0,
+                    "format": "si:reads",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1917,10 +1921,11 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "wps_panel",
+            "class": "writes_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
+            "description": "The current number of requests blocked due to reaching the memory quota. Non-zero value indicates that our bottleneck is memory",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -1990,7 +1995,8 @@
             },
             "yaxes": [
                 {
-                    "format": "si:writes/s",
+                    "decimals": 0,
+                    "format": "si:writes",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2012,10 +2018,11 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "wps_panel",
+            "class": "writes_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
+            "description": "number of currently pending allocations. A non-zero value indicates that we have a bottleneck in the disk write flow.",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -2085,7 +2092,8 @@
             },
             "yaxes": [
                 {
-                    "format": "si:writes/s",
+                    "decimals": 0,
+                    "format": "si:writes",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_2020.1/scylla-detailed.2020.1.json
+++ b/grafana/build/ver_2020.1/scylla-detailed.2020.1.json
@@ -1727,10 +1727,11 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "rps_panel",
+            "class": "reads_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
+            "description": "The number of currently active read operations",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -1800,7 +1801,8 @@
             },
             "yaxes": [
                 {
-                    "format": "si:reads/s",
+                    "decimals": 0,
+                    "format": "si:reads",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1822,10 +1824,11 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "rps_panel",
+            "class": "reads_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
+            "description": "number of currently queued read operations",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -1895,7 +1898,8 @@
             },
             "yaxes": [
                 {
-                    "format": "si:reads/s",
+                    "decimals": 0,
+                    "format": "si:reads",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1917,10 +1921,11 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "wps_panel",
+            "class": "writes_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
+            "description": "The current number of requests blocked due to reaching the memory quota. Non-zero value indicates that our bottleneck is memory",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -1990,7 +1995,8 @@
             },
             "yaxes": [
                 {
-                    "format": "si:writes/s",
+                    "decimals": 0,
+                    "format": "si:writes",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2012,10 +2018,11 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "wps_panel",
+            "class": "writes_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
+            "description": "number of currently pending allocations. A non-zero value indicates that we have a bottleneck in the disk write flow.",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -2085,7 +2092,8 @@
             },
             "yaxes": [
                 {
-                    "format": "si:writes/s",
+                    "decimals": 0,
+                    "format": "si:writes",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_3.3/scylla-detailed.3.3.json
+++ b/grafana/build/ver_3.3/scylla-detailed.3.3.json
@@ -1711,10 +1711,11 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "rps_panel",
+            "class": "reads_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
+            "description": "The number of currently active read operations",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -1784,7 +1785,8 @@
             },
             "yaxes": [
                 {
-                    "format": "si:reads/s",
+                    "decimals": 0,
+                    "format": "si:reads",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1806,10 +1808,11 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "rps_panel",
+            "class": "reads_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
+            "description": "number of currently queued read operations",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -1879,7 +1882,8 @@
             },
             "yaxes": [
                 {
-                    "format": "si:reads/s",
+                    "decimals": 0,
+                    "format": "si:reads",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1901,10 +1905,11 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "wps_panel",
+            "class": "writes_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
+            "description": "The current number of requests blocked due to reaching the memory quota. Non-zero value indicates that our bottleneck is memory",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -1974,7 +1979,8 @@
             },
             "yaxes": [
                 {
-                    "format": "si:writes/s",
+                    "decimals": 0,
+                    "format": "si:writes",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1996,10 +2002,11 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "wps_panel",
+            "class": "writes_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
+            "description": "number of currently pending allocations. A non-zero value indicates that we have a bottleneck in the disk write flow.",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -2069,7 +2076,8 @@
             },
             "yaxes": [
                 {
-                    "format": "si:writes/s",
+                    "decimals": 0,
+                    "format": "si:writes",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_4.0/scylla-detailed.4.0.json
+++ b/grafana/build/ver_4.0/scylla-detailed.4.0.json
@@ -1711,10 +1711,11 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "rps_panel",
+            "class": "reads_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
+            "description": "The number of currently active read operations",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -1784,7 +1785,8 @@
             },
             "yaxes": [
                 {
-                    "format": "si:reads/s",
+                    "decimals": 0,
+                    "format": "si:reads",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1806,10 +1808,11 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "rps_panel",
+            "class": "reads_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
+            "description": "number of currently queued read operations",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -1879,7 +1882,8 @@
             },
             "yaxes": [
                 {
-                    "format": "si:reads/s",
+                    "decimals": 0,
+                    "format": "si:reads",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1901,10 +1905,11 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "wps_panel",
+            "class": "writes_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
+            "description": "The current number of requests blocked due to reaching the memory quota. Non-zero value indicates that our bottleneck is memory",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -1974,7 +1979,8 @@
             },
             "yaxes": [
                 {
-                    "format": "si:writes/s",
+                    "decimals": 0,
+                    "format": "si:writes",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1996,10 +2002,11 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "wps_panel",
+            "class": "writes_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
+            "description": "number of currently pending allocations. A non-zero value indicates that we have a bottleneck in the disk write flow.",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -2069,7 +2076,8 @@
             },
             "yaxes": [
                 {
-                    "format": "si:writes/s",
+                    "decimals": 0,
+                    "format": "si:writes",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_4.1/scylla-detailed.4.1.json
+++ b/grafana/build/ver_4.1/scylla-detailed.4.1.json
@@ -1711,10 +1711,11 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "rps_panel",
+            "class": "reads_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
+            "description": "The number of currently active read operations",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -1784,7 +1785,8 @@
             },
             "yaxes": [
                 {
-                    "format": "si:reads/s",
+                    "decimals": 0,
+                    "format": "si:reads",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1806,10 +1808,11 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "rps_panel",
+            "class": "reads_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
+            "description": "number of currently queued read operations",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -1879,7 +1882,8 @@
             },
             "yaxes": [
                 {
-                    "format": "si:reads/s",
+                    "decimals": 0,
+                    "format": "si:reads",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1901,10 +1905,11 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "wps_panel",
+            "class": "writes_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
+            "description": "The current number of requests blocked due to reaching the memory quota. Non-zero value indicates that our bottleneck is memory",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -1974,7 +1979,8 @@
             },
             "yaxes": [
                 {
-                    "format": "si:writes/s",
+                    "decimals": 0,
+                    "format": "si:writes",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1996,10 +2002,11 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "wps_panel",
+            "class": "writes_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
+            "description": "number of currently pending allocations. A non-zero value indicates that we have a bottleneck in the disk write flow.",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -2069,7 +2076,8 @@
             },
             "yaxes": [
                 {
-                    "format": "si:writes/s",
+                    "decimals": 0,
+                    "format": "si:writes",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_4.2/scylla-detailed.4.2.json
+++ b/grafana/build/ver_4.2/scylla-detailed.4.2.json
@@ -1727,10 +1727,11 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "rps_panel",
+            "class": "reads_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
+            "description": "The number of currently active read operations",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -1800,7 +1801,8 @@
             },
             "yaxes": [
                 {
-                    "format": "si:reads/s",
+                    "decimals": 0,
+                    "format": "si:reads",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1822,10 +1824,11 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "rps_panel",
+            "class": "reads_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
+            "description": "number of currently queued read operations",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -1895,7 +1898,8 @@
             },
             "yaxes": [
                 {
-                    "format": "si:reads/s",
+                    "decimals": 0,
+                    "format": "si:reads",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1917,10 +1921,11 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "wps_panel",
+            "class": "writes_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
+            "description": "The current number of requests blocked due to reaching the memory quota. Non-zero value indicates that our bottleneck is memory",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -1990,7 +1995,8 @@
             },
             "yaxes": [
                 {
-                    "format": "si:writes/s",
+                    "decimals": 0,
+                    "format": "si:writes",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2012,10 +2018,11 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "wps_panel",
+            "class": "writes_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
+            "description": "number of currently pending allocations. A non-zero value indicates that we have a bottleneck in the disk write flow.",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -2085,7 +2092,8 @@
             },
             "yaxes": [
                 {
-                    "format": "si:writes/s",
+                    "decimals": 0,
+                    "format": "si:writes",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/build/ver_master/scylla-detailed.master.json
+++ b/grafana/build/ver_master/scylla-detailed.master.json
@@ -1727,10 +1727,11 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "rps_panel",
+            "class": "reads_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
+            "description": "The number of currently active read operations",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -1800,7 +1801,8 @@
             },
             "yaxes": [
                 {
-                    "format": "si:reads/s",
+                    "decimals": 0,
+                    "format": "si:reads",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1822,10 +1824,11 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "rps_panel",
+            "class": "reads_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
+            "description": "number of currently queued read operations",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -1895,7 +1898,8 @@
             },
             "yaxes": [
                 {
-                    "format": "si:reads/s",
+                    "decimals": 0,
+                    "format": "si:reads",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -1917,10 +1921,11 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "wps_panel",
+            "class": "writes_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
+            "description": "The current number of requests blocked due to reaching the memory quota. Non-zero value indicates that our bottleneck is memory",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -1990,7 +1995,8 @@
             },
             "yaxes": [
                 {
-                    "format": "si:writes/s",
+                    "decimals": 0,
+                    "format": "si:writes",
                     "logBase": 1,
                     "max": null,
                     "min": 0,
@@ -2012,10 +2018,11 @@
         {
             "aliasColors": {},
             "bars": false,
-            "class": "wps_panel",
+            "class": "writes_panel",
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
+            "description": "number of currently pending allocations. A non-zero value indicates that we have a bottleneck in the disk write flow.",
             "editable": true,
             "error": false,
             "fill": 0,
@@ -2085,7 +2092,8 @@
             },
             "yaxes": [
                 {
-                    "format": "si:writes/s",
+                    "decimals": 0,
+                    "format": "si:writes",
                     "logBase": 1,
                     "max": null,
                     "min": 0,

--- a/grafana/scylla-detailed.2019.1.template.json
+++ b/grafana/scylla-detailed.2019.1.template.json
@@ -304,7 +304,8 @@
                 "height": "auto",
                 "panels": [
                     {
-                        "class": "rps_panel",
+                        "class": "reads_panel",
+                        "description" : "The number of currently active read operations",
                         "span": 3,
                         "targets": [
                             {
@@ -318,7 +319,7 @@
                         "title": "Active sstable reads"
                     },
                     {
-                        "class": "rps_panel",
+                        "class": "reads_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -329,10 +330,11 @@
                                 "step": 1
                             }
                         ],
+                        "description": "number of currently queued read operations",
                         "title": "Queued sstable reads"
                     },
                     {
-                        "class": "wps_panel",
+                        "class": "writes_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -343,10 +345,11 @@
                                 "step": 1
                             }
                         ],
+                        "description" :"The current number of requests blocked due to reaching the memory quota. Non-zero value indicates that our bottleneck is memory",
                         "title": "Writes currently blocked on dirty"
                     },
                     {
-                        "class": "wps_panel",
+                        "class": "writes_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -357,6 +360,7 @@
                                 "step": 1
                             }
                         ],
+                        "description" :"number of currently pending allocations. A non-zero value indicates that we have a bottleneck in the disk write flow.",
                         "title": "Writes currently blocked on commitlog"
                     },
                     {

--- a/grafana/scylla-detailed.2020.1.template.json
+++ b/grafana/scylla-detailed.2020.1.template.json
@@ -304,7 +304,8 @@
                 "height": "auto",
                 "panels": [
                     {
-                        "class": "rps_panel",
+                        "class": "reads_panel",
+                        "description" : "The number of currently active read operations",
                         "span": 3,
                         "targets": [
                             {
@@ -318,7 +319,7 @@
                         "title": "Active sstable reads"
                     },
                     {
-                        "class": "rps_panel",
+                        "class": "reads_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -329,10 +330,11 @@
                                 "step": 1
                             }
                         ],
+                        "description": "number of currently queued read operations",
                         "title": "Queued sstable reads"
                     },
                     {
-                        "class": "wps_panel",
+                        "class": "writes_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -343,10 +345,11 @@
                                 "step": 1
                             }
                         ],
+                        "description" :"The current number of requests blocked due to reaching the memory quota. Non-zero value indicates that our bottleneck is memory",
                         "title": "Writes currently blocked on dirty"
                     },
                     {
-                        "class": "wps_panel",
+                        "class": "writes_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -357,6 +360,7 @@
                                 "step": 1
                             }
                         ],
+                        "description" :"number of currently pending allocations. A non-zero value indicates that we have a bottleneck in the disk write flow.",
                         "title": "Writes currently blocked on commitlog"
                     },
                     {

--- a/grafana/scylla-detailed.3.3.template.json
+++ b/grafana/scylla-detailed.3.3.template.json
@@ -304,7 +304,8 @@
                 "height": "auto",
                 "panels": [
                     {
-                        "class": "rps_panel",
+                        "class": "reads_panel",
+                        "description" : "The number of currently active read operations",
                         "span": 3,
                         "targets": [
                             {
@@ -318,7 +319,7 @@
                         "title": "Active sstable reads"
                     },
                     {
-                        "class": "rps_panel",
+                        "class": "reads_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -329,10 +330,11 @@
                                 "step": 1
                             }
                         ],
+                        "description": "number of currently queued read operations",
                         "title": "Queued sstable reads"
                     },
                     {
-                        "class": "wps_panel",
+                        "class": "writes_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -343,10 +345,11 @@
                                 "step": 1
                             }
                         ],
+                        "description" :"The current number of requests blocked due to reaching the memory quota. Non-zero value indicates that our bottleneck is memory",
                         "title": "Writes currently blocked on dirty"
                     },
                     {
-                        "class": "wps_panel",
+                        "class": "writes_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -357,6 +360,7 @@
                                 "step": 1
                             }
                         ],
+                        "description" :"number of currently pending allocations. A non-zero value indicates that we have a bottleneck in the disk write flow.",
                         "title": "Writes currently blocked on commitlog"
                     },
                     {

--- a/grafana/scylla-detailed.4.0.template.json
+++ b/grafana/scylla-detailed.4.0.template.json
@@ -304,7 +304,8 @@
                 "height": "auto",
                 "panels": [
                     {
-                        "class": "rps_panel",
+                        "class": "reads_panel",
+                        "description" : "The number of currently active read operations",
                         "span": 3,
                         "targets": [
                             {
@@ -318,7 +319,7 @@
                         "title": "Active sstable reads"
                     },
                     {
-                        "class": "rps_panel",
+                        "class": "reads_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -329,10 +330,11 @@
                                 "step": 1
                             }
                         ],
+                        "description": "number of currently queued read operations",
                         "title": "Queued sstable reads"
                     },
                     {
-                        "class": "wps_panel",
+                        "class": "writes_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -343,10 +345,11 @@
                                 "step": 1
                             }
                         ],
+                        "description" :"The current number of requests blocked due to reaching the memory quota. Non-zero value indicates that our bottleneck is memory",
                         "title": "Writes currently blocked on dirty"
                     },
                     {
-                        "class": "wps_panel",
+                        "class": "writes_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -357,6 +360,7 @@
                                 "step": 1
                             }
                         ],
+                        "description" :"number of currently pending allocations. A non-zero value indicates that we have a bottleneck in the disk write flow.",
                         "title": "Writes currently blocked on commitlog"
                     },
                     {

--- a/grafana/scylla-detailed.4.1.template.json
+++ b/grafana/scylla-detailed.4.1.template.json
@@ -304,7 +304,8 @@
                 "height": "auto",
                 "panels": [
                     {
-                        "class": "rps_panel",
+                        "class": "reads_panel",
+                        "description" : "The number of currently active read operations",
                         "span": 3,
                         "targets": [
                             {
@@ -318,7 +319,7 @@
                         "title": "Active sstable reads"
                     },
                     {
-                        "class": "rps_panel",
+                        "class": "reads_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -329,10 +330,11 @@
                                 "step": 1
                             }
                         ],
+                        "description": "number of currently queued read operations",
                         "title": "Queued sstable reads"
                     },
                     {
-                        "class": "wps_panel",
+                        "class": "writes_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -343,10 +345,11 @@
                                 "step": 1
                             }
                         ],
+                        "description" :"The current number of requests blocked due to reaching the memory quota. Non-zero value indicates that our bottleneck is memory",
                         "title": "Writes currently blocked on dirty"
                     },
                     {
-                        "class": "wps_panel",
+                        "class": "writes_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -357,6 +360,7 @@
                                 "step": 1
                             }
                         ],
+                        "description" :"number of currently pending allocations. A non-zero value indicates that we have a bottleneck in the disk write flow.",
                         "title": "Writes currently blocked on commitlog"
                     },
                     {

--- a/grafana/scylla-detailed.4.2.template.json
+++ b/grafana/scylla-detailed.4.2.template.json
@@ -304,7 +304,8 @@
                 "height": "auto",
                 "panels": [
                     {
-                        "class": "rps_panel",
+                        "class": "reads_panel",
+                        "description" : "The number of currently active read operations",
                         "span": 3,
                         "targets": [
                             {
@@ -318,7 +319,7 @@
                         "title": "Active sstable reads"
                     },
                     {
-                        "class": "rps_panel",
+                        "class": "reads_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -329,10 +330,11 @@
                                 "step": 1
                             }
                         ],
+                        "description": "number of currently queued read operations",
                         "title": "Queued sstable reads"
                     },
                     {
-                        "class": "wps_panel",
+                        "class": "writes_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -343,10 +345,11 @@
                                 "step": 1
                             }
                         ],
+                        "description" :"The current number of requests blocked due to reaching the memory quota. Non-zero value indicates that our bottleneck is memory",
                         "title": "Writes currently blocked on dirty"
                     },
                     {
-                        "class": "wps_panel",
+                        "class": "writes_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -357,6 +360,7 @@
                                 "step": 1
                             }
                         ],
+                        "description" :"number of currently pending allocations. A non-zero value indicates that we have a bottleneck in the disk write flow.",
                         "title": "Writes currently blocked on commitlog"
                     },
                     {

--- a/grafana/scylla-detailed.master.template.json
+++ b/grafana/scylla-detailed.master.template.json
@@ -304,7 +304,8 @@
                 "height": "auto",
                 "panels": [
                     {
-                        "class": "rps_panel",
+                        "class": "reads_panel",
+                        "description" : "The number of currently active read operations",
                         "span": 3,
                         "targets": [
                             {
@@ -318,7 +319,7 @@
                         "title": "Active sstable reads"
                     },
                     {
-                        "class": "rps_panel",
+                        "class": "reads_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -329,10 +330,11 @@
                                 "step": 1
                             }
                         ],
+                        "description": "number of currently queued read operations",
                         "title": "Queued sstable reads"
                     },
                     {
-                        "class": "wps_panel",
+                        "class": "writes_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -343,10 +345,11 @@
                                 "step": 1
                             }
                         ],
+                        "description" :"The current number of requests blocked due to reaching the memory quota. Non-zero value indicates that our bottleneck is memory",
                         "title": "Writes currently blocked on dirty"
                     },
                     {
-                        "class": "wps_panel",
+                        "class": "writes_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -357,6 +360,7 @@
                                 "step": 1
                             }
                         ],
+                        "description" :"number of currently pending allocations. A non-zero value indicates that we have a bottleneck in the disk write flow.",
                         "title": "Writes currently blocked on commitlog"
                     },
                     {

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -1053,6 +1053,46 @@
             }
         ]
     },
+    "reads_panel": {
+        "class": "iops_panel",
+        "yaxes": [
+            {
+                "format": "si:reads",
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "decimals": 0,
+                "show": true
+            },
+            {
+                "format": "short",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+            }
+        ]
+    },
+    "writes_panel": {
+        "class": "iops_panel",
+        "yaxes": [
+            {
+                "format": "si:writes",
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "decimals": 0,
+                "show": true
+            },
+            {
+                "format": "short",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+            }
+        ]
+    },
     "queue_lenght_panel": {
         "class": "iops_panel",
         "yaxes": [


### PR DESCRIPTION
This patch replaces multiple panels type to be absolute read/write instead of rate.

Fixes #1125