### PR TITLE
prometheus.rules.yml: setting the disk alerts based on node_exporter 0.17

### DIFF
--- a/prometheus/prometheus.rules.yml
+++ b/prometheus/prometheus.rules.yml
@@ -168,7 +168,7 @@ groups:
       description: '{{ $labels.instance }} instance is shutting down.'
       summary: Instance {{ $labels.instance }} down
   - alert: DiskFull
-    expr: node_filesystem_avail{mountpoint="/var/lib/scylla"} / node_filesystem_size{mountpoint="/var/lib/scylla"}
+    expr: node_filesystem_avail_bytes{mountpoint="/var/lib/scylla"} / node_filesystem_size_bytes{mountpoint="/var/lib/scylla"}
       * 100 < 25
     for: 30s
     labels:
@@ -177,7 +177,7 @@ groups:
       description: '{{ $labels.instance }} has less than 25% free disk space.'
       summary: Instance {{ $labels.instance }} low disk space
   - alert: DiskFull
-    expr: node_filesystem_avail{mountpoint="/var/lib/scylla"} / node_filesystem_size{mountpoint="/var/lib/scylla"}
+    expr: node_filesystem_avail_bytes{mountpoint="/var/lib/scylla"} / node_filesystem_size_bytes{mountpoint="/var/lib/scylla"}
       * 100 < 10
     for: 30s
     labels:
@@ -186,7 +186,7 @@ groups:
       description: '{{ $labels.instance }} has less than 10% free disk space.'
       summary: Instance {{ $labels.instance }} low disk space
   - alert: DiskFull
-    expr: node_filesystem_avail{mountpoint="/var/lib/scylla"} / node_filesystem_size{mountpoint="/var/lib/scylla"}
+    expr: node_filesystem_avail_bytes{mountpoint="/var/lib/scylla"} / node_filesystem_size_bytes{mountpoint="/var/lib/scylla"}
       * 100 < 1
     for: 30s
     labels:
@@ -195,7 +195,7 @@ groups:
       description: '{{ $labels.instance }} has less than 1% free disk space.'
       summary: Instance {{ $labels.instance }} low disk space
   - alert: DiskFull
-    expr: node_filesystem_avail{mountpoint="/"} / node_filesystem_size{mountpoint="/"}
+    expr: node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"}
       * 100 < 20
     for: 30s
     labels:


### PR DESCRIPTION
Scylla uses node_exporter greater than 0.16 with the newer names,
This require update the prometheus rules to support the new names.

Fixes #1282