### PR TITLE
Hints annotations

### DIFF
--- a/grafana/build/ver_2019.1/scylla-cql.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-cql.2019.1.json
@@ -70,6 +70,36 @@
                 "tags": [],
                 "titleFormat": "Running",
                 "type": "tags"
+            },
+            {
+                "class": "annotation_hints_writes",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_hints_manager_written[60s])>0",
+                "hide": false,
+                "iconColor": "rgb(255, 176, 0, 128)",
+                "limit": 100,
+                "name": "Hints Write",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Hints write",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_hints_sent",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_hints_manager_written[60s])>0",
+                "hide": false,
+                "iconColor": "rgb(50, 176, 0, 128)",
+                "limit": 100,
+                "name": "Hints Sent",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Hints Sent",
+                "type": "tags"
             }
         ]
     },

--- a/grafana/build/ver_2019.1/scylla-detailed.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-detailed.2019.1.json
@@ -70,6 +70,36 @@
                 "tags": [],
                 "titleFormat": "Running",
                 "type": "tags"
+            },
+            {
+                "class": "annotation_hints_writes",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_hints_manager_written[60s])>0",
+                "hide": false,
+                "iconColor": "rgb(255, 176, 0, 128)",
+                "limit": 100,
+                "name": "Hints Write",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Hints write",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_hints_sent",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_hints_manager_written[60s])>0",
+                "hide": false,
+                "iconColor": "rgb(50, 176, 0, 128)",
+                "limit": 100,
+                "name": "Hints Sent",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Hints Sent",
+                "type": "tags"
             }
         ]
     },

--- a/grafana/build/ver_2019.1/scylla-os.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-os.2019.1.json
@@ -70,6 +70,36 @@
                 "tags": [],
                 "titleFormat": "Running",
                 "type": "tags"
+            },
+            {
+                "class": "annotation_hints_writes",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_hints_manager_written[60s])>0",
+                "hide": false,
+                "iconColor": "rgb(255, 176, 0, 128)",
+                "limit": 100,
+                "name": "Hints Write",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Hints write",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_hints_sent",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_hints_manager_written[60s])>0",
+                "hide": false,
+                "iconColor": "rgb(50, 176, 0, 128)",
+                "limit": 100,
+                "name": "Hints Sent",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Hints Sent",
+                "type": "tags"
             }
         ]
     },

--- a/grafana/build/ver_2019.1/scylla-overview.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-overview.2019.1.json
@@ -70,6 +70,36 @@
                 "tags": [],
                 "titleFormat": "Running",
                 "type": "tags"
+            },
+            {
+                "class": "annotation_hints_writes",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_hints_manager_written[60s])>0",
+                "hide": false,
+                "iconColor": "rgb(255, 176, 0, 128)",
+                "limit": 100,
+                "name": "Hints Write",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Hints write",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_hints_sent",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_hints_manager_written[60s])>0",
+                "hide": false,
+                "iconColor": "rgb(50, 176, 0, 128)",
+                "limit": 100,
+                "name": "Hints Sent",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Hints Sent",
+                "type": "tags"
             }
         ]
     },

--- a/grafana/build/ver_2020.1/scylla-detailed.2020.1.json
+++ b/grafana/build/ver_2020.1/scylla-detailed.2020.1.json
@@ -70,6 +70,36 @@
                 "tags": [],
                 "titleFormat": "Running",
                 "type": "tags"
+            },
+            {
+                "class": "annotation_hints_writes",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_hints_manager_written[60s])>0",
+                "hide": false,
+                "iconColor": "rgb(255, 176, 0, 128)",
+                "limit": 100,
+                "name": "Hints Write",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Hints write",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_hints_sent",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_hints_manager_written[60s])>0",
+                "hide": false,
+                "iconColor": "rgb(50, 176, 0, 128)",
+                "limit": 100,
+                "name": "Hints Sent",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Hints Sent",
+                "type": "tags"
             }
         ]
     },

--- a/grafana/build/ver_2020.1/scylla-overview.2020.1.json
+++ b/grafana/build/ver_2020.1/scylla-overview.2020.1.json
@@ -70,6 +70,36 @@
                 "tags": [],
                 "titleFormat": "Running",
                 "type": "tags"
