### PR TITLE
start-all.sh: remove the --no-loki correctly from the command line

### DIFF
--- a/start-all.sh
+++ b/start-all.sh
@@ -54,12 +54,13 @@ LDAP_FILE=""
 RUN_RENDERER=""
 RUN_LOKI=1
 
-for var in "$@"; do
-    case $var in
-        --no-loki)
-        RUN_LOKI=0
-        shift
-        ;;
+for arg; do
+	shift
+	case $arg in
+        (--no-loki) RUN_LOKI=0
+            ;;
+        (*) set -- "$@" "$arg"
+            ;;
     esac
 done
 


### PR DESCRIPTION
This patch fixes a bug in start-all.sh that always remove the first parameter from the command line options instead of the the --no-loki parameter.

Fixes #1152