### PR TITLE
set the overview as the home dashboard

### DIFF
--- a/start-grafana.sh
+++ b/start-grafana.sh
@@ -89,7 +89,7 @@ if [ -z $GRAFANA_PORT ]; then
         GRAFANA_NAME=agraf
     fi
 fi
-
+VERSION=`echo $VERSIONS|cut -d',' -f1`
 if [ -z $GRAFANA_NAME ]; then
     GRAFANA_NAME=agraf-$GRAFANA_PORT
 fi
@@ -161,6 +161,7 @@ docker run -d $DOCKER_PARAM -i $USER_PERMISSIONS $PORT_MAPPING \
      -e "GF_PATHS_PROVISIONING=/var/lib/grafana/provisioning" \
      -e "GF_SECURITY_ADMIN_PASSWORD=$GRAFANA_ADMIN_PASSWORD" \
      -e "GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=scylladb-scylla-datasource" \
+     -e "GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/var/lib/grafana/dashboards/ver_$VERSION/scylla-overview.$VERSION.json" \
      $GRAFANA_ENV_COMMAND \
      "${proxy_args[@]}" \
      --name $GRAFANA_NAME grafana/grafana:$GRAFANA_VERSION >& /dev/null


### PR DESCRIPTION
Finaly Grafana 7.4.0 solve the default home bug.
This patch set the overview dashboard as the home dashboard.

If multiple version are given to start-all.sh the first one will be picked for the home.

Fixes #677