### PR TITLE
Add legend to graphs in the DC section

### DIFF
--- a/grafana/build/ver_2020.1/scylla-overview.2020.1.json
+++ b/grafana/build/ver_2020.1/scylla-overview.2020.1.json
@@ -1247,11 +1247,14 @@
             "id": 20,
             "isNew": true,
             "legend": {
+                "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
-                "show": false,
+                "rightSide": false,
+                "show": true,
                 "total": false,
                 "values": false
             },
@@ -1462,11 +1465,14 @@
             "id": 22,
             "isNew": true,
             "legend": {
+                "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
-                "show": false,
+                "rightSide": false,
+                "show": true,
                 "total": false,
                 "values": false
             },
@@ -2547,6 +2553,7 @@
             "legend": {
                 "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
@@ -2676,11 +2683,14 @@
             "id": 38,
             "isNew": true,
             "legend": {
+                "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
-                "show": false,
+                "rightSide": false,
+                "show": true,
                 "total": false,
                 "values": false
             },
@@ -2789,6 +2799,7 @@
             "legend": {
                 "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
@@ -2916,11 +2927,14 @@
             "id": 40,
             "isNew": true,
             "legend": {
+                "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
-                "show": false,
+                "rightSide": false,
+                "show": true,
                 "total": false,
                 "values": false
             },
@@ -3679,11 +3693,14 @@
             "id": 43,
             "isNew": true,
             "legend": {
+                "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
-                "show": false,
+                "rightSide": false,
+                "show": true,
                 "total": false,
                 "values": false
             },
@@ -3791,11 +3808,14 @@
             "id": 44,
             "isNew": true,
             "legend": {
+                "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
-                "show": false,
+                "rightSide": false,
+                "show": true,
                 "total": false,
                 "values": false
             },
@@ -3821,14 +3841,14 @@
                 {
                     "expr": "$func(rate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[$__rate_interval])) by ([[by]])",
                     "intervalFactor": 1,
-                    "legendFormat": "Writes timeout {{[[by]]}}",
+                    "legendFormat": "Writes {{[[by]]}}",
                     "refId": "A",
                     "step": 10
                 },
                 {
                     "expr": "$func(rate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])+rate(scylla_storage_proxy_coordinator_cas_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])+rate(scylla_storage_proxy_coordinator_range_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])",
                     "intervalFactor": 1,
-                    "legendFormat": "Read  timeout {{[[by]]}}",
+                    "legendFormat": "Read  {{[[by]]}}",
                     "refId": "B",
                     "step": 10
                 }

--- a/grafana/build/ver_4.2/scylla-overview.4.2.json
+++ b/grafana/build/ver_4.2/scylla-overview.4.2.json
@@ -1247,11 +1247,14 @@
             "id": 20,
             "isNew": true,
             "legend": {
+                "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
-                "show": false,
+                "rightSide": false,
+                "show": true,
                 "total": false,
                 "values": false
             },
@@ -1462,11 +1465,14 @@
             "id": 22,
             "isNew": true,
             "legend": {
+                "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
-                "show": false,
+                "rightSide": false,
+                "show": true,
                 "total": false,
                 "values": false
             },
@@ -2547,6 +2553,7 @@
             "legend": {
                 "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
@@ -2676,11 +2683,14 @@
             "id": 38,
             "isNew": true,
             "legend": {
+                "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
-                "show": false,
+                "rightSide": false,
+                "show": true,
                 "total": false,
                 "values": false
             },
@@ -2789,6 +2799,7 @@
             "legend": {
                 "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
@@ -2916,11 +2927,14 @@
             "id": 40,
             "isNew": true,
             "legend": {
+                "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
-                "show": false,
+                "rightSide": false,
+                "show": true,
                 "total": false,
                 "values": false
             },
@@ -3679,11 +3693,14 @@
             "id": 43,
             "isNew": true,
             "legend": {
+                "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
-                "show": false,
+                "rightSide": false,
+                "show": true,
                 "total": false,
                 "values": false
             },
@@ -3791,11 +3808,14 @@
             "id": 44,
             "isNew": true,
             "legend": {
+                "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
-                "show": false,
+                "rightSide": false,
+                "show": true,
                 "total": false,
                 "values": false
             },
@@ -3821,14 +3841,14 @@
                 {
                     "expr": "$func(rate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[$__rate_interval])) by ([[by]])",
                     "intervalFactor": 1,
-                    "legendFormat": "Writes timeout {{[[by]]}}",
+                    "legendFormat": "Writes {{[[by]]}}",
                     "refId": "A",
                     "step": 10
                 },
                 {
                     "expr": "$func(rate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])+rate(scylla_storage_proxy_coordinator_cas_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])+rate(scylla_storage_proxy_coordinator_range_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])",
                     "intervalFactor": 1,
-                    "legendFormat": "Read  timeout {{[[by]]}}",
+                    "legendFormat": "Read  {{[[by]]}}",
                     "refId": "B",
                     "step": 10
                 }

--- a/grafana/build/ver_4.3/scylla-overview.4.3.json
+++ b/grafana/build/ver_4.3/scylla-overview.4.3.json
@@ -1247,11 +1247,14 @@
             "id": 20,
             "isNew": true,
             "legend": {
+                "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
-                "show": false,
+                "rightSide": false,
+                "show": true,
                 "total": false,
                 "values": false
             },
@@ -1462,11 +1465,14 @@
             "id": 22,
             "isNew": true,
             "legend": {
+                "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
-                "show": false,
+                "rightSide": false,
+                "show": true,
                 "total": false,
                 "values": false
             },
@@ -2547,6 +2553,7 @@
             "legend": {
                 "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
@@ -2676,11 +2683,14 @@
             "id": 38,
             "isNew": true,
             "legend": {
+                "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
-                "show": false,
+                "rightSide": false,
+                "show": true,
                 "total": false,
                 "values": false
             },
@@ -2789,6 +2799,7 @@
             "legend": {
                 "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
@@ -2916,11 +2927,14 @@
             "id": 40,
             "isNew": true,
             "legend": {
+                "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
-                "show": false,
+                "rightSide": false,
+                "show": true,
                 "total": false,
                 "values": false
             },
@@ -3679,11 +3693,14 @@
             "id": 43,
             "isNew": true,
             "legend": {
+                "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
-                "show": false,
+                "rightSide": false,
+                "show": true,
                 "total": false,
                 "values": false
             },
@@ -3791,11 +3808,14 @@
             "id": 44,
             "isNew": true,
             "legend": {
+                "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
-                "show": false,
+                "rightSide": false,
+                "show": true,
                 "total": false,
                 "values": false
             },
@@ -3821,14 +3841,14 @@
                 {
                     "expr": "$func(rate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[$__rate_interval])) by ([[by]])",
                     "intervalFactor": 1,
-                    "legendFormat": "Writes timeout {{[[by]]}}",
+                    "legendFormat": "Writes {{[[by]]}}",
                     "refId": "A",
                     "step": 10
                 },
                 {
                     "expr": "$func(rate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])+rate(scylla_storage_proxy_coordinator_cas_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])+rate(scylla_storage_proxy_coordinator_range_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])",
                     "intervalFactor": 1,
-                    "legendFormat": "Read  timeout {{[[by]]}}",
+                    "legendFormat": "Read  {{[[by]]}}",
                     "refId": "B",
                     "step": 10
                 }

--- a/grafana/build/ver_4.4/scylla-overview.4.4.json
+++ b/grafana/build/ver_4.4/scylla-overview.4.4.json
@@ -1247,11 +1247,14 @@
             "id": 20,
             "isNew": true,
             "legend": {
+                "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
-                "show": false,
+                "rightSide": false,
+                "show": true,
                 "total": false,
                 "values": false
             },
@@ -1462,11 +1465,14 @@
             "id": 22,
             "isNew": true,
             "legend": {
+                "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
-                "show": false,
+                "rightSide": false,
+                "show": true,
                 "total": false,
                 "values": false
             },
@@ -2547,6 +2553,7 @@
             "legend": {
                 "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
@@ -2676,11 +2683,14 @@
             "id": 38,
             "isNew": true,
             "legend": {
+                "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
-                "show": false,
+                "rightSide": false,
+                "show": true,
                 "total": false,
                 "values": false
             },
@@ -2789,6 +2799,7 @@
             "legend": {
                 "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
@@ -2916,11 +2927,14 @@
             "id": 40,
             "isNew": true,
             "legend": {
+                "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
-                "show": false,
+                "rightSide": false,
+                "show": true,
                 "total": false,
                 "values": false
             },
@@ -3679,11 +3693,14 @@
             "id": 43,
             "isNew": true,
             "legend": {
+                "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
-                "show": false,
+                "rightSide": false,
+                "show": true,
                 "total": false,
                 "values": false
             },
@@ -3791,11 +3808,14 @@
             "id": 44,
             "isNew": true,
             "legend": {
+                "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
-                "show": false,
+                "rightSide": false,
+                "show": true,
                 "total": false,
                 "values": false
             },
@@ -3821,14 +3841,14 @@
                 {
                     "expr": "$func(rate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[$__rate_interval])) by ([[by]])",
                     "intervalFactor": 1,
-                    "legendFormat": "Writes timeout {{[[by]]}}",
+                    "legendFormat": "Writes {{[[by]]}}",
                     "refId": "A",
                     "step": 10
                 },
                 {
                     "expr": "$func(rate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])+rate(scylla_storage_proxy_coordinator_cas_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])+rate(scylla_storage_proxy_coordinator_range_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])",
                     "intervalFactor": 1,
-                    "legendFormat": "Read  timeout {{[[by]]}}",
+                    "legendFormat": "Read  {{[[by]]}}",
                     "refId": "B",
                     "step": 10
                 }

--- a/grafana/build/ver_master/scylla-overview.master.json
+++ b/grafana/build/ver_master/scylla-overview.master.json
@@ -1247,11 +1247,14 @@
             "id": 20,
             "isNew": true,
             "legend": {
+                "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
-                "show": false,
+                "rightSide": false,
+                "show": true,
                 "total": false,
                 "values": false
             },
@@ -1462,11 +1465,14 @@
             "id": 22,
             "isNew": true,
             "legend": {
+                "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
-                "show": false,
+                "rightSide": false,
+                "show": true,
                 "total": false,
                 "values": false
             },
@@ -2547,6 +2553,7 @@
             "legend": {
                 "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
@@ -2676,11 +2683,14 @@
             "id": 38,
             "isNew": true,
             "legend": {
+                "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
-                "show": false,
+                "rightSide": false,
+                "show": true,
                 "total": false,
                 "values": false
             },
@@ -2789,6 +2799,7 @@
             "legend": {
                 "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
@@ -2916,11 +2927,14 @@
             "id": 40,
             "isNew": true,
             "legend": {
+                "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
-                "show": false,
+                "rightSide": false,
+                "show": true,
                 "total": false,
                 "values": false
             },
@@ -3679,11 +3693,14 @@
             "id": 43,
             "isNew": true,
             "legend": {
+                "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
-                "show": false,
+                "rightSide": false,
+                "show": true,
                 "total": false,
                 "values": false
             },
@@ -3791,11 +3808,14 @@
             "id": 44,
             "isNew": true,
             "legend": {
+                "alignAsTable": false,
                 "avg": false,
+                "class": "show_legend",
                 "current": false,
                 "max": false,
                 "min": false,
-                "show": false,
+                "rightSide": false,
+                "show": true,
                 "total": false,
                 "values": false
             },
@@ -3821,14 +3841,14 @@
                 {
                     "expr": "$func(rate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[$__rate_interval])) by ([[by]])",
                     "intervalFactor": 1,
-                    "legendFormat": "Writes timeout {{[[by]]}}",
+                    "legendFormat": "Writes {{[[by]]}}",
                     "refId": "A",
                     "step": 10
                 },
                 {
                     "expr": "$func(rate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])+rate(scylla_storage_proxy_coordinator_cas_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])+rate(scylla_storage_proxy_coordinator_range_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])",
                     "intervalFactor": 1,
-                    "legendFormat": "Read  timeout {{[[by]]}}",
+                    "legendFormat": "Read  {{[[by]]}}",
                     "refId": "B",
                     "step": 10
                 }

--- a/grafana/scylla-overview.2020.1.template.json
+++ b/grafana/scylla-overview.2020.1.template.json
@@ -65,6 +65,9 @@
                                 "step": 1
                             }
                         ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
                         "title": "Write Latencies"
                     },
                     {
@@ -100,6 +103,9 @@
                                 "step": 1
                             }
                         ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
                         "title": "Read Latencies"
                     }
                 ]
@@ -501,15 +507,7 @@
                             }
                         ],
                         "legend": {
-                            "avg": false,
-                            "current": false,
-                            "max": false,
-                            "min": false,
-                            "show": true,
-                            "total": false,
-                            "values": false,
-                            "alignAsTable": false,
-                            "rightSide": false
+                            "class": "show_legend"
                         },
                         "seriesOverrides": [
                             {
@@ -544,6 +542,9 @@
                                 "step": 1
                             }
                         ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
                         "title": "Write Latencies"
                     },
                     {
@@ -573,15 +574,7 @@
                             }
                         ],
                         "legend": {
-                            "avg": false,
-                            "current": false,
-                            "max": false,
-                            "min": false,
-                            "show": true,
-                            "total": false,
-                            "values": false,
-                            "alignAsTable": false,
-                            "rightSide": false
+                            "class": "show_legend"
                         },
                         "seriesOverrides": [
                             {
@@ -616,6 +609,9 @@
                                 "step": 1
                             }
                         ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
                         "title": "Read Latencies"
                     }
                 ]
@@ -662,6 +658,9 @@
                                 "step": 10
                             }
                         ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
                         "title": "Cache Hits/Misses"
                     },
                     {
@@ -672,18 +671,21 @@
                             {
                                 "expr": "$func(rate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[$__rate_interval])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Writes timeout {{[[by]]}}",
+                                "legendFormat": "Writes {{[[by]]}}",
                                 "refId": "A",
                                 "step": 10
                             },
                             {
                                 "expr": "$func(rate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])+rate(scylla_storage_proxy_coordinator_cas_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])+rate(scylla_storage_proxy_coordinator_range_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Read  timeout {{[[by]]}}",
+                                "legendFormat": "Read  {{[[by]]}}",
                                 "refId": "B",
                                 "step": 10
                             }
                         ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
                         "title": "Read/Write Timeouts by [[by]]"
                     }
 

