### PR TITLE
Node table show errors

### DIFF
--- a/grafana/build/ver_2019.1/scylla-advanced.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-advanced.2019.1.json
@@ -630,7 +630,7 @@
             "pluginVersion": "7.1.3",
             "targets": [
                 {
-                    "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by (le))",
+                    "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"statement|$\"}[60s])) by (le))",
                     "instant": true,
                     "intervalFactor": 1,
                     "legendFormat": "",
@@ -756,7 +756,7 @@
             "pluginVersion": "7.1.3",
             "targets": [
                 {
-                    "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by (le))",
+                    "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"statement|$\"}[60s])) by (le))",
                     "instant": true,
                     "intervalFactor": 1,
                     "legendFormat": "",

--- a/grafana/build/ver_2019.1/scylla-overview.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-overview.2019.1.json
@@ -661,7 +661,7 @@
             "pluginVersion": "7.1.3",
             "targets": [
                 {
-                    "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by (le))",
+                    "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"statement|$\"}[60s])) by (le))",
                     "instant": true,
                     "intervalFactor": 1,
                     "legendFormat": "",
@@ -787,7 +787,7 @@
             "pluginVersion": "7.1.3",
             "targets": [
                 {
-                    "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by (le))",
+                    "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"statement|$\"}[60s])) by (le))",
                     "instant": true,
                     "intervalFactor": 1,
                     "legendFormat": "",
@@ -2224,7 +2224,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 90
+                                "value": 85
                             },
                             {
                                 "id": "displayName",
@@ -2240,7 +2240,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 120
+                                "value": 105
                             }
                         ]
                     },
@@ -2252,7 +2252,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 110
+                                "value": 105
                             },
                             {
                                 "id": "displayName",
@@ -2360,21 +2360,21 @@
                     {
                         "matcher": {
                             "id": "byName",
-                            "options": "CQL"
+                            "options": "Value #E"
                         },
                         "properties": [
                             {
                                 "id": "links",
                                 "value": [
                                     {
-                                        "title": "CQL Information Dashboard",
+                                        "title": "CQL Information Dashboard. Warning indicates that there are potential issues in the CQL Optimization",
                                         "url": "./d/cql-[[dash_version]]/scylla-cql?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
                                     }
                                 ]
                             },
                             {
                                 "id": "custom.width",
-                                "value": 120
+                                "value": 90
                             },
                             {
                                 "id": "custom.filterable",
@@ -2386,37 +2386,73 @@
                                     {
                                         "from": "",
                                         "id": 1,
-                                        "text": "CQL Dashboard",
+                                        "text": "CQL Info",
                                         "to": "",
                                         "type": 1,
-                                        "value": "cql"
+                                        "value": "0"
+                                    },
+                                    {
+                                        "from": "1",
+                                        "id": 1,
+                                        "text": "CQL Warnings",
+                                        "to": "20",
+                                        "type": 2,
+                                        "value": ""
                                     }
                                 ]
+                            },
+                            {
+                                "id": "thresholds",
+                                "value": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "rgba(0, 0, 0,0)",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "dark-orange",
+                                            "value": 1
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "custom.displayMode",
+                                "value": "color-background"
+                            },
+                            {
+                                "id": "custom.align",
+                                "value": "left"
+                            },
+                            {
+                                "id": "displayName",
+                                "value": "CQL"
                             }
                         ]
                     },
                     {
                         "matcher": {
                             "id": "byName",
-                            "options": "OS"
+                            "options": "Value #C"
                         },
                         "properties": [
                             {
                                 "id": "links",
                                 "value": [
                                     {
-                                        "title": "OS Information Dashboard",
+                                        "title": "OS Information Dashboard, an Error indicates there are OS related errors",
                                         "url": "./d/OS-[[dash_version]]/OS-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
                                     }
                                 ]
                             },
                             {
                                 "id": "custom.width",
-                                "value": 120
+                                "value": 90
                             },
                             {
                                 "id": "custom.filterable",
-                                "value": false
+                                "value": true
                             },
                             {
                                 "id": "mappings",
@@ -2424,12 +2460,122 @@
                                     {
                                         "from": "",
                                         "id": 1,
-                                        "text": "OS Dashboard",
+                                        "text": "OS Info",
                                         "to": "",
                                         "type": 1,
-                                        "value": "os"
+                                        "value": "0"
+                                    },
+                                    {
+                                        "from": "0",
+                                        "id": 2,
+                                        "text": "OS Errors",
+                                        "to": "100000",
+                                        "type": 2,
+                                        "value": "0"
                                     }
                                 ]
+                            },
+                            {
+                                "id": "thresholds",
+                                "value": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "rgba(0, 0, 0,0)",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "dark-orange",
+                                            "value": 0.001
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "custom.displayMode",
+                                "value": "color-background"
+                            },
+                            {
+                                "id": "custom.align",
+                                "value": "left"
+                            },
+                            {
+                                "id": "displayName",
+                                "value": "OS"
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "Value #D"
+                        },
+                        "properties": [
+                            {
+                                "id": "links",
+                                "value": [
+                                    {
+                                        "title": "Cordinator and Replica node errors",
+                                        "url": "./d/detailed-[[dash_version]]/Detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
+                                    }
+                                ]
+                            },
+                            {
+                                "id": "custom.width",
+                                "value": 80
+                            },
+                            {
+                                "id": "custom.filterable",
+                                "value": true
+                            },
+                            {
+                                "id": "mappings",
+                                "value": [
+                                    {
+                                        "from": "",
+                                        "id": 1,
+                                        "text": "",
+                                        "to": "",
+                                        "type": 1,
+                                        "value": "0"
+                                    },
+                                    {
+                                        "from": "",
+                                        "id": 2,
+                                        "text": "Errors",
+                                        "to": "",
+                                        "type": 1,
+                                        "value": "1"
+                                    }
+                                ]
+                            },
+                            {
+                                "id": "thresholds",
+                                "value": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "rgba(0, 0, 0,0)",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "dark-orange",
+                                            "value": 0.001
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "custom.displayMode",
+                                "value": "color-background"
+                            },
+                            {
+                                "id": "custom.align",
+                                "value": "left"
+                            },
+                            {
+                                "id": "displayName",
+                                "value": " "
                             }
                         ]
                     },
@@ -2485,6 +2631,30 @@
                     "interval": "",
                     "legendFormat": "",
                     "refId": "B"
+                },
+                {
+                    "expr": "sum(rate(scylla_reactor_aio_errors{cluster=~\"$cluster\", dc=~\"$dc\"}[1m])) by (instance)",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "C"
+                },
+                {
+                    "expr": "sum(errors:nodes_total{cluster=~\"$cluster\"}) by (instance) >bool 0",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "D"
+                },
+                {
+                    "expr": "(sum(cql:non_system_prepared1m{cluster=~\"$cluster\"}) by (instance) >bool 1) + (sum(rate(scylla_cql_reverse_queries{cluster=~\"$cluster\"}[60s])) by(instance) >bool 1) + (sum(cql:non_paged_no_system{cluster=~\"$cluster\"}) by (instance) >bool 1)",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "E"
                 }
             ],
             "title": "Nodes",
@@ -2498,8 +2668,9 @@
                                 "svr",
                                 "Value #A",
                                 "Value #B",
-                                "CQL",
-                                "OS"
+                                "Value #C",
+                                "Value #D",
+                                "Value #E"
                             ]
                         }
                     }
