### PR TITLE
Add nodes per dc and cluster to open-issue

### DIFF
--- a/grafana/build/ver_2020.1/scylla-overview.2020.1.json
+++ b/grafana/build/ver_2020.1/scylla-overview.2020.1.json
@@ -1713,7 +1713,7 @@
                                     {
                                         "targetBlank": true,
                                         "title": "Open an issue",
-                                        "url": "https://github.com/scylladb/scylla/issues/new?body=description%3D${__data.fields[4]}%0ASource%3DAdvisor%0AScylla-versions%3D${all_scyllas_versions}%0Ascylla-monitoring%3D${monitoring_version}"
+                                        "url": "https://github.com/scylladb/scylla/issues/new?body=description%3D${__data.fields[4]}%0ASource%3DAdvisor%0AScylla-versions%3D${all_scyllas_versions}%0Ascylla-monitoring%3D${monitoring_version}%0Acluster%3D${count_dc}%0Aname%3D${cluster}"
                                     }
                                 ]
                             },
@@ -4554,6 +4554,40 @@
                 "query": "label_values(scylla_scylladb_current_version{cluster=~\"$cluster|$^\"}, version)",
                 "refresh": 2,
                 "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "selected": true,
+                    "text": [
+                        "All"
+                    ],
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "query_result(count(up{job=\"scylla\"}) by (dc))",
+                "error": null,
+                "hide": 2,
+                "includeAll": true,
+                "multi": true,
+                "name": "count_dc",
+                "options": [],
+                "query": {
+                    "query": "query_result(count(up{job=\"scylla\"}) by (dc))",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 2,
+                "regex": "/(?<dc>\\{dc=\"[^\"]+\".* \\d+) .*/",
                 "skipUrlSync": false,
                 "sort": 1,
                 "tagValuesQuery": "",

--- a/grafana/build/ver_4.1/scylla-overview.4.1.json
+++ b/grafana/build/ver_4.1/scylla-overview.4.1.json
@@ -1646,7 +1646,7 @@
                                     {
                                         "targetBlank": true,
                                         "title": "Open an issue",
-                                        "url": "https://github.com/scylladb/scylla/issues/new?body=description%3D${__data.fields[4]}%0ASource%3DAdvisor%0AScylla-versions%3D${all_scyllas_versions}%0Ascylla-monitoring%3D${monitoring_version}"
+                                        "url": "https://github.com/scylladb/scylla/issues/new?body=description%3D${__data.fields[4]}%0ASource%3DAdvisor%0AScylla-versions%3D${all_scyllas_versions}%0Ascylla-monitoring%3D${monitoring_version}%0Acluster%3D${count_dc}%0Aname%3D${cluster}"
                                     }
                                 ]
                             },
@@ -4473,6 +4473,40 @@
                 "query": "label_values(scylla_scylladb_current_version{cluster=~\"$cluster|$^\"}, version)",
                 "refresh": 2,
                 "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "selected": true,
+                    "text": [
+                        "All"
+                    ],
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "query_result(count(up{job=\"scylla\"}) by (dc))",
+                "error": null,
+                "hide": 2,
+                "includeAll": true,
+                "multi": true,
+                "name": "count_dc",
+                "options": [],
+                "query": {
+                    "query": "query_result(count(up{job=\"scylla\"}) by (dc))",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 2,
+                "regex": "/(?<dc>\\{dc=\"[^\"]+\".* \\d+) .*/",
                 "skipUrlSync": false,
                 "sort": 1,
                 "tagValuesQuery": "",

--- a/grafana/build/ver_4.2/scylla-overview.4.2.json
+++ b/grafana/build/ver_4.2/scylla-overview.4.2.json
@@ -1713,7 +1713,7 @@
                                     {
                                         "targetBlank": true,
                                         "title": "Open an issue",
-                                        "url": "https://github.com/scylladb/scylla/issues/new?body=description%3D${__data.fields[4]}%0ASource%3DAdvisor%0AScylla-versions%3D${all_scyllas_versions}%0Ascylla-monitoring%3D${monitoring_version}"
+                                        "url": "https://github.com/scylladb/scylla/issues/new?body=description%3D${__data.fields[4]}%0ASource%3DAdvisor%0AScylla-versions%3D${all_scyllas_versions}%0Ascylla-monitoring%3D${monitoring_version}%0Acluster%3D${count_dc}%0Aname%3D${cluster}"
                                     }
                                 ]
                             },
