### PR TITLE
Add annotation for MW build in progress

### DIFF
--- a/grafana/build/ver_2019.1/scylla-cql.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-cql.2019.1.json
@@ -100,6 +100,21 @@
                 "tags": [],
                 "titleFormat": "Hints Sent",
                 "type": "tags"
+            },
+            {
+                "class": "mv_building",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "sum(scylla_view_builder_builds_in_progress)>0",
+                "hide": false,
+                "iconColor": "rgb(50, 176, 0, 128)",
+                "limit": 100,
+                "name": "MV",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Materialized View built",
+                "type": "tags"
             }
         ]
     },

--- a/grafana/build/ver_2019.1/scylla-detailed.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-detailed.2019.1.json
@@ -100,6 +100,21 @@
                 "tags": [],
                 "titleFormat": "Hints Sent",
                 "type": "tags"
+            },
+            {
+                "class": "mv_building",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "sum(scylla_view_builder_builds_in_progress)>0",
+                "hide": false,
+                "iconColor": "rgb(50, 176, 0, 128)",
+                "limit": 100,
+                "name": "MV",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Materialized View built",
+                "type": "tags"
             }
         ]
     },

--- a/grafana/build/ver_2019.1/scylla-os.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-os.2019.1.json
@@ -100,6 +100,21 @@
                 "tags": [],
                 "titleFormat": "Hints Sent",
                 "type": "tags"
+            },
+            {
+                "class": "mv_building",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "sum(scylla_view_builder_builds_in_progress)>0",
+                "hide": false,
+                "iconColor": "rgb(50, 176, 0, 128)",
+                "limit": 100,
+                "name": "MV",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Materialized View built",
+                "type": "tags"
             }
         ]
     },

--- a/grafana/build/ver_2019.1/scylla-overview.2019.1.json
+++ b/grafana/build/ver_2019.1/scylla-overview.2019.1.json
@@ -100,6 +100,21 @@
                 "tags": [],
                 "titleFormat": "Hints Sent",
                 "type": "tags"
+            },
+            {
+                "class": "mv_building",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "sum(scylla_view_builder_builds_in_progress)>0",
+                "hide": false,
+                "iconColor": "rgb(50, 176, 0, 128)",
+                "limit": 100,
+                "name": "MV",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Materialized View built",
+                "type": "tags"
             }
         ]
     },

--- a/grafana/build/ver_2020.1/scylla-detailed.2020.1.json
+++ b/grafana/build/ver_2020.1/scylla-detailed.2020.1.json
@@ -100,6 +100,21 @@
                 "tags": [],
                 "titleFormat": "Hints Sent",
                 "type": "tags"
+            },
+            {
+                "class": "mv_building",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "sum(scylla_view_builder_builds_in_progress)>0",
+                "hide": false,
+                "iconColor": "rgb(50, 176, 0, 128)",
+                "limit": 100,
+                "name": "MV",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Materialized View built",
+                "type": "tags"
             }
         ]
     },

--- a/grafana/build/ver_2020.1/scylla-overview.2020.1.json
+++ b/grafana/build/ver_2020.1/scylla-overview.2020.1.json
@@ -100,6 +100,21 @@
                 "tags": [],
                 "titleFormat": "Hints Sent",
                 "type": "tags"
+            },
+            {
+                "class": "mv_building",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "sum(scylla_view_builder_builds_in_progress)>0",
+                "hide": false,
+                "iconColor": "rgb(50, 176, 0, 128)",
+                "limit": 100,
+                "name": "MV",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Materialized View built",
+                "type": "tags"
             }
         ]
     },

--- a/grafana/build/ver_4.2/scylla-detailed.4.2.json
+++ b/grafana/build/ver_4.2/scylla-detailed.4.2.json
@@ -100,6 +100,21 @@
                 "tags": [],
                 "titleFormat": "Hints Sent",
                 "type": "tags"
+            },
+            {
+                "class": "mv_building",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "sum(scylla_view_builder_builds_in_progress)>0",
+                "hide": false,
+                "iconColor": "rgb(50, 176, 0, 128)",
+                "limit": 100,
+                "name": "MV",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Materialized View built",
+                "type": "tags"
             }
         ]
     },

--- a/grafana/build/ver_4.2/scylla-overview.4.2.json
+++ b/grafana/build/ver_4.2/scylla-overview.4.2.json
@@ -100,6 +100,21 @@
                 "tags": [],
                 "titleFormat": "Hints Sent",
                 "type": "tags"
+            },
+            {
+                "class": "mv_building",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "sum(scylla_view_builder_builds_in_progress)>0",
+                "hide": false,
+                "iconColor": "rgb(50, 176, 0, 128)",
+                "limit": 100,
+                "name": "MV",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Materialized View built",
+                "type": "tags"
             }
         ]
     },

--- a/grafana/build/ver_4.3/scylla-detailed.4.3.json
+++ b/grafana/build/ver_4.3/scylla-detailed.4.3.json
@@ -100,6 +100,21 @@
                 "tags": [],
                 "titleFormat": "Hints Sent",
                 "type": "tags"
