### PR TITLE
Adding HW to the node table

### DIFF
--- a/grafana/build/ver_2020.1/scylla-overview.2020.1.json
+++ b/grafana/build/ver_2020.1/scylla-overview.2020.1.json
@@ -3144,7 +3144,7 @@
                             },
                             {
                                 "id": "custom.width",
-                                "value": 120
+                                "value": 110
                             },
                             {
                                 "id": "custom.filterable",
@@ -3164,7 +3164,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 85
+                                "value": 80
                             },
                             {
                                 "id": "displayName",
@@ -3180,7 +3180,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 105
+                                "value": 100
                             }
                         ]
                     },
@@ -3192,7 +3192,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 105
+                                "value": 100
                             },
                             {
                                 "id": "displayName",
@@ -3388,7 +3388,7 @@
                             },
                             {
                                 "id": "custom.width",
-                                "value": 90
+                                "value": 85
                             },
                             {
                                 "id": "custom.filterable",
@@ -3462,7 +3462,7 @@
                             },
                             {
                                 "id": "custom.width",
-                                "value": 80
+                                "value": 65
                             },
                             {
                                 "id": "custom.filterable",
@@ -3516,6 +3516,54 @@
                             {
                                 "id": "displayName",
                                 "value": " "
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "Value #F"
+                        },
+                        "properties": [
+                            {
+                                "id": "displayName",
+                                "value": "HW"
+                            },
+                            {
+                                "id": "custom.width",
+                                "value": 25
+                            },
+                            {
+                                "id": "custom.filterable",
+                                "value": false
+                            },
+                            {
+                                "id": "thresholds",
+                                "value": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "rgb(51, 34, 151)",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "rgb(13, 100, 229)",
+                                            "value": 0.2
+                                        },
+                                        {
+                                            "color": "rgb(133, 193, 116)",
+                                            "value": 0.8
+                                        },
+                                        {
+                                            "color": "rgb(247, 156, 53)",
+                                            "value": 1.4
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "custom.displayMode",
+                                "value": "color-text"
                             }
                         ]
                     },
@@ -3595,6 +3643,14 @@
                     "interval": "",
                     "legendFormat": "",
                     "refId": "E"
+                },
+                {
+                    "expr": "round(sum(scalar(count(cache:hwlb{cluster=~\"$cluster\", dc=~\"$dc\"})) * cache:hwlb{cluster=~\"$cluster\", dc=~\"$dc\"}/scalar(sum(cache:hwlb{cluster=~\"$cluster\", dc=~\"$dc\"}))) by (instance), 0.1)",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "F"
                 }
             ],
             "title": "Nodes",
@@ -3610,7 +3666,8 @@
                                 "Value #B",
                                 "Value #C",
                                 "Value #D",
-                                "Value #E"
+                                "Value #E",
+                                "Value #F"
                             ]
                         }
                     }
@@ -3631,6 +3688,7 @@
                             "Value #C": 3,
                             "Value #D": 1,
                             "Value #E": 2,
+                            "Value #F": 7,
                             "instance": 0,
                             "svr": 4
                         },

--- a/grafana/build/ver_2021.1/scylla-overview.2021.1.json
+++ b/grafana/build/ver_2021.1/scylla-overview.2021.1.json
@@ -3144,7 +3144,7 @@
                             },
                             {
                                 "id": "custom.width",
-                                "value": 120
+                                "value": 110
                             },
                             {
                                 "id": "custom.filterable",
@@ -3164,7 +3164,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 85
+                                "value": 80
                             },
                             {
                                 "id": "displayName",
@@ -3180,7 +3180,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 105
+                                "value": 100
                             }
                         ]
                     },
@@ -3192,7 +3192,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 105
+                                "value": 100
                             },
                             {
                                 "id": "displayName",
@@ -3388,7 +3388,7 @@
                             },
                             {
                                 "id": "custom.width",
-                                "value": 90
+                                "value": 85
                             },
                             {
                                 "id": "custom.filterable",
@@ -3462,7 +3462,7 @@
                             },
                             {
                                 "id": "custom.width",
-                                "value": 80
+                                "value": 65
                             },
                             {
                                 "id": "custom.filterable",
@@ -3516,6 +3516,54 @@
                             {
                                 "id": "displayName",
                                 "value": " "
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "Value #F"
+                        },
+                        "properties": [
+                            {
+                                "id": "displayName",
+                                "value": "HW"
+                            },
+                            {
+                                "id": "custom.width",
+                                "value": 25
+                            },
+                            {
+                                "id": "custom.filterable",
+                                "value": false
+                            },
+                            {
+                                "id": "thresholds",
+                                "value": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "rgb(51, 34, 151)",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "rgb(13, 100, 229)",
+                                            "value": 0.2
+                                        },
+                                        {
+                                            "color": "rgb(133, 193, 116)",
+                                            "value": 0.8
+                                        },
+                                        {
+                                            "color": "rgb(247, 156, 53)",
+                                            "value": 1.4
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "custom.displayMode",
+                                "value": "color-text"
                             }
                         ]
                     },
