### PR TITLE
Cql errors

### DIFF
--- a/grafana/build/ver_4.4/scylla-cql.4.4.json
+++ b/grafana/build/ver_4.4/scylla-cql.4.4.json
@@ -1011,6 +1011,318 @@
             }
         },
         {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "CQL errors by type, only active errors are shown",
+            "editable": true,
+            "error": false,
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {},
+                    "links": []
+                },
+                "overrides": []
+            },
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 19
+            },
+            "hiddenSeries": false,
+            "id": 13,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(rate(scylla_transport_cql_errors_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]],type) >0",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "CQL Errors [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of CQL row reads",
+            "editable": true,
+            "error": false,
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {},
+                    "links": []
+                },
+                "overrides": []
+            },
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 19
+            },
+            "hiddenSeries": false,
+            "id": 14,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(rate(scylla_cql_rows_read{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "CQL Row Reads [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of reads using secondary indexes",
+            "editable": true,
+            "error": false,
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {},
+                    "links": []
+                },
+                "overrides": []
+            },
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 19
+            },
+            "hiddenSeries": false,
+            "id": 15,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(rate(scylla_cql_secondary_index_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Secondary indexes Reads [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
             "class": "collapsible_row_panel",
             "collapsed": true,
             "datasource": null,
@@ -1018,9 +1330,9 @@
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 19
+                "y": 25
             },
-            "id": 13,
+            "id": 16,
             "panels": [
                 {
                     "class": "single_value_table",
@@ -1059,9 +1371,9 @@
                         "h": 6,
                         "w": 24,
                         "x": 0,
-                        "y": 20
+                        "y": 26
                     },
-                    "id": 14,
+                    "id": 17,
                     "links": [],
                     "options": {
                         "showHeader": true
@@ -1098,9 +1410,9 @@
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 26
+                "y": 32
             },
-            "id": 15,
+            "id": 18,
             "panels": [
                 {
                     "class": "single_value_table",
@@ -1152,9 +1464,9 @@
                         "h": 6,
                         "w": 24,
                         "x": 0,
-                        "y": 27
+                        "y": 33
                     },
-                    "id": 16,
+                    "id": 19,
                     "links": [],
                     "options": {
                         "showHeader": true
@@ -1191,9 +1503,9 @@
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 33
+                "y": 39
             },
-            "id": 17,
+            "id": 20,
             "panels": [
                 {
                     "class": "single_value_table",
@@ -1245,9 +1557,9 @@
                         "h": 6,
                         "w": 24,
                         "x": 0,
-                        "y": 34
+                        "y": 40
                     },
-                    "id": 18,
+                    "id": 21,
                     "links": [],
                     "options": {
                         "showHeader": true
@@ -1284,9 +1596,9 @@
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 40
+                "y": 46
             },
-            "id": 19,
+            "id": 22,
             "panels": [
                 {
                     "class": "single_value_table",
@@ -1338,9 +1650,9 @@
                         "h": 6,
                         "w": 24,
                         "x": 0,
-                        "y": 41
+                        "y": 47
                     },
-                    "id": 20,
+                    "id": 23,
                     "links": [],
                     "options": {
                         "showHeader": true
@@ -1377,9 +1689,9 @@
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 47
+                "y": 53
             },
-            "id": 21,
+            "id": 24,
             "panels": [
                 {
                     "class": "text_panel",
@@ -1396,9 +1708,9 @@
                         "h": 2,
                         "w": 24,
                         "x": 0,
-                        "y": 48
+                        "y": 54
                     },
-                    "id": 22,
+                    "id": 25,
                     "isNew": true,
                     "links": [],
                     "mode": "html",
@@ -1436,10 +1748,10 @@
                         "h": 6,
                         "w": 6,
                         "x": 0,
-                        "y": 50
+                        "y": 56
                     },
                     "hiddenSeries": false,
-                    "id": 23,
+                    "id": 26,
                     "isNew": true,
                     "legend": {
                         "avg": false,
@@ -1542,10 +1854,10 @@
                         "h": 6,
                         "w": 6,
                         "x": 6,
-                        "y": 50
+                        "y": 56
                     },
                     "hiddenSeries": false,
-                    "id": 24,
+                    "id": 27,
                     "isNew": true,
                     "legend": {
                         "avg": false,
@@ -1648,10 +1960,10 @@
                         "h": 6,
                         "w": 6,
                         "x": 12,
-                        "y": 50
+                        "y": 56
                     },
                     "hiddenSeries": false,
-                    "id": 25,
+                    "id": 28,
                     "isNew": true,
                     "legend": {
                         "avg": false,
@@ -1754,10 +2066,10 @@
                         "h": 6,
                         "w": 6,
                         "x": 18,
-                        "y": 50
+                        "y": 56
                     },
                     "hiddenSeries": false,
-                    "id": 26,
+                    "id": 29,
                     "isNew": true,
                     "legend": {
                         "avg": false,
@@ -1849,9 +2161,9 @@
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 56
+                "y": 62
             },
-            "id": 27,
+            "id": 30,
             "panels": [],
             "repeat": "",
             "title": "LWT",
@@ -1872,9 +2184,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 57
+                "y": 63
             },
-            "id": 28,
+            "id": 31,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -1911,10 +2223,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 59
+                "y": 65
             },
             "hiddenSeries": false,
-            "id": 29,
+            "id": 32,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2016,10 +2328,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 59
+                "y": 65
             },
             "hiddenSeries": false,
-            "id": 30,
+            "id": 33,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2121,10 +2433,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 59
+                "y": 65
             },
             "hiddenSeries": false,
-            "id": 31,
+            "id": 34,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2227,10 +2539,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 59
+                "y": 65
             },
             "hiddenSeries": false,
-            "id": 32,
+            "id": 35,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2315,9 +2627,9 @@
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 65
+                "y": 71
             },
