### PR TITLE
Adding Loki as an alert source to the monitoring stack

### DIFF
--- a/kill-all.sh
+++ b/kill-all.sh
@@ -49,6 +49,8 @@ sleep 2
 ./kill-container.sh $GRAFANA_PORT -b agraf
 ./kill-container.sh $ALERTMANAGER_PORT -b aalert
 ./kill-container.sh -b agrafrender
+./kill-container.sh -b loki
+./kill-container.sh -b promtail
 
 
 

--- a/loki/conf/loki-config.template.yaml
+++ b/loki/conf/loki-config.template.yaml
@@ -1,0 +1,65 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+ingester:
+  lifecycler:
+    address: 127.0.0.1
+    ring:
+      kvstore:
+        store: inmemory
+      replication_factor: 1
+    final_sleep: 0s
+  chunk_idle_period: 1h       # Any chunk not receiving new logs in this time will be flushed
+  max_chunk_age: 1h           # All chunks will be flushed when they hit this age, default is 1h
+  chunk_target_size: 1048576  # Loki will attempt to build chunks up to 1.5MB, flushing first if chunk_idle_period or max_chunk_age is reached first
+  chunk_retain_period: 30s    # Must be greater than index read cache TTL if using an index cache (Default index read cache TTL is 5m)
+  max_transfer_retries: 0     # Chunk transfers disabled
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  boltdb_shipper:
+    active_index_directory: /tmp/loki/boltdb-shipper-active
+    cache_location: /tmp/loki/boltdb-shipper-cache
+    cache_ttl: 24h         # Can be increased for faster performance over longer query periods, uses more disk space
+    shared_store: filesystem
+  filesystem:
+    directory: /tmp/loki/chunks
+
+compactor:
+  working_directory: /tmp/loki/boltdb-shipper-compactor
+  shared_store: filesystem
+
+limits_config:
+  reject_old_samples: true
+  reject_old_samples_max_age: 24h
+
+chunk_store_config:
+  max_look_back_period: 24h
+
+table_manager:
+  retention_deletes_enabled: true
+  retention_period: 24h
+
+ruler:
+  storage:
+    type: local
+    local:
+      directory: /etc/loki/rules
+  rule_path: /tmp/loki/rules-temp
+  alertmanager_url: http://ALERTMANAGER
+  ring:
+    kvstore:
+      store: inmemory
+  enable_api: true
+

--- a/loki/promtail/promtail_config.template.yml
+++ b/loki/promtail/promtail_config.template.yml
@@ -1,0 +1,32 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://LOKI_IP/loki/api/v1/push
+
+scrape_configs:
+  - job_name: syslog
+    syslog:
+      listen_address: 0.0.0.0:1514
+      labels:
+        job: "syslog"
+    relabel_configs:
+      - source_labels: ['__syslog_connection_ip_address']
+        target_label: 'instance'
+      - source_labels: ['__syslog_message_app_name']
+        target_label: 'app'
+      - source_labels: ['__syslog_message_severity']
+        target_label: 'severity'
+    pipeline_stages:
+      - match:
+          selector: '{app="scylla"}'
+          stages:
+            - regex:
+                expression: "\\[shard (?P<shard>\\d+)\\] (?P<module>\\S+).*"
+            - labels:
+                shard:
+                module:

--- a/loki/rules/scylla/loki-rule.yaml
+++ b/loki/rules/scylla/loki-rule.yaml
@@ -1,0 +1,7 @@
+groups:
+  - name: datamodel
+    rules:
+    - alert: HighThroughputLogStreams
+      expr: rate({app="scylla", module="seastar_memory"}[1h])>0
+      for: 20s
+

--- a/start-all.sh
+++ b/start-all.sh
@@ -36,7 +36,7 @@ fi
 
 PROMETHEUS_RULES="$PWD/prometheus/prometheus.rules.yml"
 VERSIONS=$DEFAULT_VERSION
