### PR TITLE
add version variable marker

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -95,10 +95,8 @@ def setup(sphinx):
 # Adds version variables for monitoring and manager versions when used in inline text
 
 rst_prolog = """
-.. |mon_version| replace:: 3.4
-.. |man_version| replace:: 2.0
-.. |mon_root| replace::  :doc:`Scylla Monitoring Stack </operating-scylla/monitoring/index>`
-""" 
+.. |version| replace:: 3.6.0
+"""
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/docs/source/monitoring_stack.rst
+++ b/docs/source/monitoring_stack.rst
@@ -65,9 +65,9 @@ Install Scylla Monitoring
 
 .. code-block:: sh
 
-   wget https://github.com/scylladb/scylla-monitoring/archive/scylla-monitoring-3.6.0.tar.gz
-   tar -xvf scylla-monitoring-3.6.0.tar.gz
-   cd scylla-monitoring-scylla-monitoring-3.6.0
+   wget https://github.com/scylladb/scylla-monitoring/archive/scylla-monitoring-|version|.tar.gz
+   tar -xvf scylla-monitoring-|version|.tar.gz
+   cd scylla-monitoring-scylla-monitoring-|version|
 
 As an alternative, you can clone and use the Git repository directly.
 
@@ -75,7 +75,7 @@ As an alternative, you can clone and use the Git repository directly.
 
    git clone https://github.com/scylladb/scylla-monitoring.git
    cd scylla-monitoring
-   git checkout branch-3.6
+   git checkout branch-|version|
 
 2. Start Docker service if needed
 

--- a/docs/source/monitoring_stack.rst
+++ b/docs/source/monitoring_stack.rst
@@ -75,7 +75,7 @@ As an alternative, you can clone and use the Git repository directly.
 
    git clone https://github.com/scylladb/scylla-monitoring.git
    cd scylla-monitoring
-   git checkout branch-|version|
+   git checkout branch-3.6
 
 2. Start Docker service if needed
 


### PR DESCRIPTION
this PR adds a Variable to the wget commands and others where a version number is used.
it is set to 3.6.0 and should be set only to the 3.6.0 tag.
@dgarcia360 should advise and review

FIX #1039
Replaces #1236 