@@ -2508,6 +2679,22 @@
                     "id": "seriesToColumns",
                     "options": {
                         "byField": "instance"
+                    }
+                },
+                {
+                    "id": "organize",
+                    "options": {
+                        "excludeByName": {},
+                        "indexByName": {
+                            "Value #A": 5,
+                            "Value #B": 6,
+                            "Value #C": 3,
+                            "Value #D": 1,
+                            "Value #E": 2,
+                            "instance": 0,
+                            "svr": 4
+                        },
+                        "renameByName": {}
                     }
                 }
             ],

--- a/grafana/build/ver_2020.1/scylla-advanced.2020.1.json
+++ b/grafana/build/ver_2020.1/scylla-advanced.2020.1.json
@@ -630,7 +630,7 @@
             "pluginVersion": "7.1.3",
             "targets": [
                 {
-                    "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by (le))",
+                    "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"statement|$\"}[60s])) by (le))",
                     "instant": true,
                     "intervalFactor": 1,
                     "legendFormat": "",
@@ -756,7 +756,7 @@
             "pluginVersion": "7.1.3",
             "targets": [
                 {
-                    "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by (le))",
+                    "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"statement|$\"}[60s])) by (le))",
                     "instant": true,
                     "intervalFactor": 1,
                     "legendFormat": "",

--- a/grafana/build/ver_2020.1/scylla-overview.2020.1.json
+++ b/grafana/build/ver_2020.1/scylla-overview.2020.1.json
@@ -3066,7 +3066,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 90
+                                "value": 85
                             },
                             {
                                 "id": "displayName",
@@ -3082,7 +3082,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 120
+                                "value": 105
                             }
                         ]
                     },
@@ -3094,7 +3094,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 110
+                                "value": 105
                             },
                             {
                                 "id": "displayName",
@@ -3202,21 +3202,21 @@
                     {
                         "matcher": {
                             "id": "byName",
-                            "options": "CQL"
+                            "options": "Value #E"
                         },
                         "properties": [
                             {
                                 "id": "links",
                                 "value": [
                                     {
-                                        "title": "CQL Information Dashboard",
+                                        "title": "CQL Information Dashboard. Warning indicates that there are potential issues in the CQL Optimization",
                                         "url": "./d/cql-[[dash_version]]/scylla-cql?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
                                     }
                                 ]
                             },
                             {
                                 "id": "custom.width",
-                                "value": 120
+                                "value": 90
                             },
                             {
                                 "id": "custom.filterable",
@@ -3228,37 +3228,73 @@
                                     {
                                         "from": "",
                                         "id": 1,
-                                        "text": "CQL Dashboard",
+                                        "text": "CQL Info",
                                         "to": "",
                                         "type": 1,
-                                        "value": "cql"
+                                        "value": "0"
+                                    },
+                                    {
+                                        "from": "1",
+                                        "id": 1,
+                                        "text": "CQL Warnings",
+                                        "to": "20",
+                                        "type": 2,
+                                        "value": ""
                                     }
                                 ]
+                            },
+                            {
+                                "id": "thresholds",
+                                "value": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "rgba(0, 0, 0,0)",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "dark-orange",
+                                            "value": 1
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "custom.displayMode",
+                                "value": "color-background"
+                            },
+                            {
+                                "id": "custom.align",
+                                "value": "left"
+                            },
+                            {
+                                "id": "displayName",
+                                "value": "CQL"
                             }
                         ]
                     },
                     {
                         "matcher": {
                             "id": "byName",
-                            "options": "OS"
+                            "options": "Value #C"
                         },
                         "properties": [
                             {
                                 "id": "links",
                                 "value": [
                                     {
-                                        "title": "OS Information Dashboard",
+                                        "title": "OS Information Dashboard, an Error indicates there are OS related errors",
                                         "url": "./d/OS-[[dash_version]]/OS-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
                                     }
                                 ]
                             },
                             {
                                 "id": "custom.width",
-                                "value": 120
+                                "value": 90
                             },
                             {
                                 "id": "custom.filterable",
-                                "value": false
+                                "value": true
                             },
                             {
                                 "id": "mappings",
@@ -3266,12 +3302,122 @@
                                     {
                                         "from": "",
                                         "id": 1,
-                                        "text": "OS Dashboard",
+                                        "text": "OS Info",
                                         "to": "",
                                         "type": 1,
-                                        "value": "os"
+                                        "value": "0"
+                                    },
+                                    {
+                                        "from": "0",
+                                        "id": 2,
+                                        "text": "OS Errors",
+                                        "to": "100000",
+                                        "type": 2,
+                                        "value": "0"
                                     }
                                 ]
+                            },
+                            {
+                                "id": "thresholds",
+                                "value": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "rgba(0, 0, 0,0)",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "dark-orange",
+                                            "value": 0.001
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "custom.displayMode",
+                                "value": "color-background"
+                            },
+                            {
+                                "id": "custom.align",
+                                "value": "left"
+                            },
+                            {
+                                "id": "displayName",
+                                "value": "OS"
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "Value #D"
+                        },
+                        "properties": [
+                            {
+                                "id": "links",
+                                "value": [
+                                    {
+                                        "title": "Cordinator and Replica node errors",
+                                        "url": "./d/detailed-[[dash_version]]/Detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
+                                    }
+                                ]
+                            },
+                            {
+                                "id": "custom.width",
+                                "value": 80
+                            },
+                            {
+                                "id": "custom.filterable",
+                                "value": true
+                            },
+                            {
+                                "id": "mappings",
+                                "value": [
+                                    {
+                                        "from": "",
+                                        "id": 1,
+                                        "text": "",
+                                        "to": "",
+                                        "type": 1,
+                                        "value": "0"
+                                    },
+                                    {
+                                        "from": "",
+                                        "id": 2,
+                                        "text": "Errors",
+                                        "to": "",
+                                        "type": 1,
+                                        "value": "1"
+                                    }
+                                ]
+                            },
+                            {
+                                "id": "thresholds",
+                                "value": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "rgba(0, 0, 0,0)",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "dark-orange",
+                                            "value": 0.001
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "custom.displayMode",
+                                "value": "color-background"
+                            },
+                            {
+                                "id": "custom.align",
+                                "value": "left"
+                            },
+                            {
+                                "id": "displayName",
+                                "value": " "
                             }
                         ]
                     },
@@ -3327,6 +3473,30 @@
                     "interval": "",
                     "legendFormat": "",
                     "refId": "B"
+                },
+                {
+                    "expr": "sum(rate(scylla_reactor_aio_errors{cluster=~\"$cluster\", dc=~\"$dc\"}[1m])) by (instance)",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "C"
+                },
+                {
+                    "expr": "sum(errors:nodes_total{cluster=~\"$cluster\"}) by (instance) >bool 0",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "D"
+                },
+                {
+                    "expr": "(sum(cql:non_system_prepared1m{cluster=~\"$cluster\"}) by (instance) >bool 1) + (sum(rate(scylla_cql_reverse_queries{cluster=~\"$cluster\"}[60s])) by(instance) >bool 1) + (sum(cql:non_paged_no_system{cluster=~\"$cluster\"}) by (instance) >bool 1)",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "E"
                 }
             ],
             "title": "Nodes",
@@ -3340,8 +3510,9 @@
                                 "svr",
                                 "Value #A",
                                 "Value #B",