-            "id": 33,
+            "id": 36,
             "panels": [],
             "repeat": "",
             "title": "Optimization",
@@ -2338,9 +2650,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 66
+                "y": 72
             },
-            "id": 34,
+            "id": 37,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -2402,9 +2714,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 68
+                "y": 74
             },
-            "id": 35,
+            "id": 38,
             "links": [],
             "options": {
                 "orientation": "horizontal",
@@ -2460,10 +2772,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 68
+                "y": 74
             },
             "hiddenSeries": false,
-            "id": 36,
+            "id": 39,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2589,9 +2901,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 68
+                "y": 74
             },
-            "id": 37,
+            "id": 40,
             "links": [],
             "options": {
                 "orientation": "horizontal",
@@ -2647,10 +2959,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 68
+                "y": 74
             },
             "hiddenSeries": false,
-            "id": 38,
+            "id": 41,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2776,9 +3088,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 16,
-                "y": 68
+                "y": 74
             },
-            "id": 39,
+            "id": 42,
             "links": [],
             "options": {
                 "orientation": "horizontal",
@@ -2832,10 +3144,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 68
+                "y": 74
             },
             "hiddenSeries": false,
-            "id": 40,
+            "id": 43,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2961,9 +3273,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 74
+                "y": 80
             },
-            "id": 41,
+            "id": 44,
             "links": [],
             "options": {
                 "orientation": "horizontal",
@@ -3019,10 +3331,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 74
+                "y": 80
             },
             "hiddenSeries": false,
-            "id": 42,
+            "id": 45,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3148,9 +3460,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 74
+                "y": 80
             },
-            "id": 43,
+            "id": 46,
             "links": [],
             "options": {
                 "orientation": "horizontal",
@@ -3204,10 +3516,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 74
+                "y": 80
             },
             "hiddenSeries": false,
-            "id": 44,
+            "id": 47,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3331,9 +3643,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 16,
-                "y": 74
+                "y": 80
             },
-            "id": 45,
+            "id": 48,
             "links": [],
             "options": {
                 "orientation": "horizontal",
@@ -3389,10 +3701,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 74
+                "y": 80
             },
             "hiddenSeries": false,
-            "id": 46,
+            "id": 49,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3533,9 +3845,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 80
+                "y": 86
             },
-            "id": 47,
+            "id": 50,
             "links": [],
             "options": {
                 "orientation": "horizontal",
@@ -3591,10 +3903,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 80
+                "y": 86
             },
             "hiddenSeries": false,
-            "id": 48,
+            "id": 51,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3720,9 +4032,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 80
+                "y": 86
             },
-            "id": 49,
+            "id": 52,
             "links": [],
             "options": {
                 "orientation": "horizontal",
@@ -3778,10 +4090,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 80
+                "y": 86
             },
             "hiddenSeries": false,
-            "id": 50,
+            "id": 53,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3874,9 +4186,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 86
+                "y": 92
             },
-            "id": 51,
+            "id": 54,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -3938,9 +4250,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 88
+                "y": 94
             },
-            "id": 52,
+            "id": 55,
             "links": [],
             "options": {
                 "orientation": "horizontal",
@@ -3996,10 +4308,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 88
+                "y": 94
             },
             "hiddenSeries": false,
