### PR TITLE
Update grafana 7 format

### DIFF
--- a/grafana/build/manager_2.1/scylla-manager.2.1.json
+++ b/grafana/build/manager_2.1/scylla-manager.2.1.json
@@ -751,7 +751,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -854,7 +854,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -958,7 +958,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1060,7 +1060,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1191,7 +1191,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1293,7 +1293,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1385,7 +1385,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "2.1"

--- a/grafana/build/manager_2.2/scylla-manager.2.2.json
+++ b/grafana/build/manager_2.2/scylla-manager.2.2.json
@@ -751,7 +751,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -854,7 +854,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -958,7 +958,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1060,7 +1060,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1191,7 +1191,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1293,7 +1293,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1385,7 +1385,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "2.2"

--- a/grafana/build/ver_2019.1/scylla-advanced.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-advanced.2019.1.json
@@ -1016,7 +1016,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1121,7 +1121,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1224,7 +1224,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1388,7 +1388,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -1492,7 +1492,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -1596,7 +1596,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -1745,7 +1745,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1849,7 +1849,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1982,7 +1982,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2086,7 +2086,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2190,7 +2190,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2296,7 +2296,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2402,7 +2402,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2508,7 +2508,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2661,7 +2661,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2757,7 +2757,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2843,7 +2843,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "2019.1"

--- a/grafana/build/ver_2019.1/scylla-cql.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-cql.2019.1.json
@@ -225,7 +225,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -330,7 +330,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -435,7 +435,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -540,7 +540,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -646,7 +646,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -750,7 +750,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -854,7 +854,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -1114,7 +1114,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1301,7 +1301,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1486,7 +1486,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1673,7 +1673,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1858,7 +1858,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2043,7 +2043,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2245,7 +2245,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2432,7 +2432,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2648,7 +2648,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2835,7 +2835,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3009,7 +3009,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "2019.1"
@@ -3275,5 +3275,5 @@
     "timezone": "utc",
     "title": "Scylla CQL",
     "uid": "cql-2019-1",
-    "version": 0
+    "version": 1
 }

--- a/grafana/build/ver_2019.1/scylla-detailed.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-detailed.2019.1.json
@@ -164,7 +164,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -269,7 +269,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -374,7 +374,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -476,7 +476,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -638,7 +638,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -741,7 +741,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -845,7 +845,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -948,7 +948,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1051,7 +1051,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1154,7 +1154,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1257,7 +1257,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1360,7 +1360,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1463,7 +1463,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1565,7 +1565,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1670,7 +1670,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1773,7 +1773,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1905,7 +1905,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2009,7 +2009,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2113,7 +2113,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2217,7 +2217,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2348,7 +2348,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2450,7 +2450,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2552,7 +2552,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2710,7 +2710,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2812,7 +2812,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2943,7 +2943,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3045,7 +3045,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3147,7 +3147,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3249,7 +3249,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3351,7 +3351,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3453,7 +3453,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3555,7 +3555,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3657,7 +3657,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3759,7 +3759,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3863,7 +3863,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3967,7 +3967,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4071,7 +4071,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4175,7 +4175,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4279,7 +4279,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4383,7 +4383,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4485,7 +4485,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4587,7 +4587,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4689,7 +4689,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4821,7 +4821,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4924,7 +4924,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5027,7 +5027,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5130,7 +5130,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5235,7 +5235,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5338,7 +5338,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5469,7 +5469,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5571,7 +5571,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5702,7 +5702,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5807,7 +5807,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5914,7 +5914,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6047,7 +6047,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6143,7 +6143,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6229,7 +6229,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "2019.1"

--- a/grafana/build/ver_2019.1/scylla-os.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-os.2019.1.json
@@ -272,7 +272,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -383,7 +383,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -486,7 +486,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -633,7 +633,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -744,7 +744,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -853,7 +853,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -964,7 +964,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1117,7 +1117,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1228,7 +1228,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1339,7 +1339,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1450,7 +1450,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1552,7 +1552,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "2019.1"

--- a/grafana/build/ver_2019.1/scylla-overview.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-overview.2019.1.json
@@ -987,7 +987,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1091,7 +1091,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1202,7 +1202,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1306,7 +1306,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1622,7 +1622,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1731,7 +1731,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1835,7 +1835,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1946,7 +1946,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2050,7 +2050,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2521,7 +2521,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2626,7 +2626,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2738,7 +2738,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2897,7 +2897,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2993,7 +2993,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3079,7 +3079,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "2019.1"

--- a/grafana/build/ver_2020.1/alternator.2020.1.json
+++ b/grafana/build/ver_2020.1/alternator.2020.1.json
@@ -503,7 +503,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -861,7 +861,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -973,7 +973,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1254,7 +1254,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1358,7 +1358,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1462,7 +1462,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1566,7 +1566,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1670,7 +1670,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1774,7 +1774,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1878,7 +1878,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2026,7 +2026,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2130,7 +2130,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2234,7 +2234,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2339,7 +2339,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2489,7 +2489,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2593,7 +2593,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2697,7 +2697,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2801,7 +2801,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2905,7 +2905,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3097,7 +3097,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3202,7 +3202,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3307,7 +3307,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3411,7 +3411,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3546,7 +3546,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3642,7 +3642,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3728,7 +3728,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "2020.1"

--- a/grafana/build/ver_2020.1/scylla-advanced.2020.1.json
+++ b/grafana/build/ver_2020.1/scylla-advanced.2020.1.json
@@ -1016,7 +1016,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1121,7 +1121,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1224,7 +1224,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1388,7 +1388,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -1492,7 +1492,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -1596,7 +1596,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -1745,7 +1745,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1849,7 +1849,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1982,7 +1982,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2086,7 +2086,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2190,7 +2190,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2296,7 +2296,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2402,7 +2402,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2508,7 +2508,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2661,7 +2661,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2757,7 +2757,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2843,7 +2843,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "2020.1"

--- a/grafana/build/ver_2020.1/scylla-cql.2020.1.json
+++ b/grafana/build/ver_2020.1/scylla-cql.2020.1.json
@@ -210,7 +210,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -316,7 +316,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -422,7 +422,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -528,7 +528,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -634,7 +634,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -738,7 +738,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -842,7 +842,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -946,7 +946,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1172,7 +1172,7 @@
                     "links": [],
                     "nullPointMode": "connected",
                     "options": {
-                        "dataLinks": []
+                        "alertThreshold": true
                     },
                     "percentage": false,
                     "pointradius": 5,
@@ -1278,7 +1278,7 @@
                     "links": [],
                     "nullPointMode": "connected",
                     "options": {
-                        "dataLinks": []
+                        "alertThreshold": true
                     },
                     "percentage": false,
                     "pointradius": 5,
@@ -1384,7 +1384,7 @@
                     "links": [],
                     "nullPointMode": "connected",
                     "options": {
-                        "dataLinks": []
+                        "alertThreshold": true
                     },
                     "percentage": false,
                     "pointradius": 5,
@@ -1490,7 +1490,7 @@
                     "links": [],
                     "nullPointMode": "connected",
                     "options": {
-                        "dataLinks": []
+                        "alertThreshold": true
                     },
                     "percentage": false,
                     "pointradius": 5,
@@ -1645,7 +1645,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1750,7 +1750,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1855,7 +1855,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1961,7 +1961,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -2192,7 +2192,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2379,7 +2379,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2564,7 +2564,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2751,7 +2751,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2936,7 +2936,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3121,7 +3121,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3323,7 +3323,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3510,7 +3510,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3726,7 +3726,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3913,7 +3913,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4087,7 +4087,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "2020.1"
@@ -4377,5 +4377,5 @@
     "timezone": "utc",
     "title": "Scylla CQL",
     "uid": "cql-2020-1",
-    "version": 0
+    "version": 1
 }

--- a/grafana/build/ver_2020.1/scylla-detailed.2020.1.json
+++ b/grafana/build/ver_2020.1/scylla-detailed.2020.1.json
@@ -164,7 +164,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -269,7 +269,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -374,7 +374,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -476,7 +476,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -638,7 +638,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -741,7 +741,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -845,7 +845,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -948,7 +948,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1051,7 +1051,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1154,7 +1154,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1257,7 +1257,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1360,7 +1360,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1463,7 +1463,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1565,7 +1565,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1670,7 +1670,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1773,7 +1773,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1905,7 +1905,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2009,7 +2009,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2113,7 +2113,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2217,7 +2217,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2348,7 +2348,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2450,7 +2450,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2552,7 +2552,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2710,7 +2710,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2812,7 +2812,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2943,7 +2943,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3045,7 +3045,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3147,7 +3147,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3249,7 +3249,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3351,7 +3351,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3453,7 +3453,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3555,7 +3555,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3657,7 +3657,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3759,7 +3759,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3863,7 +3863,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3967,7 +3967,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4071,7 +4071,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4175,7 +4175,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4279,7 +4279,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4383,7 +4383,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4485,7 +4485,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4587,7 +4587,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4689,7 +4689,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4821,7 +4821,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4924,7 +4924,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5027,7 +5027,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5130,7 +5130,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5235,7 +5235,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5338,7 +5338,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5470,7 +5470,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5573,7 +5573,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5678,7 +5678,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5783,7 +5783,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5886,7 +5886,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5989,7 +5989,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6094,7 +6094,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6199,7 +6199,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6302,7 +6302,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6405,7 +6405,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6508,7 +6508,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6611,7 +6611,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6714,7 +6714,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6817,7 +6817,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6920,7 +6920,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7023,7 +7023,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7126,7 +7126,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7229,7 +7229,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7334,7 +7334,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7468,7 +7468,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7573,7 +7573,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7706,7 +7706,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7808,7 +7808,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7939,7 +7939,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8044,7 +8044,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8151,7 +8151,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8284,7 +8284,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8380,7 +8380,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8466,7 +8466,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "2020.1"

--- a/grafana/build/ver_2020.1/scylla-os.2020.1.json
+++ b/grafana/build/ver_2020.1/scylla-os.2020.1.json
@@ -256,7 +256,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -367,7 +367,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -470,7 +470,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -617,7 +617,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -728,7 +728,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -837,7 +837,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -948,7 +948,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1101,7 +1101,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1212,7 +1212,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1323,7 +1323,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1434,7 +1434,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1536,7 +1536,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "2020.1"

--- a/grafana/build/ver_2020.1/scylla-overview.2020.1.json
+++ b/grafana/build/ver_2020.1/scylla-overview.2020.1.json
@@ -1118,7 +1118,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1222,7 +1222,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1333,7 +1333,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1437,7 +1437,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2402,7 +2402,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2513,7 +2513,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2642,7 +2642,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2755,7 +2755,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2882,7 +2882,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3353,7 +3353,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3458,7 +3458,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3570,7 +3570,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3729,7 +3729,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3825,7 +3825,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3911,7 +3911,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "2020.1"

--- a/grafana/build/ver_4.1/alternator.4.1.json
+++ b/grafana/build/ver_4.1/alternator.4.1.json
@@ -503,7 +503,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -899,7 +899,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1011,7 +1011,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1276,7 +1276,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1380,7 +1380,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1484,7 +1484,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1588,7 +1588,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1692,7 +1692,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1796,7 +1796,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1900,7 +1900,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2033,7 +2033,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2137,7 +2137,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2241,7 +2241,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2346,7 +2346,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2451,7 +2451,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2555,7 +2555,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2659,7 +2659,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2764,7 +2764,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2869,7 +2869,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2973,7 +2973,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3077,7 +3077,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3182,7 +3182,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3287,7 +3287,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3391,7 +3391,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3495,7 +3495,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3600,7 +3600,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3734,7 +3734,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3838,7 +3838,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3942,7 +3942,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4046,7 +4046,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4150,7 +4150,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4342,7 +4342,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4447,7 +4447,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4552,7 +4552,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4656,7 +4656,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4791,7 +4791,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4887,7 +4887,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4973,7 +4973,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "4.1"

--- a/grafana/build/ver_4.1/scylla-advanced.4.1.json
+++ b/grafana/build/ver_4.1/scylla-advanced.4.1.json
@@ -1016,7 +1016,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1121,7 +1121,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1224,7 +1224,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1388,7 +1388,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -1492,7 +1492,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -1596,7 +1596,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -1745,7 +1745,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1849,7 +1849,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1982,7 +1982,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2086,7 +2086,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2190,7 +2190,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2296,7 +2296,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2402,7 +2402,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2508,7 +2508,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2661,7 +2661,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2757,7 +2757,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2843,7 +2843,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "4.1"

--- a/grafana/build/ver_4.1/scylla-cql.4.1.json
+++ b/grafana/build/ver_4.1/scylla-cql.4.1.json
@@ -210,7 +210,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -316,7 +316,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -422,7 +422,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -528,7 +528,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -634,7 +634,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -738,7 +738,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -842,7 +842,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -946,7 +946,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1172,7 +1172,7 @@
                     "links": [],
                     "nullPointMode": "connected",
                     "options": {
-                        "dataLinks": []
+                        "alertThreshold": true
                     },
                     "percentage": false,
                     "pointradius": 5,
@@ -1278,7 +1278,7 @@
                     "links": [],
                     "nullPointMode": "connected",
                     "options": {
-                        "dataLinks": []
+                        "alertThreshold": true
                     },
                     "percentage": false,
                     "pointradius": 5,
@@ -1384,7 +1384,7 @@
                     "links": [],
                     "nullPointMode": "connected",
                     "options": {
-                        "dataLinks": []
+                        "alertThreshold": true
                     },
                     "percentage": false,
                     "pointradius": 5,
@@ -1490,7 +1490,7 @@
                     "links": [],
                     "nullPointMode": "connected",
                     "options": {
-                        "dataLinks": []
+                        "alertThreshold": true
                     },
                     "percentage": false,
                     "pointradius": 5,
@@ -1645,7 +1645,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1750,7 +1750,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1855,7 +1855,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1961,7 +1961,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -2192,7 +2192,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2379,7 +2379,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2564,7 +2564,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2751,7 +2751,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2936,7 +2936,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3121,7 +3121,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3323,7 +3323,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3510,7 +3510,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3726,7 +3726,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3913,7 +3913,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4087,7 +4087,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "4.1"
@@ -4377,5 +4377,5 @@
     "timezone": "utc",
     "title": "Scylla CQL",
     "uid": "cql-4-1",
-    "version": 0
+    "version": 1
 }

--- a/grafana/build/ver_4.1/scylla-detailed.4.1.json
+++ b/grafana/build/ver_4.1/scylla-detailed.4.1.json
@@ -148,7 +148,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -253,7 +253,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -358,7 +358,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -460,7 +460,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -622,7 +622,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -725,7 +725,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -829,7 +829,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -932,7 +932,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1035,7 +1035,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1138,7 +1138,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1241,7 +1241,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1344,7 +1344,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1447,7 +1447,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1549,7 +1549,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1654,7 +1654,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1757,7 +1757,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1889,7 +1889,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1993,7 +1993,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2097,7 +2097,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2201,7 +2201,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2332,7 +2332,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2434,7 +2434,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2536,7 +2536,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2694,7 +2694,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2796,7 +2796,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2927,7 +2927,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3029,7 +3029,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3131,7 +3131,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3233,7 +3233,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3335,7 +3335,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3437,7 +3437,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3539,7 +3539,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3641,7 +3641,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3743,7 +3743,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3847,7 +3847,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3951,7 +3951,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4055,7 +4055,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4159,7 +4159,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4263,7 +4263,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4367,7 +4367,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4469,7 +4469,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4571,7 +4571,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4673,7 +4673,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4805,7 +4805,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4908,7 +4908,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5011,7 +5011,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5114,7 +5114,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5219,7 +5219,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5322,7 +5322,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5454,7 +5454,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5557,7 +5557,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5662,7 +5662,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5767,7 +5767,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5870,7 +5870,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5973,7 +5973,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6078,7 +6078,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6183,7 +6183,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6286,7 +6286,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6389,7 +6389,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6492,7 +6492,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6595,7 +6595,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6698,7 +6698,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6801,7 +6801,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6904,7 +6904,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7007,7 +7007,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7110,7 +7110,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7213,7 +7213,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7318,7 +7318,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7452,7 +7452,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7557,7 +7557,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7690,7 +7690,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7792,7 +7792,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7923,7 +7923,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8028,7 +8028,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8135,7 +8135,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8268,7 +8268,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8364,7 +8364,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8450,7 +8450,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "4.1"

--- a/grafana/build/ver_4.1/scylla-os.4.1.json
+++ b/grafana/build/ver_4.1/scylla-os.4.1.json
@@ -256,7 +256,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -367,7 +367,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -470,7 +470,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -617,7 +617,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -728,7 +728,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -837,7 +837,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -948,7 +948,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1101,7 +1101,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1212,7 +1212,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1323,7 +1323,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1434,7 +1434,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1536,7 +1536,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "4.1"

--- a/grafana/build/ver_4.1/scylla-overview.4.1.json
+++ b/grafana/build/ver_4.1/scylla-overview.4.1.json
@@ -1102,7 +1102,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1206,7 +1206,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1317,7 +1317,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1421,7 +1421,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2386,7 +2386,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2497,7 +2497,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2626,7 +2626,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2739,7 +2739,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2866,7 +2866,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3337,7 +3337,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3442,7 +3442,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3554,7 +3554,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3713,7 +3713,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3809,7 +3809,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3895,7 +3895,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "4.1"

--- a/grafana/build/ver_4.2/alternator.4.2.json
+++ b/grafana/build/ver_4.2/alternator.4.2.json
@@ -503,7 +503,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -861,7 +861,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -973,7 +973,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1254,7 +1254,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1358,7 +1358,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1462,7 +1462,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1566,7 +1566,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1670,7 +1670,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1774,7 +1774,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1878,7 +1878,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2026,7 +2026,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2130,7 +2130,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2234,7 +2234,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2339,7 +2339,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2489,7 +2489,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2593,7 +2593,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2697,7 +2697,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2801,7 +2801,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2905,7 +2905,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3097,7 +3097,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3202,7 +3202,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3307,7 +3307,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3411,7 +3411,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3546,7 +3546,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3642,7 +3642,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3728,7 +3728,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "4.2"

--- a/grafana/build/ver_4.2/scylla-advanced.4.2.json
+++ b/grafana/build/ver_4.2/scylla-advanced.4.2.json
@@ -1016,7 +1016,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1121,7 +1121,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1224,7 +1224,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1388,7 +1388,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -1492,7 +1492,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -1596,7 +1596,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -1745,7 +1745,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1849,7 +1849,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1982,7 +1982,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2086,7 +2086,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2190,7 +2190,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2296,7 +2296,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2402,7 +2402,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2508,7 +2508,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2661,7 +2661,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2757,7 +2757,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2843,7 +2843,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "4.2"