@@ -3595,6 +3643,14 @@
                     "interval": "",
                     "legendFormat": "",
                     "refId": "E"
+                },
+                {
+                    "expr": "round(sum(scalar(count(cache:hwlb{cluster=~\"$cluster\", dc=~\"$dc\"})) * cache:hwlb{cluster=~\"$cluster\", dc=~\"$dc\"}/scalar(sum(cache:hwlb{cluster=~\"$cluster\", dc=~\"$dc\"}))) by (instance), 0.1)",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "F"
                 }
             ],
             "title": "Nodes",
@@ -3610,7 +3666,8 @@
                                 "Value #B",
                                 "Value #C",
                                 "Value #D",
-                                "Value #E"
+                                "Value #E",
+                                "Value #F"
                             ]
                         }
                     }
@@ -3631,6 +3688,7 @@
                             "Value #C": 3,
                             "Value #D": 1,
                             "Value #E": 2,
+                            "Value #F": 7,
                             "instance": 0,
                             "svr": 4
                         },

--- a/grafana/build/ver_4.1/scylla-overview.4.1.json
+++ b/grafana/build/ver_4.1/scylla-overview.4.1.json
@@ -3071,7 +3071,7 @@
                             },
                             {
                                 "id": "custom.width",
-                                "value": 120
+                                "value": 110
                             },
                             {
                                 "id": "custom.filterable",
@@ -3091,7 +3091,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 85
+                                "value": 80
                             },
                             {
                                 "id": "displayName",
@@ -3107,7 +3107,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 105
+                                "value": 100
                             }
                         ]
                     },
@@ -3119,7 +3119,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 105
+                                "value": 100
                             },
                             {
                                 "id": "displayName",
@@ -3315,7 +3315,7 @@
                             },
                             {
                                 "id": "custom.width",
-                                "value": 90
+                                "value": 85
                             },
                             {
                                 "id": "custom.filterable",
@@ -3389,7 +3389,7 @@
                             },
                             {
                                 "id": "custom.width",
-                                "value": 80
+                                "value": 65
                             },
                             {
                                 "id": "custom.filterable",
@@ -3443,6 +3443,54 @@
                             {
                                 "id": "displayName",
                                 "value": " "
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "Value #F"
+                        },
+                        "properties": [
+                            {
+                                "id": "displayName",
+                                "value": "HW"
+                            },
+                            {
+                                "id": "custom.width",
+                                "value": 25
+                            },
+                            {
+                                "id": "custom.filterable",
+                                "value": false
+                            },
+                            {
+                                "id": "thresholds",
+                                "value": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "rgb(51, 34, 151)",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "rgb(13, 100, 229)",
+                                            "value": 0.2
+                                        },
+                                        {
+                                            "color": "rgb(133, 193, 116)",
+                                            "value": 0.8
+                                        },
+                                        {
+                                            "color": "rgb(247, 156, 53)",
+                                            "value": 1.4
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "custom.displayMode",
+                                "value": "color-text"
                             }
                         ]
                     },
@@ -3522,6 +3570,14 @@
                     "interval": "",
                     "legendFormat": "",
                     "refId": "E"
+                },
+                {
+                    "expr": "round(sum(scalar(count(cache:hwlb{cluster=~\"$cluster\", dc=~\"$dc\"})) * cache:hwlb{cluster=~\"$cluster\", dc=~\"$dc\"}/scalar(sum(cache:hwlb{cluster=~\"$cluster\", dc=~\"$dc\"}))) by (instance), 0.1)",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "F"
                 }
             ],
             "title": "Nodes",
@@ -3537,7 +3593,8 @@
                                 "Value #B",
                                 "Value #C",
                                 "Value #D",
