### PR TITLE
Advisor alerts on non-paged and reverse order queries memory limits

### DIFF
--- a/grafana/build/ver_2020.1/scylla-overview.2020.1.json
+++ b/grafana/build/ver_2020.1/scylla-overview.2020.1.json
@@ -1770,7 +1770,7 @@
                 {
                     "active": true,
                     "annotations": true,
-                    "filters": "advisor!=\"\",cluster=\"$cluster\"",
+                    "filters": "advisor!=\"\"",
                     "legendFormat": "{{description}}",
                     "refId": "A",
                     "target": "Query"

--- a/grafana/build/ver_4.1/scylla-overview.4.1.json
+++ b/grafana/build/ver_4.1/scylla-overview.4.1.json
@@ -1703,7 +1703,7 @@
                 {
                     "active": true,
                     "annotations": true,
-                    "filters": "advisor!=\"\",cluster=\"$cluster\"",
+                    "filters": "advisor!=\"\"",
                     "legendFormat": "{{description}}",
                     "refId": "A",
                     "target": "Query"

--- a/grafana/build/ver_4.2/scylla-overview.4.2.json
+++ b/grafana/build/ver_4.2/scylla-overview.4.2.json
@@ -1770,7 +1770,7 @@
                 {
                     "active": true,
                     "annotations": true,
-                    "filters": "advisor!=\"\",cluster=\"$cluster\"",
+                    "filters": "advisor!=\"\"",
                     "legendFormat": "{{description}}",
                     "refId": "A",
                     "target": "Query"

--- a/grafana/build/ver_4.3/scylla-overview.4.3.json
+++ b/grafana/build/ver_4.3/scylla-overview.4.3.json
@@ -1770,7 +1770,7 @@
                 {
                     "active": true,
                     "annotations": true,
-                    "filters": "advisor!=\"\",cluster=\"$cluster\"",
+                    "filters": "advisor!=\"\"",
                     "legendFormat": "{{description}}",
                     "refId": "A",
                     "target": "Query"

--- a/grafana/build/ver_4.4/scylla-overview.4.4.json
+++ b/grafana/build/ver_4.4/scylla-overview.4.4.json
@@ -1770,7 +1770,7 @@
                 {
                     "active": true,
                     "annotations": true,
-                    "filters": "advisor!=\"\",cluster=\"$cluster\"",
+                    "filters": "advisor!=\"\"",
                     "legendFormat": "{{description}}",
                     "refId": "A",
                     "target": "Query"

--- a/grafana/build/ver_master/scylla-overview.master.json
+++ b/grafana/build/ver_master/scylla-overview.master.json
@@ -1770,7 +1770,7 @@
                 {
                     "active": true,
                     "annotations": true,
-                    "filters": "advisor!=\"\",cluster=\"$cluster\"",
+                    "filters": "advisor!=\"\"",
                     "legendFormat": "{{description}}",
                     "refId": "A",
                     "target": "Query"

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -1654,7 +1654,7 @@
           "refId": "A",
           "target": "Query",
           "active": true,
-          "filters": "advisor!=\"\",cluster=\"$cluster\""
+          "filters": "advisor!=\"\""
         }
       ],
       "title": "",

--- a/loki/rules/scylla/loki-rule.yaml
+++ b/loki/rules/scylla/loki-rule.yaml
@@ -15,3 +15,21 @@ groups:
         severity: "1"
       annotations:
         description: '{{ $labels.instance }} {{ $labels.msg }} memory.'
+    - alert: nonpagedQueryLimit
+      expr: rate({app="scylla", module="mutation_partition", severity="warning"}[1h])>0
+      for: 20s
+      labels:
+        severity: "1"
+        advisor: "cqlOptimization"
+        dashboard: "cql"
+      annotations:
+        description: '{{ $labels.instance }} Unpaged query exceeds memory limit'
+    - alert: reverseOrderLimit
+      expr: rate({app="scylla", module="flat_mutation_reader", severity="warning"}[1h])>0
+      for: 20s
+      labels:
+        severity: "1"
+        advisor: "cqlOptimization"
+        dashboard: "cql"
+      annotations:
+        description: '{{ $labels.instance }} Reversed read exceeds memory limit'


### PR DESCRIPTION
Non-paged and reverser order queries or unefficient and cause larger memory allocations.
As of Scylla OS 4.3 version there are warnings on crossing a predefined limits.
This series uses loki to read these warnings from the logs and show it in the Advisor table.

There are limitations:
* Loki does not have the cluster in its labels, so the advisor will now display all advisor
* The original trace message is too long to display, so a shorter version of it is shown - we can think of adding a table to the CQL dashboard with the full text
![image](https://user-images.githubusercontent.com/2118079/110446736-2b1bf880-80c8-11eb-9c36-f83777430d39.png)

Fixes #1245
Fixes #1246