### PR TITLE
Add version variable

### DIFF
--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -13,7 +13,7 @@ sphinx-scylladb-theme = "~0.1.11"
 sphinx-sitemap = "2.1.0"
 sphinx-autobuild = "0.7.1"
 Sphinx = "2.4.4"
-sphinx-multiversion-scylla = "0.2.4"
+sphinx-multiversion-scylla = "0.2.5"
 [tool.poetry.dev-dependencies]
 pytest = "5.2"
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -90,14 +90,12 @@ def setup(sphinx):
     }, True)
     sphinx.add_transform(AutoStructify)
 
-
+# substitutions and variables - these are global to the entire Monitoring docs project.
 # Adds version variables for monitoring and manager versions when used in inline text
-
+# version should be set to the latest monitoring version
 rst_prolog = """
-.. |mon_version| replace:: 3.4
-.. |man_version| replace:: 2.0
-.. |mon_root| replace::  :doc:`Scylla Monitoring Stack </operating-scylla/monitoring/index>`
-""" 
+.. |version| replace:: 3.5.3
+"""
 
 # -- Options for HTML output ----------------------------------------------
 
@@ -250,3 +248,4 @@ epub_copyright = copyright
 
 # A list of files that should not be packed into the epub file.
 epub_exclude_files = ['search.html']
+

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -92,7 +92,8 @@ def setup(sphinx):
 
 # substitutions and variables - these are global to the entire Monitoring docs project.
 # Adds version variables for monitoring and manager versions when used in inline text
-# version should be set to the latest monitoring version
+# Version should be set to the latest monitoring version
+
 rst_prolog = """
 .. |version| replace:: 3.5.3
 """

--- a/docs/source/monitoring_stack.rst
+++ b/docs/source/monitoring_stack.rst
@@ -64,18 +64,20 @@ Install Scylla Monitoring
 .. _`Scylla Monitoring Stack binary`: https://github.com/scylladb/scylla-monitoring/releases
 
 .. code-block:: sh
+   :substitutions:
 
-   wget https://github.com/scylladb/scylla-monitoring/archive/scylla-monitoring-3.5.tar.gz
-   tar -xvf scylla-monitoring-3.5.tar.gz
-   cd scylla-monitoring-scylla-monitoring-3.5
+   wget https://github.com/scylladb/scylla-monitoring/archive/scylla-monitoring-|version|.tar.gz
+   tar -xvf scylla-monitoring-|version|.tar.gz
+   cd scylla-monitoring-scylla-monitoring-|version|
 
 As an alternative, you can clone and use the Git repository directly.
 
 .. code-block:: sh
+   :substitutions:
 
    git clone https://github.com/scylladb/scylla-monitoring.git
    cd scylla-monitoring
-   git checkout branch-3.5
+   git checkout branch-|version|
 
 2. Start Docker service if needed
 


### PR DESCRIPTION
this PR adds a Variable to the wget commands and others where a version number is used. 
it is set to 3.5.3, and should be set only to the 3.5.3 tag. 
@dgarcia360 should advise and review

FIX #1039