### PR TITLE
Alternator node link update

### DIFF
--- a/grafana/alternator.2020.1.template.json
+++ b/grafana/alternator.2020.1.template.json
@@ -867,6 +867,25 @@
                 },
                 {
                     "class": "template_variable_custom",
+                    "current": {
+                        "text": "2020.1",
+                        "value": "2020.1"
+                    },
+                    "name": "scylla_dash_version",
+                    "options": [
+                        {
+                            "selected": true,
+                            "text": "2020.1",
+                            "value": "2020.1"
+                        }
+                    ],
+                    "query": "2020.1"
+                },
+                {
+                    "class": "monitor_version_var"
+                },
+                {
+                    "class": "template_variable_custom",
                     "name": "alternator_latency_ops",
                     "multi": true,
                     "includeAll": true,

--- a/grafana/alternator.2020.1.template.json
+++ b/grafana/alternator.2020.1.template.json
@@ -181,6 +181,7 @@
                             },
                             {
                                 "colorMode": null,
+                                "alias": "Advanced",
                                 "colors": [
                                     "rgba(245, 54, 54, 0.9)",
                                     "rgba(237, 129, 40, 0.89)",
@@ -189,8 +190,8 @@
                                 "dateFormat": "YYYY-MM-DD HH:mm:ss",
                                 "decimals": 2,
                                 "link": true,
-                                "linkTooltip": "Jump to the Errors metrics information",
-                                "linkUrl": "/d/error-[[dash_version]]/scylla-errors?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
+                                "linkTooltip": "Jump to the Advanced metrics information",
+                                "linkUrl": "/d/advanced-[[dash_version]]/advanced?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
                                 "mappingType": 1,
                                 "pattern": "Errors",
                                 "thresholds": [],
@@ -198,59 +199,18 @@
                                 "unit": "short",
                                 "valueMaps": [
                                     {
-                                        "text": "Errors",
+                                        "text": "Advanced",
                                         "value": "errors"
                                     }
                                 ]
                             },
                             {
-                                "colorMode": null,
-                                "colors": [
-                                    "rgba(245, 54, 54, 0.9)",
-                                    "rgba(237, 129, 40, 0.89)",
-                                    "rgba(50, 172, 45, 0.97)"
-                                ],
-                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                                "decimals": 2,
-                                "link": true,
-                                "linkTooltip": "Jump to the Errors metrics information",
-                                "linkUrl": "/d/io-[[dash_version]]/i-o?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
-                                "mappingType": 1,
-                                "pattern": "IO",
-                                "thresholds": [],
-                                "type": "string",
-                                "unit": "short",
-                                "valueMaps": [
-                                    {
-                                        "text": "IO",
-                                        "value": "io"
-                                    }
-                                ]
+                                "class": "hidden_column",
+                                "pattern": "IO"
                             },
                             {
-                                "alias": "CPU",
-                                "colorMode": null,
-                                "colors": [
-                                    "rgba(245, 54, 54, 0.9)",
-                                    "rgba(237, 129, 40, 0.89)",
-                                    "rgba(50, 172, 45, 0.97)"
-                                ],
-                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                                "decimals": 2,
-                                "link": true,
-                                "linkTooltip": "Jump to the node CPU information",
-                                "linkUrl": "/d/cpu-[[dash_version]]/CPU-Metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
-                                "mappingType": 1,
-                                "pattern": "CPU",
-                                "thresholds": [],
-                                "type": "string",
-                                "unit": "short",
-                                "valueMaps": [
-                                    {
-                                        "text": "CPU",
-                                        "value": "cpu"
-                                    }
-                                ]
+                                "class": "hidden_column",
+                                "pattern": "CPU"
                             },
                             {
                                 "alias": "Status",

--- a/grafana/alternator.3.3.template.json
+++ b/grafana/alternator.3.3.template.json
@@ -1063,6 +1063,25 @@
                 },
                 {
                     "class": "template_variable_custom",
+                    "current": {
+                        "text": "3.3",
+                        "value": "3.3"
+                    },
+                    "name": "scylla_dash_version",
+                    "options": [
+                        {
+                            "selected": true,
+                            "text": "3.3",
+                            "value": "3.3"
+                        }
+                    ],
+                    "query": "3.3"
+                },
+                {
+                    "class": "monitor_version_var"
+                },
+                {
+                    "class": "template_variable_custom",
                     "name": "alternator_latency_ops",
                     "current": {
                         "text": "GetItem",

--- a/grafana/alternator.4.0.template.json
+++ b/grafana/alternator.4.0.template.json
@@ -1063,6 +1063,25 @@
                 },
                 {
                     "class": "template_variable_custom",
+                    "current": {
+                        "text": "4.0",
+                        "value": "4.0"
+                    },
+                    "name": "scylla_dash_version",
+                    "options": [
+                        {
+                            "selected": true,
+                            "text": "4.0",
+                            "value": "4.0"
+                        }
+                    ],
+                    "query": "4.0"
+                },
+                {
+                    "class": "monitor_version_var"
+                },
+                {
+                    "class": "template_variable_custom",
                     "name": "alternator_latency_ops",
                     "current": {
                         "text": "GetItem",

--- a/grafana/alternator.4.1.template.json
+++ b/grafana/alternator.4.1.template.json
@@ -1063,6 +1063,25 @@
                 },
                 {
                     "class": "template_variable_custom",
+                    "current": {
+                        "text": "4.1",
+                        "value": "4.1"
+                    },
+                    "name": "scylla_dash_version",
+                    "options": [
+                        {
+                            "selected": true,
+                            "text": "4.1",
+                            "value": "4.1"
+                        }
+                    ],
+                    "query": "4.1"
+                },
+                {
+                    "class": "monitor_version_var"
+                },
+                {
+                    "class": "template_variable_custom",
                     "name": "alternator_latency_ops",
                     "current": {
                         "text": "GetItem",

--- a/grafana/alternator.4.2.template.json
+++ b/grafana/alternator.4.2.template.json
@@ -867,6 +867,25 @@
                 },
                 {
                     "class": "template_variable_custom",
+                    "current": {
+                        "text": "4.2",
+                        "value": "4.2"
+                    },
+                    "name": "scylla_dash_version",
+                    "options": [
+                        {
+                            "selected": true,
+                            "text": "4.2",
+                            "value": "4.2"
+                        }
+                    ],
+                    "query": "4.2"
+                },
+                {
+                    "class": "monitor_version_var"
+                },
+                {
+                    "class": "template_variable_custom",
                     "name": "alternator_latency_ops",
                     "multi": true,
                     "includeAll": true,

--- a/grafana/alternator.4.2.template.json
+++ b/grafana/alternator.4.2.template.json
@@ -181,6 +181,7 @@
                             },
                             {
                                 "colorMode": null,
+                                "alias": "Advanced",
                                 "colors": [
                                     "rgba(245, 54, 54, 0.9)",
                                     "rgba(237, 129, 40, 0.89)",
@@ -189,8 +190,8 @@
                                 "dateFormat": "YYYY-MM-DD HH:mm:ss",
                                 "decimals": 2,
                                 "link": true,
-                                "linkTooltip": "Jump to the Errors metrics information",
-                                "linkUrl": "/d/error-[[dash_version]]/scylla-errors?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
+                                "linkTooltip": "Jump to the Advanced metrics information",
+                                "linkUrl": "/d/advanced-[[dash_version]]/advanced?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
                                 "mappingType": 1,
                                 "pattern": "Errors",
                                 "thresholds": [],
@@ -198,59 +199,18 @@
                                 "unit": "short",
                                 "valueMaps": [
                                     {
-                                        "text": "Errors",
+                                        "text": "Advanced",
                                         "value": "errors"
                                     }
                                 ]
                             },
                             {
-                                "colorMode": null,
-                                "colors": [
-                                    "rgba(245, 54, 54, 0.9)",
-                                    "rgba(237, 129, 40, 0.89)",
-                                    "rgba(50, 172, 45, 0.97)"
-                                ],
-                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                                "decimals": 2,
-                                "link": true,
-                                "linkTooltip": "Jump to the Errors metrics information",
-                                "linkUrl": "/d/io-[[dash_version]]/i-o?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
-                                "mappingType": 1,
-                                "pattern": "IO",
-                                "thresholds": [],
-                                "type": "string",
-                                "unit": "short",
-                                "valueMaps": [
-                                    {
-                                        "text": "IO",
-                                        "value": "io"
-                                    }
-                                ]
+                                "class": "hidden_column",
+                                "pattern": "IO"
                             },
                             {
-                                "alias": "CPU",
-                                "colorMode": null,
-                                "colors": [
-                                    "rgba(245, 54, 54, 0.9)",
-                                    "rgba(237, 129, 40, 0.89)",
-                                    "rgba(50, 172, 45, 0.97)"
-                                ],
-                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                                "decimals": 2,
-                                "link": true,
-                                "linkTooltip": "Jump to the node CPU information",
-                                "linkUrl": "/d/cpu-[[dash_version]]/CPU-Metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
-                                "mappingType": 1,
-                                "pattern": "CPU",
-                                "thresholds": [],
-                                "type": "string",
-                                "unit": "short",
-                                "valueMaps": [
-                                    {
-                                        "text": "CPU",
-                                        "value": "cpu"
-                                    }
-                                ]
+                                "class": "hidden_column",
+                                "pattern": "CPU"
                             },
                             {
                                 "alias": "Status",

--- a/grafana/alternator.master.template.json
+++ b/grafana/alternator.master.template.json
@@ -867,6 +867,25 @@
                 },
                 {
                     "class": "template_variable_custom",
+                    "current": {
+                        "text": "master",
+                        "value": "master"
+                    },
+                    "name": "scylla_dash_version",
+                    "options": [
+                        {
+                            "selected": true,
+                            "text": "master",
+                            "value": "master"
+                        }
+                    ],
+                    "query": "master"
+                },
+                {
+                    "class": "monitor_version_var"
+                },
+                {
+                    "class": "template_variable_custom",
                     "name": "alternator_latency_ops",
                     "multi": true,
                     "includeAll": true,

--- a/grafana/alternator.master.template.json
+++ b/grafana/alternator.master.template.json
@@ -181,6 +181,7 @@
                             },
                             {
                                 "colorMode": null,
+                                "alias": "Advanced",
                                 "colors": [
                                     "rgba(245, 54, 54, 0.9)",
                                     "rgba(237, 129, 40, 0.89)",
@@ -189,8 +190,8 @@
                                 "dateFormat": "YYYY-MM-DD HH:mm:ss",
                                 "decimals": 2,
                                 "link": true,
-                                "linkTooltip": "Jump to the Errors metrics information",
-                                "linkUrl": "/d/error-[[dash_version]]/scylla-errors?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
+                                "linkTooltip": "Jump to the Advanced metrics information",
+                                "linkUrl": "/d/advanced-[[dash_version]]/advanced?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
                                 "mappingType": 1,
                                 "pattern": "Errors",
                                 "thresholds": [],
@@ -198,59 +199,18 @@
                                 "unit": "short",
                                 "valueMaps": [
                                     {
-                                        "text": "Errors",
+                                        "text": "Advanced",
                                         "value": "errors"
                                     }
                                 ]
                             },
                             {
-                                "colorMode": null,
-                                "colors": [
-                                    "rgba(245, 54, 54, 0.9)",
-                                    "rgba(237, 129, 40, 0.89)",
-                                    "rgba(50, 172, 45, 0.97)"
-                                ],
-                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                                "decimals": 2,
-                                "link": true,
-                                "linkTooltip": "Jump to the Errors metrics information",
-                                "linkUrl": "/d/io-[[dash_version]]/i-o?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
-                                "mappingType": 1,
-                                "pattern": "IO",
-                                "thresholds": [],
-                                "type": "string",
-                                "unit": "short",
-                                "valueMaps": [
-                                    {
-                                        "text": "IO",
-                                        "value": "io"
-                                    }
-                                ]
+                                "class": "hidden_column",
+                                "pattern": "IO"
                             },
                             {
-                                "alias": "CPU",
-                                "colorMode": null,
-                                "colors": [
-                                    "rgba(245, 54, 54, 0.9)",
-                                    "rgba(237, 129, 40, 0.89)",
-                                    "rgba(50, 172, 45, 0.97)"
-                                ],
-                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                                "decimals": 2,
-                                "link": true,
-                                "linkTooltip": "Jump to the node CPU information",
-                                "linkUrl": "/d/cpu-[[dash_version]]/CPU-Metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
-                                "mappingType": 1,
-                                "pattern": "CPU",
-                                "thresholds": [],
-                                "type": "string",
-                                "unit": "short",
-                                "valueMaps": [
-                                    {
-                                        "text": "CPU",
-                                        "value": "cpu"
-                                    }
-                                ]
+                                "class": "hidden_column",
+                                "pattern": "CPU"
                             },
                             {
                                 "alias": "Status",

--- a/grafana/build/ver_2020.1/alternator.2020.1.json
+++ b/grafana/build/ver_2020.1/alternator.2020.1.json
@@ -678,6 +678,7 @@
                     "type": "hidden"
                 },
                 {
+                    "alias": "Advanced",
                     "colorMode": null,
                     "colors": [
                         "rgba(245, 54, 54, 0.9)",
@@ -687,8 +688,8 @@
                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
                     "decimals": 2,
                     "link": true,
-                    "linkTooltip": "Jump to the Errors metrics information",
-                    "linkUrl": "/d/error-[[dash_version]]/scylla-errors?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
+                    "linkTooltip": "Jump to the Advanced metrics information",
+                    "linkUrl": "/d/advanced-[[dash_version]]/advanced?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
                     "mappingType": 1,
                     "pattern": "Errors",
                     "thresholds": [],
@@ -696,59 +697,20 @@
                     "unit": "short",
                     "valueMaps": [
                         {
-                            "text": "Errors",
+                            "text": "Advanced",
                             "value": "errors"
                         }
                     ]
                 },
                 {
-                    "colorMode": null,
-                    "colors": [
-                        "rgba(245, 54, 54, 0.9)",
-                        "rgba(237, 129, 40, 0.89)",
-                        "rgba(50, 172, 45, 0.97)"
-                    ],
-                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                    "decimals": 2,
-                    "link": true,
-                    "linkTooltip": "Jump to the Errors metrics information",
-                    "linkUrl": "/d/io-[[dash_version]]/i-o?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
-                    "mappingType": 1,
+                    "class": "hidden_column",
                     "pattern": "IO",
-                    "thresholds": [],
-                    "type": "string",
-                    "unit": "short",
-                    "valueMaps": [
-                        {
-                            "text": "IO",
-                            "value": "io"
-                        }
-                    ]
+                    "type": "hidden"
                 },
                 {
-                    "alias": "CPU",
-                    "colorMode": null,
-                    "colors": [
-                        "rgba(245, 54, 54, 0.9)",
-                        "rgba(237, 129, 40, 0.89)",
-                        "rgba(50, 172, 45, 0.97)"
-                    ],
-                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                    "decimals": 2,
-                    "link": true,
-                    "linkTooltip": "Jump to the node CPU information",
-                    "linkUrl": "/d/cpu-[[dash_version]]/CPU-Metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
-                    "mappingType": 1,
+                    "class": "hidden_column",
                     "pattern": "CPU",
-                    "thresholds": [],
-                    "type": "string",
-                    "unit": "short",
-                    "valueMaps": [
-                        {
-                            "text": "CPU",
-                            "value": "cpu"
-                        }
-                    ]
+                    "type": "hidden"
                 },
                 {
                     "alias": "Status",
@@ -3733,6 +3695,52 @@
                     }
                 ],
                 "query": "2020-1",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
+                    "text": "2020.1",
+                    "value": "2020.1"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "scylla_dash_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "2020.1",
+                        "value": "2020.1"
+                    }
+                ],
+                "query": "2020.1",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "monitor_version_var",
+                "current": {
+                    "text": "master",
+                    "value": "master"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "monitoring_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "master",
+                        "value": "master"
+                    }
+                ],
+                "query": "master",
                 "skipUrlSync": false,
                 "type": "custom"
             },

--- a/grafana/build/ver_3.3/alternator.3.3.json
+++ b/grafana/build/ver_3.3/alternator.3.3.json
@@ -4863,6 +4863,52 @@
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {
+                    "text": "3.3",
+                    "value": "3.3"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "scylla_dash_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "3.3",
+                        "value": "3.3"
+                    }
+                ],
+                "query": "3.3",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "monitor_version_var",
+                "current": {
+                    "text": "master",
+                    "value": "master"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "monitoring_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "master",
+                        "value": "master"
+                    }
+                ],
+                "query": "master",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
                     "text": "GetItem",
                     "value": "GetItem"
                 },