@@ -4554,6 +4554,40 @@
                 "query": "label_values(scylla_scylladb_current_version{cluster=~\"$cluster|$^\"}, version)",
                 "refresh": 2,
                 "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "selected": true,
+                    "text": [
+                        "All"
+                    ],
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "query_result(count(up{job=\"scylla\"}) by (dc))",
+                "error": null,
+                "hide": 2,
+                "includeAll": true,
+                "multi": true,
+                "name": "count_dc",
+                "options": [],
+                "query": {
+                    "query": "query_result(count(up{job=\"scylla\"}) by (dc))",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 2,
+                "regex": "/(?<dc>\\{dc=\"[^\"]+\".* \\d+) .*/",
                 "skipUrlSync": false,
                 "sort": 1,
                 "tagValuesQuery": "",

--- a/grafana/build/ver_4.3/scylla-overview.4.3.json
+++ b/grafana/build/ver_4.3/scylla-overview.4.3.json
@@ -1713,7 +1713,7 @@
                                     {
                                         "targetBlank": true,
                                         "title": "Open an issue",
-                                        "url": "https://github.com/scylladb/scylla/issues/new?body=description%3D${__data.fields[4]}%0ASource%3DAdvisor%0AScylla-versions%3D${all_scyllas_versions}%0Ascylla-monitoring%3D${monitoring_version}"
+                                        "url": "https://github.com/scylladb/scylla/issues/new?body=description%3D${__data.fields[4]}%0ASource%3DAdvisor%0AScylla-versions%3D${all_scyllas_versions}%0Ascylla-monitoring%3D${monitoring_version}%0Acluster%3D${count_dc}%0Aname%3D${cluster}"
                                     }
                                 ]
                             },
@@ -4554,6 +4554,40 @@
                 "query": "label_values(scylla_scylladb_current_version{cluster=~\"$cluster|$^\"}, version)",
                 "refresh": 2,
                 "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "selected": true,
+                    "text": [
+                        "All"
+                    ],
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "query_result(count(up{job=\"scylla\"}) by (dc))",
+                "error": null,
+                "hide": 2,
+                "includeAll": true,
+                "multi": true,
+                "name": "count_dc",
+                "options": [],
+                "query": {
+                    "query": "query_result(count(up{job=\"scylla\"}) by (dc))",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 2,
+                "regex": "/(?<dc>\\{dc=\"[^\"]+\".* \\d+) .*/",
                 "skipUrlSync": false,
                 "sort": 1,
                 "tagValuesQuery": "",

--- a/grafana/build/ver_4.4/scylla-overview.4.4.json
+++ b/grafana/build/ver_4.4/scylla-overview.4.4.json
@@ -1713,7 +1713,7 @@
                                     {
                                         "targetBlank": true,
                                         "title": "Open an issue",
-                                        "url": "https://github.com/scylladb/scylla/issues/new?body=description%3D${__data.fields[4]}%0ASource%3DAdvisor%0AScylla-versions%3D${all_scyllas_versions}%0Ascylla-monitoring%3D${monitoring_version}"
+                                        "url": "https://github.com/scylladb/scylla/issues/new?body=description%3D${__data.fields[4]}%0ASource%3DAdvisor%0AScylla-versions%3D${all_scyllas_versions}%0Ascylla-monitoring%3D${monitoring_version}%0Acluster%3D${count_dc}%0Aname%3D${cluster}"
                                     }
                                 ]
                             },
@@ -4554,6 +4554,40 @@
                 "query": "label_values(scylla_scylladb_current_version{cluster=~\"$cluster|$^\"}, version)",
                 "refresh": 2,
                 "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "selected": true,