--- a/grafana/build/ver_4.2/scylla-cql.4.2.json
+++ b/grafana/build/ver_4.2/scylla-cql.4.2.json
@@ -210,7 +210,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -316,7 +316,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -422,7 +422,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -528,7 +528,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -634,7 +634,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -738,7 +738,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -842,7 +842,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -946,7 +946,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1172,7 +1172,7 @@
                     "links": [],
                     "nullPointMode": "connected",
                     "options": {
-                        "dataLinks": []
+                        "alertThreshold": true
                     },
                     "percentage": false,
                     "pointradius": 5,
@@ -1278,7 +1278,7 @@
                     "links": [],
                     "nullPointMode": "connected",
                     "options": {
-                        "dataLinks": []
+                        "alertThreshold": true
                     },
                     "percentage": false,
                     "pointradius": 5,
@@ -1384,7 +1384,7 @@
                     "links": [],
                     "nullPointMode": "connected",
                     "options": {
-                        "dataLinks": []
+                        "alertThreshold": true
                     },
                     "percentage": false,
                     "pointradius": 5,
@@ -1490,7 +1490,7 @@
                     "links": [],
                     "nullPointMode": "connected",
                     "options": {
-                        "dataLinks": []
+                        "alertThreshold": true
                     },
                     "percentage": false,
                     "pointradius": 5,
@@ -1645,7 +1645,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1750,7 +1750,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1855,7 +1855,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1961,7 +1961,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -2192,7 +2192,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2379,7 +2379,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2564,7 +2564,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2751,7 +2751,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2936,7 +2936,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3121,7 +3121,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3323,7 +3323,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3510,7 +3510,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3726,7 +3726,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3913,7 +3913,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4087,7 +4087,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "4.2"
@@ -4377,5 +4377,5 @@
     "timezone": "utc",
     "title": "Scylla CQL",
     "uid": "cql-4-2",
-    "version": 0
+    "version": 1
 }

--- a/grafana/build/ver_4.2/scylla-detailed.4.2.json
+++ b/grafana/build/ver_4.2/scylla-detailed.4.2.json
@@ -164,7 +164,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -269,7 +269,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -374,7 +374,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -476,7 +476,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -638,7 +638,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -741,7 +741,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -845,7 +845,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -948,7 +948,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1051,7 +1051,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1154,7 +1154,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1257,7 +1257,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1360,7 +1360,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1463,7 +1463,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1565,7 +1565,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1670,7 +1670,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1773,7 +1773,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1905,7 +1905,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2009,7 +2009,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2113,7 +2113,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2217,7 +2217,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2348,7 +2348,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2450,7 +2450,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2552,7 +2552,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2710,7 +2710,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2812,7 +2812,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2943,7 +2943,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3045,7 +3045,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3147,7 +3147,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3249,7 +3249,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3351,7 +3351,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3453,7 +3453,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3555,7 +3555,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3657,7 +3657,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3759,7 +3759,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3863,7 +3863,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3967,7 +3967,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4071,7 +4071,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4175,7 +4175,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4279,7 +4279,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4383,7 +4383,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4485,7 +4485,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4587,7 +4587,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4689,7 +4689,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4821,7 +4821,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4924,7 +4924,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5027,7 +5027,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5130,7 +5130,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5235,7 +5235,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5338,7 +5338,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5470,7 +5470,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5573,7 +5573,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5678,7 +5678,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5783,7 +5783,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5886,7 +5886,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5989,7 +5989,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6094,7 +6094,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6199,7 +6199,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6302,7 +6302,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6407,7 +6407,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6510,7 +6510,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6642,7 +6642,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6745,7 +6745,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6848,7 +6848,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6951,7 +6951,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7054,7 +7054,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7157,7 +7157,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7260,7 +7260,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7363,7 +7363,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7466,7 +7466,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7569,7 +7569,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7674,7 +7674,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7808,7 +7808,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7913,7 +7913,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8046,7 +8046,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8148,7 +8148,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8279,7 +8279,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8384,7 +8384,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8491,7 +8491,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8624,7 +8624,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8720,7 +8720,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8806,7 +8806,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "4.2"

--- a/grafana/build/ver_4.2/scylla-os.4.2.json
+++ b/grafana/build/ver_4.2/scylla-os.4.2.json
@@ -256,7 +256,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -367,7 +367,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -470,7 +470,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -617,7 +617,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -728,7 +728,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -837,7 +837,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -948,7 +948,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1101,7 +1101,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1212,7 +1212,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1323,7 +1323,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1434,7 +1434,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1536,7 +1536,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "4.2"

--- a/grafana/build/ver_4.2/scylla-overview.4.2.json
+++ b/grafana/build/ver_4.2/scylla-overview.4.2.json
@@ -1118,7 +1118,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1222,7 +1222,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1333,7 +1333,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1437,7 +1437,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2402,7 +2402,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2513,7 +2513,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2642,7 +2642,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2755,7 +2755,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2882,7 +2882,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3353,7 +3353,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3458,7 +3458,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3570,7 +3570,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3729,7 +3729,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3825,7 +3825,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3911,7 +3911,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "4.2"

--- a/grafana/build/ver_4.3/alternator.4.3.json
+++ b/grafana/build/ver_4.3/alternator.4.3.json
@@ -503,7 +503,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -861,7 +861,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -973,7 +973,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1254,7 +1254,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1358,7 +1358,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1462,7 +1462,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1566,7 +1566,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1670,7 +1670,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1774,7 +1774,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1878,7 +1878,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2026,7 +2026,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2130,7 +2130,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2234,7 +2234,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2339,7 +2339,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2489,7 +2489,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2593,7 +2593,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2697,7 +2697,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2801,7 +2801,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2949,7 +2949,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3053,7 +3053,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3157,7 +3157,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3262,7 +3262,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3412,7 +3412,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3516,7 +3516,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3620,7 +3620,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3724,7 +3724,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3828,7 +3828,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4020,7 +4020,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4125,7 +4125,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4230,7 +4230,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4334,7 +4334,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4469,7 +4469,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4565,7 +4565,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4651,7 +4651,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "4.3"

--- a/grafana/build/ver_4.3/scylla-advanced.4.3.json
+++ b/grafana/build/ver_4.3/scylla-advanced.4.3.json
@@ -1016,7 +1016,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1121,7 +1121,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1224,7 +1224,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1388,7 +1388,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -1492,7 +1492,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -1596,7 +1596,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -1745,7 +1745,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1849,7 +1849,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1982,7 +1982,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2086,7 +2086,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2190,7 +2190,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2296,7 +2296,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2402,7 +2402,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2508,7 +2508,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2661,7 +2661,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2757,7 +2757,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2843,7 +2843,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "4.3"

--- a/grafana/build/ver_4.3/scylla-cql.4.3.json
+++ b/grafana/build/ver_4.3/scylla-cql.4.3.json
@@ -210,7 +210,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -316,7 +316,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -422,7 +422,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -528,7 +528,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -634,7 +634,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -738,7 +738,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -842,7 +842,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -946,7 +946,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1448,7 +1448,7 @@
                     "links": [],
                     "nullPointMode": "connected",
                     "options": {
-                        "dataLinks": []
+                        "alertThreshold": true
                     },
                     "percentage": false,
                     "pointradius": 5,
@@ -1554,7 +1554,7 @@
                     "links": [],
                     "nullPointMode": "connected",
                     "options": {
-                        "dataLinks": []
+                        "alertThreshold": true
                     },
                     "percentage": false,
                     "pointradius": 5,
@@ -1660,7 +1660,7 @@
                     "links": [],
                     "nullPointMode": "connected",
                     "options": {
-                        "dataLinks": []
+                        "alertThreshold": true
                     },
                     "percentage": false,
                     "pointradius": 5,
@@ -1766,7 +1766,7 @@
                     "links": [],
                     "nullPointMode": "connected",
                     "options": {
-                        "dataLinks": []
+                        "alertThreshold": true
                     },
                     "percentage": false,
                     "pointradius": 5,
@@ -1921,7 +1921,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2026,7 +2026,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2131,7 +2131,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2237,7 +2237,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -2468,7 +2468,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2655,7 +2655,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2840,7 +2840,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3027,7 +3027,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3212,7 +3212,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3397,7 +3397,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3599,7 +3599,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3786,7 +3786,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4002,7 +4002,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4189,7 +4189,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4363,7 +4363,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "4.3"
@@ -4653,5 +4653,5 @@
     "timezone": "utc",
     "title": "Scylla CQL",
     "uid": "cql-4-3",
-    "version": 0
+    "version": 1
 }

--- a/grafana/build/ver_4.3/scylla-detailed.4.3.json
+++ b/grafana/build/ver_4.3/scylla-detailed.4.3.json
@@ -164,7 +164,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -269,7 +269,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -374,7 +374,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -476,7 +476,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -638,7 +638,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -741,7 +741,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -845,7 +845,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -948,7 +948,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1051,7 +1051,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1154,7 +1154,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1257,7 +1257,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1360,7 +1360,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1463,7 +1463,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1565,7 +1565,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1670,7 +1670,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1773,7 +1773,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1905,7 +1905,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2009,7 +2009,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2113,7 +2113,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2217,7 +2217,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2348,7 +2348,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2450,7 +2450,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2552,7 +2552,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2710,7 +2710,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2812,7 +2812,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2943,7 +2943,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3045,7 +3045,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3147,7 +3147,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3249,7 +3249,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3351,7 +3351,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3453,7 +3453,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3555,7 +3555,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3657,7 +3657,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3759,7 +3759,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3863,7 +3863,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3967,7 +3967,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4071,7 +4071,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4175,7 +4175,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4279,7 +4279,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4383,7 +4383,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4485,7 +4485,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4587,7 +4587,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4689,7 +4689,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4821,7 +4821,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4924,7 +4924,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5027,7 +5027,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5130,7 +5130,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5235,7 +5235,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5338,7 +5338,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5470,7 +5470,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5573,7 +5573,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5678,7 +5678,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5783,7 +5783,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5886,7 +5886,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5989,7 +5989,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6094,7 +6094,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6199,7 +6199,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6302,7 +6302,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6407,7 +6407,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6510,7 +6510,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6642,7 +6642,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6745,7 +6745,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6848,7 +6848,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6951,7 +6951,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7054,7 +7054,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7157,7 +7157,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7260,7 +7260,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7363,7 +7363,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7466,7 +7466,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7569,7 +7569,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7674,7 +7674,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7808,7 +7808,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7913,7 +7913,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8046,7 +8046,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8148,7 +8148,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8279,7 +8279,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8384,7 +8384,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8491,7 +8491,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8624,7 +8624,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8720,7 +8720,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8806,7 +8806,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "4.3"

--- a/grafana/build/ver_4.3/scylla-os.4.3.json
+++ b/grafana/build/ver_4.3/scylla-os.4.3.json
@@ -256,7 +256,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -367,7 +367,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -470,7 +470,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -617,7 +617,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -728,7 +728,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -837,7 +837,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -948,7 +948,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1101,7 +1101,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1212,7 +1212,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1323,7 +1323,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1434,7 +1434,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1536,7 +1536,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "4.3"

--- a/grafana/build/ver_4.3/scylla-overview.4.3.json
+++ b/grafana/build/ver_4.3/scylla-overview.4.3.json
@@ -1118,7 +1118,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1222,7 +1222,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1333,7 +1333,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1437,7 +1437,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2402,7 +2402,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2513,7 +2513,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2642,7 +2642,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2755,7 +2755,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2882,7 +2882,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3353,7 +3353,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3458,7 +3458,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3570,7 +3570,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3729,7 +3729,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3825,7 +3825,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3911,7 +3911,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "4.3"

--- a/grafana/build/ver_master/alternator.master.json
+++ b/grafana/build/ver_master/alternator.master.json
@@ -503,7 +503,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -861,7 +861,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -973,7 +973,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1254,7 +1254,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1358,7 +1358,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1462,7 +1462,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1566,7 +1566,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1670,7 +1670,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1774,7 +1774,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1878,7 +1878,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2026,7 +2026,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2130,7 +2130,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2234,7 +2234,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2339,7 +2339,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2489,7 +2489,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2593,7 +2593,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2697,7 +2697,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2801,7 +2801,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2949,7 +2949,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3053,7 +3053,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3157,7 +3157,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3262,7 +3262,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3412,7 +3412,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3516,7 +3516,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3620,7 +3620,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3724,7 +3724,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3828,7 +3828,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4020,7 +4020,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4125,7 +4125,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4230,7 +4230,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4334,7 +4334,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4469,7 +4469,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4565,7 +4565,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4651,7 +4651,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "master"

--- a/grafana/build/ver_master/scylla-advanced.master.json
+++ b/grafana/build/ver_master/scylla-advanced.master.json
@@ -1016,7 +1016,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1121,7 +1121,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1224,7 +1224,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1388,7 +1388,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -1492,7 +1492,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -1596,7 +1596,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -1745,7 +1745,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1849,7 +1849,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1982,7 +1982,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2086,7 +2086,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2190,7 +2190,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2296,7 +2296,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2402,7 +2402,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2508,7 +2508,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2661,7 +2661,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2757,7 +2757,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2843,7 +2843,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "master"

