### PR TITLE
Fix dynamic code-block tag

### DIFF
--- a/docs/source/monitoring_stack.rst
+++ b/docs/source/monitoring_stack.rst
@@ -64,6 +64,7 @@ Install Scylla Monitoring
 .. _`Scylla Monitoring Stack binary`: https://github.com/scylladb/scylla-monitoring/releases
 
 .. code-block:: sh
+   :substitutions:
 
    wget https://github.com/scylladb/scylla-monitoring/archive/scylla-monitoring-|version|.tar.gz
    tar -xvf scylla-monitoring-|version|.tar.gz


### PR DESCRIPTION
Closes #1260 

To use substitutions in code-blocks, the option ``:substitutions:`` must be added.

This change should be backported to the tag ``scylla-monitoring-3.6.0``.

## How to test the PR

1. IRun ``make preview`` form the ``docs`` directory.
2. Open http://127.0.0.1:5500/monitoring_stack/
3. Check if |version| is rendered as ``3.6.0``.

![image](https://user-images.githubusercontent.com/9107969/107610219-06ec0980-6c39-11eb-853f-9a061fedd262.png)
