### PR TITLE
Add a simple way of starting the monitoring stack using docker-compose

### DIFF
--- a/docs/source/docker-compose.example.yml
+++ b/docs/source/docker-compose.example.yml
@@ -1,0 +1,65 @@
+services:
+  alertmanager:
+    container_name: aalert
+    image: prom/alertmanager:v0.21.0
+    ports:
+    - 9093:9093
+    volumes:
+    - ./prometheus/rule_config.yml:/etc/alertmanager/config.yml
+  grafana:
+    container_name: agraf
+    environment:
+    - GF_PANELS_DISABLE_SANITIZE_HTML=true
+    - GF_PATHS_PROVISIONING=/var/lib/grafana/provisioning
+    - GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=scylladb-scylla-datasource
+    # This is where you set Grafana security
+    - GF_AUTH_BASIC_ENABLED=false
+    - GF_AUTH_ANONYMOUS_ENABLED=true
+    - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+    - GF_SECURITY_ADMIN_PASSWORD=admin
+    image: grafana/grafana:7.3.5
+    ports:
+    - 3000:3000
+    user: 1000:1000
+    volumes:
+    - ./grafana/build:/var/lib/grafana/dashboards
+    - ./grafana/plugins:/var/lib/grafana/plugins
+    - ./grafana/provisioning:/var/lib/grafana/provisioning
+    # Uncomment the following line for grafana persistency
+    # - path/to/grafana/dir:/var/lib/grafana
+  loki:
+    command:
+    - --config.file=/mnt/config/loki-config.yaml
+    container_name: loki
+    image: grafana/loki:2.0.0
+    ports:
+    - 3100:3100
+    volumes:
+    - ./loki/rules:/etc/loki/rules
+    - ./loki/conf:/mnt/config
+  promotheus:
+    command:
+    - --config.file=/etc/prometheus/prometheus.compose.yml
+    container_name: aprom
+    image: prom/prometheus:v2.18.1
+    ports:
+    - 9090:9090
+    volumes:
+    - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    - ./prometheus/prometheus.rules.yml:/etc/prometheus/prometheus.rules.yml
+    - ./prometheus/scylla_servers.yml:/etc/scylla.d/prometheus/scylla_servers.yml
+    - ./prometheus/scylla_manager_servers.yml:/etc/scylla.d/prometheus/scylla_manager_servers.yml
+    - ./prometheus/scylla_servers.yml:/etc/scylla.d/prometheus/node_exporter_servers.yml
+    # Uncomment the following line for prometheus persistency 
+    # - path/to/data/dir:/prometheus/data
+  promtail:
+    command:
+    - --config.file=/etc/promtail/config.yml
+    container_name: promtail
+    image: grafana/promtail:2.0.0
+    ports:
+    - 1514:1514
+    - 9080:9080
+    volumes:
+    - ./loki/promtail/promtail_config.compose.yml:/etc/promtail/config.yml
+version: '3'

--- a/docs/source/docker_compose.rst
+++ b/docs/source/docker_compose.rst
@@ -1,7 +1,17 @@
 Using Docker Compose
 ====================
 
-Scylla-Monitor is container-based, using Docker Compose file allows you to simplify starting and stopping the monitoring stack.
+Scylla-Monitoring is container-based.
+You can start and stop the monitoring stack with the `start-all.sh` and `kill-all.sh` scripts.
+ 
+Docker Compose is an alternative method to start and stop the stack. It requires more manual steps, but once
+set it simplify starting and stopping the monitoring stack.
+
+.. warning:: 
+
+    *docker-compose* **and** *start_all.sh* are two **alternative** ways to launch Scylla Monitoring Stack.
+    You should use **one** method, **not both**. In particular,  creating and updating *docker-compose.yml* is ignored
+    when using *start_all.sh*
 
 Prerequisite 
 ------------
@@ -11,8 +21,8 @@ Make sure you have `docker` and `docker-compose` installed.
 Setting Prometheus
 ------------------
 