--- a/grafana/build/ver_4.0/alternator.4.0.json
+++ b/grafana/build/ver_4.0/alternator.4.0.json
@@ -4863,6 +4863,52 @@
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {
+                    "text": "4.0",
+                    "value": "4.0"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "scylla_dash_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "4.0",
+                        "value": "4.0"
+                    }
+                ],
+                "query": "4.0",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "monitor_version_var",
+                "current": {
+                    "text": "master",
+                    "value": "master"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "monitoring_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "master",
+                        "value": "master"
+                    }
+                ],
+                "query": "master",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
                     "text": "GetItem",
                     "value": "GetItem"
                 },

--- a/grafana/build/ver_4.1/alternator.4.1.json
+++ b/grafana/build/ver_4.1/alternator.4.1.json
@@ -4863,6 +4863,52 @@
                 "allValue": null,
                 "class": "template_variable_custom",
                 "current": {
+                    "text": "4.1",
+                    "value": "4.1"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "scylla_dash_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "4.1",
+                        "value": "4.1"
+                    }
+                ],
+                "query": "4.1",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "monitor_version_var",
+                "current": {
+                    "text": "master",
+                    "value": "master"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "monitoring_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "master",
+                        "value": "master"
+                    }
+                ],
+                "query": "master",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
                     "text": "GetItem",
                     "value": "GetItem"
                 },