--- a/grafana/scylla-overview.4.2.template.json
+++ b/grafana/scylla-overview.4.2.template.json
@@ -65,6 +65,9 @@
                                 "step": 1
                             }
                         ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
                         "title": "Write Latencies"
                     },
                     {
@@ -100,6 +103,9 @@
                                 "step": 1
                             }
                         ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
                         "title": "Read Latencies"
                     }
                 ]
@@ -501,15 +507,7 @@
                             }
                         ],
                         "legend": {
-                            "avg": false,
-                            "current": false,
-                            "max": false,
-                            "min": false,
-                            "show": true,
-                            "total": false,
-                            "values": false,
-                            "alignAsTable": false,
-                            "rightSide": false
+                            "class": "show_legend"
                         },
                         "seriesOverrides": [
                             {
@@ -544,6 +542,9 @@
                                 "step": 1
                             }
                         ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
                         "title": "Write Latencies"
                     },
                     {
@@ -573,15 +574,7 @@
                             }
                         ],
                         "legend": {
-                            "avg": false,
-                            "current": false,
-                            "max": false,
-                            "min": false,
-                            "show": true,
-                            "total": false,
-                            "values": false,
-                            "alignAsTable": false,
-                            "rightSide": false
+                            "class": "show_legend"
                         },
                         "seriesOverrides": [
                             {
@@ -616,6 +609,9 @@
                                 "step": 1
                             }
                         ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
                         "title": "Read Latencies"
                     }
                 ]