-Prometheus configuration file contains among others the IP address of the alertmanager and either the location
-of the `scylla_server.yml` file or a Consul IP address of Scylla-Manager, if Scylla-Manager is used for server provisioning.
+The Prometheus configuration file contains among others the IP address of the *alertmanager* and either the location
+of the *scylla_server.yml* file or a Consul IP address of Scylla Manager, if Scylla Manager is used for server provisioning.
 
 You can use `./prometheus-config.sh` to generate the file, for example: 
 
@@ -20,19 +30,19 @@ You can use `./prometheus-config.sh` to generate the file, for example:
 
    ./prometheus-config.sh --compose
    
-For production usage, It is advice that you will use an external directory for the Prometheus database, make sure to create one and
-update the docker-compose file accordingly (see the docker-compose example).  
+For production systems, It is advised to use an external directory for the Prometheus database. Make sure to create one and
+update the docker-compose file accordingly (see the docker-compose example below).  
 
 Setting Grafana Provisioning
 ----------------------------
 
-Grafana reads its provisioning configuration from files, one for the data-source and one
-for the dashboards. Note that the latter tells Grafana where the dashboards are not the dashboard themselves that are
-in a different location.
+Grafana reads its provisioning configuration from files, one for the data-source and one for the dashboards.
+Note that the latter tells Grafana where the dashboards are located, it is not the dashboards themselves, which are
+at a different location.
 
 Grafana Data-Source file
 ^^^^^^^^^^^^^^^^^^^^^^^^
-to update the datasource you can run
+Run the following command to update the datasource:
 
 .. code-block:: shell
 