+            },
+            {
+                "class": "mv_building",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "sum(scylla_view_builder_builds_in_progress)>0",
+                "hide": false,
+                "iconColor": "rgb(50, 176, 0, 128)",
+                "limit": 100,
+                "name": "MV",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Materialized View built",
+                "type": "tags"
             }
         ]
     },

--- a/grafana/build/ver_4.3/scylla-overview.4.3.json
+++ b/grafana/build/ver_4.3/scylla-overview.4.3.json
@@ -100,6 +100,21 @@
                 "tags": [],
                 "titleFormat": "Hints Sent",
                 "type": "tags"
+            },
+            {
+                "class": "mv_building",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "sum(scylla_view_builder_builds_in_progress)>0",
+                "hide": false,
+                "iconColor": "rgb(50, 176, 0, 128)",
+                "limit": 100,
+                "name": "MV",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Materialized View built",
+                "type": "tags"
             }
         ]
     },

--- a/grafana/build/ver_4.4/scylla-detailed.4.4.json
+++ b/grafana/build/ver_4.4/scylla-detailed.4.4.json
@@ -100,6 +100,21 @@
                 "tags": [],
                 "titleFormat": "Hints Sent",
                 "type": "tags"
+            },
+            {
+                "class": "mv_building",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "sum(scylla_view_builder_builds_in_progress)>0",
+                "hide": false,
+                "iconColor": "rgb(50, 176, 0, 128)",
+                "limit": 100,
+                "name": "MV",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Materialized View built",
+                "type": "tags"
             }
         ]
     },

--- a/grafana/build/ver_4.4/scylla-overview.4.4.json
+++ b/grafana/build/ver_4.4/scylla-overview.4.4.json
@@ -100,6 +100,21 @@
                 "tags": [],
                 "titleFormat": "Hints Sent",
                 "type": "tags"
+            },
+            {
+                "class": "mv_building",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "sum(scylla_view_builder_builds_in_progress)>0",
+                "hide": false,
+                "iconColor": "rgb(50, 176, 0, 128)",
+                "limit": 100,
+                "name": "MV",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Materialized View built",
+                "type": "tags"
             }
         ]
     },

--- a/grafana/build/ver_master/scylla-detailed.master.json
+++ b/grafana/build/ver_master/scylla-detailed.master.json
@@ -100,6 +100,21 @@
                 "tags": [],
                 "titleFormat": "Hints Sent",
                 "type": "tags"
+            },
+            {
+                "class": "mv_building",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "sum(scylla_view_builder_builds_in_progress)>0",
+                "hide": false,
+                "iconColor": "rgb(50, 176, 0, 128)",
+                "limit": 100,
+                "name": "MV",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Materialized View built",
+                "type": "tags"
             }
         ]
     },

--- a/grafana/build/ver_master/scylla-overview.master.json
+++ b/grafana/build/ver_master/scylla-overview.master.json
@@ -100,6 +100,21 @@
                 "tags": [],
                 "titleFormat": "Hints Sent",
                 "type": "tags"
+            },
+            {
+                "class": "mv_building",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "sum(scylla_view_builder_builds_in_progress)>0",
+                "hide": false,
+                "iconColor": "rgb(50, 176, 0, 128)",
+                "limit": 100,
+                "name": "MV",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "Materialized View built",
+                "type": "tags"
             }
         ]
     },

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -153,7 +153,6 @@
                "w":9,
                "h":1
             },
-            "title":"",
             "transparent":false,
             "options":{
                "content":"# "
@@ -165,7 +164,6 @@
                "w":4,
                "h":1
             },
-            "title":"",
             "transparent":false,
             "options":{
                "content":"# "
@@ -177,7 +175,6 @@
                "w":4,
                "h":1
             },
-            "title":"",
             "transparent":false,
             "options":{
                "content":"# "
@@ -189,7 +186,6 @@
                "w":7,
                "h":1
             },
-            "title":"",
             "transparent":false,
             "options":{
                "content":"# "
@@ -2664,6 +2660,13 @@
       "name":"Hints Sent",
       "titleFormat":"Hints Sent"
    },
+   "mv_building":{
+      "class":"annotation_restart",
+      "expr":"sum(scylla_view_builder_builds_in_progress)>0",
+      "iconColor":"rgb(50, 176, 0, 128)",
+      "name":"MV",
+      "titleFormat":"Materialized View built"
+   },
    "vertical_lcd":{
       "datasource":"prometheus",
       "fieldConfig":{
@@ -2764,6 +2767,9 @@
          },
          {
             "class":"annotation_hints_sent"
+         },
+         {
+            "class":"mv_building"
          }
       ]
    },


### PR DESCRIPTION
A materialized view build in progress can have impact on the system.
This series adds annoations that show when a MW is in porgress, this is not very frequent so the annotation is on by default
![Screenshot from 2021-03-02 18-09-24](https://user-images.githubusercontent.com/2118079/109683306-e81dca80-7b87-11eb-9918-9f01568e6aa2.png)


Fixes #1257 