-usage="$(basename "$0") [-h] [--version] [-e] [-d Prometheus data-dir] [-L resolve the servers from the manger running on the given address] [-G path to grafana data-dir] [-s scylla-target-file] [-n node-target-file] [-l] [-v comma separated versions] [-j additional dashboard to load to Grafana, multiple params are supported] [-c grafana environment variable, multiple params are supported] [-b Prometheus command line options] [-g grafana port ] [ -p prometheus port ] [-a admin password] [-m alertmanager port] [ -M scylla-manager version ] [-D encapsulate docker param] [-r alert-manager-config] [-R prometheus-alert-file] [-N manager target file] [-A bind-to-ip-address] [-C alertmanager commands] [-Q Grafana anonymous role (Admin/Editor/Viewer)] [-S start with a system specific dashboard set] -- starts Grafana and Prometheus Docker instances"
+usage="$(basename "$0") [-h] [--version] [-e] [-d Prometheus data-dir] [-L resolve the servers from the manger running on the given address] [-G path to grafana data-dir] [-s scylla-target-file] [-n node-target-file] [-l] [-v comma separated versions] [-j additional dashboard to load to Grafana, multiple params are supported] [-c grafana environment variable, multiple params are supported] [-b Prometheus command line options] [-g grafana port ] [ -p prometheus port ] [-a admin password] [-m alertmanager port] [ -M scylla-manager version ] [-D encapsulate docker param] [-r alert-manager-config] [-R prometheus-alert-file] [-N manager target file] [-A bind-to-ip-address] [-C alertmanager commands] [-Q Grafana anonymous role (Admin/Editor/Viewer)] [-S start with a system specific dashboard set] [--no-loki] -- starts Grafana and Prometheus Docker instances"
 PROMETHEUS_VERSION=v2.18.1
 
 SCYLLA_TARGET_FILES=($PWD/prometheus/scylla_servers.yml $PWD/scylla_servers.yml)
@@ -52,6 +52,16 @@ GRAFNA_ANONYMOUS_ROLE=""
 SPECIFIC_SOLUTION=""
 LDAP_FILE=""
 RUN_RENDERER=""
+RUN_LOKI=1
+
+for var in "$@"; do
+    case $var in
+        --no-loki)
+        RUN_LOKI=0
+        shift
+        ;;
+    esac
+done
 
 while getopts ':hleEd:g:p:v:s:n:a:c:j:b:m:r:R:M:G:D:L:N:C:Q:A:P:S:' option; do
   case "$option" in
@@ -186,6 +196,11 @@ if [ $? -ne 0 ]; then
     echo "$AM_ADDRESS"
     exit 1
 fi
+
+if [ $RUN_LOKI -eq 1 ]; then
+	./start-loki.sh $BIND_ADDRESS_CONFIG -D "$DOCKER_PARAM" -m $AM_ADDRESS
+fi
+
 if [ -z $PROMETHEUS_PORT ]; then
     PROMETHEUS_PORT=9090
     PROMETHEUS_NAME=aprom