@@ -662,6 +658,9 @@
                                 "step": 10
                             }
                         ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
                         "title": "Cache Hits/Misses"
                     },
                     {
@@ -672,18 +671,21 @@
                             {
                                 "expr": "$func(rate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[$__rate_interval])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Writes timeout {{[[by]]}}",
+                                "legendFormat": "Writes {{[[by]]}}",
                                 "refId": "A",
                                 "step": 10
                             },
                             {
                                 "expr": "$func(rate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])+rate(scylla_storage_proxy_coordinator_cas_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])+rate(scylla_storage_proxy_coordinator_range_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Read  timeout {{[[by]]}}",
+                                "legendFormat": "Read  {{[[by]]}}",
                                 "refId": "B",
                                 "step": 10
                             }
                         ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
                         "title": "Read/Write Timeouts by [[by]]"
                     }
 

--- a/grafana/scylla-overview.4.3.template.json
+++ b/grafana/scylla-overview.4.3.template.json
@@ -65,6 +65,9 @@
                                 "step": 1
                             }
                         ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
                         "title": "Write Latencies"
                     },
                     {
@@ -100,6 +103,9 @@
                                 "step": 1
                             }
                         ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
                         "title": "Read Latencies"
                     }
                 ]
@@ -501,15 +507,7 @@
                             }
                         ],
                         "legend": {
-                            "avg": false,
-                            "current": false,
-                            "max": false,
-                            "min": false,
-                            "show": true,
-                            "total": false,
-                            "values": false,
-                            "alignAsTable": false,
-                            "rightSide": false
+                            "class": "show_legend"
                         },
                         "seriesOverrides": [
                             {
@@ -544,6 +542,9 @@
                                 "step": 1
                             }
                         ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
                         "title": "Write Latencies"
                     },
                     {
@@ -573,15 +574,7 @@
                             }
                         ],
                         "legend": {
-                            "avg": false,
-                            "current": false,
-                            "max": false,
-                            "min": false,
-                            "show": true,
-                            "total": false,
-                            "values": false,
-                            "alignAsTable": false,
-                            "rightSide": false
+                            "class": "show_legend"
                         },
                         "seriesOverrides": [
                             {
@@ -616,6 +609,9 @@
                                 "step": 1
                             }
                         ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
                         "title": "Read Latencies"
                     }
                 ]