--- a/grafana/build/ver_4.2/alternator.4.2.json
+++ b/grafana/build/ver_4.2/alternator.4.2.json
@@ -678,6 +678,7 @@
                     "type": "hidden"
                 },
                 {
+                    "alias": "Advanced",
                     "colorMode": null,
                     "colors": [
                         "rgba(245, 54, 54, 0.9)",
@@ -687,8 +688,8 @@
                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
                     "decimals": 2,
                     "link": true,
-                    "linkTooltip": "Jump to the Errors metrics information",
-                    "linkUrl": "/d/error-[[dash_version]]/scylla-errors?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
+                    "linkTooltip": "Jump to the Advanced metrics information",
+                    "linkUrl": "/d/advanced-[[dash_version]]/advanced?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
                     "mappingType": 1,
                     "pattern": "Errors",
                     "thresholds": [],
@@ -696,59 +697,20 @@
                     "unit": "short",
                     "valueMaps": [
                         {
-                            "text": "Errors",
+                            "text": "Advanced",
                             "value": "errors"
                         }
                     ]
                 },
                 {
-                    "colorMode": null,
-                    "colors": [
-                        "rgba(245, 54, 54, 0.9)",
-                        "rgba(237, 129, 40, 0.89)",
-                        "rgba(50, 172, 45, 0.97)"
-                    ],
-                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                    "decimals": 2,
-                    "link": true,
-                    "linkTooltip": "Jump to the Errors metrics information",
-                    "linkUrl": "/d/io-[[dash_version]]/i-o?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
-                    "mappingType": 1,
+                    "class": "hidden_column",
                     "pattern": "IO",
-                    "thresholds": [],
-                    "type": "string",
-                    "unit": "short",
-                    "valueMaps": [
-                        {
-                            "text": "IO",
-                            "value": "io"
-                        }
-                    ]
+                    "type": "hidden"
                 },
                 {
-                    "alias": "CPU",
-                    "colorMode": null,
-                    "colors": [
-                        "rgba(245, 54, 54, 0.9)",
-                        "rgba(237, 129, 40, 0.89)",
-                        "rgba(50, 172, 45, 0.97)"
-                    ],
-                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                    "decimals": 2,
-                    "link": true,
-                    "linkTooltip": "Jump to the node CPU information",
-                    "linkUrl": "/d/cpu-[[dash_version]]/CPU-Metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
-                    "mappingType": 1,
+                    "class": "hidden_column",
                     "pattern": "CPU",
-                    "thresholds": [],
-                    "type": "string",
-                    "unit": "short",
-                    "valueMaps": [
-                        {
-                            "text": "CPU",
-                            "value": "cpu"
-                        }
-                    ]
+                    "type": "hidden"
                 },
                 {
                     "alias": "Status",
@@ -3733,6 +3695,52 @@
                     }
                 ],
                 "query": "4-2",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
