### PR TITLE
prometheus.rules.yml add node restart alert

### DIFF
--- a/prometheus/prometheus.rules.yml
+++ b/prometheus/prometheus.rules.yml
@@ -249,3 +249,11 @@ groups:
     annotations:
       description: 'Repair failed'
       summary: Repair task failed
+  - alert: restart
+    expr: resets(scylla_gossip_heart_beat[1h])>0
+    for: 10s
+    labels:
+      severity: "1"
+    annotations:
+      description: 'node restarted'
+      summary: Instance {{ $labels.instance }} restarted


### PR DESCRIPTION
The new alert will be on for an hour, it is set as priority 1, so it should not generate too much noise.
Fixes #1243