-                                "Value #E"
+                                "Value #E",
+                                "Value #F"
                             ]
                         }
                     }
@@ -3558,6 +3615,7 @@
                             "Value #C": 3,
                             "Value #D": 1,
                             "Value #E": 2,
+                            "Value #F": 7,
                             "instance": 0,
                             "svr": 4
                         },

--- a/grafana/build/ver_4.2/scylla-overview.4.2.json
+++ b/grafana/build/ver_4.2/scylla-overview.4.2.json
@@ -3146,7 +3146,7 @@
                             },
                             {
                                 "id": "custom.width",
-                                "value": 120
+                                "value": 110
                             },
                             {
                                 "id": "custom.filterable",
@@ -3166,7 +3166,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 85
+                                "value": 80
                             },
                             {
                                 "id": "displayName",
@@ -3182,7 +3182,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 105
+                                "value": 100
                             }
                         ]
                     },
@@ -3194,7 +3194,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 105
+                                "value": 100
                             },
                             {
                                 "id": "displayName",
@@ -3390,7 +3390,7 @@
                             },
                             {
                                 "id": "custom.width",
-                                "value": 90
+                                "value": 85
                             },
                             {
                                 "id": "custom.filterable",
@@ -3464,7 +3464,7 @@
                             },
                             {
                                 "id": "custom.width",
-                                "value": 80
+                                "value": 65
                             },
                             {
                                 "id": "custom.filterable",
@@ -3518,6 +3518,54 @@
                             {
                                 "id": "displayName",
                                 "value": " "
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "Value #F"
+                        },
+                        "properties": [
+                            {
+                                "id": "displayName",
+                                "value": "HW"
+                            },
+                            {
+                                "id": "custom.width",
+                                "value": 25
+                            },
+                            {
+                                "id": "custom.filterable",
+                                "value": false
+                            },
+                            {
+                                "id": "thresholds",
+                                "value": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "rgb(51, 34, 151)",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "rgb(13, 100, 229)",
+                                            "value": 0.2
+                                        },
+                                        {
+                                            "color": "rgb(133, 193, 116)",
+                                            "value": 0.8
+                                        },
+                                        {
+                                            "color": "rgb(247, 156, 53)",
+                                            "value": 1.4
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "custom.displayMode",
+                                "value": "color-text"
                             }
                         ]
                     },
@@ -3597,6 +3645,14 @@
                     "interval": "",
                     "legendFormat": "",
                     "refId": "E"
+                },
+                {
+                    "expr": "round(sum(scalar(count(cache:hwlb{cluster=~\"$cluster\", dc=~\"$dc\"})) * cache:hwlb{cluster=~\"$cluster\", dc=~\"$dc\"}/scalar(sum(cache:hwlb{cluster=~\"$cluster\", dc=~\"$dc\"}))) by (instance), 0.1)",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "F"
                 }
             ],
             "title": "Nodes",
@@ -3612,7 +3668,8 @@
                                 "Value #B",
                                 "Value #C",
                                 "Value #D",
-                                "Value #E"
+                                "Value #E",
+                                "Value #F"
                             ]
                         }
                     }
@@ -3633,6 +3690,7 @@
                             "Value #C": 3,
                             "Value #D": 1,
                             "Value #E": 2,
+                            "Value #F": 7,
                             "instance": 0,
                             "svr": 4
                         },

--- a/grafana/build/ver_4.3/scylla-overview.4.3.json
+++ b/grafana/build/ver_4.3/scylla-overview.4.3.json
@@ -3146,7 +3146,7 @@
                             },
                             {
                                 "id": "custom.width",
-                                "value": 120
+                                "value": 110
                             },
                             {
                                 "id": "custom.filterable",
@@ -3166,7 +3166,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 85
+                                "value": 80
                             },
                             {
                                 "id": "displayName",
@@ -3182,7 +3182,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 105
+                                "value": 100
                             }
                         ]
                     },