+                    "text": [
+                        "All"
+                    ],
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "query_result(count(up{job=\"scylla\"}) by (dc))",
+                "error": null,
+                "hide": 2,
+                "includeAll": true,
+                "multi": true,
+                "name": "count_dc",
+                "options": [],
+                "query": {
+                    "query": "query_result(count(up{job=\"scylla\"}) by (dc))",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 2,
+                "regex": "/(?<dc>\\{dc=\"[^\"]+\".* \\d+) .*/",
                 "skipUrlSync": false,
                 "sort": 1,
                 "tagValuesQuery": "",

--- a/grafana/build/ver_master/scylla-overview.master.json
+++ b/grafana/build/ver_master/scylla-overview.master.json
@@ -1713,7 +1713,7 @@
                                     {
                                         "targetBlank": true,
                                         "title": "Open an issue",
-                                        "url": "https://github.com/scylladb/scylla/issues/new?body=description%3D${__data.fields[4]}%0ASource%3DAdvisor%0AScylla-versions%3D${all_scyllas_versions}%0Ascylla-monitoring%3D${monitoring_version}"
+                                        "url": "https://github.com/scylladb/scylla/issues/new?body=description%3D${__data.fields[4]}%0ASource%3DAdvisor%0AScylla-versions%3D${all_scyllas_versions}%0Ascylla-monitoring%3D${monitoring_version}%0Acluster%3D${count_dc}%0Aname%3D${cluster}"
                                     }
                                 ]
                             },
@@ -4554,6 +4554,40 @@
                 "query": "label_values(scylla_scylladb_current_version{cluster=~\"$cluster|$^\"}, version)",
                 "refresh": 2,
                 "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "selected": true,