-                                "CQL",
-                                "OS"
+                                "Value #C",
+                                "Value #D",
+                                "Value #E"
                             ]
                         }
                     }
@@ -3350,6 +3521,22 @@
                     "id": "seriesToColumns",
                     "options": {
                         "byField": "instance"
+                    }
+                },
+                {
+                    "id": "organize",
+                    "options": {
+                        "excludeByName": {},
+                        "indexByName": {
+                            "Value #A": 5,
+                            "Value #B": 6,
+                            "Value #C": 3,
+                            "Value #D": 1,
+                            "Value #E": 2,
+                            "instance": 0,
+                            "svr": 4
+                        },
+                        "renameByName": {}
                     }
                 }
             ],

--- a/grafana/build/ver_4.1/scylla-advanced.4.1.json
+++ b/grafana/build/ver_4.1/scylla-advanced.4.1.json
@@ -630,7 +630,7 @@
             "pluginVersion": "7.1.3",
             "targets": [
                 {
-                    "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by (le))",
+                    "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"statement|$\"}[60s])) by (le))",
                     "instant": true,
                     "intervalFactor": 1,
                     "legendFormat": "",
@@ -756,7 +756,7 @@
             "pluginVersion": "7.1.3",
             "targets": [
                 {
-                    "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by (le))",
+                    "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"statement|$\"}[60s])) by (le))",
                     "instant": true,
                     "intervalFactor": 1,
                     "legendFormat": "",

--- a/grafana/build/ver_4.1/scylla-overview.4.1.json
+++ b/grafana/build/ver_4.1/scylla-overview.4.1.json
@@ -3050,7 +3050,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 90
+                                "value": 85
                             },
                             {
                                 "id": "displayName",
@@ -3066,7 +3066,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 120
+                                "value": 105
                             }
                         ]
                     },
@@ -3078,7 +3078,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 110
+                                "value": 105
                             },
                             {
                                 "id": "displayName",
@@ -3186,21 +3186,21 @@
                     {
                         "matcher": {
                             "id": "byName",
-                            "options": "CQL"
+                            "options": "Value #E"
                         },
                         "properties": [
                             {
                                 "id": "links",
                                 "value": [
                                     {
-                                        "title": "CQL Information Dashboard",
+                                        "title": "CQL Information Dashboard. Warning indicates that there are potential issues in the CQL Optimization",
                                         "url": "./d/cql-[[dash_version]]/scylla-cql?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
                                     }
                                 ]
                             },
                             {
                                 "id": "custom.width",
-                                "value": 120
+                                "value": 90
                             },
                             {
                                 "id": "custom.filterable",
@@ -3212,37 +3212,73 @@
                                     {
                                         "from": "",
                                         "id": 1,
-                                        "text": "CQL Dashboard",
+                                        "text": "CQL Info",
                                         "to": "",
                                         "type": 1,
-                                        "value": "cql"
+                                        "value": "0"
+                                    },
+                                    {
+                                        "from": "1",
+                                        "id": 1,
+                                        "text": "CQL Warnings",
+                                        "to": "20",
+                                        "type": 2,
+                                        "value": ""
                                     }
                                 ]
+                            },
+                            {
+                                "id": "thresholds",
+                                "value": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "rgba(0, 0, 0,0)",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "dark-orange",
+                                            "value": 1
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "custom.displayMode",
+                                "value": "color-background"
+                            },
+                            {
+                                "id": "custom.align",
+                                "value": "left"
+                            },
+                            {
+                                "id": "displayName",
+                                "value": "CQL"
                             }
                         ]
                     },
                     {
                         "matcher": {
                             "id": "byName",
-                            "options": "OS"
+                            "options": "Value #C"
                         },
                         "properties": [
                             {
                                 "id": "links",
                                 "value": [
                                     {
-                                        "title": "OS Information Dashboard",
+                                        "title": "OS Information Dashboard, an Error indicates there are OS related errors",
                                         "url": "./d/OS-[[dash_version]]/OS-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
                                     }
                                 ]
                             },
                             {
                                 "id": "custom.width",
-                                "value": 120
+                                "value": 90
                             },
                             {
                                 "id": "custom.filterable",
-                                "value": false
+                                "value": true
                             },
                             {
                                 "id": "mappings",
@@ -3250,12 +3286,122 @@
                                     {
                                         "from": "",
                                         "id": 1,
-                                        "text": "OS Dashboard",
+                                        "text": "OS Info",
                                         "to": "",
                                         "type": 1,
-                                        "value": "os"
+                                        "value": "0"
+                                    },
+                                    {
+                                        "from": "0",
+                                        "id": 2,
+                                        "text": "OS Errors",
+                                        "to": "100000",
+                                        "type": 2,
+                                        "value": "0"
                                     }
                                 ]
+                            },
+                            {
+                                "id": "thresholds",
+                                "value": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "rgba(0, 0, 0,0)",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "dark-orange",
+                                            "value": 0.001
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "custom.displayMode",
+                                "value": "color-background"
+                            },
+                            {
+                                "id": "custom.align",
+                                "value": "left"
+                            },
+                            {
+                                "id": "displayName",
+                                "value": "OS"
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "Value #D"
+                        },
+                        "properties": [
+                            {
+                                "id": "links",
+                                "value": [
+                                    {
+                                        "title": "Cordinator and Replica node errors",
+                                        "url": "./d/detailed-[[dash_version]]/Detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
+                                    }
+                                ]
+                            },
+                            {
+                                "id": "custom.width",
+                                "value": 80
+                            },
+                            {
+                                "id": "custom.filterable",
+                                "value": true
+                            },
+                            {
+                                "id": "mappings",
+                                "value": [
+                                    {
+                                        "from": "",
+                                        "id": 1,
+                                        "text": "",
+                                        "to": "",
+                                        "type": 1,
+                                        "value": "0"
+                                    },
+                                    {
+                                        "from": "",
+                                        "id": 2,
+                                        "text": "Errors",
+                                        "to": "",
+                                        "type": 1,
+                                        "value": "1"
+                                    }
+                                ]
+                            },
+                            {
+                                "id": "thresholds",
+                                "value": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "rgba(0, 0, 0,0)",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "dark-orange",
+                                            "value": 0.001
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "custom.displayMode",
+                                "value": "color-background"
+                            },
+                            {
+                                "id": "custom.align",
+                                "value": "left"
+                            },
+                            {
+                                "id": "displayName",
+                                "value": " "
                             }
                         ]
                     },
@@ -3311,6 +3457,30 @@
                     "interval": "",
                     "legendFormat": "",
                     "refId": "B"
+                },
+                {
+                    "expr": "sum(rate(scylla_reactor_aio_errors{cluster=~\"$cluster\", dc=~\"$dc\"}[1m])) by (instance)",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "C"
+                },
+                {
+                    "expr": "sum(errors:nodes_total{cluster=~\"$cluster\"}) by (instance) >bool 0",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "D"
+                },
+                {
+                    "expr": "(sum(cql:non_system_prepared1m{cluster=~\"$cluster\"}) by (instance) >bool 1) + (sum(rate(scylla_cql_reverse_queries{cluster=~\"$cluster\"}[60s])) by(instance) >bool 1) + (sum(cql:non_paged_no_system{cluster=~\"$cluster\"}) by (instance) >bool 1)",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "E"
                 }
             ],
             "title": "Nodes",
@@ -3324,8 +3494,9 @@
                                 "svr",
                                 "Value #A",
                                 "Value #B",