@@ -3194,7 +3194,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 105
+                                "value": 100
                             },
                             {
                                 "id": "displayName",
@@ -3390,7 +3390,7 @@
                             },
                             {
                                 "id": "custom.width",
-                                "value": 90
+                                "value": 85
                             },
                             {
                                 "id": "custom.filterable",
@@ -3464,7 +3464,7 @@
                             },
                             {
                                 "id": "custom.width",
-                                "value": 80
+                                "value": 65
                             },
                             {
                                 "id": "custom.filterable",
@@ -3518,6 +3518,54 @@
                             {
                                 "id": "displayName",
                                 "value": " "
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "Value #F"
+                        },
+                        "properties": [
+                            {
+                                "id": "displayName",
+                                "value": "HW"
+                            },
+                            {
+                                "id": "custom.width",
+                                "value": 25
+                            },
+                            {
+                                "id": "custom.filterable",
+                                "value": false
+                            },
+                            {
+                                "id": "thresholds",
+                                "value": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "rgb(51, 34, 151)",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "rgb(13, 100, 229)",
+                                            "value": 0.2
+                                        },
+                                        {
+                                            "color": "rgb(133, 193, 116)",
+                                            "value": 0.8
+                                        },
+                                        {
+                                            "color": "rgb(247, 156, 53)",
+                                            "value": 1.4
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "custom.displayMode",
+                                "value": "color-text"
                             }
                         ]
                     },
@@ -3597,6 +3645,14 @@
                     "interval": "",
                     "legendFormat": "",
                     "refId": "E"
+                },
+                {
+                    "expr": "round(sum(scalar(count(cache:hwlb{cluster=~\"$cluster\", dc=~\"$dc\"})) * cache:hwlb{cluster=~\"$cluster\", dc=~\"$dc\"}/scalar(sum(cache:hwlb{cluster=~\"$cluster\", dc=~\"$dc\"}))) by (instance), 0.1)",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "F"
                 }
             ],
             "title": "Nodes",
@@ -3612,7 +3668,8 @@
                                 "Value #B",
                                 "Value #C",
                                 "Value #D",
-                                "Value #E"
+                                "Value #E",
+                                "Value #F"
                             ]
                         }
                     }
@@ -3633,6 +3690,7 @@
                             "Value #C": 3,
                             "Value #D": 1,
                             "Value #E": 2,
+                            "Value #F": 7,
                             "instance": 0,
                             "svr": 4
                         },

--- a/grafana/build/ver_4.4/scylla-overview.4.4.json
+++ b/grafana/build/ver_4.4/scylla-overview.4.4.json
@@ -3146,7 +3146,7 @@
                             },
                             {
                                 "id": "custom.width",
-                                "value": 120
+                                "value": 110
                             },
                             {
                                 "id": "custom.filterable",
@@ -3166,7 +3166,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 85
+                                "value": 80
                             },
                             {
                                 "id": "displayName",
@@ -3182,7 +3182,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 105
+                                "value": 100
                             }
                         ]
                     },
@@ -3194,7 +3194,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 105
+                                "value": 100
                             },
                             {
                                 "id": "displayName",
@@ -3390,7 +3390,7 @@
                             },
                             {
                                 "id": "custom.width",
-                                "value": 90
+                                "value": 85
                             },
                             {
                                 "id": "custom.filterable",
@@ -3464,7 +3464,7 @@
                             },
                             {
                                 "id": "custom.width",
-                                "value": 80
+                                "value": 65
                             },
                             {
                                 "id": "custom.filterable",
@@ -3518,6 +3518,54 @@
                             {
                                 "id": "displayName",
                                 "value": " "
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "Value #F"
+                        },
+                        "properties": [
+                            {
+                                "id": "displayName",
+                                "value": "HW"
+                            },
+                            {
+                                "id": "custom.width",
+                                "value": 25
+                            },
+                            {
+                                "id": "custom.filterable",
+                                "value": false
+                            },
+                            {
+                                "id": "thresholds",
+                                "value": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "rgb(51, 34, 151)",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "rgb(13, 100, 229)",
+                                            "value": 0.2
+                                        },
+                                        {
+                                            "color": "rgb(133, 193, 116)",
+                                            "value": 0.8
+                                        },
+                                        {
+                                            "color": "rgb(247, 156, 53)",
+                                            "value": 1.4
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "custom.displayMode",
+                                "value": "color-text"
                             }
                         ]
                     },
@@ -3597,6 +3645,14 @@
                     "interval": "",
                     "legendFormat": "",
                     "refId": "E"
+                },
+                {
+                    "expr": "round(sum(scalar(count(cache:hwlb{cluster=~\"$cluster\", dc=~\"$dc\"})) * cache:hwlb{cluster=~\"$cluster\", dc=~\"$dc\"}/scalar(sum(cache:hwlb{cluster=~\"$cluster\", dc=~\"$dc\"}))) by (instance), 0.1)",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "F"
                 }
             ],
             "title": "Nodes",