@@ -662,6 +658,9 @@
                                 "step": 10
                             }
                         ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
                         "title": "Cache Hits/Misses"
                     },
                     {
@@ -672,18 +671,21 @@
                             {
                                 "expr": "$func(rate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[$__rate_interval])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Writes timeout {{[[by]]}}",
+                                "legendFormat": "Writes {{[[by]]}}",
                                 "refId": "A",
                                 "step": 10
                             },
                             {
                                 "expr": "$func(rate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])+rate(scylla_storage_proxy_coordinator_cas_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])+rate(scylla_storage_proxy_coordinator_range_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Read  timeout {{[[by]]}}",
+                                "legendFormat": "Read  {{[[by]]}}",
                                 "refId": "B",
                                 "step": 10
                             }
                         ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
                         "title": "Read/Write Timeouts by [[by]]"
                     }
 

--- a/grafana/scylla-overview.4.4.template.json
+++ b/grafana/scylla-overview.4.4.template.json
@@ -65,6 +65,9 @@
                                 "step": 1
                             }
                         ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
                         "title": "Write Latencies"
                     },
                     {
@@ -100,6 +103,9 @@
                                 "step": 1
                             }
                         ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
                         "title": "Read Latencies"
                     }
                 ]
@@ -501,15 +507,7 @@
                             }
                         ],
                         "legend": {
-                            "avg": false,
-                            "current": false,
-                            "max": false,
-                            "min": false,
-                            "show": true,
-                            "total": false,
-                            "values": false,
-                            "alignAsTable": false,
-                            "rightSide": false
+                            "class": "show_legend"
                         },
                         "seriesOverrides": [
                             {
@@ -544,6 +542,9 @@
                                 "step": 1
                             }
                         ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
                         "title": "Write Latencies"
                     },
                     {
@@ -573,15 +574,7 @@
                             }
                         ],
                         "legend": {
-                            "avg": false,
-                            "current": false,
-                            "max": false,
-                            "min": false,
-                            "show": true,
-                            "total": false,
-                            "values": false,
-                            "alignAsTable": false,
-                            "rightSide": false
+                            "class": "show_legend"
                         },
                         "seriesOverrides": [
                             {
@@ -616,6 +609,9 @@
                                 "step": 1
                             }
                         ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
                         "title": "Read Latencies"
                     }
                 ]