+            },
+            {
+                "class": "annotation_hints_writes",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_hints_manager_written[60s])>0",
+                "hide": false,
+                "iconColor": "rgb(255, 176, 0, 128)",
+                "limit": 100,
+                "name": "Hints Write",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Hints write",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_hints_sent",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_hints_manager_written[60s])>0",
+                "hide": false,
+                "iconColor": "rgb(50, 176, 0, 128)",
+                "limit": 100,
+                "name": "Hints Sent",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Hints Sent",
+                "type": "tags"
             }
         ]
     },

--- a/grafana/build/ver_4.2/scylla-detailed.4.2.json
+++ b/grafana/build/ver_4.2/scylla-detailed.4.2.json
@@ -70,6 +70,36 @@
                 "tags": [],
                 "titleFormat": "Running",
                 "type": "tags"
+            },
+            {
+                "class": "annotation_hints_writes",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_hints_manager_written[60s])>0",
+                "hide": false,
+                "iconColor": "rgb(255, 176, 0, 128)",
+                "limit": 100,
+                "name": "Hints Write",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Hints write",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_hints_sent",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_hints_manager_written[60s])>0",
+                "hide": false,
+                "iconColor": "rgb(50, 176, 0, 128)",
+                "limit": 100,
+                "name": "Hints Sent",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Hints Sent",
+                "type": "tags"
             }
         ]
     },

--- a/grafana/build/ver_4.2/scylla-overview.4.2.json
+++ b/grafana/build/ver_4.2/scylla-overview.4.2.json
@@ -70,6 +70,36 @@
                 "tags": [],
                 "titleFormat": "Running",
                 "type": "tags"
+            },
+            {
+                "class": "annotation_hints_writes",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_hints_manager_written[60s])>0",
+                "hide": false,
+                "iconColor": "rgb(255, 176, 0, 128)",
+                "limit": 100,
+                "name": "Hints Write",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Hints write",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_hints_sent",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_hints_manager_written[60s])>0",
+                "hide": false,
+                "iconColor": "rgb(50, 176, 0, 128)",
+                "limit": 100,
+                "name": "Hints Sent",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Hints Sent",
+                "type": "tags"
             }
         ]
     },

--- a/grafana/build/ver_4.3/scylla-detailed.4.3.json
+++ b/grafana/build/ver_4.3/scylla-detailed.4.3.json
@@ -70,6 +70,36 @@
                 "tags": [],
                 "titleFormat": "Running",
                 "type": "tags"
+            },
+            {
+                "class": "annotation_hints_writes",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_hints_manager_written[60s])>0",
+                "hide": false,
+                "iconColor": "rgb(255, 176, 0, 128)",
+                "limit": 100,
+                "name": "Hints Write",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Hints write",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_hints_sent",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_hints_manager_written[60s])>0",
+                "hide": false,
+                "iconColor": "rgb(50, 176, 0, 128)",
+                "limit": 100,
+                "name": "Hints Sent",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Hints Sent",
+                "type": "tags"
             }
         ]
     },

--- a/grafana/build/ver_4.3/scylla-overview.4.3.json
+++ b/grafana/build/ver_4.3/scylla-overview.4.3.json
@@ -70,6 +70,36 @@
                 "tags": [],
                 "titleFormat": "Running",
                 "type": "tags"
+            },
+            {
+                "class": "annotation_hints_writes",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_hints_manager_written[60s])>0",
+                "hide": false,
+                "iconColor": "rgb(255, 176, 0, 128)",
+                "limit": 100,
+                "name": "Hints Write",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Hints write",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_hints_sent",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_hints_manager_written[60s])>0",
+                "hide": false,
+                "iconColor": "rgb(50, 176, 0, 128)",
+                "limit": 100,
+                "name": "Hints Sent",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Hints Sent",
+                "type": "tags"
             }
         ]
     },

--- a/grafana/build/ver_4.4/scylla-detailed.4.4.json
+++ b/grafana/build/ver_4.4/scylla-detailed.4.4.json
@@ -70,6 +70,36 @@
                 "tags": [],
                 "titleFormat": "Running",
                 "type": "tags"