@@ -3612,7 +3668,8 @@
                                 "Value #B",
                                 "Value #C",
                                 "Value #D",
-                                "Value #E"
+                                "Value #E",
+                                "Value #F"
                             ]
                         }
                     }
@@ -3633,6 +3690,7 @@
                             "Value #C": 3,
                             "Value #D": 1,
                             "Value #E": 2,
+                            "Value #F": 7,
                             "instance": 0,
                             "svr": 4
                         },

--- a/grafana/build/ver_master/scylla-overview.master.json
+++ b/grafana/build/ver_master/scylla-overview.master.json
@@ -3146,7 +3146,7 @@
                             },
                             {
                                 "id": "custom.width",
-                                "value": 120
+                                "value": 110
                             },
                             {
                                 "id": "custom.filterable",
@@ -3166,7 +3166,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 85
+                                "value": 80
                             },
                             {
                                 "id": "displayName",
@@ -3182,7 +3182,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 105
+                                "value": 100
                             }
                         ]
                     },
@@ -3194,7 +3194,7 @@
                         "properties": [
                             {
                                 "id": "custom.width",
-                                "value": 105
+                                "value": 100
                             },
                             {
                                 "id": "displayName",
@@ -3390,7 +3390,7 @@
                             },
                             {
                                 "id": "custom.width",
-                                "value": 90
+                                "value": 85
                             },
                             {
                                 "id": "custom.filterable",
@@ -3464,7 +3464,7 @@
                             },
                             {
                                 "id": "custom.width",
-                                "value": 80
+                                "value": 65
                             },
                             {
                                 "id": "custom.filterable",
@@ -3518,6 +3518,54 @@
                             {
                                 "id": "displayName",
                                 "value": " "
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "Value #F"
+                        },
+                        "properties": [
+                            {
+                                "id": "displayName",
+                                "value": "HW"
+                            },
+                            {
+                                "id": "custom.width",
+                                "value": 25
+                            },
+                            {
+                                "id": "custom.filterable",
+                                "value": false
+                            },
+                            {
+                                "id": "thresholds",
+                                "value": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "rgb(51, 34, 151)",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "rgb(13, 100, 229)",
+                                            "value": 0.2
+                                        },
+                                        {
+                                            "color": "rgb(133, 193, 116)",
+                                            "value": 0.8
+                                        },
+                                        {
+                                            "color": "rgb(247, 156, 53)",
+                                            "value": 1.4
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "custom.displayMode",
+                                "value": "color-text"
                             }
                         ]
                     },
@@ -3597,6 +3645,14 @@
                     "interval": "",
                     "legendFormat": "",
                     "refId": "E"
+                },
+                {
+                    "expr": "round(sum(scalar(count(cache:hwlb{cluster=~\"$cluster\", dc=~\"$dc\"})) * cache:hwlb{cluster=~\"$cluster\", dc=~\"$dc\"}/scalar(sum(cache:hwlb{cluster=~\"$cluster\", dc=~\"$dc\"}))) by (instance), 0.1)",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "F"
                 }
             ],
             "title": "Nodes",
@@ -3612,7 +3668,8 @@
                                 "Value #B",
                                 "Value #C",
                                 "Value #D",
-                                "Value #E"
+                                "Value #E",
+                                "Value #F"
                             ]
                         }
                     }
@@ -3633,6 +3690,7 @@
                             "Value #C": 3,
                             "Value #D": 1,
                             "Value #E": 2,
+                            "Value #F": 7,
                             "instance": 0,
                             "svr": 4
                         },

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -2186,6 +2186,14 @@
             "refId":"E",
             "instant":true,
             "format":"table"
+         },
+         {
+            "expr":"round(sum(scalar(count(cache:hwlb{cluster=~\"$cluster\", dc=~\"$dc\"})) * cache:hwlb{cluster=~\"$cluster\", dc=~\"$dc\"}/scalar(sum(cache:hwlb{cluster=~\"$cluster\", dc=~\"$dc\"}))) by (instance), 0.1)",
+            "legendFormat":"",
+            "interval":"",
+            "refId":"F",
+            "instant":true,
+            "format":"table"
          }
       ],
       "type":"table",