-                                "CQL",
-                                "OS"
+                                "Value #C",
+                                "Value #D",
+                                "Value #E"
                             ]
                         }
                     }
@@ -3334,6 +3505,22 @@
                     "id": "seriesToColumns",
                     "options": {
                         "byField": "instance"
+                    }
+                },
+                {
+                    "id": "organize",
+                    "options": {
+                        "excludeByName": {},
+                        "indexByName": {
+                            "Value #A": 5,
+                            "Value #B": 6,
+                            "Value #C": 3,
+                            "Value #D": 1,
+                            "Value #E": 2,
+                            "instance": 0,
+                            "svr": 4
+                        },
+                        "renameByName": {}
                     }
                 }
             ],

--- a/grafana/build/ver_4.2/scylla-advanced.4.2.json
+++ b/grafana/build/ver_4.2/scylla-advanced.4.2.json
@@ -630,7 +630,7 @@
             "pluginVersion": "7.1.3",
             "targets": [
                 {
-                    "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by (le))",
+                    "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"statement|$\"}[60s])) by (le))",
                     "instant": true,
                     "intervalFactor": 1,
                     "legendFormat": "",
@@ -756,7 +756,7 @@
             "pluginVersion": "7.1.3",
             "targets": [
                 {
-                    "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by (le))",
+                    "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"statement|$\"}[60s])) by (le))",
                     "instant": true,
                     "intervalFactor": 1,
                     "legendFormat": "",

--- a/grafana/build/ver_4.2/scylla-overview.4.2.json
+++ b/grafana/build/ver_4.2/scylla-overview.4.2.json
@@ -3066,7 +3066,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 90
+                                "value": 85
                             },
                             {
                                 "id": "displayName",
@@ -3082,7 +3082,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 120
+                                "value": 105
                             }
                         ]
                     },
@@ -3094,7 +3094,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 110
+                                "value": 105
                             },
                             {
                                 "id": "displayName",
@@ -3202,21 +3202,21 @@
                     {
                         "matcher": {
                             "id": "byName",
-                            "options": "CQL"
+                            "options": "Value #E"
                         },
                         "properties": [
                             {
                                 "id": "links",
                                 "value": [
                                     {
-                                        "title": "CQL Information Dashboard",
+                                        "title": "CQL Information Dashboard. Warning indicates that there are potential issues in the CQL Optimization",
                                         "url": "./d/cql-[[dash_version]]/scylla-cql?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
                                     }
                                 ]
                             },
                             {
                                 "id": "custom.width",
-                                "value": 120
+                                "value": 90
                             },
                             {
                                 "id": "custom.filterable",
@@ -3228,37 +3228,73 @@
                                     {
                                         "from": "",
                                         "id": 1,
-                                        "text": "CQL Dashboard",
+                                        "text": "CQL Info",
                                         "to": "",
                                         "type": 1,
-                                        "value": "cql"
+                                        "value": "0"
+                                    },
+                                    {
+                                        "from": "1",
+                                        "id": 1,
+                                        "text": "CQL Warnings",
+                                        "to": "20",
+                                        "type": 2,
+                                        "value": ""
                                     }
                                 ]
+                            },
+                            {
+                                "id": "thresholds",
+                                "value": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "rgba(0, 0, 0,0)",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "dark-orange",
+                                            "value": 1
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "custom.displayMode",
+                                "value": "color-background"
+                            },
+                            {
+                                "id": "custom.align",
+                                "value": "left"
+                            },
+                            {
+                                "id": "displayName",
+                                "value": "CQL"
                             }
                         ]
                     },
                     {
                         "matcher": {
                             "id": "byName",
-                            "options": "OS"
+                            "options": "Value #C"
                         },
                         "properties": [
                             {
                                 "id": "links",
                                 "value": [
                                     {
-                                        "title": "OS Information Dashboard",
+                                        "title": "OS Information Dashboard, an Error indicates there are OS related errors",
                                         "url": "./d/OS-[[dash_version]]/OS-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
                                     }
                                 ]
                             },
                             {
                                 "id": "custom.width",
-                                "value": 120
+                                "value": 90
                             },
                             {
                                 "id": "custom.filterable",
-                                "value": false
+                                "value": true
                             },
                             {
                                 "id": "mappings",
@@ -3266,12 +3302,122 @@
                                     {
                                         "from": "",
                                         "id": 1,
-                                        "text": "OS Dashboard",
+                                        "text": "OS Info",
                                         "to": "",
                                         "type": 1,
-                                        "value": "os"
+                                        "value": "0"
+                                    },
+                                    {
+                                        "from": "0",
+                                        "id": 2,
+                                        "text": "OS Errors",
+                                        "to": "100000",
+                                        "type": 2,
+                                        "value": "0"
                                     }
                                 ]
+                            },
+                            {
+                                "id": "thresholds",
+                                "value": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "rgba(0, 0, 0,0)",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "dark-orange",
+                                            "value": 0.001
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "custom.displayMode",
+                                "value": "color-background"
+                            },
+                            {
+                                "id": "custom.align",
+                                "value": "left"
+                            },
+                            {
+                                "id": "displayName",
+                                "value": "OS"
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "Value #D"
+                        },
+                        "properties": [
+                            {
+                                "id": "links",
+                                "value": [
+                                    {
+                                        "title": "Cordinator and Replica node errors",
+                                        "url": "./d/detailed-[[dash_version]]/Detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
+                                    }
+                                ]
+                            },
+                            {
+                                "id": "custom.width",
+                                "value": 80
+                            },
+                            {
+                                "id": "custom.filterable",
+                                "value": true
+                            },
+                            {
+                                "id": "mappings",
+                                "value": [
+                                    {
+                                        "from": "",
+                                        "id": 1,
+                                        "text": "",
+                                        "to": "",
+                                        "type": 1,
+                                        "value": "0"
+                                    },
+                                    {
+                                        "from": "",
+                                        "id": 2,
+                                        "text": "Errors",
+                                        "to": "",
+                                        "type": 1,
+                                        "value": "1"
+                                    }
+                                ]
+                            },
+                            {
+                                "id": "thresholds",
+                                "value": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "rgba(0, 0, 0,0)",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "dark-orange",
+                                            "value": 0.001
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "custom.displayMode",
+                                "value": "color-background"
+                            },
+                            {
+                                "id": "custom.align",
+                                "value": "left"
+                            },
+                            {
+                                "id": "displayName",
+                                "value": " "
                             }
                         ]
                     },
@@ -3327,6 +3473,30 @@
                     "interval": "",
                     "legendFormat": "",
                     "refId": "B"
+                },
+                {
+                    "expr": "sum(rate(scylla_reactor_aio_errors{cluster=~\"$cluster\", dc=~\"$dc\"}[1m])) by (instance)",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "C"
+                },
+                {
+                    "expr": "sum(errors:nodes_total{cluster=~\"$cluster\"}) by (instance) >bool 0",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "D"
+                },
+                {
+                    "expr": "(sum(cql:non_system_prepared1m{cluster=~\"$cluster\"}) by (instance) >bool 1) + (sum(rate(scylla_cql_reverse_queries{cluster=~\"$cluster\"}[60s])) by(instance) >bool 1) + (sum(cql:non_paged_no_system{cluster=~\"$cluster\"}) by (instance) >bool 1)",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "E"
                 }
             ],
             "title": "Nodes",