--- a/grafana/build/ver_master/scylla-cql.master.json
+++ b/grafana/build/ver_master/scylla-cql.master.json
@@ -212,7 +212,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -318,7 +318,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -424,7 +424,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -530,7 +530,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -636,7 +636,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -740,7 +740,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -844,7 +844,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -948,7 +948,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1012,7 +1012,7 @@
         },
         {
             "class": "collapsible_row_panel",
-            "collapsed": false,
+            "collapsed": true,
             "datasource": null,
             "gridPos": {
                 "h": 1,
@@ -1021,77 +1021,78 @@
                 "y": 19
             },
             "id": 13,
-            "panels": [],
+            "panels": [
+                {
+                    "class": "single_value_table",
+                    "columns": [
+                        {
+                            "text": "Avg",
+                            "value": "avg"
+                        }
+                    ],
+                    "datasource": "scylla-datasource",
+                    "fieldConfig": {
+                        "defaults": {
+                            "custom": {
+                                "align": null,
+                                "filterable": false
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            }
+                        },
+                        "overrides": []
+                    },
+                    "fontSize": "100%",
+                    "gridPos": {
+                        "h": 6,
+                        "w": 24,
+                        "x": 0,
+                        "y": 20
+                    },
+                    "id": 14,
+                    "links": [],
+                    "options": {
+                        "showHeader": true
+                    },
+                    "pageSize": null,
+                    "scroll": true,
+                    "showHeader": true,
+                    "sort": {
+                        "col": 0,
+                        "desc": true
+                    },
+                    "span": 12,
+                    "targets": [
+                        {
+                            "queryHost": "$node",
+                            "queryText": "select address, port, shard_id, ssl_enabled, username from system.clients",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Connection Table",
+                    "transform": "table",
+                    "type": "table"
+                }
+            ],
             "repeat": "",
             "title": "Connection",
             "type": "row"
         },
         {
-            "class": "single_value_table",
-            "columns": [
-                {
-                    "text": "Avg",
-                    "value": "avg"
-                }
-            ],
-            "datasource": "scylla-datasource",
-            "fieldConfig": {
-                "defaults": {
-                    "custom": {
-                        "align": null,
-                        "filterable": false
-                    },
-                    "mappings": [],
-                    "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                            {
-                                "color": "green",
-                                "value": null
-                            },
-                            {
-                                "color": "red",
-                                "value": 80
-                            }
-                        ]
-                    }
-                },
-                "overrides": []
-            },
-            "fontSize": "100%",
-            "gridPos": {
-                "h": 6,
-                "w": 24,
-                "x": 0,
-                "y": 20
-            },
-            "id": 14,
-            "links": [],
-            "options": {
-                "showHeader": true
-            },
-            "pageSize": null,
-            "scroll": true,
-            "showHeader": true,
-            "sort": {
-                "col": 0,
-                "desc": true
-            },
-            "span": 12,
-            "targets": [
-                {
-                    "queryHost": "$node",
-                    "queryText": "select address, port, shard_id, ssl_enabled, username from system.clients",
-                    "refId": "A"
-                }
-            ],
-            "title": "Connection Table",
-            "transform": "table",
-            "type": "table"
-        },
-        {
             "class": "collapsible_row_panel",
-            "collapsed": false,
+            "collapsed": true,
             "datasource": null,
             "gridPos": {
                 "h": 1,
@@ -1100,90 +1101,91 @@
                 "y": 26
             },
             "id": 15,
-            "panels": [],
+            "panels": [
+                {
+                    "class": "single_value_table",
+                    "columns": [
+                        {
+                            "text": "Avg",
+                            "value": "avg"
+                        }
+                    ],
+                    "datasource": "scylla-datasource",
+                    "fieldConfig": {
+                        "defaults": {
+                            "custom": {
+                                "align": null,
+                                "filterable": false
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            }
+                        },
+                        "overrides": [
+                            {
+                                "matcher": {
+                                    "id": "byName",
+                                    "options": "row_size"
+                                },
+                                "properties": [
+                                    {
+                                        "id": "unit",
+                                        "value": "bytes"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "fontSize": "100%",
+                    "gridPos": {
+                        "h": 6,
+                        "w": 24,
+                        "x": 0,
+                        "y": 27
+                    },
+                    "id": 16,
+                    "links": [],
+                    "options": {
+                        "showHeader": true
+                    },
+                    "pageSize": null,
+                    "scroll": true,
+                    "showHeader": true,
+                    "sort": {
+                        "col": 0,
+                        "desc": true
+                    },
+                    "span": 12,
+                    "targets": [
+                        {
+                            "queryHost": "$node",
+                            "queryText": "select keyspace_name, table_name,partition_key, clustering_key, row_size  from system.large_rows",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Large Rows",
+                    "transform": "table",
+                    "type": "table"
+                }
+            ],
             "repeat": "",
             "title": "Large Rows",
             "type": "row"
         },
         {
-            "class": "single_value_table",
-            "columns": [
-                {
-                    "text": "Avg",
-                    "value": "avg"
-                }
-            ],
-            "datasource": "scylla-datasource",
-            "fieldConfig": {
-                "defaults": {
-                    "custom": {
-                        "align": null,
-                        "filterable": false
-                    },
-                    "mappings": [],
-                    "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                            {
-                                "color": "green",
-                                "value": null
-                            },
-                            {
-                                "color": "red",
-                                "value": 80
-                            }
-                        ]
-                    }
-                },
-                "overrides": [
-                    {
-                        "matcher": {
-                            "id": "byName",
-                            "options": "row_size"
-                        },
-                        "properties": [
-                            {
-                                "id": "unit",
-                                "value": "bytes"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "fontSize": "100%",
-            "gridPos": {
-                "h": 6,
-                "w": 24,
-                "x": 0,
-                "y": 27
-            },
-            "id": 16,
-            "links": [],
-            "options": {
-                "showHeader": true
-            },
-            "pageSize": null,
-            "scroll": true,
-            "showHeader": true,
-            "sort": {
-                "col": 0,
-                "desc": true
-            },
-            "span": 12,
-            "targets": [
-                {
-                    "queryHost": "$node",
-                    "queryText": "select keyspace_name, table_name,partition_key, clustering_key, row_size  from system.large_rows",
-                    "refId": "A"
-                }
-            ],
-            "title": "Large Rows",
-            "transform": "table",
-            "type": "table"
-        },
-        {
             "class": "collapsible_row_panel",
-            "collapsed": false,
+            "collapsed": true,
             "datasource": null,
             "gridPos": {
                 "h": 1,
@@ -1192,90 +1194,91 @@
                 "y": 33
             },
             "id": 17,
-            "panels": [],
+            "panels": [
+                {
+                    "class": "single_value_table",
+                    "columns": [
+                        {
+                            "text": "Avg",
+                            "value": "avg"
+                        }
+                    ],
+                    "datasource": "scylla-datasource",
+                    "fieldConfig": {
+                        "defaults": {
+                            "custom": {
+                                "align": null,
+                                "filterable": false
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            }
+                        },
+                        "overrides": [
+                            {
+                                "matcher": {
+                                    "id": "byName",
+                                    "options": "cell_size"
+                                },
+                                "properties": [
+                                    {
+                                        "id": "unit",
+                                        "value": "bytes"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "fontSize": "100%",
+                    "gridPos": {
+                        "h": 6,
+                        "w": 24,
+                        "x": 0,
+                        "y": 34
+                    },
+                    "id": 18,
+                    "links": [],
+                    "options": {
+                        "showHeader": true
+                    },
+                    "pageSize": null,
+                    "scroll": true,
+                    "showHeader": true,
+                    "sort": {
+                        "col": 0,
+                        "desc": true
+                    },
+                    "span": 12,
+                    "targets": [
+                        {
+                            "queryHost": "$node",
+                            "queryText": "select keyspace_name, table_name,partition_key, clustering_key,  column_name,cell_size  from system.large_cells",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Large Cells",
+                    "transform": "table",
+                    "type": "table"
+                }
+            ],
             "repeat": "",
             "title": "Large Cells",
             "type": "row"
         },
         {
-            "class": "single_value_table",
-            "columns": [
-                {
-                    "text": "Avg",
-                    "value": "avg"
-                }
-            ],
-            "datasource": "scylla-datasource",
-            "fieldConfig": {
-                "defaults": {
-                    "custom": {
-                        "align": null,
-                        "filterable": false
-                    },
-                    "mappings": [],
-                    "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                            {
-                                "color": "green",
-                                "value": null
-                            },
-                            {
-                                "color": "red",
-                                "value": 80
-                            }
-                        ]
-                    }
-                },
-                "overrides": [
-                    {
-                        "matcher": {
-                            "id": "byName",
-                            "options": "cell_size"
-                        },
-                        "properties": [
-                            {
-                                "id": "unit",
-                                "value": "bytes"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "fontSize": "100%",
-            "gridPos": {
-                "h": 6,
-                "w": 24,
-                "x": 0,
-                "y": 34
-            },
-            "id": 18,
-            "links": [],
-            "options": {
-                "showHeader": true
-            },
-            "pageSize": null,
-            "scroll": true,
-            "showHeader": true,
-            "sort": {
-                "col": 0,
-                "desc": true
-            },
-            "span": 12,
-            "targets": [
-                {
-                    "queryHost": "$node",
-                    "queryText": "select keyspace_name, table_name,partition_key, clustering_key,  column_name,cell_size  from system.large_cells",
-                    "refId": "A"
-                }
-            ],
-            "title": "Large Cells",
-            "transform": "table",
-            "type": "table"
-        },
-        {
             "class": "collapsible_row_panel",
-            "collapsed": false,
+            "collapsed": true,
             "datasource": null,
             "gridPos": {
                 "h": 1,
@@ -1284,90 +1287,91 @@
                 "y": 40
             },
             "id": 19,
-            "panels": [],
+            "panels": [
+                {
+                    "class": "single_value_table",
+                    "columns": [
+                        {
+                            "text": "Avg",
+                            "value": "avg"
+                        }
+                    ],
+                    "datasource": "scylla-datasource",
+                    "fieldConfig": {
+                        "defaults": {
+                            "custom": {
+                                "align": null,
+                                "filterable": false
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            }
+                        },
+                        "overrides": [
+                            {
+                                "matcher": {
+                                    "id": "byName",
+                                    "options": "partition_size"
+                                },
+                                "properties": [
+                                    {
+                                        "id": "unit",
+                                        "value": "bytes"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "fontSize": "100%",
+                    "gridPos": {
+                        "h": 6,
+                        "w": 24,
+                        "x": 0,
+                        "y": 41
+                    },
+                    "id": 20,
+                    "links": [],
+                    "options": {
+                        "showHeader": true
+                    },
+                    "pageSize": null,
+                    "scroll": true,
+                    "showHeader": true,
+                    "sort": {
+                        "col": 0,
+                        "desc": true
+                    },
+                    "span": 12,
+                    "targets": [
+                        {
+                            "queryHost": "$node",
+                            "queryText": "select keyspace_name, table_name,partition_key, partition_size  from system.large_partitions",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Large Partitions",
+                    "transform": "table",
+                    "type": "table"
+                }
+            ],
             "repeat": "",
             "title": "Large Partitions",
             "type": "row"
         },
         {
-            "class": "single_value_table",
-            "columns": [
-                {
-                    "text": "Avg",
-                    "value": "avg"
-                }
-            ],
-            "datasource": "scylla-datasource",
-            "fieldConfig": {
-                "defaults": {
-                    "custom": {
-                        "align": null,
-                        "filterable": false
-                    },
-                    "mappings": [],
-                    "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                            {
-                                "color": "green",
-                                "value": null
-                            },
-                            {
-                                "color": "red",
-                                "value": 80
-                            }
-                        ]
-                    }
-                },
-                "overrides": [
-                    {
-                        "matcher": {
-                            "id": "byName",
-                            "options": "partition_size"
-                        },
-                        "properties": [
-                            {
-                                "id": "unit",
-                                "value": "bytes"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "fontSize": "100%",
-            "gridPos": {
-                "h": 6,
-                "w": 24,
-                "x": 0,
-                "y": 41
-            },
-            "id": 20,
-            "links": [],
-            "options": {
-                "showHeader": true
-            },
-            "pageSize": null,
-            "scroll": true,
-            "showHeader": true,
-            "sort": {
-                "col": 0,
-                "desc": true
-            },
-            "span": 12,
-            "targets": [
-                {
-                    "queryHost": "$node",
-                    "queryText": "select keyspace_name, table_name,partition_key, partition_size  from system.large_partitions",
-                    "refId": "A"
-                }
-            ],
-            "title": "Large Partitions",
-            "transform": "table",
-            "type": "table"
-        },
-        {
             "class": "collapsible_row_panel",
-            "collapsed": false,
+            "collapsed": true,
             "datasource": null,
             "gridPos": {
                 "h": 1,
@@ -1376,465 +1380,466 @@
                 "y": 47
             },
             "id": 21,
-            "panels": [],
+            "panels": [
+                {
+                    "class": "text_panel",
+                    "datasource": null,
+                    "editable": true,
+                    "error": false,
+                    "fieldConfig": {
+                        "defaults": {
+                            "custom": {}
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 2,
+                        "w": 24,
+                        "x": 0,
+                        "y": 48
+                    },
+                    "id": 22,
+                    "isNew": true,
+                    "links": [],
+                    "mode": "html",
+                    "options": {
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">CQL Internal - Coordinator</h1>",
+                        "mode": "html"
+                    },
+                    "span": 12,
+                    "style": {},
+                    "title": "",
+                    "transparent": true,
+                    "type": "text"
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "class": "ops_panel",
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": "prometheus",
+                    "description": "Number of CQL INSERT commands generated by intenal operations",
+                    "editable": true,
+                    "error": false,
+                    "fieldConfig": {
+                        "defaults": {
+                            "custom": {},
+                            "links": []
+                        },
+                        "overrides": []
+                    },
+                    "fill": 0,
+                    "fillGradient": 0,
+                    "grid": {},
+                    "gridPos": {
+                        "h": 6,
+                        "w": 6,
+                        "x": 0,
+                        "y": 50
+                    },
+                    "hiddenSeries": false,
+                    "id": 23,
+                    "isNew": true,
+                    "legend": {
+                        "avg": false,
+                        "current": false,
+                        "max": false,
+                        "min": false,
+                        "show": false,
+                        "total": false,
+                        "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 2,
+                    "links": [],
+                    "nullPointMode": "connected",
+                    "options": {
+                        "alertThreshold": true
+                    },
+                    "percentage": false,
+                    "pointradius": 5,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [
+                        {}
+                    ],
+                    "spaceLength": 10,
+                    "span": 3,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "expr": "sum(rate(scylla_cql_inserts_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[$__rate_interval])) by ([[by]])",
+                            "intervalFactor": 1,
+                            "legendFormat": "",
+                            "metric": "",
+                            "refId": "A",
+                            "step": 1
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeFrom": null,
+                    "timeRegions": [],
+                    "timeShift": null,
+                    "title": "CQL Internal Insert",
+                    "tooltip": {
+                        "msResolution": false,
+                        "shared": true,
+                        "sort": 2,
+                        "value_type": "cumulative"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "buckets": null,
+                        "mode": "time",
+                        "name": null,
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "format": "si:ops/s",
+                            "logBase": 1,
+                            "max": null,
+                            "min": 0,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": true
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false,
+                        "alignLevel": null
+                    }
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "class": "ops_panel",
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": "prometheus",
+                    "description": "Number of CQL SELECT commands generated by intenal operations",
+                    "editable": true,
+                    "error": false,
+                    "fieldConfig": {
+                        "defaults": {
+                            "custom": {},
+                            "links": []
+                        },
+                        "overrides": []
+                    },
+                    "fill": 0,
+                    "fillGradient": 0,
+                    "grid": {},
+                    "gridPos": {
+                        "h": 6,
+                        "w": 6,
+                        "x": 6,
+                        "y": 50
+                    },
+                    "hiddenSeries": false,
+                    "id": 24,
+                    "isNew": true,
+                    "legend": {
+                        "avg": false,
+                        "current": false,
+                        "max": false,
+                        "min": false,
+                        "show": false,
+                        "total": false,
+                        "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 2,
+                    "links": [],
+                    "nullPointMode": "connected",
+                    "options": {
+                        "alertThreshold": true
+                    },
+                    "percentage": false,
+                    "pointradius": 5,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [
+                        {}
+                    ],
+                    "spaceLength": 10,
+                    "span": 3,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "expr": "sum(rate(scylla_cql_reads_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[$__rate_interval])) by ([[by]])",
+                            "intervalFactor": 1,
+                            "legendFormat": "",
+                            "metric": "",
+                            "refId": "A",
+                            "step": 1
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeFrom": null,
+                    "timeRegions": [],
+                    "timeShift": null,
+                    "title": "CQL Internal Reads",
+                    "tooltip": {
+                        "msResolution": false,
+                        "shared": true,
+                        "sort": 2,
+                        "value_type": "cumulative"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "buckets": null,
+                        "mode": "time",
+                        "name": null,
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "format": "si:ops/s",
+                            "logBase": 1,
+                            "max": null,
+                            "min": 0,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": true
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false,
+                        "alignLevel": null
+                    }
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "class": "ops_panel",
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": "prometheus",
+                    "description": "Number of CQL DELETE commands generated by intenal operations",
+                    "editable": true,
+                    "error": false,
+                    "fieldConfig": {
+                        "defaults": {
+                            "custom": {},
+                            "links": []
+                        },
+                        "overrides": []
+                    },
+                    "fill": 0,
+                    "fillGradient": 0,
+                    "grid": {},
+                    "gridPos": {
+                        "h": 6,
+                        "w": 6,
+                        "x": 12,
+                        "y": 50
+                    },
+                    "hiddenSeries": false,
+                    "id": 25,
+                    "isNew": true,
+                    "legend": {
+                        "avg": false,
+                        "current": false,
+                        "max": false,
+                        "min": false,
+                        "show": false,
+                        "total": false,
+                        "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 2,
+                    "links": [],
+                    "nullPointMode": "connected",
+                    "options": {
+                        "alertThreshold": true
+                    },
+                    "percentage": false,
+                    "pointradius": 5,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [
+                        {}
+                    ],
+                    "spaceLength": 10,
+                    "span": 3,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "expr": "sum(rate(scylla_cql_deletes_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[$__rate_interval])) by ([[by]])",
+                            "intervalFactor": 1,
+                            "legendFormat": "",
+                            "metric": "",
+                            "refId": "A",
+                            "step": 1
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeFrom": null,
+                    "timeRegions": [],
+                    "timeShift": null,
+                    "title": "CQL Deletes",
+                    "tooltip": {
+                        "msResolution": false,
+                        "shared": true,
+                        "sort": 2,
+                        "value_type": "cumulative"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "buckets": null,
+                        "mode": "time",
+                        "name": null,
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "format": "si:ops/s",
+                            "logBase": 1,
+                            "max": null,
+                            "min": 0,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": true
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false,
+                        "alignLevel": null
+                    }
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "class": "ops_panel",
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": "prometheus",
+                    "description": "Number of CQL UPDATE commands generated by intenal operations",
+                    "editable": true,
+                    "error": false,
+                    "fieldConfig": {
+                        "defaults": {
+                            "custom": {},
+                            "links": []
+                        },
+                        "overrides": []
+                    },
+                    "fill": 0,
+                    "fillGradient": 0,
+                    "grid": {},
+                    "gridPos": {
+                        "h": 6,
+                        "w": 6,
+                        "x": 18,
+                        "y": 50
+                    },
+                    "hiddenSeries": false,
+                    "id": 26,
+                    "isNew": true,
+                    "legend": {
+                        "avg": false,
+                        "current": false,
+                        "max": false,
+                        "min": false,
+                        "show": false,
+                        "total": false,
+                        "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 2,
+                    "links": [],
+                    "nullPointMode": "connected",
+                    "options": {
+                        "alertThreshold": true
+                    },
+                    "percentage": false,
+                    "pointradius": 5,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [
+                        {}
+                    ],
+                    "spaceLength": 10,
+                    "span": 3,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "expr": "sum(rate(scylla_cql_updates_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[$__rate_interval])) by ([[by]])",
+                            "intervalFactor": 1,
+                            "legendFormat": "",
+                            "metric": "",
+                            "refId": "A",
+                            "step": 1
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeFrom": null,
+                    "timeRegions": [],
+                    "timeShift": null,
+                    "title": "CQL Updates",
+                    "tooltip": {
+                        "msResolution": false,
+                        "shared": true,
+                        "sort": 2,
+                        "value_type": "cumulative"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "buckets": null,
+                        "mode": "time",
+                        "name": null,
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "format": "si:ops/s",
+                            "logBase": 1,
+                            "max": null,
+                            "min": 0,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": true
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false,
+                        "alignLevel": null
+                    }
+                }
+            ],
             "repeat": "",
             "title": "CQL Internal",
             "type": "row"
-        },
-        {
-            "class": "text_panel",
-            "datasource": null,
-            "editable": true,
-            "error": false,
-            "fieldConfig": {
-                "defaults": {
-                    "custom": {}
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "h": 2,
-                "w": 24,
-                "x": 0,
-                "y": 48
-            },
-            "id": 22,
-            "isNew": true,
-            "links": [],
-            "mode": "html",
-            "options": {
-                "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">CQL Internal - Coordinator</h1>",
-                "mode": "html"
-            },
-            "span": 12,
-            "style": {},
-            "title": "",
-            "transparent": true,
-            "type": "text"
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "ops_panel",
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "prometheus",
-            "description": "Number of CQL INSERT commands generated by intenal operations",
-            "editable": true,
-            "error": false,
-            "fieldConfig": {
-                "defaults": {
-                    "custom": {},
-                    "links": []
-                },
-                "overrides": []
-            },
-            "fill": 0,
-            "fillGradient": 0,
-            "grid": {},
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 0,
-                "y": 50
-            },
-            "hiddenSeries": false,
-            "id": 23,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "options": {
-                "dataLinks": []
-            },
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "spaceLength": 10,
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(rate(scylla_cql_inserts_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[$__rate_interval])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "CQL Internal Insert",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-                {
-                    "format": "si:ops/s",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "ops_panel",
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "prometheus",
-            "description": "Number of CQL SELECT commands generated by intenal operations",
-            "editable": true,
-            "error": false,
-            "fieldConfig": {
-                "defaults": {
-                    "custom": {},
-                    "links": []
-                },
-                "overrides": []
-            },
-            "fill": 0,
-            "fillGradient": 0,
-            "grid": {},
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 6,
-                "y": 50
-            },
-            "hiddenSeries": false,
-            "id": 24,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "options": {
-                "dataLinks": []
-            },
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "spaceLength": 10,
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(rate(scylla_cql_reads_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[$__rate_interval])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "CQL Internal Reads",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-                {
-                    "format": "si:ops/s",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "ops_panel",
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "prometheus",
-            "description": "Number of CQL DELETE commands generated by intenal operations",
-            "editable": true,
-            "error": false,
-            "fieldConfig": {
-                "defaults": {
-                    "custom": {},
-                    "links": []
-                },
-                "overrides": []
-            },
-            "fill": 0,
-            "fillGradient": 0,
-            "grid": {},
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 12,
-                "y": 50
-            },
-            "hiddenSeries": false,
-            "id": 25,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "options": {
-                "dataLinks": []
-            },
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "spaceLength": 10,
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(rate(scylla_cql_deletes_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[$__rate_interval])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "CQL Deletes",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-                {
-                    "format": "si:ops/s",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "class": "ops_panel",
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "prometheus",
-            "description": "Number of CQL UPDATE commands generated by intenal operations",
-            "editable": true,
-            "error": false,
-            "fieldConfig": {
-                "defaults": {
-                    "custom": {},
-                    "links": []
-                },
-                "overrides": []
-            },
-            "fill": 0,
-            "fillGradient": 0,
-            "grid": {},
-            "gridPos": {
-                "h": 6,
-                "w": 6,
-                "x": 18,
-                "y": 50
-            },
-            "hiddenSeries": false,
-            "id": 26,
-            "isNew": true,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": false,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "options": {
-                "dataLinks": []
-            },
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {}
-            ],
-            "spaceLength": 10,
-            "span": 3,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "expr": "sum(rate(scylla_cql_updates_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[$__rate_interval])) by ([[by]])",
-                    "intervalFactor": 1,
-                    "legendFormat": "",
-                    "metric": "",
-                    "refId": "A",
-                    "step": 1
-                }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "CQL Updates",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-                {
-                    "format": "si:ops/s",
-                    "logBase": 1,
-                    "max": null,
-                    "min": 0,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
         },
         {
             "class": "collapsible_row_panel",
@@ -1925,7 +1930,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2030,7 +2035,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2135,7 +2140,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2241,7 +2246,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 1,
@@ -2474,7 +2479,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2661,7 +2666,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2846,7 +2851,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3033,7 +3038,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3218,7 +3223,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3403,7 +3408,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3605,7 +3610,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3792,7 +3797,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4010,7 +4015,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4197,7 +4202,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4371,7 +4376,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "master"
@@ -4661,5 +4666,5 @@
     "timezone": "utc",
     "title": "Scylla CQL",
     "uid": "cql-master",
-    "version": 0
+    "version": 1
 }

--- a/grafana/build/ver_master/scylla-detailed.master.json
+++ b/grafana/build/ver_master/scylla-detailed.master.json
@@ -164,7 +164,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -269,7 +269,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -374,7 +374,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -476,7 +476,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -638,7 +638,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -741,7 +741,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -845,7 +845,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -948,7 +948,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1051,7 +1051,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1154,7 +1154,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1257,7 +1257,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1360,7 +1360,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1463,7 +1463,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1565,7 +1565,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1670,7 +1670,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1773,7 +1773,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1905,7 +1905,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2009,7 +2009,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2113,7 +2113,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2217,7 +2217,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2348,7 +2348,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2450,7 +2450,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2552,7 +2552,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2710,7 +2710,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2812,7 +2812,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2943,7 +2943,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3045,7 +3045,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3147,7 +3147,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3249,7 +3249,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3351,7 +3351,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3453,7 +3453,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3555,7 +3555,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3657,7 +3657,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3759,7 +3759,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3863,7 +3863,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3967,7 +3967,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4071,7 +4071,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4175,7 +4175,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4279,7 +4279,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4383,7 +4383,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4485,7 +4485,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4587,7 +4587,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4689,7 +4689,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4821,7 +4821,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -4924,7 +4924,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5027,7 +5027,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5130,7 +5130,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5235,7 +5235,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5338,7 +5338,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5470,7 +5470,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5573,7 +5573,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5678,7 +5678,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5783,7 +5783,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5886,7 +5886,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -5989,7 +5989,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6094,7 +6094,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6199,7 +6199,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6302,7 +6302,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6407,7 +6407,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6510,7 +6510,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6642,7 +6642,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6745,7 +6745,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6848,7 +6848,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -6951,7 +6951,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7054,7 +7054,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7157,7 +7157,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7260,7 +7260,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7363,7 +7363,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7466,7 +7466,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7569,7 +7569,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7674,7 +7674,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7808,7 +7808,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -7913,7 +7913,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8046,7 +8046,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8148,7 +8148,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8279,7 +8279,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8384,7 +8384,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8491,7 +8491,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8624,7 +8624,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8720,7 +8720,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -8806,7 +8806,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "master"

--- a/grafana/build/ver_master/scylla-os.master.json
+++ b/grafana/build/ver_master/scylla-os.master.json
@@ -256,7 +256,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -367,7 +367,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -470,7 +470,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -617,7 +617,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -728,7 +728,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -837,7 +837,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -948,7 +948,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1101,7 +1101,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1212,7 +1212,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1323,7 +1323,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1434,7 +1434,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1536,7 +1536,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "master"

--- a/grafana/build/ver_master/scylla-overview.master.json
+++ b/grafana/build/ver_master/scylla-overview.master.json
@@ -1118,7 +1118,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1222,7 +1222,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1333,7 +1333,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -1437,7 +1437,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2402,7 +2402,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2513,7 +2513,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2642,7 +2642,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2755,7 +2755,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -2882,7 +2882,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3353,7 +3353,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3458,7 +3458,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3570,7 +3570,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3729,7 +3729,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3825,7 +3825,7 @@
             "links": [],
             "nullPointMode": "connected",
             "options": {
-                "dataLinks": []
+                "alertThreshold": true
             },
             "percentage": false,
             "pointradius": 5,
@@ -3911,7 +3911,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 16,
+    "schemaVersion": 26,
     "style": "dark",
     "tags": [
         "master"

--- a/grafana/scylla-cql.master.template.json
+++ b/grafana/scylla-cql.master.template.json
@@ -32,7 +32,10 @@
                 "panels": [
                     {
                         "class": "text_panel",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">CQL By User - Coordinator</h1>",
+                        "options": {
+                            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">CQL By User - Coordinator</h1>",
+                            "mode": "html"
+                        },
                         "style": {}
                     }
                 ],
@@ -179,7 +182,7 @@
                 "panels": [
                     {
                         "class": "collapsible_row_panel",
-                        "collapsed": "true",
+                        "collapsed": true,
                         "title": "Connection"
                     }
                 ]
@@ -207,7 +210,7 @@
                 "panels": [
                     {
                         "class": "collapsible_row_panel",
-                        "collapsed": "true",
+                        "collapsed": true,
                         "title": "Large Rows"
                     }
                 ]
@@ -229,7 +232,8 @@
                         "fieldConfig": {
                             "defaults": {
                               "custom": {
-                                "align": null
+                                "align": null,
+                                "filterable": false
                               },
                               "thresholds": {
                                 "mode": "absolute",
@@ -270,7 +274,7 @@
                 "panels": [
                     {
                         "class": "collapsible_row_panel",
-                        "collapsed": "true",
+                        "collapsed": true,
                         "title": "Large Cells"
                     }
                 ]
@@ -292,7 +296,8 @@
                         "fieldConfig": {
                             "defaults": {
                               "custom": {
-                                "align": null
+                                "align": null,
+                                "filterable": false
                               },
                               "thresholds": {
                                 "mode": "absolute",
@@ -333,7 +338,7 @@
                 "panels": [
                     {
                         "class": "collapsible_row_panel",
-                        "collapsed": "true",
+                        "collapsed": true,
                         "title": "Large Partitions"
                     }
                 ]
@@ -355,7 +360,8 @@
                         "fieldConfig": {
                             "defaults": {
                               "custom": {
-                                "align": null
+                                "align": null,
+                                "filterable": false
                               },
                               "thresholds": {
                                 "mode": "absolute",
@@ -396,7 +402,7 @@
                 "panels": [
                     {
                         "class": "collapsible_row_panel",
-                        "collapsed": "true",
+                        "collapsed": true,
                         "title": "CQL Internal"
                     }
                 ]
@@ -408,7 +414,10 @@
                 "panels": [
                     {
                         "class": "text_panel",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">CQL Internal - Coordinator</h1>",
+                        "options": {
+                            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">CQL Internal - Coordinator</h1>",
+                            "mode": "html"
+                        },
                         "style": {}
                     }
                 ],
@@ -500,7 +509,10 @@
                 "panels": [
                     {
                         "class": "text_panel",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">LWT</h1>",
+                        "options": {
+                            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">LWT</h1>",
+                            "mode": "html"
+                        },
                         "style": {}
                     }
                 ],
@@ -590,7 +602,10 @@
                 "panels": [
                     {
                         "class": "text_panel",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Optimization</h1>",
+                        "options": {
+                            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Optimization</h1>",
+                            "mode": "html"
+                        },
                         "style": {}
                     }
                 ],
@@ -891,7 +906,10 @@
                 "panels": [
                     {
                         "class": "text_panel",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Cross DC Information</h1>",
+                        "options": {
+                            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Cross DC Information</h1>",
+                            "mode": "html"
+                        },
                         "style": {}
                     }
                 ],

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -631,7 +631,7 @@
                         },
                         "gridPos": {
                             "x": 0,
-                            "y": 0,
+                            "y": 1,
                             "w": 24,
                             "h": 3
                           }
@@ -659,7 +659,10 @@
                 "panels": [
                     {
                         "class": "text_panel",
-                        "content": "<div id=\"amnon\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAASMAAAEHCAYAAADlHSANAAAACXBIWXMAAAsSAAALEgHS3X78AAAgAElEQVR4nO2de5gcdZnv3+65dM89FyYhJGY4KywgMhAJoOuERM951nh5losyPkfxEMBnOSou8Q91MahRiS6wzxrl4oEjEB447HMGBdyzStgjmMscIQFMnIiCAc0guWcymfulb+f5Vlf1VP26uruqui6/qn4/z9PPTPdMV1X3zO/b7+33vrFcLkcMwzBBE+e/AMMwMsBixDCMFLAYMQwjBSxGDMNIAYsRwzBSwGLEMIwUsBgxDCMFLEYMw0gBixHDMFLAYsQwjBSwGDEMIwUsRgzDSAGLEcMwUsBixDCMFLAYMQwjBSxGDMNIAYsRwzBSwGLEMIwUsBgxDCMFLEYMw0gBixHDMFLAYsQwjBSwGDEMIwUsRgzDSAGLEcMwUsBixDCMFLAYMQwjBSxGDMNIAYsRwzBSwGLEMIwUsBgxDCMFLEYMw0gBixHDMFLAYsQwjBSwGDEMIwUsRgzDSAGLEcMwUsBixDCMFLAYMQwjBSxGDMNIQT3/Gfyjp7v3IiKap54QXy9ycPID6g2c6h/o2xu294FhzIjlcjl+Y1yip7tXExhNdNaoR17tw+l/C3Eior3q120Qrf6BvgMWnsswgcNi5JCe7t4zdcKzRv3aIenlbldFCrdtLFCMjLAYWUQVnzW6W1coLtycEdVywu1pFidGBliMyqDGeNapAnSh0+PUnbaA6jsXKN8nzjur8HhD11KKNzfZOtbMH94ofJ8aPEjZySnKTkxR6q2DTi8PDOqE6elqDsQwTmExElAFaD0RXWnX7YLQNCxfqggPhEYvQn6QPn6SMidOKiKF7yFQqcG3KTs5befssJqeZmFi/IbFaM4F0wTIkvsF0VHEp2spNXYtVb7KypwwHVQsK711VQFNmDZz1o7xmpoWo57u3nWqG1Yx2wUrp+niCyjxrrMUEbLrXskGBGnq5X3KV4suHrJ1m1WL6VSoXzwjJTUnRmr6fZ1qCZW1gmD9tFx+KSUvvsBXd8tvYDlBlKZf2UdTr+yrdPYRVZS2cOCbcZOaESNVhNart5KxoFoRoFIgIA6LaXLnbivu3CNEtJFFiXGDyIuRFRGKNycpeXE3ta1dLXXsx29gMUGUJnbsVgLjZWBRYqom0mLU090LAdpYSoQQB2q/ei01rbwg9DEgr4EgWbCWvqUGuzmmxNgmkmLU092LuqAtpWJCCEC3rl2tBKQZe0CMNGEqAWJK6/sH+rbwW8vYIVJipKboEVy9wuznECFYQvrCQ8YZcOFGn9xaTpSQfVvHJQGMVSIjRuVcMrhjC276FIuQB8BSgiiVcd/YdWMsEXoxUq2hLWa1QghMd1x7tZIdY7wFYnTy/sdLBbrZSmIqEmox6unuvVIVoiJrqPVDq6n942s5MO0zsJLGt24rtQXlW/0DfRuj/PoZ54RWjHq6exEbukV8HHVC8z5zFbtkAYJ40vADj5dy3dDO5Ep22xiR0ImRWje0zWwXPawhCBEjB+Nbt9Pok8+YWUmDqiCx28YUCJUYqTvqt4luGQeo5QVW0tD3HzTb/8YlAIyB0IiRuqn1YfFx1ArNv+lTHBuSnFOPPkXjz243u0iOIzEKoRCjUkKEmiHcmHCAYsmRx540c9se6R/oW8d/xtpGejEyC1QjZT//pk9zBXUIQU+l45vuZkFiipBajHq6exFPuE7/GISoc8MXeUNriEFngOO332MWR+JMWw0j7RBHMyFC2n7Rpq+wEIUcxPc6b7vZLOGwWk1QMDWIlJaRmWsGIcI/MAeqowWqtk32t7HLVoNIJ0ZmwWoWomjDgsSQbG4aC1Ftghqx5lVF+wevUy1kpkaQxjIyK2hkIaotjm+6x2wLyfVcGFkbSCFG6haPA3ohQtYMwWq/+lDrx/mIQxFxHxkg/bVAILXZaLKPKgoLZbJsK3jrSPSRRYz26vea+ZG+10/EmPnDfruDDk1BdkgZZ6TOU2PsA0E6+rW7xFYk2DpyJqf8o03gYmSWOZv/95/ypAeRNvkCGzirHAddEVhMeA2IhdTilJFqKFEYub1/oG9N6F4MY5lAxUjtR/SU/jEvtnhoLVKnXxlwbAG1tjbT+Piko+fCWkLPbd7Iax3Mb8MGWwHexxZhAhMjszgRFmvnhptdO4eFPs0FLlr5Ljr7nDPp7HPPpCVndCpfW9taSv7+/tcO0JFDx2n/6weU7/e89GpFseIe3PYosbmW40cRJUgxelrfOB9xotM3f9O1zFmFjoOKpbPqg5fQ5R+8VPnqBhClX/xsG+381UuKUJUCrhv6LnGWsDKIHwku9W/7B/oukvRymSoIRIzM3LOFX7rRlY2viDegiK5UTAgW0EeuWKPcvATC1PfYz+mZfzNtm8H9uS0C6/bYhjvFDxV21yKI72Jk5p651aER1hBuZkCEbvzcNbTikvOrPo8dDh86Tg/d11dSlLgfU2WQcDj12FPi77G7FjGCECND9gxZp8Xf/XJVixFZsuH7H1eCniJnndNFt3xlne8iJAJR+uEdWxQXTgTvwWlfupHLAcpgUhDJ2bWI4asYqWOF/qx/rFr3rFRbU8SEbvj8NdR77UedX7AHINC96ev3FcWUuEdTefB3PvKlb4u/c1X/QN/Tkl0q4xC/96YZyvq1IkGnID6EeIIoRLCG7n5oo3RCBGChbXniTvrw3xnHvCEmAlFFN0SmGNRqmZR88N61COGbGKnz7w0rEMWNTinVMRCL/J6HNiqpeVlBycCG279AX/vO54uuECN+WJDMQa0WXFodXeokYSYC+GkZGbIfCFo7rUyGyW4mRDd87hplkZerD5IJZPTufvCbikuphwXJHMQVTayjjWpShAk5voiRaBUhPoJpr05AsBrujChEsDIgRmEDbhtcSlGQ0Lge1h9jBKUQgnWErCxbRxHAlwB2T3fvNr0YVbPlw6zNBITI67qhUux8/iXa8fxuJVumgUru91xyvq1iStQlffGGjYYqbrcLQaMCrEZYjzoG+wf65PXLGUt4LkZqn6I92v1qFphZHdE/fOW6QALV42MTtOm2+0xT9Rqwdno/81HqvfYjllxHCNL1vV8xPOb2FpmocHj9t8Wd/dz3KOT44aYZTOjmVZc5EiK4LKIQIVgdVMaskhABWDkP/egJ+sSHvqBsE6kEgu5iUBtWYKlCzlrGxLJmVy3keCpGamDRMOEDGREnnBB2cCvFjF8NpkWytv/MKhCl7379Ptp0272KRVUOuJvXfPojht+AGHH8yIhJ7OhCNTbJhBSvLSODWqCmyEkGDYtRb5LD/dnwneCyZrB2nIAtITcjLlRBkCCyEFs9Jtshah6TfX3cwD/E+CpGzQ42hSKNj933elBZHVQdEQLW5XbkV+KN1wctCRLEVg/cNU73GynRxJ/T/CHFMzFSA9eFVrIwqZ1UW8Mq0qfxYTEEWVmNzFm1QJAQcyoHxFYsVeDYkRFY2Sb/U1cGfFmMQ7y0jIpcNLvAKhIbo2HTa5Dsefn3rpwdMadK7h6ycKef0Vm4D1eVrSMjJtY2i1FI8VKMDP8UTgLXZtmzIHffw7WqxkUTgRghnV8KxMTYOioPPuRQLqLjCnbVwoknYqS6aIUILOaf2Q1co9JatIpu+HyvexfpgHLC4ZQf3Fm+NAbZNdE6MmuVUsskL+4WXz1bRyHEK8vI8M/QtNK+izYpuCNojrZEtyijwt6Xf1+xBgnuWrn3ptYx+f9iMQohXomRod7DSbxIjI18UsJ2IG5RKXYE60i/dw2WESxHJo/J/xfXG4UQ18VI9dcNm2LtdjDUprtqwE1xq2m+jCAOhaZrpUDsSHz9mP/GzCEIUgcXQIYPLywjwz+BiT9fkWkhJrLqA9EVIo1KrhqmmOgR36Nax2T8E4tRyPBCjAxjZJzMCBN35V8eYatIA9XZ5QohYRmJrhozB4tR+PHcMmp00GQes+81sACDbqav4fV17HmpfA2TeH5RtGsZk1AAz1YLGV6IUVXxImwINVRcS9Y+Flk9r/hNmbgRKWJkPDeLkRHBOupQB0AwIcFVMRL/+A1dy2wfY1bYnf4eSawiDS+buO15ubwYoWmbHgT6mTlMXDW2jkKE25ZR1fEioWFW0QIMGrEI0U2wZ60copsmvle1Drtq4cZTMRL6zVhC7Nvj1cKvhu9t/rJn11Wpylt/XnbTjNQX/7+xGIUIt8XIYMY46V0kFvPJOHII12Q2+8wNKrUWkVGcZcHEMuKYUYjwVIycuGlhQZt99nCfu6J02OZGXI4bGRG7P0pwSYxFPHXTnKB3PcRuhzICKwmi9MTWe10RpUpdAcSAPseNjIjWOO/gDw9ui1GH9o0bVlFYhjECbOKFKJkNZWT8Ax0iBDhuFBJcEyP+BMoDS6m1PTwiGjXiLTxjLqzUu3jdhk8gk0+oyIPNruhP5GYDNqZqOIgdEtwUIwNOP6EQgNTiIHtdavHqNRChB3/0hC/Xe/jgMcN9njZrxCQ8wGIUEjwTI6cgABmWoKwXIrSiwnYTMdtmd7sNw8iKdGIkgrobGQPZP7hjCz3xv37h+3kr1SExTFhxM5tmiBk5dR/EWJMXfaerBZNhvRKiSkWe+i0jtRiXY6KLm2JkyKY5dR/EOpH9r8slRnDN0HvIC1BdXc4KFIWZM0dMlPB6oqxtRBGTzTKq1JGxGiptChaFOcoV7kztIb0YuTU00S0w3torxH5FIqIwc/CaiRJuitFe/R2nO8oRa9LHQlCzY3e/llfgOsbHJz07/qoPFk1HNYAptHrYMmKihJtidMqtA4mLbKcL8+3d4IhQ4+Mm2IdXbi4chFBfTAnB5hojJkpI56aRyVA+L+M0slCpg+QzwnvAVhETNTwTo+yE8yGDWGj6+elIZ8viqnkBNtZWEiNRkFsuL+/S1Som4YG9tf6ehAXXxKh/oM+wWvRDGJ0gzlvre/TnEXi7zen9zEfLpvRRTqB30bBlhoPXlnEtfMB4i5RuGmhba+wNBDclitXHsIrEWfoiDwrjr8X3hpmjGos8TKBLRk9378YovSa3xahQHpwafLuqA+GTXx8XQRar7zH/t1/oOX3pItePecPnr6loFYl735rZRSuJaJGLFnsUUNv14HV9s6e7d0tUXpfbYlQohNHPPnNK8yrjooOrFqR1VC7b5QTMYOu99qNlnylaRXhPOItW86zXtdS9rqe7NxLTc90WI4N/Xm1/ZgRp9T2NYR09eN8TZZ/jNW7N/Yd79k8/+HLZ3zGzitqvXhvUSw8FQgD7t7X+foQJt8XIkLlwoxXIgps+ZbiPDapBbhGpVCVtBQjR3Q9tLOuewQLc9PX7DI+1fmi1o4krNQwHr0OE1JYRqWl+saZm09fvrfq4Tql2oiyECL2yK+3OhwWoz6Ch1KH942wVlcMkrS9fywemJNJbRmD+3xutI9QdoZ9QEMCacToFRLOIVn2wvKsH90xsUdJ+9Yc5VlQBceYei1G48NQyEqfDOgWuiRgrwWL1ctNqOW756jrbE0AQrH74J3dVtIhQ3HnrLXcZHoNl2Mrp/IqY/L9xwWOIcFWM+gf6DH98k08qx0CMity12+4NJH4E60iJ+VgQJPQo+tp3Pk/3PLSxYjYOcaJbb7nTsBkX7ploGTLmmNQYccwoRHhR9FioNXJ7FjwWpX6bCBbtF2/YGIggwcKBpVMqu4bHIUI/2Xqv5TjTzTdsNHRyBPNv+jQHrS1iUvXPllGI8KIHNpShMAoW1pFbsQ4syoVf+iwd33RP4TFNkGCp+D2XH5bO99T0POI8pBZGOqlHgpUnChGswaaLLyj5HMaImDDpH+hjyyhEeGEZGT6N3IobacBVE92WIC0kjRWXnK/c7AoRXLN113y5qJUtihut1hTBAsXNTbc4jAgJE296A9cQPd2963q6e3PqzfNKdi8so6L0fuI8d0+g7VgffuDxwmOaIMFSWSHMo5eVfLD6ziKLCEIk1leVAlai3h2GWJvF16KOyYceW0VVACEioof9PKcXlpFBQb2agQZBMrWQbvwW9T0m/w5/uHXXf+LLVQkRmcTlcB8ChVstWUrp4v8zjhc5pIQQeS7uXoiRJ+l9M8wECfzwzkeUYLCsPZBQIwXRFFvY2hUiUtuJmAFROrL+W56+/zLBaX13KCFE2Fazzutzuy5GYnrfjSrsckCQFn7pRkOWjdTR2LA8ZLKSYA19Yu0XTGeuwbWyK0Sgc8PNyjYRM7cMm5WPb7q7Jiwkk/8zdtNsUkaI1viRDPCqn1Fhg2K1TdasgIxT54YvFg01hOUBKwkCEFSBJKmxIVhqsIaOCNYaRBRi6nQDLDKM8z5zlSJKZzzwPWr928uJYnM/hyANff/Bal+C9IjhgCi2DvGSoIWIPBxvXRTE9rpWBv2POm+7mUZ/upXGnzUmUiAAt66/SylAvOFz11S9v8wqsITQg0mc6qGhZQbdeG9g/Qzf/zhNvbKv6Gdati3KQW0hdjZY+jcZERmEiDwUI3wqFfYv4FPLj8I91DPBSkBD/5P3P170aQlR+u7X76Mf3rGFPnzFGkWU3K5NghWEaSYQIdEKmrvOpLLXzK0tHhM7dtPIY0+W7SE1+uRWxXqKIlb2pL3vA+u/StnsO/SPxWYmPyb+Xn0y2V7KY8im09Px1o7XY40J5R8rm8nMpMfHTryw/Yd+v7GiQDgWDFmECMRyuZzrBxVfIFyQIPrwYAGOb91WdpHCWlqx8l1KOQAmutoVJ4jPG68doN+89CrtefnVouyYCILUEEw3CkERtD312FMlK92bLrmQpl6aa+kDNy5qm21HnttFs2+8RVOvDOCfmSiToVgmnSXKZSmT9urDtiSxunqieDxH8bpMrKVtLJtOz1JLx7OZ6akxN0VL7fB4HRFd3z/Q52jXuExCRB6KEfygX2n3nWSJ3AKfmuNbt1cUJT3Y1ErquOm29uKeQ79Rq60hQlaHOmpFjG65ZKcefYomd5rPk0OGDe833DJ9HRIso7C6aief+A9K/eUwZY4PUfboUaJUStGbUNLQmI0lmydy9Y1HMxR/NtfQeP+Lv/znYv+6AlhnTmNjsgkReSVGlH+xhQNjAQTtImABT728TxEmP4LqpIoCsn0QIrdEqJKwilYofh/WE6l7+8Iw4gjWzvRvX6PUm39GFoIok5bgqjwmFidqTKRyyZY/ZeP1v/TS9ZNRiMhjMTLsUVv22GZPzuMEBNSnX9mnxFrcFiYIELJ7WPRujROyIkLlguGwonCMoKzTSkzs/SONP/8CpV77I9Fk9CbAOKa+MZtrad+frW98+IVfbb7DjUP2dPdeSURPCQ8HLkTksRgZgtinf/8bUu4+xyKFG4P4C75CqKxWjSMQ3dC1TCkp0KaZuPkarYiQ3iULE7B+xv/9OcqdPOmJ5RNraFDiN7FkE8WbWvPvVVsH1S9cbHz/2udTosvaeze5rzgrOjH4J0pP5V31+Mwk0Wz+7xRLz7rwKnTAckokJzLJlmdf2HHvx50eRh1v9E3dQ1IIEXmYTaOgMmp2QUAXloy4Ox5CUKp6GQLg5WuBIEKEJnfuKilCEMKOa68O1WRZWECj/+c5yvxxf/Xxnngd5RoTlG1qp1xTG2XaF1C2bQHFFi2jZUsWUjwes3AQezRfUNwuJnn+Snr78BCl0xnTY9Uf+TOydlR38gjFUjMUHztJsQziXTaNALxf05MtddOTVyMEkmtqPZFtbv/nKi0maYSIPLaMpMiohQlYZnAdSwWmSRWh1rVrlLKAsGTGEHye3PZrohEn//MxyiWSitBk2xZSZv4iSncuL/uM+fNaaX5H6WEHbjMxOUNHj9t/bQ2Dr1Ld2DDFR4coPnEKtQL2r6y+IZNpbv9/L/T/yFKdSE93L9LFWsp4r0xtVrwUI2kyajKjxa/Gtm4v6x6GVoSeeY5odsb6k+J1lG2ZR5n5iym97BzKtM23fV5YRcuXdnpiHZXi0NFhmp6u3jWDQNUfHcxbUHZcvViMMm0LdlgVJRnxTIxIwoyaLGiZPYiQWcW0nlhDPc27vjdU7tjs4RN07PZ7LFtCuWQLZRYupdkz30XZVnfc37bWJupc2O7KsawAN+2tgydcPWZ8epwa/vIa1R85QLHJUWtPqm9IZzo6b3Mr4O0nXouRtBk1v7EjQHoQHF/83fLDHmXi+I9/SjPbdla8IghQenEXzZ71HsrVN3ryCpYvPY3q6+t8e3eGT43T8Ih32cDE/pctC1O2uX3w1y/+2N/Wp1XidYWqQYz82KMmE9qeMIiQlRICVIOjd/a2X75Ix4/mXTa/aqLc4PB3fkSZ118vfSS4Ep3voJlz30tZNcPlJceHRmnJYvtunlMQqxqbmC4ZzK6WmbNXKjdYTI1v7KX6Q/tLBsLjk6Nd71953WhmXuf7nRRUBoHXYmTIqGFhRVWMtOybJkBWhxFgwgjmqF3+wUsL89T2v36gIEZh4dCt/0LZv7xlfrWxGKWXvJNmznuvZ1aQGVPTs0ocJ5n075xwDQ8fHfb0HNlkK02/u4fo3T2U/F1/SVGKzU611Q8d+g0MbE8vyCX8sIwKYLFGocE8Xgc6C+IrbrODB211tIQAYS9cXoQuKRpzrZ+vX6p5mkzANSslROnFZ9LMu3t8FSE9J4bHlFS/XzQlG6mlOaFk2PygIEp7nqP6Yyb7IjPp+r+59IZjv9790KJA/gA28FqMPG3OT7rtDloBIjJNWuWzWA+k/5mIWOyorzPSfmanINKMj1z5AVq1ZmXZibJo0K9HdksSwWrTGFEsRtMr/gulO99h9jTfmJ1N09j4lBLQ9ovOhR00NX2cslnv4rEi0yv+M9UNH6Wml7cWlQjEp8c737f6H+4JoLuALTwVI3R97OnuLdx3u+sjanK0fVcoDtRcIzsBYq+AEMYaGyh96GjhDBddfJ6F0da/N9wXG8bJxtCPnyi+oliMJt93hVIbJAMIKrc0J31L9eM88ztaaWh4zNdXj3KIyVUfp+adPy0WpPHhz2I0n68XZBOvOj3q8azrI9LdMmyDgFWmTeVA10ZsfVmy+RvU8Uljuxwr3SZ3PG8seHRrf5tXZP5cPB5q5oLV0ggRqWn3kTFr3RXcoqO9mRobfe9gosSTIEgisdRMwveLsYkf7xb+Wy/U7sD1cXOBYfFP7thdcKvyX9+23C7EKprLp7l62n18X6oIURRKdH6EGybGiDTQG0mcn4ZGcVIjFDTmGhKUWvJX0l3xyOgEdbQ1+1oIuXB+m+fBbDMgSJn5p1Pd8BHDT2V31fwQI8SNrtDuzLosRhCCUh0T4cZps9WamhL0rbvW06nhsZIdGJFah1igbzapVsniTc5rfLR9b5rbiN5HO55/qWTbW3Sg1IPnhq0ZGuqHZATxG7hNfhZCIpgNAfTbKgOZeYuKxKgcPd2984hofZWnPdU/0Oe4mNAPMdqm3yXs1Rw1M+DGodsjzjk1NUOvvfonpQd2ObQx1aSKSbUkdWIEHvrRE6YZNEwxEXtlu9WW1k/iEyPKNoagsmflQCAbe9b8LITM1x5N+RrMBvUn3i56LNeYNF18qhBt03swTunp7r2of6DP0VgjP2JGhqCC1fobt9BvzoUQVBqBjRofDTfECIKoT8/DKvuBzgKCJYb7mjWmgb18oezKmM1Q4g+7JLgQc1AI6SdwC+Gu+UnDwf3K3jaRXKK5lCWwzg0hUrlO3SRvG8/FqH+gD6t7RLuPeI6fiGKAKSFi+lyPPpvlljspditAXGjt36xTxhetff/1RXPUkEFDn+ywgiK85L7KW0KCQCuE9BOUFfhVeAkhSvzO3nuvulaPWPhVKzzitCe3H5YR6euNEFj2e6igvlvAEXWGmZkgKZM9dK6SWwWaZlk/xI/0xY0aWrO0sDfOhyA1//ppik+NS3A1Rk74nHIHizyOVcE1Tu75pW0h0lBdqw9Ue3PqopFPMSNSxWhuW8jgQV9dEC3tjvgRwAQPCNItX1mnVEKT6i5tuu3ewnMgCm5n/TBMsZybCvGbHwEh0oCr0Lyjj2bfuYJSZ54vTRwpiEJIxKkQr/JiIy2socbXdlXdXTLowZd+ilGBIAYKQoxQdKk1LoMgYcLrWed0KcFkcdKH224SBAYtVLTmaZooQfTwXshSM+UFjW/uUfr0pLrOl0aU/C6EJKX2qMXVjbSKCL25h2ISWp9O8EuMDFFjr+fvlwLuD2qDNAuJVFESQfDYqz10EJ0w9SayS66p1XRx4FMbCwe39BlnU2rpWZRZsCSw69QKIf3sCKkFs510hSwcY+ykIkL1B/eXtYRyjU3YKOv4PEHgixjB/NNvC/Fij5pVYCFBbCBIYntXtye91iKpM86mXEMjNb6xp+RiQTwJNwhXelEXpZaeHUjFdhCFkNhEa3cjLeJudccGS2bJRGCBZhYuoeRvfunehfuAn/Xqv9XSh0H36IF1BCsJN81dKreJlrGHshgWdSmCpLS3KAEsKLhvuMF1w3MyC05XLCY/+h2h9md4ZNz31DvOh6xeqdojiHjdycNKE3/sxLfqhuG9Q3wO7x+eHzb8FCPDtpAg4kZmRDVOEzQQk+kLVlH8rBUVRYnUBahZTKS6e5n5S/Li1L7QM8tpZHRSsY78LITEuXBOLZgNyyc+NqSID0TEivWjRy9CYcZPMTJsC0HcKHFeqN87xgJ6UVKazVeIdWjAGqif2m8QMSy6XLJNOabyfVObKxYUtoks7pzn+Z8zNztNqRPHKD10lBrGRqj58NsUGxlynAWTIfbmJn6KkWFbSJBxI8Z/IBoz516m3OB61B99S4mD2FmIsByI1P1Wb849DqsJcSqMMoK7B6tKE6ls+8KK2TvEb9zoCDl7KN9gDqIDwdE/ljpc3HzOSZFfetFyxZ1F/3AZt9xUg9+WUYEw9XZm3AVBa9yIVinCZDc2IqK5NXmxKg0Wb7bd3N0b6VxGmdak6c8gLNmZ4oBzdmyEMuMjps9xC30sLYoCpMc3McKwuJ7uXvzlOiiAPWqMnGjCBItJyRqpgVvEUOzGTiqRDwyXEHyqHJAAABErSURBVKyTR0iGKf9KrKxtgeJ6KYF8ifpCeY3f3Z8Mldi1Ni2EKQ9cq+zSs5VUP6nigWmrBXFSAr3hGlRQjrrWDpptbFIC9dn2/MRcP7KIsuK3GNXMtBCmehQXRbUQ9CjTVlMz+fn1EKyxIYqlZqUUKghOvK2D6tRb/cLFFGtMUuMZ+RHdfxo8WvEYtUIQllGBqEwLYfxFc11KZZG0Gpu8ZTUnUHXDxbU3+LnVIHrDkuIZ/w0Ql0S+oyvEJt6az8o1nLZIER3GOn6LUaC9jZjawCBSi7p0r3lFxdd/xuL5vs5ZY+bwq4WIAqaF6O8HtUeNYRj58FWMVAod59EO1u/eRgzDyEkQYuT5YEeGYcJH4GLEcSOGYSggMSqav88wDOO7GImtLWdZjBjGF2LpWan7GQdhGZF+5DUHsaNFtX2YGXcw+zvEpsalbtgVlBhxEDuiYMMrEzxme/ByjQmpa2lYjBhX0bo3MsGBPXzoGyWSS7SwGJlgECOOG0WLxGu7lH7NjP9o89PC6C4HIkZiEJsto+iBYYKYKssxJP9Q5tRhcGZIOxv4vTdNjzQN+hlvQMtYdHOcPfeyQlsQxn2UMVBv7Am9exykGO2VsUE/4y5YKLCSMC9NmSzLouQaWmwIIhQFCzRoMbpOu+P3yGvGI9AW1TytXBAlzFZLY1ZaDTcSqwath3i5iSu5unqKZdJheDkFghajAhzEjgapd5xLlM2UdBkgStpkWfQlgqWEHs8sTOWxM8RA6Ze97FxKDAQ6Ot820ogRB7GjQS5eR7N/vVKZYpH83c6yTfYRaEXmjV7bpQgT+hAp0y8iMnqnGvDe5PuBH6b6Y8WTRcxA/2zNFeYhjjZQG/SjQk7pfsVB7GgBQZm4vFdJ8cMKqjT5A4tPmSOvWlTK8Ea1NzSOFeWpGNoQR3SdRDdKO90nSRChMBOkZUSqdVRoxcdB7OiRUhvsK27Gwf2WP+Xz01Xnqoi1qRlK03o0r8cAx5BNztAPccSYo9TQUWo5fsRx8Flxx844OzJJARnEqDBlloPY0UUbSaSMIzo2SI3IANmYk5afMDtOJIiZNrBRmzSrH+Dot7unzVezOsQRxGyeA68vqgmAoMXIMGWWg9jRRxlH1HU+pbrOLwgTXDmnhXoQqTpF1MoPcIQVoUebPisycyRJmTJz9zVx0YDo5GaLBzy6iWIBKYMcoz1HTQbLqAAHsWsLvTDlByweVt2zw65XEYsbR0sNc5xRb0GSLQxxPD3y8TI9gYoRB7EZDSy4ubHXeQzTZSM2wFEjq8bBMsoQxwU1nUkM2jKiqAexJ3bsViy+eZ+5KtTnCAKzAY4QKG0emjK8Uf1e5gpks0GO2lce4jiHLGIUWBAbjd1OPfqUspDjze42wsNrGX7gceV7TM5tXbu64nOqOUdD11JqufxS188x+uRW5W8iw4dEQZwM89DyaJNm9cMbtYmzekrO27eBONBRmxBLys/y16aJD2MNGcTIURD7+KZ7lGm01S7w47ffo7iH6DjZueHmqo4lou9g6VU3y/SJOdclc8J9NwZCPf7sdoo3J+mMB/7J9eO7iSG4ayJWVuAhjsEhi2VUwEoQe3zrdsWdww3WQDWf2JpIeD2lJDvhjRh5HfTX4njZyWlPz8MwQTVXK4AgNhEVepXaDWJXKyJwnzS8nHAb1uB8avBtCa6CqQUCFyMVW7PUYA1puGkZeOHmhB3NIoKbxjBeIqUYVRKYutPmrJlqCyX1x+I6JyP6D4WGrmVyXBQTWWQRI1uz1PSuVbWjjvTHCuPIJC8FlEdIMX4SSssINCyfc9XcCj57GcT2KvbipWDo/w5ulz0wjIgUYuQkiK23aKqxDvRumlcZLwppNkof0NfH6RjGC2SxjKiaIHY1Fo1B1Hg7igEO6DN+IpMY2RpfZAw8u+cCcZxkDv37ym5a+ImPnZR6n5W0lpGdIDZcIKc1QqL7EbaAsJdxLr1radVNE7deMMEQxk3F0oiR3cGORSLi0MUSP/E9LXwMUemA02tFJ8co7q4PG+isKZJtW+DtNoMqkckyInWwo0IlcYGI6Avx3FroHCfJI1pxere4Esl9O3iSbIBgoKMbm4H9RjYxshnEXmb5d8uh39vmpWUUJsT3U+8WVyLsY5bDDIQIAxDCiNRiVNFVW67fFuJOEJstI3dAO1gIEhYH4z1oPtf00i9CK0Qkya59PbaC2PGWuXiPFsS28wleOI4ubhSmjaFeBq/1x66mKwIWR8Oh/Tza2iPgDjcceDUSI66lsozEIHalxSYuEqdBbH0w3MviRK/blNiJ61TCzQJQbbR1y46+yMyFDxq4wMl9O6l5e19+Lh3P2vcEBLEvJN2+s1I1LuLig1uHhmvVguOEseLYiVVYCr2w26kxyixaTvGT5rPAFFF6bZdyw7yv9OLlhp7XTHnsTFPB+1tuFr+MyChGezUxogptaMXF59TyEEWt1gsfxddvR5gzbQtp5tz3UuJ3O8pmdLBQcEMjfszahzDV0iQMq2hDCZCqt5IQQLfLmXMvU75nMaoeuGrXaUep1KAfP9NEyGm8RxS1Wh8mWW2ZBEYQTV3yEWUBwQoqN6wRFpQmTKQba62N6ak1CuOabI65Fkdc86x9d3Dc2wjxnnJunVXCYhl5VYZQTY2RHm30ENwKiI2V2pfCWOs31WuJ6CgfbdR1w+AbVKdOOnFSChGVOfskoxj1D/Tt7enuLdy3sy2EHFo1RYFwlwooRffGbfHwqgxBfP3VxqK0eftYbI0HXlXiHlY/8fEc3OoPzT2mjbCGBZVraFREKtfUJt24Z01wtHHXmbER5aafQptwclzVtU0tPStS1qOMlhHYTkTK2I9KQWxRSNyYu+aWZSRec1hqmLxqpQLRmL5gFRGtUly4+qNv2RImDW2ktZmlhYWabV+gnm9uhDUe08ejcg0J26OiNXHRkzo8t+1CG32dheiMj9g6dsVz62JrUQ36yypGezUxIlVgSmXJzDJqTsBxNLGo9Sb0YomEF/Gzuemxq5T4Bva0uTHWOj8mOy9STrZEjKo3GYBY5mfs10b8TGYxKlAuZS+6EE57YuM4mhjV+lgeL5vMmaGfHKvN3Efw1m4QN8xoFp0WvM+2L6y5zGIoxKjiHrXlSwuf5pXcOqtEbcy2HfSWkZuFlFbQZu7nhzCuUJ6Rn7M/VBhpHfa5+5hGq02bPRFvkzLeFQRSipEaxIbTrcwGruQ2warRLyCnQWyvK6Tdxotsmhgvc7OQ0ilZNWAtTomFKMWmxtSx1rP5+9Njys+C2rUea0woM/RBw8LFFEskFNGJt86jhtMWUazROPLpKM/aLyCrZUT6uFGlfWfIWk29sq9w3w2rxgvLKAzZtDD1XFIEClm1CvEUseZGEy8z2lqTVF9fV/54qrgUjpeYEyDGOTKL0TZ9EBuWTzkx0uNk0fvhjoQhmyZaRlFwVUWxKideCZ61HxiytRDRY4wb/b60C1XvQkbNra0lYYcHWTJBERoxKrcj360WtEyxVel3AJupXaQVo/6BvgP6WWpWMmp67Fo2ZsWTtYjoSsoQwGZqA5ktI7KzT81sW4iMuLnvTRRMN9qecNtdJihCJUblChrFheik+FF0Sdywjqq12EphJmpuzDYTLaNa7l7A+IvsYmS586MoRk4WfaNwjKmX95X8XauIFpsbxwSTO3Yb7rsR29GXR5AibsmSv8swbiO1GIltaCd37i7p5oif4PiErzZuJC5OJ4jHnH5lwBVXbUIQo8TZZ1Z9TFHgEudxz2rGP2S3jMDP9HfGt243/SW4KOLCP/XoU7ZOlBT2v0HQSp3PKrGEsWYFBZzVHhMiW5QxzOWqPqYovuL7wTBeEgYx2qy/M/rk1pIWT/OqSw33sWDx+1aBSyUK2uiTzzgOhiMYPPKvPyt6HNfk9Jiwqk7e/3jR45Mv7nEcj8IxReGGi9Zy+aUln1OKeJmujox/hPHvIL0Yqa6awZQY+v6PTRczFo8YMMbCF12acrRfvdbwU1gyxzfdbVs8IERD33+wZAcAJ8eEaBy//Z6Sldyl3hcrxxQtrfarP2zp+bnmNsN9J/2JGPcx7/XUYM9V8JkwWEZgHREVulVpAmEW01lw06eKHht+4HHFmrASq0EguG7BPMNj2vmsihqu69iGO8sWX2rHtOqyweo5+rW7Kh7z6Ia7qj5mrLHBehZtwWnG56ZnKfGHXdaey3iC0h9KaMafSzTP7n56Q/EAfomI5aqMNfhFT3fvlURUpOxYNK1rVxv6HUE0IEAicD2aV12Wt6BMsm94Xj7AXLqfESwvnA/n1WfKIHTIlCHIXsJdgpj+hYjeLf4AAgiLzOyYOBbExckx29auVuI+No9ZAG5v08oLlOvSlw3A6pt+ZR+Nbd1OqZmY0tZDBKNyZs67LHQ9ec7weW/an1zetY9NwE27f1FknaaW/vWDu565/bOunsxlQiNGlBckWEgPm/0MQqOfvZ8ZGaX0oWNmv1pAS4dXs4FV30upDBCNNUR0QC1XuLDSEyxg65h4f6ptGqfvhqkn29FJ8ZHjxY+rY3PC1KUwzGKEAZmYxiKSbemY+vUL/7PZtRN5RKjEiPKCdBERPU1EfjQCRgfSNwtdvpyBoZRr+gf6TqnXP08Nyl8n2TH/iLAbEdku44b1k0s0UXzCvO8zrKTZs1aEooFYGMUIbhlEyKzhXK6+IZd6x3mX7/7Zbf1Vn8hjQidGNLf41qu3Do9O8wgRbcQeOdVF3GxTALEyN/cP9G00+2EVx8Q1bTb7YbXXqb6vuN5bbDxfoZIgUUhEKUxiVGkEFIQoveyc/7rr377xv6u4RN8IpRhpqIvnSvW2xkSYBlUXZpu6tWSd+rulFuuganVtVjfqiufTnn9FmctC9HgLjqNZLhVeg5fHNHtP9MfEa90iHrOnu/dM3XtVyv0b0Z6v3l+Xa2i8NNfccZ6Zy6YHPZ7z4627pIspyS5GsH4UEULWskz6Hq5ZelHX34bBItIItRg5RV1sYsnyXisLXUN1Fw1pN7Fi3C6yHrOnu3eN8NABM7HWeO/aW5+qO/bWFbF0Klbp2OlFy9URPHIIk4xipE1PqSRAGunT/9P2F//jDvFvJj01KUaM91x65aauupETz9UNHXyn1ZPJMNpaBjGC9ZMfc50fdW21bivTuezPmdYF/y1M1pAeFiPGUy694vaeutGhLXZESUMTp2x7fsS1H7Emv8XowO/+QHWj+dHWKJFwMkgg7CKkwWLE+AIspfj0+Oa6k4c/FpuedNR7XZstpgmTF2OtvRIjTJvVxlxro67TQ+VLT8rS3JrNzFv8QibR8o9hFyENFiPGdy77u29/Mj42vCk+cuyvrMSVrKDN388l58QJlpWGVbfPrhhBWLIzM4XvITi5mRlKDeXdr9Tht9x7exsaKTt/8WAm0fKvu37+7VvdO7AcsBgxgQJhik2O/mN8YuSc+MRI9d3hLKJYVQ3FotPYUE/xeOldUnnBmfHtLYt1LEhlmuftzySavx2WFL1TWIwYaYArF0vN/PfYzORav8VJFmKnLZnJJVv/korV/STXkPgfsu8ncxMWI0ZqLvvYxvWx9Mzq2Mz0BbHU9ML46NC8KPzFMHk21r5gOtfcdjhb37g7naWnom75VILFiAkdyNDFMumVECnKZufHZibPiWXSydjkaIdbMSg3iLe056i5dTaWbJ7INSQOU2NycGZy6v+ilUctWTxWYTFiIofi7qVTVymvK5ddHEvNvK/wGrOZjvj0RMkevfWJRFM8His53zqXo1wum83ULVx8NH8/l87Mzo7XLVzUn02np2aGhw/u+veNptt1mPKwGDEMIwVhaa7GMEzEYTFiGEYKWIwYhpECFiOGYaSAxYhhGClgMWIYJniI6P8DS4M9PZB60rwAAAAASUVORK5CYII=\" style=\"margin-top:-20px\" height=\"55\">\n<span style=\"font-size:40px\">  [[cluster]]</span><span style=\"padding-top: 25px;float:right\"><a href=\"https://github.com/scylladb/scylla-monitoring/issues/new?body=scylla-version%3D[[scylla_dash_version]]%0Amonitoring-version%3D[[monitoring_version]]%0Adashboard%3D${__dashboard.uid}\" target=\"_blank\"><input title=\"Report an issue with Scylla Monitoring\" type=\"button\" style=\"background-color:#57d1e5;color:black;font-size:20px\" value=\"Report an issue\"></a></span><hr style=\"border-top: 3px solid #5780c1;\"></div>",
+                        "options": {
+                            "content": "<div id=\"amnon\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAASMAAAEHCAYAAADlHSANAAAACXBIWXMAAAsSAAALEgHS3X78AAAgAElEQVR4nO2de5gcdZnv3+65dM89FyYhJGY4KywgMhAJoOuERM951nh5losyPkfxEMBnOSou8Q91MahRiS6wzxrl4oEjEB447HMGBdyzStgjmMscIQFMnIiCAc0guWcymfulb+f5Vlf1VP26uruqui6/qn4/z9PPTPdMV1X3zO/b7+33vrFcLkcMwzBBE+e/AMMwMsBixDCMFLAYMQwjBSxGDMNIAYsRwzBSwGLEMIwUsBgxDCMFLEYMw0gBixHDMFLAYsQwjBSwGDEMIwUsRgzDSAGLEcMwUsBixDCMFLAYMQwjBSxGDMNIAYsRwzBSwGLEMIwUsBgxDCMFLEYMw0gBixHDMFLAYsQwjBSwGDEMIwUsRgzDSAGLEcMwUsBixDCMFLAYMQwjBSxGDMNIAYsRwzBSwGLEMIwUsBgxDCMFLEYMw0gBixHDMFLAYsQwjBSwGDEMIwUsRgzDSAGLEcMwUsBixDCMFLAYMQwjBSxGDMNIQT3/Gfyjp7v3IiKap54QXy9ycPID6g2c6h/o2xu294FhzIjlcjl+Y1yip7tXExhNdNaoR17tw+l/C3Eior3q120Qrf6BvgMWnsswgcNi5JCe7t4zdcKzRv3aIenlbldFCrdtLFCMjLAYWUQVnzW6W1coLtycEdVywu1pFidGBliMyqDGeNapAnSh0+PUnbaA6jsXKN8nzjur8HhD11KKNzfZOtbMH94ofJ8aPEjZySnKTkxR6q2DTi8PDOqE6elqDsQwTmExElAFaD0RXWnX7YLQNCxfqggPhEYvQn6QPn6SMidOKiKF7yFQqcG3KTs5befssJqeZmFi/IbFaM4F0wTIkvsF0VHEp2spNXYtVb7KypwwHVQsK711VQFNmDZz1o7xmpoWo57u3nWqG1Yx2wUrp+niCyjxrrMUEbLrXskGBGnq5X3KV4suHrJ1m1WL6VSoXzwjJTUnRmr6fZ1qCZW1gmD9tFx+KSUvvsBXd8tvYDlBlKZf2UdTr+yrdPYRVZS2cOCbcZOaESNVhNart5KxoFoRoFIgIA6LaXLnbivu3CNEtJFFiXGDyIuRFRGKNycpeXE3ta1dLXXsx29gMUGUJnbsVgLjZWBRYqom0mLU090LAdpYSoQQB2q/ei01rbwg9DEgr4EgWbCWvqUGuzmmxNgmkmLU092LuqAtpWJCCEC3rl2tBKQZe0CMNGEqAWJK6/sH+rbwW8vYIVJipKboEVy9wuznECFYQvrCQ8YZcOFGn9xaTpSQfVvHJQGMVSIjRuVcMrhjC276FIuQB8BSgiiVcd/YdWMsEXoxUq2hLWa1QghMd1x7tZIdY7wFYnTy/sdLBbrZSmIqEmox6unuvVIVoiJrqPVDq6n942s5MO0zsJLGt24rtQXlW/0DfRuj/PoZ54RWjHq6exEbukV8HHVC8z5zFbtkAYJ40vADj5dy3dDO5Ep22xiR0ImRWje0zWwXPawhCBEjB+Nbt9Pok8+YWUmDqiCx28YUCJUYqTvqt4luGQeo5QVW0tD3HzTb/8YlAIyB0IiRuqn1YfFx1ArNv+lTHBuSnFOPPkXjz243u0iOIzEKoRCjUkKEmiHcmHCAYsmRx540c9se6R/oW8d/xtpGejEyC1QjZT//pk9zBXUIQU+l45vuZkFiipBajHq6exFPuE7/GISoc8MXeUNriEFngOO332MWR+JMWw0j7RBHMyFC2n7Rpq+wEIUcxPc6b7vZLOGwWk1QMDWIlJaRmWsGIcI/MAeqowWqtk32t7HLVoNIJ0ZmwWoWomjDgsSQbG4aC1Ftghqx5lVF+wevUy1kpkaQxjIyK2hkIaotjm+6x2wLyfVcGFkbSCFG6haPA3ohQtYMwWq/+lDrx/mIQxFxHxkg/bVAILXZaLKPKgoLZbJsK3jrSPSRRYz26vea+ZG+10/EmPnDfruDDk1BdkgZZ6TOU2PsA0E6+rW7xFYk2DpyJqf8o03gYmSWOZv/95/ypAeRNvkCGzirHAddEVhMeA2IhdTilJFqKFEYub1/oG9N6F4MY5lAxUjtR/SU/jEvtnhoLVKnXxlwbAG1tjbT+Piko+fCWkLPbd7Iax3Mb8MGWwHexxZhAhMjszgRFmvnhptdO4eFPs0FLlr5Ljr7nDPp7HPPpCVndCpfW9taSv7+/tcO0JFDx2n/6weU7/e89GpFseIe3PYosbmW40cRJUgxelrfOB9xotM3f9O1zFmFjoOKpbPqg5fQ5R+8VPnqBhClX/xsG+381UuKUJUCrhv6LnGWsDKIHwku9W/7B/oukvRymSoIRIzM3LOFX7rRlY2viDegiK5UTAgW0EeuWKPcvATC1PfYz+mZfzNtm8H9uS0C6/bYhjvFDxV21yKI72Jk5p651aER1hBuZkCEbvzcNbTikvOrPo8dDh86Tg/d11dSlLgfU2WQcDj12FPi77G7FjGCECND9gxZp8Xf/XJVixFZsuH7H1eCniJnndNFt3xlne8iJAJR+uEdWxQXTgTvwWlfupHLAcpgUhDJ2bWI4asYqWOF/qx/rFr3rFRbU8SEbvj8NdR77UedX7AHINC96ev3FcWUuEdTefB3PvKlb4u/c1X/QN/Tkl0q4xC/96YZyvq1IkGnID6EeIIoRLCG7n5oo3RCBGChbXniTvrw3xnHvCEmAlFFN0SmGNRqmZR88N61COGbGKnz7w0rEMWNTinVMRCL/J6HNiqpeVlBycCG279AX/vO54uuECN+WJDMQa0WXFodXeokYSYC+GkZGbIfCFo7rUyGyW4mRDd87hplkZerD5IJZPTufvCbikuphwXJHMQVTayjjWpShAk5voiRaBUhPoJpr05AsBrujChEsDIgRmEDbhtcSlGQ0Lge1h9jBKUQgnWErCxbRxHAlwB2T3fvNr0YVbPlw6zNBITI67qhUux8/iXa8fxuJVumgUru91xyvq1iStQlffGGjYYqbrcLQaMCrEZYjzoG+wf65PXLGUt4LkZqn6I92v1qFphZHdE/fOW6QALV42MTtOm2+0xT9Rqwdno/81HqvfYjllxHCNL1vV8xPOb2FpmocHj9t8Wd/dz3KOT44aYZTOjmVZc5EiK4LKIQIVgdVMaskhABWDkP/egJ+sSHvqBsE6kEgu5iUBtWYKlCzlrGxLJmVy3keCpGamDRMOEDGREnnBB2cCvFjF8NpkWytv/MKhCl7379Ptp0272KRVUOuJvXfPojht+AGHH8yIhJ7OhCNTbJhBSvLSODWqCmyEkGDYtRb5LD/dnwneCyZrB2nIAtITcjLlRBkCCyEFs9Jtshah6TfX3cwD/E+CpGzQ42hSKNj933elBZHVQdEQLW5XbkV+KN1wctCRLEVg/cNU73GynRxJ/T/CHFMzFSA9eFVrIwqZ1UW8Mq0qfxYTEEWVmNzFm1QJAQcyoHxFYsVeDYkRFY2Sb/U1cGfFmMQ7y0jIpcNLvAKhIbo2HTa5Dsefn3rpwdMadK7h6ycKef0Vm4D1eVrSMjJtY2i1FI8VKMDP8UTgLXZtmzIHffw7WqxkUTgRghnV8KxMTYOioPPuRQLqLjCnbVwoknYqS6aIUILOaf2Q1co9JatIpu+HyvexfpgHLC4ZQf3Fm+NAbZNdE6MmuVUsskL+4WXz1bRyHEK8vI8M/QtNK+izYpuCNojrZEtyijwt6Xf1+xBgnuWrn3ptYx+f9iMQohXomRod7DSbxIjI18UsJ2IG5RKXYE60i/dw2WESxHJo/J/xfXG4UQ18VI9dcNm2LtdjDUprtqwE1xq2m+jCAOhaZrpUDsSHz9mP/GzCEIUgcXQIYPLywjwz+BiT9fkWkhJrLqA9EVIo1KrhqmmOgR36Nax2T8E4tRyPBCjAxjZJzMCBN35V8eYatIA9XZ5QohYRmJrhozB4tR+PHcMmp00GQes+81sACDbqav4fV17HmpfA2TeH5RtGsZk1AAz1YLGV6IUVXxImwINVRcS9Y+Flk9r/hNmbgRKWJkPDeLkRHBOupQB0AwIcFVMRL/+A1dy2wfY1bYnf4eSawiDS+buO15ubwYoWmbHgT6mTlMXDW2jkKE25ZR1fEioWFW0QIMGrEI0U2wZ60copsmvle1Drtq4cZTMRL6zVhC7Nvj1cKvhu9t/rJn11Wpylt/XnbTjNQX/7+xGIUIt8XIYMY46V0kFvPJOHII12Q2+8wNKrUWkVGcZcHEMuKYUYjwVIycuGlhQZt99nCfu6J02OZGXI4bGRG7P0pwSYxFPHXTnKB3PcRuhzICKwmi9MTWe10RpUpdAcSAPseNjIjWOO/gDw9ui1GH9o0bVlFYhjECbOKFKJkNZWT8Ax0iBDhuFBJcEyP+BMoDS6m1PTwiGjXiLTxjLqzUu3jdhk8gk0+oyIPNruhP5GYDNqZqOIgdEtwUIwNOP6EQgNTiIHtdavHqNRChB3/0hC/Xe/jgMcN9njZrxCQ8wGIUEjwTI6cgABmWoKwXIrSiwnYTMdtmd7sNw8iKdGIkgrobGQPZP7hjCz3xv37h+3kr1SExTFhxM5tmiBk5dR/EWJMXfaerBZNhvRKiSkWe+i0jtRiXY6KLm2JkyKY5dR/EOpH9r8slRnDN0HvIC1BdXc4KFIWZM0dMlPB6oqxtRBGTzTKq1JGxGiptChaFOcoV7kztIb0YuTU00S0w3torxH5FIqIwc/CaiRJuitFe/R2nO8oRa9LHQlCzY3e/llfgOsbHJz07/qoPFk1HNYAptHrYMmKihJtidMqtA4mLbKcL8+3d4IhQ4+Mm2IdXbi4chFBfTAnB5hojJkpI56aRyVA+L+M0slCpg+QzwnvAVhETNTwTo+yE8yGDWGj6+elIZ8viqnkBNtZWEiNRkFsuL+/S1Som4YG9tf6ehAXXxKh/oM+wWvRDGJ0gzlvre/TnEXi7zen9zEfLpvRRTqB30bBlhoPXlnEtfMB4i5RuGmhba+wNBDclitXHsIrEWfoiDwrjr8X3hpmjGos8TKBLRk9378YovSa3xahQHpwafLuqA+GTXx8XQRar7zH/t1/oOX3pItePecPnr6loFYl735rZRSuJaJGLFnsUUNv14HV9s6e7d0tUXpfbYlQohNHPPnNK8yrjooOrFqR1VC7b5QTMYOu99qNlnylaRXhPOItW86zXtdS9rqe7NxLTc90WI4N/Xm1/ZgRp9T2NYR09eN8TZZ/jNW7N/Yd79k8/+HLZ3zGzitqvXhvUSw8FQgD7t7X+foQJt8XIkLlwoxXIgps+ZbiPDapBbhGpVCVtBQjR3Q9tLOuewQLc9PX7DI+1fmi1o4krNQwHr0OE1JYRqWl+saZm09fvrfq4Tql2oiyECL2yK+3OhwWoz6Ch1KH942wVlcMkrS9fywemJNJbRmD+3xutI9QdoZ9QEMCacToFRLOIVn2wvKsH90xsUdJ+9Yc5VlQBceYei1G48NQyEqfDOgWuiRgrwWL1ctNqOW756jrbE0AQrH74J3dVtIhQ3HnrLXcZHoNl2Mrp/IqY/L9xwWOIcFWM+gf6DH98k08qx0CMity12+4NJH4E60iJ+VgQJPQo+tp3Pk/3PLSxYjYOcaJbb7nTsBkX7ploGTLmmNQYccwoRHhR9FioNXJ7FjwWpX6bCBbtF2/YGIggwcKBpVMqu4bHIUI/2Xqv5TjTzTdsNHRyBPNv+jQHrS1iUvXPllGI8KIHNpShMAoW1pFbsQ4syoVf+iwd33RP4TFNkGCp+D2XH5bO99T0POI8pBZGOqlHgpUnChGswaaLLyj5HMaImDDpH+hjyyhEeGEZGT6N3IobacBVE92WIC0kjRWXnK/c7AoRXLN113y5qJUtihut1hTBAsXNTbc4jAgJE296A9cQPd2963q6e3PqzfNKdi8so6L0fuI8d0+g7VgffuDxwmOaIMFSWSHMo5eVfLD6ziKLCEIk1leVAlai3h2GWJvF16KOyYceW0VVACEioof9PKcXlpFBQb2agQZBMrWQbvwW9T0m/w5/uHXXf+LLVQkRmcTlcB8ChVstWUrp4v8zjhc5pIQQeS7uXoiRJ+l9M8wECfzwzkeUYLCsPZBQIwXRFFvY2hUiUtuJmAFROrL+W56+/zLBaX13KCFE2Fazzutzuy5GYnrfjSrsckCQFn7pRkOWjdTR2LA8ZLKSYA19Yu0XTGeuwbWyK0Sgc8PNyjYRM7cMm5WPb7q7Jiwkk/8zdtNsUkaI1viRDPCqn1Fhg2K1TdasgIxT54YvFg01hOUBKwkCEFSBJKmxIVhqsIaOCNYaRBRi6nQDLDKM8z5zlSJKZzzwPWr928uJYnM/hyANff/Bal+C9IjhgCi2DvGSoIWIPBxvXRTE9rpWBv2POm+7mUZ/upXGnzUmUiAAt66/SylAvOFz11S9v8wqsITQg0mc6qGhZQbdeG9g/Qzf/zhNvbKv6Gdati3KQW0hdjZY+jcZERmEiDwUI3wqFfYv4FPLj8I91DPBSkBD/5P3P170aQlR+u7X76Mf3rGFPnzFGkWU3K5NghWEaSYQIdEKmrvOpLLXzK0tHhM7dtPIY0+W7SE1+uRWxXqKIlb2pL3vA+u/StnsO/SPxWYmPyb+Xn0y2V7KY8im09Px1o7XY40J5R8rm8nMpMfHTryw/Yd+v7GiQDgWDFmECMRyuZzrBxVfIFyQIPrwYAGOb91WdpHCWlqx8l1KOQAmutoVJ4jPG68doN+89CrtefnVouyYCILUEEw3CkERtD312FMlK92bLrmQpl6aa+kDNy5qm21HnttFs2+8RVOvDOCfmSiToVgmnSXKZSmT9urDtiSxunqieDxH8bpMrKVtLJtOz1JLx7OZ6akxN0VL7fB4HRFd3z/Q52jXuExCRB6KEfygX2n3nWSJ3AKfmuNbt1cUJT3Y1ErquOm29uKeQ79Rq60hQlaHOmpFjG65ZKcefYomd5rPk0OGDe833DJ9HRIso7C6aief+A9K/eUwZY4PUfboUaJUStGbUNLQmI0lmydy9Y1HMxR/NtfQeP+Lv/znYv+6AlhnTmNjsgkReSVGlH+xhQNjAQTtImABT728TxEmP4LqpIoCsn0QIrdEqJKwilYofh/WE6l7+8Iw4gjWzvRvX6PUm39GFoIok5bgqjwmFidqTKRyyZY/ZeP1v/TS9ZNRiMhjMTLsUVv22GZPzuMEBNSnX9mnxFrcFiYIELJ7WPRujROyIkLlguGwonCMoKzTSkzs/SONP/8CpV77I9Fk9CbAOKa+MZtrad+frW98+IVfbb7DjUP2dPdeSURPCQ8HLkTksRgZgtinf/8bUu4+xyKFG4P4C75CqKxWjSMQ3dC1TCkp0KaZuPkarYiQ3iULE7B+xv/9OcqdPOmJ5RNraFDiN7FkE8WbWvPvVVsH1S9cbHz/2udTosvaeze5rzgrOjH4J0pP5V31+Mwk0Wz+7xRLz7rwKnTAckokJzLJlmdf2HHvx50eRh1v9E3dQ1IIEXmYTaOgMmp2QUAXloy4Ox5CUKp6GQLg5WuBIEKEJnfuKilCEMKOa68O1WRZWECj/+c5yvxxf/Xxnngd5RoTlG1qp1xTG2XaF1C2bQHFFi2jZUsWUjwes3AQezRfUNwuJnn+Snr78BCl0xnTY9Uf+TOydlR38gjFUjMUHztJsQziXTaNALxf05MtddOTVyMEkmtqPZFtbv/nKi0maYSIPLaMpMiohQlYZnAdSwWmSRWh1rVrlLKAsGTGEHye3PZrohEn//MxyiWSitBk2xZSZv4iSncuL/uM+fNaaX5H6WEHbjMxOUNHj9t/bQ2Dr1Ld2DDFR4coPnEKtQL2r6y+IZNpbv9/L/T/yFKdSE93L9LFWsp4r0xtVrwUI2kyajKjxa/Gtm4v6x6GVoSeeY5odsb6k+J1lG2ZR5n5iym97BzKtM23fV5YRcuXdnpiHZXi0NFhmp6u3jWDQNUfHcxbUHZcvViMMm0LdlgVJRnxTIxIwoyaLGiZPYiQWcW0nlhDPc27vjdU7tjs4RN07PZ7LFtCuWQLZRYupdkz30XZVnfc37bWJupc2O7KsawAN+2tgydcPWZ8epwa/vIa1R85QLHJUWtPqm9IZzo6b3Mr4O0nXouRtBk1v7EjQHoQHF/83fLDHmXi+I9/SjPbdla8IghQenEXzZ71HsrVN3ryCpYvPY3q6+t8e3eGT43T8Ih32cDE/pctC1O2uX3w1y/+2N/Wp1XidYWqQYz82KMmE9qeMIiQlRICVIOjd/a2X75Ix4/mXTa/aqLc4PB3fkSZ118vfSS4Ep3voJlz30tZNcPlJceHRmnJYvtunlMQqxqbmC4ZzK6WmbNXKjdYTI1v7KX6Q/tLBsLjk6Nd71953WhmXuf7nRRUBoHXYmTIqGFhRVWMtOybJkBWhxFgwgjmqF3+wUsL89T2v36gIEZh4dCt/0LZv7xlfrWxGKWXvJNmznuvZ1aQGVPTs0ocJ5n075xwDQ8fHfb0HNlkK02/u4fo3T2U/F1/SVGKzU611Q8d+g0MbE8vyCX8sIwKYLFGocE8Xgc6C+IrbrODB211tIQAYS9cXoQuKRpzrZ+vX6p5mkzANSslROnFZ9LMu3t8FSE9J4bHlFS/XzQlG6mlOaFk2PygIEp7nqP6Yyb7IjPp+r+59IZjv9790KJA/gA28FqMPG3OT7rtDloBIjJNWuWzWA+k/5mIWOyorzPSfmanINKMj1z5AVq1ZmXZibJo0K9HdksSwWrTGFEsRtMr/gulO99h9jTfmJ1N09j4lBLQ9ovOhR00NX2cslnv4rEi0yv+M9UNH6Wml7cWlQjEp8c737f6H+4JoLuALTwVI3R97OnuLdx3u+sjanK0fVcoDtRcIzsBYq+AEMYaGyh96GjhDBddfJ6F0da/N9wXG8bJxtCPnyi+oliMJt93hVIbJAMIKrc0J31L9eM88ztaaWh4zNdXj3KIyVUfp+adPy0WpPHhz2I0n68XZBOvOj3q8azrI9LdMmyDgFWmTeVA10ZsfVmy+RvU8Uljuxwr3SZ3PG8seHRrf5tXZP5cPB5q5oLV0ggRqWn3kTFr3RXcoqO9mRobfe9gosSTIEgisdRMwveLsYkf7xb+Wy/U7sD1cXOBYfFP7thdcKvyX9+23C7EKprLp7l62n18X6oIURRKdH6EGybGiDTQG0mcn4ZGcVIjFDTmGhKUWvJX0l3xyOgEdbQ1+1oIuXB+m+fBbDMgSJn5p1Pd8BHDT2V31fwQI8SNrtDuzLosRhCCUh0T4cZps9WamhL0rbvW06nhsZIdGJFah1igbzapVsniTc5rfLR9b5rbiN5HO55/qWTbW3Sg1IPnhq0ZGuqHZATxG7hNfhZCIpgNAfTbKgOZeYuKxKgcPd2984hofZWnPdU/0Oe4mNAPMdqm3yXs1Rw1M+DGodsjzjk1NUOvvfonpQd2ObQx1aSKSbUkdWIEHvrRE6YZNEwxEXtlu9WW1k/iEyPKNoagsmflQCAbe9b8LITM1x5N+RrMBvUn3i56LNeYNF18qhBt03swTunp7r2of6DP0VgjP2JGhqCC1fobt9BvzoUQVBqBjRofDTfECIKoT8/DKvuBzgKCJYb7mjWmgb18oezKmM1Q4g+7JLgQc1AI6SdwC+Gu+UnDwf3K3jaRXKK5lCWwzg0hUrlO3SRvG8/FqH+gD6t7RLuPeI6fiGKAKSFi+lyPPpvlljspditAXGjt36xTxhetff/1RXPUkEFDn+ywgiK85L7KW0KCQCuE9BOUFfhVeAkhSvzO3nuvulaPWPhVKzzitCe3H5YR6euNEFj2e6igvlvAEXWGmZkgKZM9dK6SWwWaZlk/xI/0xY0aWrO0sDfOhyA1//ppik+NS3A1Rk74nHIHizyOVcE1Tu75pW0h0lBdqw9Ue3PqopFPMSNSxWhuW8jgQV9dEC3tjvgRwAQPCNItX1mnVEKT6i5tuu3ewnMgCm5n/TBMsZybCvGbHwEh0oCr0Lyjj2bfuYJSZ54vTRwpiEJIxKkQr/JiIy2socbXdlXdXTLowZd+ilGBIAYKQoxQdKk1LoMgYcLrWed0KcFkcdKH224SBAYtVLTmaZooQfTwXshSM+UFjW/uUfr0pLrOl0aU/C6EJKX2qMXVjbSKCL25h2ISWp9O8EuMDFFjr+fvlwLuD2qDNAuJVFESQfDYqz10EJ0w9SayS66p1XRx4FMbCwe39BlnU2rpWZRZsCSw69QKIf3sCKkFs510hSwcY+ykIkL1B/eXtYRyjU3YKOv4PEHgixjB/NNvC/Fij5pVYCFBbCBIYntXtye91iKpM86mXEMjNb6xp+RiQTwJNwhXelEXpZaeHUjFdhCFkNhEa3cjLeJudccGS2bJRGCBZhYuoeRvfunehfuAn/Xqv9XSh0H36IF1BCsJN81dKreJlrGHshgWdSmCpLS3KAEsKLhvuMF1w3MyC05XLCY/+h2h9md4ZNz31DvOh6xeqdojiHjdycNKE3/sxLfqhuG9Q3wO7x+eHzb8FCPDtpAg4kZmRDVOEzQQk+kLVlH8rBUVRYnUBahZTKS6e5n5S/Li1L7QM8tpZHRSsY78LITEuXBOLZgNyyc+NqSID0TEivWjRy9CYcZPMTJsC0HcKHFeqN87xgJ6UVKazVeIdWjAGqif2m8QMSy6XLJNOabyfVObKxYUtoks7pzn+Z8zNztNqRPHKD10lBrGRqj58NsUGxlynAWTIfbmJn6KkWFbSJBxI8Z/IBoz516m3OB61B99S4mD2FmIsByI1P1Wb849DqsJcSqMMoK7B6tKE6ls+8KK2TvEb9zoCDl7KN9gDqIDwdE/ljpc3HzOSZFfetFyxZ1F/3AZt9xUg9+WUYEw9XZm3AVBa9yIVinCZDc2IqK5NXmxKg0Wb7bd3N0b6VxGmdak6c8gLNmZ4oBzdmyEMuMjps9xC30sLYoCpMc3McKwuJ7uXvzlOiiAPWqMnGjCBItJyRqpgVvEUOzGTiqRDwyXEHyqHJAAABErSURBVKyTR0iGKf9KrKxtgeJ6KYF8ifpCeY3f3Z8Mldi1Ni2EKQ9cq+zSs5VUP6nigWmrBXFSAr3hGlRQjrrWDpptbFIC9dn2/MRcP7KIsuK3GNXMtBCmehQXRbUQ9CjTVlMz+fn1EKyxIYqlZqUUKghOvK2D6tRb/cLFFGtMUuMZ+RHdfxo8WvEYtUIQllGBqEwLYfxFc11KZZG0Gpu8ZTUnUHXDxbU3+LnVIHrDkuIZ/w0Ql0S+oyvEJt6az8o1nLZIER3GOn6LUaC9jZjawCBSi7p0r3lFxdd/xuL5vs5ZY+bwq4WIAqaF6O8HtUeNYRj58FWMVAod59EO1u/eRgzDyEkQYuT5YEeGYcJH4GLEcSOGYSggMSqav88wDOO7GImtLWdZjBjGF2LpWan7GQdhGZF+5DUHsaNFtX2YGXcw+zvEpsalbtgVlBhxEDuiYMMrEzxme/ByjQmpa2lYjBhX0bo3MsGBPXzoGyWSS7SwGJlgECOOG0WLxGu7lH7NjP9o89PC6C4HIkZiEJsto+iBYYKYKssxJP9Q5tRhcGZIOxv4vTdNjzQN+hlvQMtYdHOcPfeyQlsQxn2UMVBv7Am9exykGO2VsUE/4y5YKLCSMC9NmSzLouQaWmwIIhQFCzRoMbpOu+P3yGvGI9AW1TytXBAlzFZLY1ZaDTcSqwath3i5iSu5unqKZdJheDkFghajAhzEjgapd5xLlM2UdBkgStpkWfQlgqWEHs8sTOWxM8RA6Ze97FxKDAQ6Ot820ogRB7GjQS5eR7N/vVKZYpH83c6yTfYRaEXmjV7bpQgT+hAp0y8iMnqnGvDe5PuBH6b6Y8WTRcxA/2zNFeYhjjZQG/SjQk7pfsVB7GgBQZm4vFdJ8cMKqjT5A4tPmSOvWlTK8Ea1NzSOFeWpGNoQR3SdRDdKO90nSRChMBOkZUSqdVRoxcdB7OiRUhvsK27Gwf2WP+Xz01Xnqoi1qRlK03o0r8cAx5BNztAPccSYo9TQUWo5fsRx8Flxx844OzJJARnEqDBlloPY0UUbSaSMIzo2SI3IANmYk5afMDtOJIiZNrBRmzSrH+Dot7unzVezOsQRxGyeA68vqgmAoMXIMGWWg9jRRxlH1HU+pbrOLwgTXDmnhXoQqTpF1MoPcIQVoUebPisycyRJmTJz9zVx0YDo5GaLBzy6iWIBKYMcoz1HTQbLqAAHsWsLvTDlByweVt2zw65XEYsbR0sNc5xRb0GSLQxxPD3y8TI9gYoRB7EZDSy4ubHXeQzTZSM2wFEjq8bBMsoQxwU1nUkM2jKiqAexJ3bsViy+eZ+5KtTnCAKzAY4QKG0emjK8Uf1e5gpks0GO2lce4jiHLGIUWBAbjd1OPfqUspDjze42wsNrGX7gceV7TM5tXbu64nOqOUdD11JqufxS188x+uRW5W8iw4dEQZwM89DyaJNm9cMbtYmzekrO27eBONBRmxBLys/y16aJD2MNGcTIURD7+KZ7lGm01S7w47ffo7iH6DjZueHmqo4lou9g6VU3y/SJOdclc8J9NwZCPf7sdoo3J+mMB/7J9eO7iSG4ayJWVuAhjsEhi2VUwEoQe3zrdsWdww3WQDWf2JpIeD2lJDvhjRh5HfTX4njZyWlPz8MwQTVXK4AgNhEVepXaDWJXKyJwnzS8nHAb1uB8avBtCa6CqQUCFyMVW7PUYA1puGkZeOHmhB3NIoKbxjBeIqUYVRKYutPmrJlqCyX1x+I6JyP6D4WGrmVyXBQTWWQRI1uz1PSuVbWjjvTHCuPIJC8FlEdIMX4SSssINCyfc9XcCj57GcT2KvbipWDo/w5ulz0wjIgUYuQkiK23aKqxDvRumlcZLwppNkof0NfH6RjGC2SxjKiaIHY1Fo1B1Hg7igEO6DN+IpMY2RpfZAw8u+cCcZxkDv37ym5a+ImPnZR6n5W0lpGdIDZcIKc1QqL7EbaAsJdxLr1radVNE7deMMEQxk3F0oiR3cGORSLi0MUSP/E9LXwMUemA02tFJ8co7q4PG+isKZJtW+DtNoMqkckyInWwo0IlcYGI6Avx3FroHCfJI1pxere4Esl9O3iSbIBgoKMbm4H9RjYxshnEXmb5d8uh39vmpWUUJsT3U+8WVyLsY5bDDIQIAxDCiNRiVNFVW67fFuJOEJstI3dAO1gIEhYH4z1oPtf00i9CK0Qkya59PbaC2PGWuXiPFsS28wleOI4ubhSmjaFeBq/1x66mKwIWR8Oh/Tza2iPgDjcceDUSI66lsozEIHalxSYuEqdBbH0w3MviRK/blNiJ61TCzQJQbbR1y46+yMyFDxq4wMl9O6l5e19+Lh3P2vcEBLEvJN2+s1I1LuLig1uHhmvVguOEseLYiVVYCr2w26kxyixaTvGT5rPAFFF6bZdyw7yv9OLlhp7XTHnsTFPB+1tuFr+MyChGezUxogptaMXF59TyEEWt1gsfxddvR5gzbQtp5tz3UuJ3O8pmdLBQcEMjfszahzDV0iQMq2hDCZCqt5IQQLfLmXMvU75nMaoeuGrXaUep1KAfP9NEyGm8RxS1Wh8mWW2ZBEYQTV3yEWUBwQoqN6wRFpQmTKQba62N6ak1CuOabI65Fkdc86x9d3Dc2wjxnnJunVXCYhl5VYZQTY2RHm30ENwKiI2V2pfCWOs31WuJ6CgfbdR1w+AbVKdOOnFSChGVOfskoxj1D/Tt7enuLdy3sy2EHFo1RYFwlwooRffGbfHwqgxBfP3VxqK0eftYbI0HXlXiHlY/8fEc3OoPzT2mjbCGBZVraFREKtfUJt24Z01wtHHXmbER5aafQptwclzVtU0tPStS1qOMlhHYTkTK2I9KQWxRSNyYu+aWZSRec1hqmLxqpQLRmL5gFRGtUly4+qNv2RImDW2ktZmlhYWabV+gnm9uhDUe08ejcg0J26OiNXHRkzo8t+1CG32dheiMj9g6dsVz62JrUQ36yypGezUxIlVgSmXJzDJqTsBxNLGo9Sb0YomEF/Gzuemxq5T4Bva0uTHWOj8mOy9STrZEjKo3GYBY5mfs10b8TGYxKlAuZS+6EE57YuM4mhjV+lgeL5vMmaGfHKvN3Efw1m4QN8xoFp0WvM+2L6y5zGIoxKjiHrXlSwuf5pXcOqtEbcy2HfSWkZuFlFbQZu7nhzCuUJ6Rn7M/VBhpHfa5+5hGq02bPRFvkzLeFQRSipEaxIbTrcwGruQ2warRLyCnQWyvK6Tdxotsmhgvc7OQ0ilZNWAtTomFKMWmxtSx1rP5+9Njys+C2rUea0woM/RBw8LFFEskFNGJt86jhtMWUazROPLpKM/aLyCrZUT6uFGlfWfIWk29sq9w3w2rxgvLKAzZtDD1XFIEClm1CvEUseZGEy8z2lqTVF9fV/54qrgUjpeYEyDGOTKL0TZ9EBuWTzkx0uNk0fvhjoQhmyZaRlFwVUWxKideCZ61HxiytRDRY4wb/b60C1XvQkbNra0lYYcHWTJBERoxKrcj360WtEyxVel3AJupXaQVo/6BvgP6WWpWMmp67Fo2ZsWTtYjoSsoQwGZqA5ktI7KzT81sW4iMuLnvTRRMN9qecNtdJihCJUblChrFheik+FF0Sdywjqq12EphJmpuzDYTLaNa7l7A+IvsYmS586MoRk4WfaNwjKmX95X8XauIFpsbxwSTO3Yb7rsR29GXR5AibsmSv8swbiO1GIltaCd37i7p5oif4PiErzZuJC5OJ4jHnH5lwBVXbUIQo8TZZ1Z9TFHgEudxz2rGP2S3jMDP9HfGt243/SW4KOLCP/XoU7ZOlBT2v0HQSp3PKrGEsWYFBZzVHhMiW5QxzOWqPqYovuL7wTBeEgYx2qy/M/rk1pIWT/OqSw33sWDx+1aBSyUK2uiTzzgOhiMYPPKvPyt6HNfk9Jiwqk7e/3jR45Mv7nEcj8IxReGGi9Zy+aUln1OKeJmujox/hPHvIL0Yqa6awZQY+v6PTRczFo8YMMbCF12acrRfvdbwU1gyxzfdbVs8IERD33+wZAcAJ8eEaBy//Z6Sldyl3hcrxxQtrfarP2zp+bnmNsN9J/2JGPcx7/XUYM9V8JkwWEZgHREVulVpAmEW01lw06eKHht+4HHFmrASq0EguG7BPMNj2vmsihqu69iGO8sWX2rHtOqyweo5+rW7Kh7z6Ia7qj5mrLHBehZtwWnG56ZnKfGHXdaey3iC0h9KaMafSzTP7n56Q/EAfomI5aqMNfhFT3fvlURUpOxYNK1rVxv6HUE0IEAicD2aV12Wt6BMsm94Xj7AXLqfESwvnA/n1WfKIHTIlCHIXsJdgpj+hYjeLf4AAgiLzOyYOBbExckx29auVuI+No9ZAG5v08oLlOvSlw3A6pt+ZR+Nbd1OqZmY0tZDBKNyZs67LHQ9ec7weW/an1zetY9NwE27f1FknaaW/vWDu565/bOunsxlQiNGlBckWEgPm/0MQqOfvZ8ZGaX0oWNmv1pAS4dXs4FV30upDBCNNUR0QC1XuLDSEyxg65h4f6ptGqfvhqkn29FJ8ZHjxY+rY3PC1KUwzGKEAZmYxiKSbemY+vUL/7PZtRN5RKjEiPKCdBERPU1EfjQCRgfSNwtdvpyBoZRr+gf6TqnXP08Nyl8n2TH/iLAbEdku44b1k0s0UXzCvO8zrKTZs1aEooFYGMUIbhlEyKzhXK6+IZd6x3mX7/7Zbf1Vn8hjQidGNLf41qu3Do9O8wgRbcQeOdVF3GxTALEyN/cP9G00+2EVx8Q1bTb7YbXXqb6vuN5bbDxfoZIgUUhEKUxiVGkEFIQoveyc/7rr377xv6u4RN8IpRhpqIvnSvW2xkSYBlUXZpu6tWSd+rulFuuganVtVjfqiufTnn9FmctC9HgLjqNZLhVeg5fHNHtP9MfEa90iHrOnu/dM3XtVyv0b0Z6v3l+Xa2i8NNfccZ6Zy6YHPZ7z4627pIspyS5GsH4UEULWskz6Hq5ZelHX34bBItIItRg5RV1sYsnyXisLXUN1Fw1pN7Fi3C6yHrOnu3eN8NABM7HWeO/aW5+qO/bWFbF0Klbp2OlFy9URPHIIk4xipE1PqSRAGunT/9P2F//jDvFvJj01KUaM91x65aauupETz9UNHXyn1ZPJMNpaBjGC9ZMfc50fdW21bivTuezPmdYF/y1M1pAeFiPGUy694vaeutGhLXZESUMTp2x7fsS1H7Emv8XowO/+QHWj+dHWKJFwMkgg7CKkwWLE+AIspfj0+Oa6k4c/FpuedNR7XZstpgmTF2OtvRIjTJvVxlxro67TQ+VLT8rS3JrNzFv8QibR8o9hFyENFiPGdy77u29/Mj42vCk+cuyvrMSVrKDN388l58QJlpWGVbfPrhhBWLIzM4XvITi5mRlKDeXdr9Tht9x7exsaKTt/8WAm0fKvu37+7VvdO7AcsBgxgQJhik2O/mN8YuSc+MRI9d3hLKJYVQ3FotPYUE/xeOldUnnBmfHtLYt1LEhlmuftzySavx2WFL1TWIwYaYArF0vN/PfYzORav8VJFmKnLZnJJVv/korV/STXkPgfsu8ncxMWI0ZqLvvYxvWx9Mzq2Mz0BbHU9ML46NC8KPzFMHk21r5gOtfcdjhb37g7naWnom75VILFiAkdyNDFMumVECnKZufHZibPiWXSydjkaIdbMSg3iLe056i5dTaWbJ7INSQOU2NycGZy6v+ilUctWTxWYTFiIofi7qVTVymvK5ddHEvNvK/wGrOZjvj0RMkevfWJRFM8His53zqXo1wum83ULVx8NH8/l87Mzo7XLVzUn02np2aGhw/u+veNptt1mPKwGDEMIwVhaa7GMEzEYTFiGEYKWIwYhpECFiOGYaSAxYhhGClgMWIYJniI6P8DS4M9PZB60rwAAAAASUVORK5CYII=\" style=\"margin-top:-20px\" height=\"55\">\n<span style=\"font-size:40px\">  [[cluster]]</span><span style=\"padding-top: 25px;float:right\"><a href=\"https://github.com/scylladb/scylla-monitoring/issues/new?body=scylla-version%3D[[scylla_dash_version]]%0Amonitoring-version%3D[[monitoring_version]]%0Adashboard%3D${__dashboard.uid}\" target=\"_blank\"><input title=\"Report an issue with Scylla Monitoring\" type=\"button\" style=\"background-color:#57d1e5;color:black;font-size:20px\" value=\"Report an issue\"></a></span><hr style=\"border-top: 3px solid #5780c1;\"></div>",
+                            "mode": "html"
+                        },
                         "gridPos": {
                             "x": 0,
                             "y": 0,
@@ -814,51 +817,63 @@
         "id": "auto",
         "datasource": "prometheus",
           "cacheTimeout": null,
-          "links": [],
           "transparent": true,
           "type": "gauge",
-          "options": {
-            "showThresholdMarkers": true,
-            "showThresholdLabels": false,
-            "fieldOptions": {
-              "values": false,
-              "calcs": [
-                "lastNotNull"
-              ],
-              "defaults": {
-                "min": 0,
-                "max": 100,
-                "thresholds": [
-                  {
-                    "value": null,
-                    "color": "#299c46"
-                  },
-                  {
-                    "value": 4,
-                    "color": "rgba(237, 129, 40, 0.89)"
-                  },
-                  {
-                    "value": 10,
-                    "color": "#d44a3a"
-                  }
-                ],
-                "mappings": [
-                  {
-                    "op": "=",
-                    "text": "N/A",
-                    "value": "null",
-                    "id": 0,
-                    "type": 1
-                  }
-                ],
-                "unit": "percent",
-                "nullValueMode": "connected"
-              },
-              "override": {}
+          "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "custom": {},
+                    "mappings": [
+                        {
+                            "id": 0,
+                            "op": "=",
+                            "text": "N/A",
+                            "type": 1,
+                            "value": "null"
+                        }
+                    ],
+                    "max": 100,
+                    "min": 0,
+                    "nullValueMode": "connected",
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "#299c46",
+                                "value": null
+                            },
+                            {
+                                "color": "rgba(237, 129, 40, 0.89)",
+                                "value": 4
+                            },
+                            {
+                                "color": "#d44a3a",
+                                "value": 10
+                            }
+                        ]
+
+                    },
+                    "unit": "percent"
+                },
+                "overrides": []
             },
-            "orientation": "horizontal"
-          },
-          "pluginVersion": "6.5.1"
+            "links": [],
+            "options": {
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+
+                "showThresholdLabels": false,
+                "showThresholdMarkers": true
+            },
+          "pluginVersion": "7.3.5"
       },
     "single_stat_panel_fail": {
         "class": "base_stat_panel",
@@ -888,9 +903,16 @@
         "dashLength": 10,
         "spaceLength": 10,
         "options": {
-           "dataLinks": []
+           "alertThreshold": true
         },
         "dashes": false,
+        "fieldConfig": {
+            "defaults": {
+                "custom": {},
+                "links": []
+            },
+            "overrides": []
+        },
         "fillGradient": 0,
         "thresholds": [],
         "timeRegions": [],
@@ -1025,7 +1047,10 @@
         "panels": [
             {
                 "class": "plain_text",
-                "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Your Panels</h1>"
+                "options": {
+                    "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Your Panels</h1>",
+                    "mode": "html"
+                }
             }
         ],
         "title": "New row"
@@ -1035,7 +1060,10 @@
         "panels": [
             {
                 "class": "plain_text",
-                "content": "<div style=\"color:#5881c2; border-bottom: 0px solid #5881c2;\">Scylla Monitoring version - __MONITOR_VERSION__</div> <div style=\"\"><a href=\"https://github.com/scylladb/scylla-monitoring/issues/new?body=scylla-version%3D[[scylla_dash_version]]%0Amonitoring-version%3D[[monitoring_version]]%0Adashboard%3D${__dashboard.uid}\" target=\"_blank\">\n<input title=\"Report an issue with Scylla Monitoring\" type=\"button\" style=\"background-color:#306EE6;color:white;border-radius: 15px;font-size:14px;line-height:22px;padding:2px\" value=\"&nbsp;Report an issue on this page&nbsp;\"></a>&nbsp;&nbsp;&nbsp;&nbsp;<a href=\"/render/d/${__dashboard.uid}?orgId=1&from=${__from}&to=${__to}&width=1000&height=2500\" target=\"_blank\" download=\"dashboard_${__dashboard.uid}-${__from:date:iso}.png\"><input title=\"Make a Screenshot\" type=\"button\" style=\"background-color:#306EE6;color:white;border-radius: 15px;font-size:14px;line-height:22px;padding:2px\" value=\"&nbsp;&nbsp;&nbsp;Screenshot&nbsp;&nbsp;&nbsp;\"></input></a></span></div>"
+                "options": {
+                    "content": "<div style=\"color:#5881c2; border-bottom: 0px solid #5881c2;\">Scylla Monitoring version - __MONITOR_VERSION__</div> <div style=\"\"><a href=\"https://github.com/scylladb/scylla-monitoring/issues/new?body=scylla-version%3D[[scylla_dash_version]]%0Amonitoring-version%3D[[monitoring_version]]%0Adashboard%3D${__dashboard.uid}\" target=\"_blank\">\n<input title=\"Report an issue with Scylla Monitoring\" type=\"button\" style=\"background-color:#306EE6;color:white;border-radius: 15px;font-size:14px;line-height:22px;padding:2px\" value=\"&nbsp;Report an issue on this page&nbsp;\"></a>&nbsp;&nbsp;&nbsp;&nbsp;<a href=\"/render/d/${__dashboard.uid}?orgId=1&from=${__from}&to=${__to}&width=1000&height=2500\" target=\"_blank\" download=\"dashboard_${__dashboard.uid}-${__from:date:iso}.png\"><input title=\"Make a Screenshot\" type=\"button\" style=\"background-color:#306EE6;color:white;border-radius: 15px;font-size:14px;line-height:22px;padding:2px\" value=\"&nbsp;&nbsp;&nbsp;Screenshot&nbsp;&nbsp;&nbsp;\"></input></a></span></div>",                
+                    "mode": "html"
+                }
             }
         ],
         "title": "New row"
@@ -1427,8 +1455,8 @@
             "class": "default_annotations"
         },
         "refresh": "30s",
-        "schemaVersion": 16,
-        "version": 0,
+        "schemaVersion": 26,
+        "version": 1,
         "links": [
             {
               "icon": "external link",
@@ -1451,6 +1479,12 @@
         "span": 12,
         "style": {
 
+        },
+        "fieldConfig": {
+            "defaults": {
+                "custom": {}
+            },
+            "overrides": []
         },
         "options": {},
         "datasource": null,
@@ -1590,8 +1624,33 @@
     "single_value_table": {
       "type": "table",
       "id": "auto",
-      "options": {},
+      "options": {
+            "showHeader": true
+        },
       "datasource": "prometheus",
+      "fieldConfig": {
+            "defaults": {
+                "custom": {
+                    "align": null,
+                    "filterable": false
+                },
+                "mappings": [],
+                "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                        {
+                            "color": "green",
+                            "value": null
+                        },
+                        {
+                            "color": "red",
+                            "value": 80
+                        }
+                    ]
+                }
+            },
+            "overrides": []
+        },
       "transform": "table",
       "pageSize": null,
       "showHeader": true,
@@ -2224,6 +2283,7 @@
             },
             "datasource": "prometheus",
             "hide": 0,
+            "error": null,
             "includeAll": false,
             "multi": false,
             "options": [],
@@ -2241,6 +2301,7 @@
     "template_variable_custom": {
         "allValue": null,
         "hide": 2,
+        "error": null,
         "includeAll": false,
         "label": null,
         "multi": false,
@@ -2299,12 +2360,14 @@
             "class": "template_variable_single",
             "allValue": null,
             "current": {
-                "text": "All",
+                "selected": true,
+                "text": ["All"],
                 "value": [
                     "$__all"
                 ]
             },
             "datasource": "prometheus",
+            "error": null,
             "hide": 0,
             "includeAll": true,
             "multi": true,
@@ -2457,6 +2520,7 @@
         "hide": 0,
         "label": "ad hoc",
         "name": "adhoc",
+        "error": null,
         "skipUrlSync": false,
         "type": "adhoc"
       },
@@ -2497,6 +2561,7 @@
                     "label": "by",
                     "multi": false,
                     "name": "by",
+                    "error": null,
                     "options": [
                         {
                             "selected": false,


### PR DESCRIPTION
There is a repeated issue with Grafana, when the format is being change, it would automatically update the dashboard to match the new format but then it would ask the user to save the dashboard even there was no change done by the user.
The best option so far is to hunt the changes and update the definitions accordingly.

Fixes #1203 