@@ -2238,7 +2246,7 @@
                   },
                   {
                      "id":"custom.width",
-                     "value":120
+                     "value":110
                   },
                   {
                      "id":"custom.filterable",
@@ -2258,7 +2266,7 @@
                "properties":[
                   {
                      "id":"custom.width",
-                     "value":85
+                     "value":80
                   },
                   {
                      "id":"displayName",
@@ -2274,7 +2282,7 @@
                "properties":[
                   {
                      "id":"custom.width",
-                     "value":105
+                     "value":100
                   }
                ]
             },
@@ -2286,7 +2294,7 @@
                "properties":[
                   {
                      "id":"custom.width",
-                     "value":105
+                     "value":100
                   },
                   {
                      "id":"displayName",
@@ -2482,7 +2490,7 @@
                   },
                   {
                      "id":"custom.width",
-                     "value":90
+                     "value":85
                   },
                   {
                      "id":"custom.filterable",
@@ -2556,7 +2564,7 @@
                   },
                   {
                      "id":"custom.width",
-                     "value":80
+                     "value":65
                   },
                   {
                      "id":"custom.filterable",
@@ -2616,6 +2624,54 @@
             {
                "matcher":{
                   "id":"byName",
+                  "options":"Value #F"
+               },
+               "properties":[
+                  {
+                     "id":"displayName",
+                     "value":"HW"
+                  },
+                  {
+                     "id":"custom.width",
+                     "value":25
+                  },
+                  {
+                     "id":"custom.filterable",
+                     "value":false
+                  },
+                  {
+                     "id":"thresholds",
+                     "value":{
+                        "mode":"absolute",
+                        "steps":[
+                           {
+                              "color":"rgb(51, 34, 151)",
+                              "value":null
+                           },
+                           {
+                              "color":"rgb(13, 100, 229)",
+                              "value":0.2
+                           },
+                           {
+                              "color":"rgb(133, 193, 116)",
+                              "value":0.8
+                           },
+                           {
+                              "color":"rgb(247, 156, 53)",
+                              "value":1.4
+                           }
+                        ]
+                     }
+                  },
+                  {
+                     "id":"custom.displayMode",
+                     "value":"color-text"
+                  }
+               ]
+            },
+            {
+               "matcher":{
+                  "id":"byName",
                   "options":"instance"
                },
                "properties":[
@@ -2651,7 +2707,8 @@
                      "Value #B",
                      "Value #C",
                      "Value #D",
-                     "Value #E"
+                     "Value #E",
+                     "Value #F"
                   ]
                }
             }
@@ -2674,7 +2731,8 @@
                   "Value #C":3,
                   "svr":4,
                   "Value #A":5,
-                  "Value #B":6
+                  "Value #B":6,
+                  "Value #F":7
                },
                "renameByName":{
                }

--- a/prometheus/prometheus.rules.yml
+++ b/prometheus/prometheus.rules.yml
@@ -31,6 +31,8 @@ groups:
     expr: sum(rate(scylla_storage_proxy_coordinator_read_errors_local_node[60s])) by (cluster, dc, instance) + sum(rate(scylla_storage_proxy_coordinator_write_errors_local_node[60s])) by (cluster, dc, instance)
   - record: errors:nodes_total
     expr: errors:local_failed + errors:operation_unavailable
+  - record: cache:hwlb
+    expr: sum(rate(scylla_cache_row_hits[1m])) by (cluster, dc, instance)/(sum(rate(scylla_cache_row_hits[1m])) by (cluster, dc, instance) + sum(rate(scylla_cache_row_misses[1m])) by (cluster, dc, instance) + 0.00001)
   - alert: cqlNonPrepared
     expr: cql:non_prepared > 0
     for: 10s


### PR DESCRIPTION
This series add some indication to the heat-weighted load balance score of a node, the score is calculated per node.

For each node we calculate the `hwlb` score: `hwlb` = cache_hits/(cache_hits+cache_miss)

if there are n nodes the relative hw for node `i`:
HW(`i`) = (hwlb(i)/sum(hwlb)) / (1/n) = n* hwlb(i)/sum(hwlb)

In a normal mode, we expect that the HW score will be around 1. If the score is close to zero, the node is cold, if the score is above 1 the node is hot.

The implmentation uses color codes:
![image](https://user-images.githubusercontent.com/2118079/111215261-9d666e80-85db-11eb-8ad2-fa63fd77916c.png)

An alternative implementatio uses cell color:
![image](https://user-images.githubusercontent.com/2118079/111215390-c850c280-85db-11eb-8c90-ec00ba77093c.png)


Fixes #907