@@ -662,6 +658,9 @@
                                 "step": 10
                             }
                         ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
                         "title": "Cache Hits/Misses"
                     },
                     {
@@ -672,18 +671,21 @@
                             {
                                 "expr": "$func(rate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[$__rate_interval])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Writes timeout {{[[by]]}}",
+                                "legendFormat": "Writes {{[[by]]}}",
                                 "refId": "A",
                                 "step": 10
                             },
                             {
                                 "expr": "$func(rate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])+rate(scylla_storage_proxy_coordinator_cas_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])+rate(scylla_storage_proxy_coordinator_range_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Read  timeout {{[[by]]}}",
+                                "legendFormat": "Read  {{[[by]]}}",
                                 "refId": "B",
                                 "step": 10
                             }
                         ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
                         "title": "Read/Write Timeouts by [[by]]"
                     }
 

--- a/grafana/scylla-overview.master.template.json
+++ b/grafana/scylla-overview.master.template.json
@@ -65,6 +65,9 @@
                                 "step": 1
                             }
                         ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
                         "title": "Write Latencies"
                     },
                     {
@@ -100,6 +103,9 @@
                                 "step": 1
                             }
                         ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
                         "title": "Read Latencies"
                     }
                 ]
@@ -501,15 +507,7 @@
                             }
                         ],
                         "legend": {
-                            "avg": false,
-                            "current": false,
-                            "max": false,
-                            "min": false,
-                            "show": true,
-                            "total": false,
-                            "values": false,
-                            "alignAsTable": false,
-                            "rightSide": false
+                            "class": "show_legend"
                         },
                         "seriesOverrides": [
                             {
@@ -544,6 +542,9 @@
                                 "step": 1
                             }
                         ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
                         "title": "Write Latencies"
                     },
                     {
@@ -573,15 +574,7 @@
                             }
                         ],
                         "legend": {
-                            "avg": false,
-                            "current": false,
-                            "max": false,
-                            "min": false,
-                            "show": true,
-                            "total": false,
-                            "values": false,
-                            "alignAsTable": false,
-                            "rightSide": false
+                            "class": "show_legend"
                         },
                         "seriesOverrides": [
                             {
@@ -616,6 +609,9 @@
                                 "step": 1
                             }
                         ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
                         "title": "Read Latencies"
                     }
                 ]