+                    "text": "4.2",
+                    "value": "4.2"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "scylla_dash_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "4.2",
+                        "value": "4.2"
+                    }
+                ],
+                "query": "4.2",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "monitor_version_var",
+                "current": {
+                    "text": "master",
+                    "value": "master"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "monitoring_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "master",
+                        "value": "master"
+                    }
+                ],
+                "query": "master",
                 "skipUrlSync": false,
                 "type": "custom"
             },

--- a/grafana/build/ver_master/alternator.master.json
+++ b/grafana/build/ver_master/alternator.master.json
@@ -678,6 +678,7 @@
                     "type": "hidden"
                 },
                 {
+                    "alias": "Advanced",
                     "colorMode": null,
                     "colors": [
                         "rgba(245, 54, 54, 0.9)",
@@ -687,8 +688,8 @@
                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
                     "decimals": 2,
                     "link": true,
-                    "linkTooltip": "Jump to the Errors metrics information",
-                    "linkUrl": "/d/error-[[dash_version]]/scylla-errors?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
+                    "linkTooltip": "Jump to the Advanced metrics information",
+                    "linkUrl": "/d/advanced-[[dash_version]]/advanced?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
                     "mappingType": 1,
                     "pattern": "Errors",
                     "thresholds": [],
@@ -696,59 +697,20 @@
                     "unit": "short",
                     "valueMaps": [
                         {
-                            "text": "Errors",
+                            "text": "Advanced",
                             "value": "errors"
                         }
                     ]
                 },
                 {
-                    "colorMode": null,
-                    "colors": [
-                        "rgba(245, 54, 54, 0.9)",
-                        "rgba(237, 129, 40, 0.89)",
-                        "rgba(50, 172, 45, 0.97)"
-                    ],
-                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                    "decimals": 2,
-                    "link": true,
-                    "linkTooltip": "Jump to the Errors metrics information",
-                    "linkUrl": "/d/io-[[dash_version]]/i-o?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
-                    "mappingType": 1,
+                    "class": "hidden_column",
                     "pattern": "IO",
-                    "thresholds": [],
-                    "type": "string",
-                    "unit": "short",
-                    "valueMaps": [
-                        {
-                            "text": "IO",
-                            "value": "io"
-                        }
-                    ]
+                    "type": "hidden"
                 },
                 {
-                    "alias": "CPU",
-                    "colorMode": null,
-                    "colors": [
-                        "rgba(245, 54, 54, 0.9)",
-                        "rgba(237, 129, 40, 0.89)",
-                        "rgba(50, 172, 45, 0.97)"
-                    ],
-                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                    "decimals": 2,
-                    "link": true,
-                    "linkTooltip": "Jump to the node CPU information",
-                    "linkUrl": "/d/cpu-[[dash_version]]/CPU-Metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
-                    "mappingType": 1,
+                    "class": "hidden_column",
                     "pattern": "CPU",
-                    "thresholds": [],
-                    "type": "string",
-                    "unit": "short",
-                    "valueMaps": [
-                        {
-                            "text": "CPU",
-                            "value": "cpu"
-                        }
-                    ]
+                    "type": "hidden"
                 },
                 {
                     "alias": "Status",
@@ -3725,6 +3687,52 @@
                 "label": null,
                 "multi": false,
                 "name": "dash_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "master",
+                        "value": "master"
+                    }
+                ],
+                "query": "master",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
+                    "text": "master",
+                    "value": "master"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "scylla_dash_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "master",
+                        "value": "master"
+                    }
+                ],
+                "query": "master",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "monitor_version_var",
+                "current": {
+                    "text": "master",
+                    "value": "master"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "monitoring_version",
                 "options": [
                     {
                         "selected": true,


### PR DESCRIPTION
This patch addresses two issues in the alternator dashboard,
1. Some of the links in the node table were pointing to the old dashboard.
2. Some dashboards parameters were missing which result in missing information when opening an issue.
Fixes #1134 