+                    "text": [
+                        "All"
+                    ],
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "query_result(count(up{job=\"scylla\"}) by (dc))",
+                "error": null,
+                "hide": 2,
+                "includeAll": true,
+                "multi": true,
+                "name": "count_dc",
+                "options": [],
+                "query": {
+                    "query": "query_result(count(up{job=\"scylla\"}) by (dc))",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 2,
+                "regex": "/(?<dc>\\{dc=\"[^\"]+\".* \\d+) .*/",
                 "skipUrlSync": false,
                 "sort": 1,
                 "tagValuesQuery": "",

--- a/grafana/scylla-overview.2020.1.template.json
+++ b/grafana/scylla-overview.2020.1.template.json
@@ -714,6 +714,17 @@
                     "query": "label_values(scylla_scylladb_current_version{cluster=~\"$cluster|$^\"}, version)"
                 },
                 {
+                    "class": "template_variable_all",
+                    "hide":2,
+                    "name": "count_dc",
+                    "definition": "query_result(count(up{job=\"scylla\"}) by (dc))",
+                    "query": {
+                      "query": "query_result(count(up{job=\"scylla\"}) by (dc))",
+                      "refId": "StandardVariableQuery"
+                    },
+                    "regex": "/(?<dc>\\{dc=\"[^\"]+\".* \\d+) .*/"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "2020.1",

--- a/grafana/scylla-overview.4.1.template.json
+++ b/grafana/scylla-overview.4.1.template.json
@@ -712,6 +712,17 @@
                     "query": "label_values(scylla_scylladb_current_version{cluster=~\"$cluster|$^\"}, version)"
                 },
                 {
+                    "class": "template_variable_all",
+                    "hide":2,
+                    "name": "count_dc",
+                    "definition": "query_result(count(up{job=\"scylla\"}) by (dc))",
+                    "query": {
+                      "query": "query_result(count(up{job=\"scylla\"}) by (dc))",
+                      "refId": "StandardVariableQuery"
+                    },
+                    "regex": "/(?<dc>\\{dc=\"[^\"]+\".* \\d+) .*/"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "4.1",

--- a/grafana/scylla-overview.4.2.template.json
+++ b/grafana/scylla-overview.4.2.template.json
@@ -714,6 +714,17 @@
                     "query": "label_values(scylla_scylladb_current_version{cluster=~\"$cluster|$^\"}, version)"
                 },
                 {
+                    "class": "template_variable_all",
+                    "hide":2,
+                    "name": "count_dc",
+                    "definition": "query_result(count(up{job=\"scylla\"}) by (dc))",
+                    "query": {
+                      "query": "query_result(count(up{job=\"scylla\"}) by (dc))",
+                      "refId": "StandardVariableQuery"
+                    },
+                    "regex": "/(?<dc>\\{dc=\"[^\"]+\".* \\d+) .*/"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "4.2",

--- a/grafana/scylla-overview.4.3.template.json
+++ b/grafana/scylla-overview.4.3.template.json
@@ -714,6 +714,17 @@
                     "query": "label_values(scylla_scylladb_current_version{cluster=~\"$cluster|$^\"}, version)"
                 },
                 {
+                    "class": "template_variable_all",
+                    "hide":2,
+                    "name": "count_dc",
+                    "definition": "query_result(count(up{job=\"scylla\"}) by (dc))",
+                    "query": {
+                      "query": "query_result(count(up{job=\"scylla\"}) by (dc))",
+                      "refId": "StandardVariableQuery"
+                    },
+                    "regex": "/(?<dc>\\{dc=\"[^\"]+\".* \\d+) .*/"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "4.3",

--- a/grafana/scylla-overview.4.4.template.json
+++ b/grafana/scylla-overview.4.4.template.json
@@ -714,6 +714,17 @@
                     "query": "label_values(scylla_scylladb_current_version{cluster=~\"$cluster|$^\"}, version)"
                 },
                 {
+                    "class": "template_variable_all",
+                    "hide":2,
+                    "name": "count_dc",
+                    "definition": "query_result(count(up{job=\"scylla\"}) by (dc))",
+                    "query": {
+                      "query": "query_result(count(up{job=\"scylla\"}) by (dc))",
+                      "refId": "StandardVariableQuery"
+                    },
+                    "regex": "/(?<dc>\\{dc=\"[^\"]+\".* \\d+) .*/"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "4.4",

--- a/grafana/scylla-overview.master.template.json
+++ b/grafana/scylla-overview.master.template.json
@@ -714,6 +714,17 @@
                     "query": "label_values(scylla_scylladb_current_version{cluster=~\"$cluster|$^\"}, version)"
                 },
                 {
+                    "class": "template_variable_all",
+                    "hide":2,
+                    "name": "count_dc",
+                    "definition": "query_result(count(up{job=\"scylla\"}) by (dc))",
+                    "query": {
+                      "query": "query_result(count(up{job=\"scylla\"}) by (dc))",
+                      "refId": "StandardVariableQuery"
+                    },
+                    "regex": "/(?<dc>\\{dc=\"[^\"]+\".* \\d+) .*/"
+                },
+                {
                     "class": "template_variable_custom",
                     "current": {
                         "text": "master",

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -1729,7 +1729,7 @@
                 "value": [
                   {
                     "title": "Open an issue",
-                    "url": "https://github.com/scylladb/scylla/issues/new?body=description%3D${__data.fields[4]}%0ASource%3DAdvisor%0AScylla-versions%3D${all_scyllas_versions}%0Ascylla-monitoring%3D${monitoring_version}",
+                    "url": "https://github.com/scylladb/scylla/issues/new?body=description%3D${__data.fields[4]}%0ASource%3DAdvisor%0AScylla-versions%3D${all_scyllas_versions}%0Ascylla-monitoring%3D${monitoring_version}%0Acluster%3D${count_dc}%0Aname%3D${cluster}",
                     "targetBlank": true
                   }
                 ]


### PR DESCRIPTION
This series adds a list of nodes per dc and the cluster name to an open issue.
After this change, it looks like:
![image](https://user-images.githubusercontent.com/2118079/110295344-ad89b700-7ff9-11eb-87cf-84bf2a9aecf8.png)

Relates to #1302 