--- a/start-loki.sh
+++ b/start-loki.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+
+is_podman="$(docker --help | grep -o podman)"
+VERSIONS=$DEFAULT_VERSION
+LOKI_RULE_DIR=$PWD/loki/rules
+LOKI_CONF_DIR=$PWD/loki/conf
+PROMTAIL_CONFIG=$PWD/loki/promtail/promtail_config.yml
+LOKI_VERSION="2.0.0"
+DOCKER_PARAM=""
+BIND_ADDRESS=""
+LOKI_COMMANDS=""
+usage="$(basename "$0") [-h] [-l] [-D encapsulate docker param] [-m alert_manager address]"
+
+while getopts ':hlp:D:m:' option; do
+  case "$option" in
+    h) echo "$usage"
+       exit
+       ;;
+    p) LOKI_PORT=$OPTARG
+       ;;
+    r) LOKI_RULE_DIR=`readlink -m $OPTARG`
+       ;;
+    l) DOCKER_PARAM="$DOCKER_PARAM --net=host"
+       ;;
+    D) DOCKER_PARAM="$DOCKER_PARAM $OPTARG"
+       ;;
+    C) LOKI_COMMANDS="$LOKI_COMMANDS $OPTARG"
+       ;;
+    A) BIND_ADDRESS="$OPTARG:"
+       ;;
+    m) ALERT_MANAGER_ADDRESS=$OPTARG
+       ;;
+    :) printf "missing argument for -%s\n" "$OPTARG" >&2
+       echo "$usage" >&2
+       exit 1
+       ;;
+   \?) printf "illegal option: -%s\n" "$OPTARG" >&2
+       echo "$usage" >&2
+       exit 1
+       ;;
+  esac
+done
+if [ -z $LOKI_PORT ]; then
+    LOKI_PORT=3100
+    LOKI_NAME=loki
+else
+    LOKI_NAME=loki-$LOKI_PORT
+fi
+
+docker container inspect $LOKI_NAME > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+    printf "\nSome of the monitoring docker instances ($LOKI_NAME) exist. Make sure all containers are killed and removed. You can use kill-all.sh for that\n"
+    exit 1
+fi
+
+if [[ ! $DOCKER_PARAM = *"--net=host"* ]]; then
+    PORT_MAPPING="-p $BIND_ADDRESS$LOKI_PORT:3100"
+fi
+
+if [ -z $ALERT_MANAGER_ADDRESS ]; then
+	ALERT_MANAGER_ADDRESS="$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' aalert):9093"
+fi
+
+sed "s/ALERTMANAGER/$ALERT_MANAGER_ADDRESS/" loki/conf/loki-config.template.yaml > loki/conf/loki-config.yaml
+printf "Wait for Loki container to start."
+docker run -d $DOCKER_PARAM -i $PORT_MAPPING \
+	 -v $LOKI_RULE_DIR:/etc/loki/rules \
+	 -v $LOKI_CONF_DIR:/mnt/config \
+     --name $LOKI_NAME grafana/loki:$LOKI_VERSION $LOKI_COMMANDS --config.file=/mnt/config/loki-config.yaml >& /dev/null
+
+if [ $? -ne 0 ]; then
+    echo "Error: Loki container failed to start"
+    echo "For more information use: docker logs $LOKI_NAME"
+    exit 1
+fi
+
+# Wait till Loki is available
+RETRIES=5
+TRIES=0
+until $(curl --output /dev/null -f --silent http://localhost:$LOKI_PORT) || [ $TRIES -eq $RETRIES ]; do
+    ((TRIES=TRIES+1))
+    sleep 5
+    printf "."
+done
+
+if [ ! "$(docker ps -q -f name=$LOKI_NAME)" ]
+then
+    echo "Error: Loki container failed to start"
+    exit 1
+fi
+echo
+
+LOKI_ADDRESS="$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' $LOKI_NAME):3100"
+if [ ! -z "$is_podman" ] && [ "$AM_ADDRESS" = ":3100" ]; then
+    HOST_IP=`hostname -I | awk '{print $1}'`
+    LOKI_ADDRESS="$HOST_IP:3100"
+fi
+
+if [ -z $PROMTAIL_PORT ]; then
+    PROMTAIL_PORT=9080
+    PROMTAIL_NAME=promtail
+else
+    PROMTAIL_NAME=promtail-$PROMTAIL_PORT
+fi
+
+docker container inspect $PROMTAIL_NAME > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+    printf "\nSome of the monitoring docker instances ($PROMTAIL_NAME) exist. Make sure all containers are killed and removed. You can use kill-all.sh for that\n"
+    exit 1
+fi
+
+if [[ ! $DOCKER_PARAM = *"--net=host"* ]]; then
+    PROMTAIL_PORT_MAPPING="-p $BIND_ADDRESS$PROMTAIL_PORT:9080 -p ${BIND_ADDRESS}1514:1514"
+fi
+
+sed "s/LOKI_IP/$LOKI_ADDRESS/" loki/promtail/promtail_config.template.yml > loki/promtail/promtail_config.yml
+
+printf "Wait for Promtail container to start."
+docker run -d $DOCKER_PARAM -i $PROMTAIL_PORT_MAPPING \
+	 -v $PROMTAIL_CONFIG:/etc/promtail/config.yml \
+     --name $PROMTAIL_NAME grafana/promtail:$LOKI_VERSION --config.file=/etc/promtail/config.yml >& /dev/null
+
+if [ $? -ne 0 ]; then
+    echo "Error: Promtail container failed to start"
+    echo "For more information use: docker logs $PROMTAIL_NAME"
+    exit 1
+fi
+
+# Wait till Loki is available
+RETRIES=5
+TRIES=0
+until $(curl --output /dev/null -f --silent http://localhost:$PROMTAIL_PORT) || [ $TRIES -eq $RETRIES ]; do
+    ((TRIES=TRIES+1))
+    sleep 5
+    printf "."
+done
+
+if [ ! "$(docker ps -q -f name=$PROMTAIL_NAME)" ]
+then
+    echo "Error: Promtail container failed to start"
+    exit 1
+fi
+echo


### PR DESCRIPTION
This patch adds loki as an alert data source to the monitoring stack.
The first alert that it sends is for large cells/row/partition.

loki and promtail will be started by default, you can disable it with `--no-loki`

It's possible to add loki as an independent data source, but it's not part of this series.
This patch also requires that rsyslog would send log to the monitoring from the scylla servers.

Fixes #617