@@ -3340,8 +3510,9 @@
                                 "svr",
                                 "Value #A",
                                 "Value #B",
-                                "CQL",
-                                "OS"
+                                "Value #C",
+                                "Value #D",
+                                "Value #E"
                             ]
                         }
                     }
@@ -3350,6 +3521,22 @@
                     "id": "seriesToColumns",
                     "options": {
                         "byField": "instance"
+                    }
+                },
+                {
+                    "id": "organize",
+                    "options": {
+                        "excludeByName": {},
+                        "indexByName": {
+                            "Value #A": 5,
+                            "Value #B": 6,
+                            "Value #C": 3,
+                            "Value #D": 1,
+                            "Value #E": 2,
+                            "instance": 0,
+                            "svr": 4
+                        },
+                        "renameByName": {}
                     }
                 }
             ],

--- a/grafana/build/ver_4.3/scylla-advanced.4.3.json
+++ b/grafana/build/ver_4.3/scylla-advanced.4.3.json
@@ -630,7 +630,7 @@
             "pluginVersion": "7.1.3",
             "targets": [
                 {
-                    "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by (le))",
+                    "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"statement|$\"}[60s])) by (le))",
                     "instant": true,
                     "intervalFactor": 1,
                     "legendFormat": "",
@@ -756,7 +756,7 @@
             "pluginVersion": "7.1.3",
             "targets": [
                 {
-                    "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by (le))",
+                    "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"statement|$\"}[60s])) by (le))",
                     "instant": true,
                     "intervalFactor": 1,
                     "legendFormat": "",

--- a/grafana/build/ver_4.3/scylla-overview.4.3.json
+++ b/grafana/build/ver_4.3/scylla-overview.4.3.json
@@ -3066,7 +3066,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 90
+                                "value": 85
                             },
                             {
                                 "id": "displayName",
@@ -3082,7 +3082,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 120
+                                "value": 105
                             }
                         ]
                     },
@@ -3094,7 +3094,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 110
+                                "value": 105
                             },
                             {
                                 "id": "displayName",
@@ -3202,21 +3202,21 @@
                     {
                         "matcher": {
                             "id": "byName",
-                            "options": "CQL"
+                            "options": "Value #E"
                         },
                         "properties": [
                             {
                                 "id": "links",
                                 "value": [
                                     {
-                                        "title": "CQL Information Dashboard",
+                                        "title": "CQL Information Dashboard. Warning indicates that there are potential issues in the CQL Optimization",
                                         "url": "./d/cql-[[dash_version]]/scylla-cql?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
                                     }
                                 ]
                             },
                             {
                                 "id": "custom.width",
-                                "value": 120
+                                "value": 90
                             },
                             {
                                 "id": "custom.filterable",
@@ -3228,37 +3228,73 @@
                                     {
                                         "from": "",
                                         "id": 1,
-                                        "text": "CQL Dashboard",
+                                        "text": "CQL Info",
                                         "to": "",
                                         "type": 1,
-                                        "value": "cql"
+                                        "value": "0"
+                                    },
+                                    {
+                                        "from": "1",
+                                        "id": 1,
+                                        "text": "CQL Warnings",
+                                        "to": "20",
+                                        "type": 2,
+                                        "value": ""
                                     }
                                 ]
+                            },
+                            {
+                                "id": "thresholds",
+                                "value": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "rgba(0, 0, 0,0)",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "dark-orange",
+                                            "value": 1
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "custom.displayMode",
+                                "value": "color-background"
+                            },
+                            {
+                                "id": "custom.align",
+                                "value": "left"
+                            },
+                            {
+                                "id": "displayName",
+                                "value": "CQL"
                             }
                         ]
                     },
                     {
                         "matcher": {
                             "id": "byName",
-                            "options": "OS"
+                            "options": "Value #C"
                         },
                         "properties": [
                             {
                                 "id": "links",
                                 "value": [
                                     {
-                                        "title": "OS Information Dashboard",
+                                        "title": "OS Information Dashboard, an Error indicates there are OS related errors",
                                         "url": "./d/OS-[[dash_version]]/OS-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
                                     }
                                 ]
                             },
                             {
                                 "id": "custom.width",
-                                "value": 120
+                                "value": 90
                             },
                             {
                                 "id": "custom.filterable",
-                                "value": false
+                                "value": true
                             },
                             {
                                 "id": "mappings",
@@ -3266,12 +3302,122 @@
                                     {
                                         "from": "",
                                         "id": 1,
-                                        "text": "OS Dashboard",
+                                        "text": "OS Info",
                                         "to": "",
                                         "type": 1,
-                                        "value": "os"
+                                        "value": "0"
+                                    },
+                                    {
+                                        "from": "0",
+                                        "id": 2,
+                                        "text": "OS Errors",
+                                        "to": "100000",
+                                        "type": 2,
+                                        "value": "0"
                                     }
                                 ]
+                            },
+                            {
+                                "id": "thresholds",
+                                "value": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "rgba(0, 0, 0,0)",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "dark-orange",
+                                            "value": 0.001
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "custom.displayMode",
+                                "value": "color-background"
+                            },
+                            {
+                                "id": "custom.align",
+                                "value": "left"
+                            },
+                            {
+                                "id": "displayName",
+                                "value": "OS"
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "Value #D"
+                        },
+                        "properties": [
+                            {
+                                "id": "links",
+                                "value": [
+                                    {
+                                        "title": "Cordinator and Replica node errors",
+                                        "url": "./d/detailed-[[dash_version]]/Detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
+                                    }
+                                ]
+                            },
+                            {
+                                "id": "custom.width",
+                                "value": 80
+                            },
+                            {
+                                "id": "custom.filterable",
+                                "value": true
+                            },
+                            {
+                                "id": "mappings",
+                                "value": [
+                                    {
+                                        "from": "",
+                                        "id": 1,
+                                        "text": "",
+                                        "to": "",
+                                        "type": 1,
+                                        "value": "0"
+                                    },
+                                    {
+                                        "from": "",
+                                        "id": 2,
+                                        "text": "Errors",
+                                        "to": "",
+                                        "type": 1,
+                                        "value": "1"
+                                    }
+                                ]
+                            },
+                            {
+                                "id": "thresholds",
+                                "value": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "rgba(0, 0, 0,0)",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "dark-orange",
+                                            "value": 0.001
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "custom.displayMode",
+                                "value": "color-background"
+                            },
+                            {
+                                "id": "custom.align",
+                                "value": "left"
+                            },
+                            {
+                                "id": "displayName",
+                                "value": " "
                             }
                         ]
                     },
@@ -3327,6 +3473,30 @@
                     "interval": "",
                     "legendFormat": "",
                     "refId": "B"
+                },
+                {
+                    "expr": "sum(rate(scylla_reactor_aio_errors{cluster=~\"$cluster\", dc=~\"$dc\"}[1m])) by (instance)",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "C"
+                },
+                {
+                    "expr": "sum(errors:nodes_total{cluster=~\"$cluster\"}) by (instance) >bool 0",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "D"
+                },
+                {
+                    "expr": "(sum(cql:non_system_prepared1m{cluster=~\"$cluster\"}) by (instance) >bool 1) + (sum(rate(scylla_cql_reverse_queries{cluster=~\"$cluster\"}[60s])) by(instance) >bool 1) + (sum(cql:non_paged_no_system{cluster=~\"$cluster\"}) by (instance) >bool 1)",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "E"
                 }
             ],
             "title": "Nodes",