-            "id": 53,
+            "id": 56,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -4125,9 +4437,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 88
+                "y": 94
             },
-            "id": 54,
+            "id": 57,
             "links": [],
             "options": {
                 "orientation": "horizontal",
@@ -4183,10 +4495,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 88
+                "y": 94
             },
             "hiddenSeries": false,
-            "id": 55,
+            "id": 58,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -4312,9 +4624,9 @@
                 "h": 6,
                 "w": 4,
                 "x": 0,
-                "y": 94
+                "y": 100
             },
-            "id": 56,
+            "id": 59,
             "links": [],
             "options": {
                 "orientation": "horizontal",
@@ -4358,9 +4670,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 100
+                "y": 106
             },
-            "id": 57,
+            "id": 60,
             "isNew": true,
             "links": [],
             "mode": "html",

--- a/grafana/build/ver_master/scylla-cql.master.json
+++ b/grafana/build/ver_master/scylla-cql.master.json
@@ -1011,6 +1011,318 @@
             }
         },
         {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "CQL errors by type, only active errors are shown",
+            "editable": true,
+            "error": false,
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {},
+                    "links": []
+                },
+                "overrides": []
+            },
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 19
+            },
+            "hiddenSeries": false,
+            "id": 13,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(rate(scylla_transport_cql_errors_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]],type) >0",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "CQL Errors [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of CQL row reads",
+            "editable": true,
+            "error": false,
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {},
+                    "links": []
+                },
+                "overrides": []
+            },
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 19
+            },
+            "hiddenSeries": false,
+            "id": 14,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(rate(scylla_cql_rows_read{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "CQL Row Reads [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of reads using secondary indexes",
+            "editable": true,
+            "error": false,
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {},
+                    "links": []
+                },
+                "overrides": []
+            },
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 19
+            },
+            "hiddenSeries": false,
+            "id": 15,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(rate(scylla_cql_secondary_index_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Secondary indexes Reads [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
             "class": "collapsible_row_panel",
             "collapsed": true,
             "datasource": null,
@@ -1018,9 +1330,9 @@
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 19
+                "y": 25
             },
-            "id": 13,
+            "id": 16,
             "panels": [
                 {
                     "class": "single_value_table",
@@ -1059,9 +1371,9 @@
                         "h": 6,
                         "w": 24,
                         "x": 0,
-                        "y": 20
+                        "y": 26
                     },
-                    "id": 14,
+                    "id": 17,
                     "links": [],
                     "options": {
                         "showHeader": true
@@ -1098,9 +1410,9 @@
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 26
+                "y": 32
             },
-            "id": 15,
+            "id": 18,
             "panels": [
                 {
                     "class": "single_value_table",
@@ -1152,9 +1464,9 @@
                         "h": 6,
                         "w": 24,
                         "x": 0,
-                        "y": 27
+                        "y": 33
                     },
-                    "id": 16,
+                    "id": 19,
                     "links": [],
                     "options": {
                         "showHeader": true
@@ -1191,9 +1503,9 @@
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 33
+                "y": 39
             },
-            "id": 17,
+            "id": 20,
             "panels": [
                 {
                     "class": "single_value_table",
@@ -1245,9 +1557,9 @@
                         "h": 6,
                         "w": 24,
                         "x": 0,
-                        "y": 34
+                        "y": 40
                     },
-                    "id": 18,
+                    "id": 21,
                     "links": [],
                     "options": {
                         "showHeader": true
@@ -1284,9 +1596,9 @@
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 40
+                "y": 46
             },
-            "id": 19,
+            "id": 22,
             "panels": [
                 {
                     "class": "single_value_table",
@@ -1338,9 +1650,9 @@
                         "h": 6,
                         "w": 24,
                         "x": 0,
-                        "y": 41
+                        "y": 47
                     },
-                    "id": 20,
+                    "id": 23,
                     "links": [],
                     "options": {
                         "showHeader": true
@@ -1377,9 +1689,9 @@
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 47
+                "y": 53
             },
-            "id": 21,
+            "id": 24,
             "panels": [
                 {
                     "class": "text_panel",
@@ -1396,9 +1708,9 @@
                         "h": 2,
                         "w": 24,
                         "x": 0,
-                        "y": 48
+                        "y": 54
                     },
-                    "id": 22,
+                    "id": 25,
                     "isNew": true,
                     "links": [],
                     "mode": "html",
@@ -1436,10 +1748,10 @@
                         "h": 6,
                         "w": 6,
                         "x": 0,
-                        "y": 50
+                        "y": 56
                     },
                     "hiddenSeries": false,
-                    "id": 23,
+                    "id": 26,
                     "isNew": true,
                     "legend": {
                         "avg": false,
@@ -1542,10 +1854,10 @@
                         "h": 6,
                         "w": 6,
                         "x": 6,
-                        "y": 50
+                        "y": 56
                     },
                     "hiddenSeries": false,
-                    "id": 24,
+                    "id": 27,
                     "isNew": true,
                     "legend": {
                         "avg": false,
@@ -1648,10 +1960,10 @@
                         "h": 6,
                         "w": 6,
                         "x": 12,
-                        "y": 50
+                        "y": 56
                     },
                     "hiddenSeries": false,
-                    "id": 25,
+                    "id": 28,
                     "isNew": true,
                     "legend": {
                         "avg": false,
@@ -1754,10 +2066,10 @@
                         "h": 6,
                         "w": 6,
                         "x": 18,
-                        "y": 50
+                        "y": 56
                     },
                     "hiddenSeries": false,
-                    "id": 26,
+                    "id": 29,
                     "isNew": true,
                     "legend": {
                         "avg": false,
@@ -1849,9 +2161,9 @@
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 56
+                "y": 62
             },
-            "id": 27,
+            "id": 30,
             "panels": [],
             "repeat": "",
             "title": "LWT",
@@ -1872,9 +2184,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 57
+                "y": 63
             },
-            "id": 28,
+            "id": 31,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -1911,10 +2223,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 59
+                "y": 65
             },
             "hiddenSeries": false,
-            "id": 29,
+            "id": 32,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2016,10 +2328,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 59
+                "y": 65
             },
             "hiddenSeries": false,
-            "id": 30,
+            "id": 33,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2121,10 +2433,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 59
+                "y": 65
             },
             "hiddenSeries": false,
-            "id": 31,
+            "id": 34,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2227,10 +2539,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 59
+                "y": 65
             },
             "hiddenSeries": false,
-            "id": 32,
+            "id": 35,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2315,9 +2627,9 @@
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 65
+                "y": 71
             },
