### PR TITLE
prometheus.rules.yml: Generate an alert when an OOM kill happens

### DIFF
--- a/prometheus/prometheus.rules.yml
+++ b/prometheus/prometheus.rules.yml
@@ -257,3 +257,11 @@ groups:
     annotations:
       description: 'node restarted'
       summary: Instance {{ $labels.instance }} restarted
+  - alert: oomKill
+    expr: changes(node_vmstat_oom_kill[1h])>0
+    for: 10s
+    labels:
+      severity: "2"
+    annotations:
+      description: 'OOM Kill on {{ $labels.instance }}'
+      summary: A process was terminate on Instance {{ $labels.instance }}


### PR DESCRIPTION
This patch adds an alert when ever an OOM kill is happend on a host.
The current alert only show that there was such a kill which is an indication that the node running out of memory but it does not indicate which process was terminated.

Fixes #1242 