@@ -3340,8 +3510,9 @@
                                 "svr",
                                 "Value #A",
                                 "Value #B",
-                                "CQL",
-                                "OS"
+                                "Value #C",
+                                "Value #D",
+                                "Value #E"
                             ]
                         }
                     }
@@ -3350,6 +3521,22 @@
                     "id": "seriesToColumns",
                     "options": {
                         "byField": "instance"
+                    }
+                },
+                {
+                    "id": "organize",
+                    "options": {
+                        "excludeByName": {},
+                        "indexByName": {
+                            "Value #A": 5,
+                            "Value #B": 6,
+                            "Value #C": 3,
+                            "Value #D": 1,
+                            "Value #E": 2,
+                            "instance": 0,
+                            "svr": 4
+                        },
+                        "renameByName": {}
                     }
                 }
             ],

--- a/grafana/build/ver_4.4/scylla-overview.4.4.json
+++ b/grafana/build/ver_4.4/scylla-overview.4.4.json
@@ -3066,7 +3066,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 90
+                                "value": 85
                             },
                             {
                                 "id": "displayName",
@@ -3082,7 +3082,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 120
+                                "value": 105
                             }
                         ]
                     },
@@ -3094,7 +3094,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 110
+                                "value": 105
                             },
                             {
                                 "id": "displayName",
@@ -3202,21 +3202,21 @@
                     {
                         "matcher": {
                             "id": "byName",
-                            "options": "CQL"
+                            "options": "Value #E"
                         },
                         "properties": [
                             {
                                 "id": "links",
                                 "value": [
                                     {
-                                        "title": "CQL Information Dashboard",
+                                        "title": "CQL Information Dashboard. Warning indicates that there are potential issues in the CQL Optimization",
                                         "url": "./d/cql-[[dash_version]]/scylla-cql?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
                                     }
                                 ]
                             },
                             {
                                 "id": "custom.width",
-                                "value": 120
+                                "value": 90
                             },
                             {
                                 "id": "custom.filterable",
@@ -3228,12 +3228,48 @@
                                     {
                                         "from": "",
                                         "id": 1,
-                                        "text": "CQL Dashboard",
+                                        "text": "CQL Info",
                                         "to": "",
                                         "type": 1,
-                                        "value": "cql"
+                                        "value": "0"
+                                    },
+                                    {
+                                        "from": "1",
+                                        "id": 1,
+                                        "text": "CQL Warnings",
+                                        "to": "20",
+                                        "type": 2,
+                                        "value": ""
                                     }
                                 ]
+                            },
+                            {
+                                "id": "thresholds",
+                                "value": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "rgba(0, 0, 0,0)",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "dark-orange",
+                                            "value": 1
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "custom.displayMode",
+                                "value": "color-background"
+                            },
+                            {
+                                "id": "custom.align",
+                                "value": "left"
+                            },
+                            {
+                                "id": "displayName",
+                                "value": "CQL"
                             }
                         ]
                     },
@@ -3247,14 +3283,14 @@
                                 "id": "links",
                                 "value": [
                                     {
-                                        "title": "OS Information Dashboard",
+                                        "title": "OS Information Dashboard, an Error indicates there are OS related errors",
                                         "url": "./d/OS-[[dash_version]]/OS-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
                                     }
                                 ]
                             },
                             {
                                 "id": "custom.width",
-                                "value": 120
+                                "value": 90
                             },
                             {
                                 "id": "custom.filterable",
@@ -3266,7 +3302,7 @@
                                     {
                                         "from": "",
                                         "id": 1,
-                                        "text": "OS Dashboard",
+                                        "text": "OS Info",
                                         "to": "",
                                         "type": 1,
                                         "value": "0"
@@ -3308,6 +3344,80 @@
                             {
                                 "id": "displayName",
                                 "value": "OS"
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "Value #D"
+                        },
+                        "properties": [
+                            {
+                                "id": "links",
+                                "value": [
+                                    {
+                                        "title": "Cordinator and Replica node errors",
+                                        "url": "./d/detailed-[[dash_version]]/Detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
+                                    }
+                                ]
+                            },
+                            {
+                                "id": "custom.width",
+                                "value": 80
+                            },
+                            {
+                                "id": "custom.filterable",
+                                "value": true
+                            },
+                            {
+                                "id": "mappings",
+                                "value": [
+                                    {
+                                        "from": "",
+                                        "id": 1,
+                                        "text": "",
+                                        "to": "",
+                                        "type": 1,
+                                        "value": "0"
+                                    },
+                                    {
+                                        "from": "",
+                                        "id": 2,
+                                        "text": "Errors",
+                                        "to": "",
+                                        "type": 1,
+                                        "value": "1"
+                                    }
+                                ]
+                            },
+                            {
+                                "id": "thresholds",
+                                "value": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "rgba(0, 0, 0,0)",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "dark-orange",
+                                            "value": 0.001
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "custom.displayMode",
+                                "value": "color-background"
+                            },
+                            {
+                                "id": "custom.align",
+                                "value": "left"
+                            },
+                            {
+                                "id": "displayName",
+                                "value": " "
                             }
                         ]
                     },
@@ -3371,6 +3481,22 @@
                     "interval": "",
                     "legendFormat": "",
                     "refId": "C"
+                },
+                {
+                    "expr": "sum(errors:nodes_total{cluster=~\"$cluster\"}) by (instance) >bool 0",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "D"
+                },
+                {
+                    "expr": "(sum(cql:non_system_prepared1m{cluster=~\"$cluster\"}) by (instance) >bool 1) + (sum(rate(scylla_cql_reverse_queries{cluster=~\"$cluster\"}[60s])) by(instance) >bool 1) + (sum(cql:non_paged_no_system{cluster=~\"$cluster\"}) by (instance) >bool 1)",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "E"
                 }
             ],
             "title": "Nodes",
@@ -3384,8 +3510,9 @@
                                 "svr",
                                 "Value #A",
                                 "Value #B",
-                                "CQL",
-                                "Value #C"
+                                "Value #C",
+                                "Value #D",
+                                "Value #E"
                             ]
                         }
                     }
@@ -3401,12 +3528,13 @@
                     "options": {
                         "excludeByName": {},
                         "indexByName": {
-                            "CQL": 1,
-                            "Value #A": 4,
-                            "Value #B": 5,
-                            "Value #C": 2,
+                            "Value #A": 5,
+                            "Value #B": 6,
+                            "Value #C": 3,
+                            "Value #D": 1,
+                            "Value #E": 2,
                             "instance": 0,
-                            "svr": 3
+                            "svr": 4
                         },
                         "renameByName": {}
                     }

--- a/grafana/build/ver_master/scylla-overview.master.json
+++ b/grafana/build/ver_master/scylla-overview.master.json
@@ -3066,7 +3066,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 90
+                                "value": 85
                             },
                             {
                                 "id": "displayName",
@@ -3082,7 +3082,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 120
+                                "value": 105
                             }
                         ]
                     },