+            },
+            {
+                "class": "annotation_hints_writes",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_hints_manager_written[60s])>0",
+                "hide": false,
+                "iconColor": "rgb(255, 176, 0, 128)",
+                "limit": 100,
+                "name": "Hints Write",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Hints write",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_hints_sent",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_hints_manager_written[60s])>0",
+                "hide": false,
+                "iconColor": "rgb(50, 176, 0, 128)",
+                "limit": 100,
+                "name": "Hints Sent",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Hints Sent",
+                "type": "tags"
             }
         ]
     },

--- a/grafana/build/ver_4.4/scylla-overview.4.4.json
+++ b/grafana/build/ver_4.4/scylla-overview.4.4.json
@@ -70,6 +70,36 @@
                 "tags": [],
                 "titleFormat": "Running",
                 "type": "tags"
+            },
+            {
+                "class": "annotation_hints_writes",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_hints_manager_written[60s])>0",
+                "hide": false,
+                "iconColor": "rgb(255, 176, 0, 128)",
+                "limit": 100,
+                "name": "Hints Write",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Hints write",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_hints_sent",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_hints_manager_written[60s])>0",
+                "hide": false,
+                "iconColor": "rgb(50, 176, 0, 128)",
+                "limit": 100,
+                "name": "Hints Sent",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Hints Sent",
+                "type": "tags"
             }
         ]
     },

--- a/grafana/build/ver_master/scylla-detailed.master.json
+++ b/grafana/build/ver_master/scylla-detailed.master.json
@@ -70,6 +70,36 @@
                 "tags": [],
                 "titleFormat": "Running",
                 "type": "tags"
+            },
+            {
+                "class": "annotation_hints_writes",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_hints_manager_written[60s])>0",
+                "hide": false,
+                "iconColor": "rgb(255, 176, 0, 128)",
+                "limit": 100,
+                "name": "Hints Write",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Hints write",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_hints_sent",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_hints_manager_written[60s])>0",
+                "hide": false,
+                "iconColor": "rgb(50, 176, 0, 128)",
+                "limit": 100,
+                "name": "Hints Sent",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Hints Sent",
+                "type": "tags"
             }
         ]
     },

--- a/grafana/build/ver_master/scylla-overview.master.json
+++ b/grafana/build/ver_master/scylla-overview.master.json
@@ -70,6 +70,36 @@
                 "tags": [],
                 "titleFormat": "Running",
                 "type": "tags"
+            },
+            {
+                "class": "annotation_hints_writes",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_hints_manager_written[60s])>0",
+                "hide": false,
+                "iconColor": "rgb(255, 176, 0, 128)",
+                "limit": 100,
+                "name": "Hints Write",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Hints write",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_hints_sent",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_hints_manager_written[60s])>0",
+                "hide": false,
+                "iconColor": "rgb(50, 176, 0, 128)",
+                "limit": 100,
+                "name": "Hints Sent",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Hints Sent",
+                "type": "tags"
             }
         ]
     },

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -2671,6 +2671,20 @@
         "titleFormat": "Running",
         "type": "tags"
       },
+      "annotation_hints_writes": {
+            "class": "annotation_schema_changed",
+            "expr": "changes(scylla_hints_manager_written[60s])>0",
+            "iconColor": "rgb(255, 176, 0, 128)",
+            "name": "Hints Write",
+            "titleFormat": "Hints write"
+      },
+      "annotation_hints_sent": {
+            "class": "annotation_schema_changed",
+            "expr": "changes(scylla_hints_manager_written[60s])>0",
+            "iconColor": "rgb(50, 176, 0, 128)",
+            "name": "Hints Sent",
+            "titleFormat": "Hints Sent"
+      },
       "vertical_lcd": {
           "datasource": "prometheus",
           "fieldConfig": {
@@ -2764,6 +2778,12 @@
               },
               {
               "class" : "annotation_manager_task"
+              },
+              {
+              "class" : "annotation_hints_writes"
+              },
+              {
+              "class" : "annotation_hints_sent"
               }
             ]
         },


### PR DESCRIPTION
This series adds annotations for write and send hints, when turn on, it will annotate the time hints are written by a node or hints are sent by a node.

![image](https://user-images.githubusercontent.com/2118079/107877486-78e07f00-6ed5-11eb-99b3-8bd0b0b672f3.png)
![image](https://user-images.githubusercontent.com/2118079/107877526-aa594a80-6ed5-11eb-9854-a6f64369b6af.png)

Fixes #1280 