-            "id": 33,
+            "id": 36,
             "panels": [],
             "repeat": "",
             "title": "Optimization",
@@ -2338,9 +2650,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 66
+                "y": 72
             },
-            "id": 34,
+            "id": 37,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -2402,9 +2714,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 68
+                "y": 74
             },
-            "id": 35,
+            "id": 38,
             "links": [],
             "options": {
                 "orientation": "horizontal",
@@ -2460,10 +2772,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 68
+                "y": 74
             },
             "hiddenSeries": false,
-            "id": 36,
+            "id": 39,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2589,9 +2901,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 68
+                "y": 74
             },
-            "id": 37,
+            "id": 40,
             "links": [],
             "options": {
                 "orientation": "horizontal",
@@ -2647,10 +2959,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 68
+                "y": 74
             },
             "hiddenSeries": false,
-            "id": 38,
+            "id": 41,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2776,9 +3088,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 16,
-                "y": 68
+                "y": 74
             },
-            "id": 39,
+            "id": 42,
             "links": [],
             "options": {
                 "orientation": "horizontal",
@@ -2832,10 +3144,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 68
+                "y": 74
             },
             "hiddenSeries": false,
-            "id": 40,
+            "id": 43,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -2961,9 +3273,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 74
+                "y": 80
             },
-            "id": 41,
+            "id": 44,
             "links": [],
             "options": {
                 "orientation": "horizontal",
@@ -3019,10 +3331,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 74
+                "y": 80
             },
             "hiddenSeries": false,
-            "id": 42,
+            "id": 45,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3148,9 +3460,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 74
+                "y": 80
             },
-            "id": 43,
+            "id": 46,
             "links": [],
             "options": {
                 "orientation": "horizontal",
@@ -3204,10 +3516,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 74
+                "y": 80
             },
             "hiddenSeries": false,
-            "id": 44,
+            "id": 47,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3331,9 +3643,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 16,
-                "y": 74
+                "y": 80
             },
-            "id": 45,
+            "id": 48,
             "links": [],
             "options": {
                 "orientation": "horizontal",
@@ -3389,10 +3701,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 74
+                "y": 80
             },
             "hiddenSeries": false,
-            "id": 46,
+            "id": 49,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3533,9 +3845,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 80
+                "y": 86
             },
-            "id": 47,
+            "id": 50,
             "links": [],
             "options": {
                 "orientation": "horizontal",
@@ -3591,10 +3903,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 80
+                "y": 86
             },
             "hiddenSeries": false,
-            "id": 48,
+            "id": 51,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3720,9 +4032,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 80
+                "y": 86
             },