@@ -3094,7 +3094,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 110
+                                "value": 105
                             },
                             {
                                 "id": "displayName",
@@ -3202,21 +3202,21 @@
                     {
                         "matcher": {
                             "id": "byName",
-                            "options": "CQL"
+                            "options": "Value #E"
                         },
                         "properties": [
                             {
                                 "id": "links",
                                 "value": [
                                     {
-                                        "title": "CQL Information Dashboard",
+                                        "title": "CQL Information Dashboard. Warning indicates that there are potential issues in the CQL Optimization",
                                         "url": "./d/cql-[[dash_version]]/scylla-cql?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
                                     }
                                 ]
                             },
                             {
                                 "id": "custom.width",
-                                "value": 120
+                                "value": 90
                             },
                             {
                                 "id": "custom.filterable",
@@ -3228,37 +3228,73 @@
                                     {
                                         "from": "",
                                         "id": 1,
-                                        "text": "CQL Dashboard",
+                                        "text": "CQL Info",
                                         "to": "",
                                         "type": 1,
-                                        "value": "cql"
+                                        "value": "0"
+                                    },
+                                    {
+                                        "from": "1",
+                                        "id": 1,
+                                        "text": "CQL Warnings",
+                                        "to": "20",
+                                        "type": 2,
+                                        "value": ""
                                     }
                                 ]
+                            },
+                            {
+                                "id": "thresholds",
+                                "value": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "rgba(0, 0, 0,0)",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "dark-orange",
+                                            "value": 1
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "custom.displayMode",
+                                "value": "color-background"
+                            },
+                            {
+                                "id": "custom.align",
+                                "value": "left"
+                            },
+                            {
+                                "id": "displayName",
+                                "value": "CQL"
                             }
                         ]
                     },
                     {
                         "matcher": {
                             "id": "byName",
-                            "options": "OS"
+                            "options": "Value #C"
                         },
                         "properties": [
                             {
                                 "id": "links",
                                 "value": [
                                     {
-                                        "title": "OS Information Dashboard",
+                                        "title": "OS Information Dashboard, an Error indicates there are OS related errors",
                                         "url": "./d/OS-[[dash_version]]/OS-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
                                     }
                                 ]
                             },
                             {
                                 "id": "custom.width",
-                                "value": 120
+                                "value": 90
                             },
                             {
                                 "id": "custom.filterable",
-                                "value": false
+                                "value": true
                             },
                             {
                                 "id": "mappings",
@@ -3266,12 +3302,122 @@
                                     {
                                         "from": "",
                                         "id": 1,
-                                        "text": "OS Dashboard",
+                                        "text": "OS Info",
                                         "to": "",
                                         "type": 1,
-                                        "value": "os"
+                                        "value": "0"
+                                    },
+                                    {
+                                        "from": "0",
+                                        "id": 2,
+                                        "text": "OS Errors",
+                                        "to": "100000",
+                                        "type": 2,
+                                        "value": "0"
                                     }
                                 ]
+                            },
+                            {
+                                "id": "thresholds",
+                                "value": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "rgba(0, 0, 0,0)",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "dark-orange",
+                                            "value": 0.001
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "custom.displayMode",
+                                "value": "color-background"
+                            },
+                            {
+                                "id": "custom.align",
+                                "value": "left"
+                            },
+                            {
+                                "id": "displayName",
+                                "value": "OS"
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "Value #D"
+                        },
+                        "properties": [
+                            {
+                                "id": "links",
+                                "value": [
+                                    {
+                                        "title": "Cordinator and Replica node errors",
+                                        "url": "./d/detailed-[[dash_version]]/Detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
+                                    }
+                                ]
+                            },
+                            {
+                                "id": "custom.width",
+                                "value": 80
+                            },
+                            {
+                                "id": "custom.filterable",
+                                "value": true
+                            },
+                            {
+                                "id": "mappings",
+                                "value": [
+                                    {
+                                        "from": "",
+                                        "id": 1,
+                                        "text": "",
+                                        "to": "",
+                                        "type": 1,
+                                        "value": "0"
+                                    },
+                                    {
+                                        "from": "",
+                                        "id": 2,
+                                        "text": "Errors",
+                                        "to": "",
+                                        "type": 1,
+                                        "value": "1"
+                                    }
+                                ]
+                            },
+                            {
+                                "id": "thresholds",
+                                "value": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "rgba(0, 0, 0,0)",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "dark-orange",
+                                            "value": 0.001
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "custom.displayMode",
+                                "value": "color-background"
+                            },
+                            {
+                                "id": "custom.align",
+                                "value": "left"
+                            },
+                            {
+                                "id": "displayName",
+                                "value": " "
                             }
                         ]
                     },
@@ -3327,6 +3473,30 @@
                     "interval": "",
                     "legendFormat": "",
                     "refId": "B"
+                },
+                {
+                    "expr": "sum(rate(scylla_reactor_aio_errors{cluster=~\"$cluster\", dc=~\"$dc\"}[1m])) by (instance)",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "C"
+                },
+                {
+                    "expr": "sum(errors:nodes_total{cluster=~\"$cluster\"}) by (instance) >bool 0",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "D"
+                },
+                {
+                    "expr": "(sum(cql:non_system_prepared1m{cluster=~\"$cluster\"}) by (instance) >bool 1) + (sum(rate(scylla_cql_reverse_queries{cluster=~\"$cluster\"}[60s])) by(instance) >bool 1) + (sum(cql:non_paged_no_system{cluster=~\"$cluster\"}) by (instance) >bool 1)",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "E"
                 }
             ],
             "title": "Nodes",
@@ -3340,8 +3510,9 @@
                                 "svr",
                                 "Value #A",
                                 "Value #B",
-                                "CQL",
-                                "OS"
+                                "Value #C",
+                                "Value #D",
+                                "Value #E"
                             ]
                         }
                     }
@@ -3350,6 +3521,22 @@
                     "id": "seriesToColumns",
                     "options": {
                         "byField": "instance"
+                    }
+                },
+                {
+                    "id": "organize",
+                    "options": {
+                        "excludeByName": {},
+                        "indexByName": {
+                            "Value #A": 5,
+                            "Value #B": 6,
+                            "Value #C": 3,
+                            "Value #D": 1,
+                            "Value #E": 2,
+                            "instance": 0,
+                            "svr": 4
+                        },
+                        "renameByName": {}
                     }
                 }
             ],

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -1974,6 +1974,30 @@
               "refId": "B",
               "instant": true,
               "format": "table"
+            },
+            {
+              "expr": "sum(rate(scylla_reactor_aio_errors{cluster=~\"$cluster\", dc=~\"$dc\"}[1m])) by (instance)",
+              "legendFormat": "",
+              "interval": "",
+              "refId": "C",
+              "instant": true,
+              "format": "table"
+            },
+            {
+              "expr": "sum(errors:nodes_total{cluster=~\"$cluster\"}) by (instance) >bool 0",
+              "legendFormat": "",
+              "interval": "",
+              "refId": "D",
+              "instant": true,
+              "format": "table"
+            },
+            {
+              "expr": "(sum(cql:non_system_prepared1m{cluster=~\"$cluster\"}) by (instance) >bool 1) + (sum(rate(scylla_cql_reverse_queries{cluster=~\"$cluster\"}[60s])) by(instance) >bool 1) + (sum(cql:non_paged_no_system{cluster=~\"$cluster\"}) by (instance) >bool 1)",
+              "legendFormat": "",
+              "interval": "",
+              "refId": "E",
+              "instant": true,
+              "format": "table"
             }
           ],
           "type": "table",
