### PR TITLE
docs: Update URL

### DIFF
--- a/docs/_utils/deploy.sh
+++ b/docs/_utils/deploy.sh
@@ -2,12 +2,11 @@
 
 # Copy contents
 mkdir gh-pages
-cp -r ./docs/_build/dirhtml/* gh-pages
+cp -r ./docs/_build/dirhtml/. gh-pages
 ./docs/_utils/redirect.sh > gh-pages/index.html
 
 # Create gh-pages branch
 cd gh-pages
-touch .nojekyll
 git init
 git config --local user.email "action@scylladb.com"
 git config --local user.name "GitHub Action"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -159,7 +159,7 @@ html_use_index = False
 htmlhelp_basename = 'ScyllaMonitorDocumentationdoc'
 
 # URL which points to the root of the HTML documentation. 
-html_baseurl = 'https:// monitoring.docs.scylladb.com'
+html_baseurl = 'https://monitoring.docs.scylladb.com'
 
 # Dictionary of values to pass into the template engine’s context for all pages
 html_context = {'html_baseurl': html_baseurl}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -159,7 +159,7 @@ html_use_index = False
 htmlhelp_basename = 'ScyllaMonitorDocumentationdoc'
 
 # URL which points to the root of the HTML documentation. 
-html_baseurl = 'https://scylladb.github.io/scylla-monitoring/'
+html_baseurl = 'https:// monitoring.docs.scylladb.com'
 
 # Dictionary of values to pass into the template engine’s context for all pages
 html_context = {'html_baseurl': html_baseurl}


### PR DESCRIPTION
Related issue https://github.com/scylladb/sphinx-scylladb-theme/issues/88

Once this commit is merged, the docs will be published under the new domain name https://monitoring.docs.scylladb.com

## Frequently asked questions

> Should we change the links in the README/docs folder?

GitHub automatically handles the redirections. For example, https://scylladb.github.io/sphinx-scylladb-theme/stable/examples/index.html redirects to https://sphinx-theme.scylladb.com/stable/examples/index.html
Nevertheless, it would be great to change URLs progressively to avoid the 301 redirections.

> Do I need to add this new domain in the custom dns domain section on GitHub settings?

It is not necessary. We have already edited the DNS for this domain and the theme creates programmatically the required CNAME file. If everything goes well, GitHub should detect the new URL after this PR is merged.

> The DNS doesn't seem to have the right SSL certificates

GitHub handles the certificate provisioning but is not aware of the subdomain for this repo yet.  ``make multi-version`` will create a  new file "CNAME". This is published in `gh-pages` branch, therefore GitHub should create the missing cert.

## How to test this PR

1. Run ``make multiversion``.
2. You should see ``CNAME`` and ``.nojekyll`` files under the ``docs/_build/dirhtml`` folder.
3. The contents of the CNAME file should be ``monitoring.docs.scylladb.com``