@@ -662,6 +658,9 @@
                                 "step": 10
                             }
                         ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
                         "title": "Cache Hits/Misses"
                     },
                     {
@@ -672,18 +671,21 @@
                             {
                                 "expr": "$func(rate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[$__rate_interval])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Writes timeout {{[[by]]}}",
+                                "legendFormat": "Writes {{[[by]]}}",
                                 "refId": "A",
                                 "step": 10
                             },
                             {
                                 "expr": "$func(rate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])+rate(scylla_storage_proxy_coordinator_cas_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])+rate(scylla_storage_proxy_coordinator_range_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "Read  timeout {{[[by]]}}",
+                                "legendFormat": "Read  {{[[by]]}}",
                                 "refId": "B",
                                 "step": 10
                             }
                         ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
                         "title": "Read/Write Timeouts by [[by]]"
                     }
 

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -1003,6 +1003,17 @@
             }
         ]
     },
+    "show_legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false,
+        "alignAsTable": false,
+        "rightSide": false
+    },
     "graph_panel_int": {
         "class": "graph_panel",
         "yaxes": [


### PR DESCRIPTION
This series adds legends where they were missing in the DC section.
![image](https://user-images.githubusercontent.com/2118079/108676610-2c0e3100-74f1-11eb-9f7d-f86910d3957e.png)

Fixes #1290