@@ -2046,7 +2070,7 @@
                 "properties": [
                   {
                     "id": "custom.width",
-                    "value": 90
+                    "value": 85
                   },
                   {
                     "id": "displayName",
@@ -2062,7 +2086,7 @@
                 "properties": [
                   {
                     "id": "custom.width",
-                    "value": 120
+                    "value": 105
                   }
                 ]
               },
@@ -2074,7 +2098,7 @@
                 "properties": [
                   {
                     "id": "custom.width",
-                    "value": 110
+                    "value": 105
                   },
                   {
                     "id": "displayName",
@@ -2182,21 +2206,21 @@
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "CQL"
+                  "options": "Value #E"
                 },
                 "properties": [
                   {
                     "id": "links",
                     "value": [
                       {
-                        "title": "CQL Information Dashboard",
+                        "title": "CQL Information Dashboard. Warning indicates that there are potential issues in the CQL Optimization",
                         "url": "./d/cql-[[dash_version]]/scylla-cql?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
                       }
                     ]
                   },
                   {
                     "id": "custom.width",
-                    "value": 120
+                    "value": 90
                   },
                   {
                     "id": "custom.filterable",
@@ -2210,48 +2234,194 @@
                         "type": 1,
                         "from": "",
                         "to": "",
-                        "text": "CQL Dashboard",
-                        "value": "cql"
+                        "text": "CQL Info",
+                        "value": "0"
+                      },
+                      {
+                        "id": 1,
+                        "type": 2,
+                        "from": "1",
+                        "to": "20",
+                        "text": "CQL Warnings",
+                        "value": ""
                       }
                     ]
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "rgba(0, 0, 0,0)",
+                          "value": null
+                        },
+                        {
+                          "color": "dark-orange",
+                          "value": 1
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "custom.displayMode",
+                    "value": "color-background"
+                  },
+                  {
+                    "id": "custom.align",
+                    "value": "left"
+                  },
+                  {
+                    "id": "displayName",
+                    "value": "CQL"
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "OS"
+                  "options": "Value #C"
                 },
                 "properties": [
                   {
                     "id": "links",
                     "value": [
                       {
-                        "title": "OS Information Dashboard",
+                        "title": "OS Information Dashboard, an Error indicates there are OS related errors",
                         "url": "./d/OS-[[dash_version]]/OS-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
                       }
                     ]
                   },
                   {
                     "id": "custom.width",
-                    "value": 120
+                    "value": 90
                   },
                   {
                     "id": "custom.filterable",
-                    "value": false
+                    "value": true
                   },
                   {
                     "id": "mappings",
                     "value": [
                       {
+                        "from": "",
                         "id": 1,
+                        "text": "OS Info",
+                        "to": "",
+                        "type": 1,
+                        "value": "0"
+                      },
+                      {
+                        "id": 2,
+                        "type": 2,
+                        "from": "0",
+                        "to": "100000",
+                        "text": "OS Errors",
+                        "value": "0"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "rgba(0, 0, 0,0)",
+                          "value": null
+                        },
+                        {
+                          "color": "dark-orange",
+                          "value": 0.001
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "custom.displayMode",
+                    "value": "color-background"
+                  },
+                  {
+                    "id": "custom.align",
+                    "value": "left"
+                  },
+                  {
+                    "id": "displayName",
+                    "value": "OS"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Value #D"
+                },
+                "properties": [
+                  {
+                    "id": "links",
+                    "value": [
+                      {
+                        "title": "Cordinator and Replica node errors",
+                        "url": "./d/detailed-[[dash_version]]/Detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 80
+                  },
+                  {
+                    "id": "custom.filterable",
+                    "value": true
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "from": "",
+                        "id": 1,
+                        "text": "",
+                        "to": "",
+                        "type": 1,
+                        "value": "0"
+                      },
+                      {
+                        "id": 2,
                         "type": 1,
                         "from": "",
                         "to": "",
-                        "text": "OS Dashboard",
-                        "value": "os"
+                        "text": "Errors",
+                        "value": "1"
                       }
                     ]
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "rgba(0, 0, 0,0)",
+                          "value": null
+                        },
+                        {
+                          "color": "dark-orange",
+                          "value": 0.001
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "custom.displayMode",
+                    "value": "color-background"
+                  },
+                  {
+                    "id": "custom.align",
+                    "value": "left"
+                  },
+                  {
+                    "id": "displayName",
+                    "value": " "
                   }
                 ]
               },
@@ -2290,8 +2460,9 @@
                     "svr",
                     "Value #A",
                     "Value #B",
-                    "CQL",
-                    "OS"
+                    "Value #C",
+                    "Value #D",
+                    "Value #E"
                   ]
                 }
               }
@@ -2300,6 +2471,22 @@
               "id": "seriesToColumns",
               "options": {
                 "byField": "instance"
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {},
+                "indexByName": {
+                  "instance": 0,
+                  "Value #D": 1,
+                  "Value #E": 2,
+                  "Value #C": 3,
+                  "svr": 4,
+                  "Value #A": 5,
+                  "Value #B": 6
+                },
+                "renameByName": {}
               }
             }
           ]

--- a/prometheus/prometheus.rules.yml
+++ b/prometheus/prometheus.rules.yml
@@ -13,6 +13,8 @@ groups:
     expr: clamp_min(sum(rate(scylla_query_processor_statements_prepared[1m])) by (cluster, dc, instance, shard) - cql:all_system_shardrate1m, 0)
   - record: cql:non_prepared
     expr: (sum(cql:non_system_prepared1m) by (cluster) >bool 10) * (sum(cql:non_system_prepared1m)  by (cluster) / clamp_min(sum(cql:all_rate1m) - sum(cql:all_system_shardrate1m) by (cluster), 0.001))
+  - record: cql:non_paged_no_system
+    expr: clamp_min(sum(rate(scylla_cql_unpaged_select_queries[60s])) by (cluster, instance) - sum(rate(scylla_cql_unpaged_select_queries_per_ks{ks="system"}[60s])) by (cluster, instance), 0)
   - record: cql:non_paged
     expr: sum(rate(scylla_cql_unpaged_select_queries[60s])) by (cluster)/sum(rate(scylla_cql_reads{}[60s])) by (cluster)
   - record: cql:reverse_queries
@@ -27,6 +29,8 @@ groups:
     expr: sum(rate(scylla_storage_proxy_coordinator_read_unavailable[60s])) by (cluster, instance) + sum(rate(scylla_storage_proxy_coordinator_write_unavailable[60s])) by (cluster, instance) + sum(rate(scylla_storage_proxy_coordinator_range_unavailable[60s])) by (cluster, instance)
   - record: errors:local_failed
     expr: sum(rate(scylla_storage_proxy_coordinator_read_errors_local_node[60s])) by (cluster, instance) + sum(rate(scylla_storage_proxy_coordinator_write_errors_local_node[60s])) by (cluster, instance)
+  - record: errors:nodes_total
+    expr: errors:local_failed + errors:operation_unavailable
   - alert: cqlNonPrepared
     expr: cql:non_prepared > 0
     for: 10s


### PR DESCRIPTION
This series adds warning indication to the links of the node table in the overview dashboard.

Here are a few examples:
![Screenshot from 2021-02-09 17-44-17](https://user-images.githubusercontent.com/2118079/107389474-79f16500-6aff-11eb-9b5f-4c4edc430fec.png)
![Screenshot from 2021-02-09 16-00-04](https://user-images.githubusercontent.com/2118079/107389620-9b525100-6aff-11eb-8abd-a01d0a557b1e.png)

Fixes #1229