-            "id": 49,
+            "id": 52,
             "links": [],
             "options": {
                 "orientation": "horizontal",
@@ -3778,10 +4090,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 80
+                "y": 86
             },
             "hiddenSeries": false,
-            "id": 50,
+            "id": 53,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -3874,9 +4186,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 86
+                "y": 92
             },
-            "id": 51,
+            "id": 54,
             "isNew": true,
             "links": [],
             "mode": "html",
@@ -3938,9 +4250,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 0,
-                "y": 88
+                "y": 94
             },
-            "id": 52,
+            "id": 55,
             "links": [],
             "options": {
                 "orientation": "horizontal",
@@ -3996,10 +4308,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 2,
-                "y": 88
+                "y": 94
             },
             "hiddenSeries": false,
-            "id": 53,
+            "id": 56,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -4125,9 +4437,9 @@
                 "h": 6,
                 "w": 2,
                 "x": 8,
-                "y": 88
+                "y": 94
             },
-            "id": 54,
+            "id": 57,
             "links": [],
             "options": {
                 "orientation": "horizontal",
@@ -4183,10 +4495,10 @@
                 "h": 6,
                 "w": 6,
                 "x": 10,
-                "y": 88
+                "y": 94
             },
             "hiddenSeries": false,
-            "id": 55,
+            "id": 58,
             "isNew": true,
             "legend": {
                 "avg": false,
@@ -4312,9 +4624,9 @@
                 "h": 6,
                 "w": 4,
                 "x": 0,
-                "y": 94
+                "y": 100
             },
-            "id": 56,
+            "id": 59,
             "links": [],
             "options": {
                 "orientation": "horizontal",
@@ -4358,9 +4670,9 @@
                 "h": 2,
                 "w": 24,
                 "x": 0,
-                "y": 100
+                "y": 106
             },
-            "id": 57,
+            "id": 60,
             "isNew": true,
             "links": [],
             "mode": "html",

--- a/grafana/scylla-cql.4.4.template.json
+++ b/grafana/scylla-cql.4.4.template.json
@@ -173,6 +173,57 @@
                             }
                         ],
                         "title": "BYPASS CACHE"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span": 3,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "sum(rate(scylla_transport_cql_errors_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]],type) >0",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "CQL Errors [[by]]",
+                        "description": "CQL errors by type, only active errors are shown"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span": 3,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "sum(rate(scylla_cql_rows_read{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "CQL Row Reads [[by]]",
+                        "description": "Number of CQL row reads"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span": 3,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "sum(rate(scylla_cql_secondary_index_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "Secondary indexes Reads [[by]]",
+                        "description": "Number of reads using secondary indexes"
                     }
                 ],
                 "title": "New row"

--- a/grafana/scylla-cql.master.template.json
+++ b/grafana/scylla-cql.master.template.json
@@ -173,6 +173,57 @@
                             }
                         ],
                         "title": "BYPASS CACHE"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span": 3,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "sum(rate(scylla_transport_cql_errors_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]],type) >0",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "CQL Errors [[by]]",
+                        "description": "CQL errors by type, only active errors are shown"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span": 3,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "sum(rate(scylla_cql_rows_read{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "CQL Row Reads [[by]]",
+                        "description": "Number of CQL row reads"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span": 3,
+                        "pointradius": 1,
+                        "targets": [
+                            {
+                                "expr": "sum(rate(scylla_cql_secondary_index_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "Secondary indexes Reads [[by]]",
+                        "description": "Number of reads using secondary indexes"
                     }
                 ],
                 "title": "New row"

--- a/prometheus/prometheus.yml.template
+++ b/prometheus/prometheus.yml.template
@@ -55,7 +55,7 @@ scrape_configs:
       regex:  '(.+)'
       target_label: Errors
       replacement: 'errors'
-    - regex: 'help|exported_instance|type'
+    - regex: 'help|exported_instance'
       action: labeldrop
     - source_labels: [version]
       regex: '([0-9]+\.[0-9]+)(\.?[0-9]*).*'


### PR DESCRIPTION
This patch adds 3 panels to the cql dashboard:
CQL Errors, CQL Row reads and CQL secondary index.

The exception here is the CQL Errors, there are many potential errors, each can be reported on any shard (depends on filtering and aggregation).
To make graph readable, only non zero values are shown as can be seen in the example

![Screenshot from 2021-02-17 15-57-22](https://user-images.githubusercontent.com/2118079/108216139-cc9fd200-713a-11eb-9c27-44e9ff5a07e4.png)

Fixes #1276 