### PR TITLE
Update pages.yml

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     env:
-      LATEST_VERSION: scylla-monitoring-3.5.2
+      LATEST_VERSION: scylla-monitoring-3.5.3
     steps:
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
update default latest version to 3.5.3
This will fix the error we currently have where 3.5.3 pages are marked old 