### PR TITLE
docs: added multiversion_regex_builder

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -72,3 +72,7 @@ multiversion: setup
 	$(POETRY) run sphinx-multiversion $(SOURCEDIR) $(BUILDDIR)/dirhtml
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
+
+.PHONY: multiversionpreview
+multiversionpreview: multiversion
+	$(POETRY) run python3 -m http.server 5500 --directory $(BUILDDIR)/dirhtml 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,6 +5,7 @@ from datetime import date
 from sphinx.util import logging
 import recommonmark
 from recommonmark.transform import AutoStructify	
+from sphinx_scylladb_theme.utils import multiversion_regex_builder
 
 logger = logging.getLogger(__name__)
 sys.path.insert(0, os.path.abspath('.'))
@@ -180,10 +181,11 @@ redirects_file = "_utils/redirections.yaml"
 # -- Options for multiversion --------------------------------------------
 
 # Whitelist pattern for tags (set to None to ignore all tags)
-# smv_tag_whitelist = r'^.*$'
-smv_tag_whitelist = r'\b(scylla-monitoring-3\.4\.2|scylla-monitoring-3\.5|scylla-monitoring-3\.5\.\d+)\b(?!\S)'
+TAGS = ['scylla-monitoring-3.4.2', 'scylla-monitoring-3.5', 'scylla-monitoring-3.5.\d+']
+smv_tag_whitelist = multiversion_regex_builder(TAGS)
 # Whitelist pattern for branches (set to None to ignore all branches)
-smv_branch_whitelist = "None"
+BRANCHES = []
+smv_branch_whitelist = multiversion_regex_builder(BRANCHES)
 # Whitelist pattern for remotes (set to None to use local branches only)
 smv_remote_whitelist = r"^origin$"
 # Pattern for released versions


### PR DESCRIPTION
Related issue https://github.com/scylladb/sphinx-scylladb-theme/issues/86

The new built-in function `multiversion_regex_builder(versions)` enables maintainers to define versions in an array instead of defining complex regex expressions.

## Example

**Before:** 

`smv_tag_whitelist = r'\b(3.22.0-scylla|3.21.0-scylla|3.22.3-scylla|3.24.0-scylla)\b'`

**Now:** 

`TAGS = ['3.21.0-scylla', '3.22.0-scylla', '3.22.3-scylla', '3.24.0-scylla']`

The PR  also adds a new command ``make multiversionpreview`` that launches a webserver to quickly preview the multiversion build.

## How to test this PR

1. Run ``make multiversionpreview``.
2. Open http://0.0.0.0:5500 in a new browser tab.
3. You should see folders for every version listed in ``TAGS`` (conf.py).