@@ -42,14 +52,14 @@ You can see the generated file under: `grafana/provisioning/datasources/datasour
 
 Grafana Dashboard Load file
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-To set the dashboard load file, you can use the `./generate-sashboards.sh` with the `-t` command line flag, for example
-to use scylla-enterprise version 2020.1
+To set the dashboard load file, you can run the `./generate-sashboards.sh` with the `-t` command line flag and the `-v` flag to specify the version.
+For example, Scylla-enterprise version 2020.1:
 
 .. code-block:: shell
 
    ./generate-dashboards.sh -t -v 2020.1
 
-You can see the generated files `grafana/provisioning/dashboards/`
+This command generates the files under: `grafana/provisioning/dashboards/`
 
 Docker Compose file
 -------------------
@@ -58,75 +68,11 @@ You can use the following example as a base for your docker compose.
 Pass the following to a file called `docker-compose.yml`
 
 
-.. code-block:: yaml
+.. literalinclude:: docker-compose.example.yml
+   :language: ruby
 
-    services:
-      alertmanager:
-        container_name: aalert
-        image: prom/alertmanager:v0.21.0
-        ports:
-        - 9093:9093
-        volumes:
-        - ./prometheus/rule_config.yml:/etc/alertmanager/config.yml
-      grafana:
-        container_name: agraf
-        environment:
-        - GF_PANELS_DISABLE_SANITIZE_HTML=true
-        - GF_PATHS_PROVISIONING=/var/lib/grafana/provisioning
-        - GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=scylladb-scylla-datasource
-        # This is where you set Grafana security
-        - GF_AUTH_BASIC_ENABLED=false
-        - GF_AUTH_ANONYMOUS_ENABLED=true
-        - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
-        - GF_SECURITY_ADMIN_PASSWORD=admin
-        image: grafana/grafana:7.3.5
-        ports:
-        - 3000:3000
-        user: 1000:1000
-        volumes:
-        - ./grafana/build:/var/lib/grafana/dashboards
-        - ./grafana/plugins:/var/lib/grafana/plugins
-        - ./grafana/provisioning:/var/lib/grafana/provisioning
-        # Uncomment the following line for grafana persistency
-        # - path/to/grafana/dir:/var/lib/grafana
-      loki:
-        command:
-        - --config.file=/mnt/config/loki-config.yaml
-        container_name: loki
-        image: grafana/loki:2.0.0
-        ports:
-        - 3100:3100
-        volumes:
-        - ./loki/rules:/etc/loki/rules
-        - ./loki/conf:/mnt/config
-      promotheus:
-        command:
-        - --config.file=/etc/prometheus/prometheus.compose.yml
-        container_name: aprom
-        image: prom/prometheus:v2.18.1
-        ports:
-        - 9090:9090
-        volumes:
-        - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
-        - ./prometheus/prometheus.rules.yml:/etc/prometheus/prometheus.rules.yml
-        - ./prometheus/scylla_servers.yml:/etc/scylla.d/prometheus/scylla_servers.yml
-        - ./prometheus/scylla_manager_servers.yml:/etc/scylla.d/prometheus/scylla_manager_servers.yml
-        - ./prometheus/scylla_servers.yml:/etc/scylla.d/prometheus/node_exporter_servers.yml
-        # Uncomment the following line for prometheus persistency 
-        # - path/to/data/dir:/prometheus/data
-      promtail:
-        command:
-        - --config.file=/etc/promtail/config.yml
-        container_name: promtail
-        image: grafana/promtail:2.0.0
-        ports:
-        - 1514:1514
-        - 9080:9080
-        volumes:
-        - ./loki/promtail/promtail_config.compose.yml:/etc/promtail/config.yml
-    version: '3'
 
 Start and Stop
 ^^^^^^^^^^^^^^
 
-use `docker-compose up` and `docker-compose down` to start and stop the monitoring stack. 
+To start the Scylla Monitoring Stack run ``docker-compose up`` and to stop run ``docker-compose down``.

--- a/docs/source/docker_compose.rst
+++ b/docs/source/docker_compose.rst
@@ -1,0 +1,132 @@
+Using Docker Compose
+====================
+
+Scylla-Monitor is container-based, using Docker Compose file allows you to simplify starting and stopping the monitoring stack.
+
+Prerequisite 
+------------
+
+Make sure you have `docker` and `docker-compose` installed.
+
+Setting Prometheus
+------------------
+
+Prometheus configuration file contains among others the IP address of the alertmanager and either the location
+of the `scylla_server.yml` file or a Consul IP address of Scylla-Manager, if Scylla-Manager is used for server provisioning.
+
+You can use `./prometheus-config.sh` to generate the file, for example: 
+
+.. code-block:: shell
+
+   ./prometheus-config.sh --compose
+   
+For production usage, It is advice that you will use an external directory for the Prometheus database, make sure to create one and
+update the docker-compose file accordingly (see the docker-compose example).  
+
+Setting Grafana Provisioning
+----------------------------
+
+Grafana reads its provisioning configuration from files, one for the data-source and one
+for the dashboards. Note that the latter tells Grafana where the dashboards are not the dashboard themselves that are
+in a different location.
+
+Grafana Data-Source file
+^^^^^^^^^^^^^^^^^^^^^^^^
+to update the datasource you can run
+
+.. code-block:: shell
+
+   ./grafana-datasource.sh --compose
+
+You can see the generated file under: `grafana/provisioning/datasources/datasource.yaml` 
+
+Grafana Dashboard Load file
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+To set the dashboard load file, you can use the `./generate-sashboards.sh` with the `-t` command line flag, for example
+to use scylla-enterprise version 2020.1
+
+.. code-block:: shell
+
+   ./generate-dashboards.sh -t -v 2020.1
+
+You can see the generated files `grafana/provisioning/dashboards/`
+
+Docker Compose file
+-------------------
+You can use the following example as a base for your docker compose.
+
+Pass the following to a file called `docker-compose.yml`
+
+
+.. code-block:: yaml
+
+    services:
+      alertmanager:
+        container_name: aalert
+        image: prom/alertmanager:v0.21.0
+        ports:
+        - 9093:9093
+        volumes:
+        - ./prometheus/rule_config.yml:/etc/alertmanager/config.yml
+      grafana:
+        container_name: agraf
+        environment:
+        - GF_PANELS_DISABLE_SANITIZE_HTML=true
+        - GF_PATHS_PROVISIONING=/var/lib/grafana/provisioning
+        - GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=scylladb-scylla-datasource
+        # This is where you set Grafana security
+        - GF_AUTH_BASIC_ENABLED=false
+        - GF_AUTH_ANONYMOUS_ENABLED=true
+        - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+        - GF_SECURITY_ADMIN_PASSWORD=admin
+        image: grafana/grafana:7.3.5
+        ports:
+        - 3000:3000
+        user: 1000:1000
+        volumes:
+        - ./grafana/build:/var/lib/grafana/dashboards
+        - ./grafana/plugins:/var/lib/grafana/plugins
+        - ./grafana/provisioning:/var/lib/grafana/provisioning
+        # Uncomment the following line for grafana persistency
+        # - path/to/grafana/dir:/var/lib/grafana
+      loki:
+        command:
+        - --config.file=/mnt/config/loki-config.yaml
+        container_name: loki
+        image: grafana/loki:2.0.0
+        ports:
+        - 3100:3100
+        volumes:
+        - ./loki/rules:/etc/loki/rules
+        - ./loki/conf:/mnt/config
+      promotheus:
+        command:
+        - --config.file=/etc/prometheus/prometheus.compose.yml
+        container_name: aprom
+        image: prom/prometheus:v2.18.1
+        ports:
+        - 9090:9090
+        volumes:
+        - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+        - ./prometheus/prometheus.rules.yml:/etc/prometheus/prometheus.rules.yml
+        - ./prometheus/scylla_servers.yml:/etc/scylla.d/prometheus/scylla_servers.yml
+        - ./prometheus/scylla_manager_servers.yml:/etc/scylla.d/prometheus/scylla_manager_servers.yml
+        - ./prometheus/scylla_servers.yml:/etc/scylla.d/prometheus/node_exporter_servers.yml
+        # Uncomment the following line for prometheus persistency 
+        # - path/to/data/dir:/prometheus/data
+      promtail:
+        command:
+        - --config.file=/etc/promtail/config.yml
+        container_name: promtail
+        image: grafana/promtail:2.0.0
+        ports:
+        - 1514:1514
+        - 9080:9080
+        volumes:
+        - ./loki/promtail/promtail_config.compose.yml:/etc/promtail/config.yml
+    version: '3'
+
+Start and Stop
+^^^^^^^^^^^^^^
+
+use `docker-compose up` and `docker-compose down` to start and stop the monitoring stack. 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,6 +7,7 @@ Scylla Monitor
    
    Install Scylla Monitor Stack <monitoring_stack>
    The start-all.sh script <start_all>
+   Running using Docker Compose <docker_compose>
    Scylla Monitor Interfaces <monitoring_apis>
    Deploy Scylla Monitor Without Docker <monitor_without_docker>
    Troubleshoot Monitor <monitor_troubleshoot>
@@ -35,6 +36,7 @@ The Scylla Monitor Stack consists of three components, wrapped in Docker contain
 
 * :doc:`Install Scylla Monitor Stack <monitoring_stack>`
 * :doc:`The start-all.sh script <start_all>`
+* :doc:`Running using Docker Compose <docker_compose>`
 * :doc:`Scylla Monitor Interfaces <monitoring_apis>`
 * :doc:`Deploy Scylla Monitor Without Docker <monitor_without_docker>`
 * :doc:`Troubleshoot Scylla Monitor <monitor_troubleshoot>`

--- a/grafana-datasource.sh
+++ b/grafana-datasource.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+usage="$(basename "$0") [-h] [-p ip:port address of prometheus ] [-m alert_manager address] [-L loki address] [--compose] -- Generate grafna's datasource file"
+
+if [ "$1" = "" ]; then
+    echo "$usage"
+    exit
+fi
+
+if [ "$1" = "--compose" ]; then
+    DB_ADDRESS="aprom:9090"
+    ALERT_MANAGER_ADDRESS="aalert:9093"
+    LOKI_ADDRESS="loki:3100"
+else
+    while getopts ':hlEg:n:p:v:a:x:c:j:m:G:M:D:A:S:P:L:Q:' option; do
+      case "$option" in
+        h) echo "$usage"
+           exit
+           ;;
+        p) DB_ADDRESS=$OPTARG
+           ;;
+        m) AM_ADDRESS="-m $OPTARG"
+           ALERT_MANAGER_ADDRESS=$OPTARG
+           ;;
+        L) LOKI_ADDRESS=$OPTARG
+           ;;
+        :) printf "missing argument for -%s\n" "$OPTARG" >&2
+           echo "$usage" >&2
+           exit 1
+           ;;
+       \?) printf "illegal option: -%s\n" "$OPTARG" >&2
+           echo "$usage" >&2
+           exit 1
+           ;;
+      esac
+    done
+fi
+mkdir -p grafana/provisioning/datasources
+sed "s/DB_ADDRESS/$DB_ADDRESS/" grafana/datasource.yml | sed "s/AM_ADDRESS/$ALERT_MANAGER_ADDRESS/" | sed "s/LOKI_ADDRESS/$LOKI_ADDRESS/" > grafana/provisioning/datasources/datasource.yaml

--- a/loki/conf/loki-config.compose.yaml
+++ b/loki/conf/loki-config.compose.yaml
@@ -1,0 +1,65 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+ingester:
+  lifecycler:
+    address: 127.0.0.1
+    ring:
+      kvstore:
+        store: inmemory
+      replication_factor: 1
+    final_sleep: 0s
+  chunk_idle_period: 1h       # Any chunk not receiving new logs in this time will be flushed
+  max_chunk_age: 1h           # All chunks will be flushed when they hit this age, default is 1h
+  chunk_target_size: 1048576  # Loki will attempt to build chunks up to 1.5MB, flushing first if chunk_idle_period or max_chunk_age is reached first
+  chunk_retain_period: 30s    # Must be greater than index read cache TTL if using an index cache (Default index read cache TTL is 5m)
+  max_transfer_retries: 0     # Chunk transfers disabled
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  boltdb_shipper:
+    active_index_directory: /tmp/loki/boltdb-shipper-active
+    cache_location: /tmp/loki/boltdb-shipper-cache
+    cache_ttl: 24h         # Can be increased for faster performance over longer query periods, uses more disk space
+    shared_store: filesystem
+  filesystem:
+    directory: /tmp/loki/chunks
+
+compactor:
+  working_directory: /tmp/loki/boltdb-shipper-compactor
+  shared_store: filesystem
+
+limits_config:
+  reject_old_samples: true
+  reject_old_samples_max_age: 24h
+
+chunk_store_config:
+  max_look_back_period: 24h
+
+table_manager:
+  retention_deletes_enabled: true
+  retention_period: 24h
+
+ruler:
+  storage:
+    type: local
+    local:
+      directory: /etc/loki/rules
+  rule_path: /tmp/loki/rules-temp
+  alertmanager_url: http://aalert:9093
+  ring:
+    kvstore:
+      store: inmemory
+  enable_api: true
+

--- a/loki/promtail/promtail_config.compose.yml
+++ b/loki/promtail/promtail_config.compose.yml
@@ -1,0 +1,32 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: syslog
+    syslog:
+      listen_address: 0.0.0.0:1514
+      labels:
+        job: "syslog"
+    relabel_configs:
+      - source_labels: ['__syslog_connection_ip_address']
+        target_label: 'instance'
+      - source_labels: ['__syslog_message_app_name']
+        target_label: 'app'
+      - source_labels: ['__syslog_message_severity']
+        target_label: 'severity'
+    pipeline_stages:
+      - match:
+          selector: '{app="scylla"}'
+          stages:
+            - regex:
+                expression: "\\[shard (?P<shard>\\d+)\\] (?P<module>\\S+).*"
+            - labels:
+                shard:
+                module:

--- a/prometheus-config.sh
+++ b/prometheus-config.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+usage="$(basename "$0") [-h] [-m alert_manager address]  [-L] [--compose] -- Generate grafna's datasource file"
+CONSUL_ADDRESS=""
+COMPOSE=0
+if [ "$1" = "" ]; then
+    echo "$usage"
+    exit
+fi
+for arg; do
+    shift
+    case $arg in
+        (--compose) COMPOSE=1
+            AM_ADDRESS="aalert:9093"
+            ;;
+        (*) set -- "$@" "$arg"
+            ;;
+    esac
+done
+
+while getopts ':hL:m:' option; do
+  case "$option" in
+    h) echo "$usage"
+       exit
+       ;;
+    L) CONSUL_ADDRESS="$OPTARG"
+       ;;
+    m) AM_ADDRESS="$$OPTARG"
+       ;;
+    :) printf "missing argument for -%s\n" "$OPTARG" >&2
+       echo "$usage" >&2
+       exit 1
+       ;;
+   \?) printf "illegal option: -%s\n" "$OPTARG" >&2
+       echo "$usage" >&2
+       exit 1
+       ;;
+  esac
+done
+
+mkdir -p $PWD/prometheus/build/
+if [ -z $CONSUL_ADDRESS ]; then
+    sed "s/AM_ADDRESS/$AM_ADDRESS/" $PWD/prometheus/prometheus.yml.template > $PWD/prometheus/build/prometheus.yml
+else
+    if [[ ! $CONSUL_ADDRESS = *":"* ]]; then
+        CONSUL_ADDRESS="$CONSUL_ADDRESS:5090"
+    fi
+    sed "s/AM_ADDRESS/$AM_ADDRESS/" $PWD/prometheus/prometheus.consul.yml.template| sed "s/MANAGER_ADDRESS/$CONSUL_ADDRESS/" > $PWD/prometheus/build/prometheus.yml
+fi

--- a/start-all.sh
+++ b/start-all.sh
@@ -98,7 +98,7 @@ while getopts ':hleEd:g:p:v:s:n:a:c:j:b:m:r:R:M:G:D:L:N:C:Q:A:P:S:' option; do
        ;;
     l) DOCKER_PARAM="$DOCKER_PARAM --net=host"
        ;;
-    L) CONSUL_ADDRESS="$OPTARG"
+    L) CONSUL_ADDRESS="-L $OPTARG"
        ;;
     P) LDAP_FILE="-P $OPTARG"
        ;;
@@ -170,9 +170,6 @@ if [ -z $CONSUL_ADDRESS ]; then
     SCYLLA_MANGER_TARGET_FILE="-v "$(readlink -m $SCYLLA_MANGER_TARGET_FILE)":/etc/scylla.d/prometheus/scylla_manager_servers.yml:Z"
     NODE_TARGET_FILE="-v "$(readlink -m $NODE_TARGET_FILE)":/etc/scylla.d/prometheus/node_exporter_servers.yml:Z"
 else
-    if [[ ! $CONSUL_ADDRESS = *":"* ]]; then
-        CONSUL_ADDRESS="$CONSUL_ADDRESS:56090"
-    fi
     SCYLLA_TARGET_FILE=""
     SCYLLA_MANGER_TARGET_FILE=""
     NODE_TARGET_FILE=""
@@ -232,12 +229,7 @@ for val in "${PROMETHEUS_COMMAND_LINE_OPTIONS_ARRAY[@]}"; do
     PROMETHEUS_COMMAND_LINE_OPTIONS+=" -$val"
 done
 
-mkdir -p $PWD/prometheus/build/
-if [ -z $CONSUL_ADDRESS ]; then
-    sed "s/AM_ADDRESS/$AM_ADDRESS/" $PWD/prometheus/prometheus.yml.template > $PWD/prometheus/build/prometheus.yml
-else
-    sed "s/AM_ADDRESS/$AM_ADDRESS/" $PWD/prometheus/prometheus.consul.yml.template| sed "s/MANAGER_ADDRESS/$CONSUL_ADDRESS/" > $PWD/prometheus/build/prometheus.yml
-fi
+./prometheus-config.sh -m $AM_ADDRESS $CONSUL_ADDRESS
 
 if [ -z $HOST_NETWORK ]; then
     PORT_MAPPING="-p $BIND_ADDRESS$PROMETHEUS_PORT:9090"


### PR DESCRIPTION
This series adds support for docker-compose.

It breaks some of the functionality of start-all.sh and start-grafana.sh to specific script to make
the configurtion simpler.
It adds documentation on how to create a compose file and use it
Fixes #273 