### PR TITLE
Docs: change product name to Scylla Monitoring Stack in all places

### DIFF
--- a/docs/source/_common/monitor-description.rst
+++ b/docs/source/_common/monitor-description.rst
@@ -1,1 +1,1 @@
-Scylla Monitor is a full stack for Scylla monitoring and alerting. The stack contains open source tools including Prometheus and Grafana, as well as custom Scylla dashboards and tooling.
+Scylla Monitoring Stack is a full stack for Scylla monitoring and alerting. The stack contains open source tools including Prometheus and Grafana, as well as custom Scylla dashboards and tooling.

--- a/docs/source/advisor.rst
+++ b/docs/source/advisor.rst
@@ -1,8 +1,8 @@
-=========================
-Scylla Monitoring Advisor
-=========================
+===============================
+Scylla Monitoring Stack Advisor
+===============================
 
-Scylla Advisor is an element of Scylla Monitoring that recognize bad practice, bad configuration, and potential problems and advice on how to solve them.
+The Scylla Monitoring Stack Advisor is an element of the Scylla Monitoring Stack that recognize bad practices, bad configurations, and potential problems and advises on how to solve them.
 
 The Advisor section
 ^^^^^^^^^^^^^^^^^^^^
@@ -10,12 +10,12 @@ The Advisor section
 
     **The Advisor section**
 
-The Advisor section is on the Overview dashboard and consists of two parts:
+The Advisor section is located on the Overview dashboard and consists of two parts:
     
-On the left, the Advisor issues table. Each issue has a category, a link to jump to a relevant dashboard, and a description of the issue.
+On the left, is the Advisor issues table. Each issue has a category, a link to jump to a relevant dashboard, and a description of the issue.
 
-For example, the Advisor would warn of large cells. Large cells in the data usually indicate a problem with the data model or a problem with the client code, impacting system performance.
+For example, the Advisor could warn about using large cells. Large cells in the data usually indicate a problem with the data model or a problem with the client code, and can impact system performance.
     
-On the right, the system balance section.  This section notifies for an imbalance between shards or nodes. An imbalanced system may indicate a potential problem.
+On the right, is the system balance section.  This section notifies you about an imbalance between shards or nodes. An imbalanced system may indicate a potential problem.
 
 For example, when a single, hot partition gets most of the requests, making one shard a bottleneck, the balance section will indicate that the latency and cache hits are imbalanced between shards.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -112,7 +112,7 @@ html_style = ''
 #
 html_theme_options = {
     'header_links': [
-    ('Scylla Monitor', 'https://scylladb.github.io/scylla-monitoring/'),
+    ('Scylla Monitoring Stack', 'https://scylladb.github.io/scylla-monitoring/'),
     ('Scylla Cloud', 'https://docs.scylladb.com/scylla-cloud/'),
     ('Scylla University', 'https://university.scylladb.com/'),
     ('ScyllaDB Home', 'https://www.scylladb.com/')],

--- a/docs/source/cql_optimization.rst
+++ b/docs/source/cql_optimization.rst
@@ -143,7 +143,7 @@ as queries may end in the non-local DC. Use LOCAL_QUORUM and LOCAL_ONE instead.
 Cross DC read requests
 ^^^^^^^^^^^^^^^^^^^^^^
 .. note::
-   The CQL Optimization Dashboard relies on the definition of nodes per Data Center in the Monitoring Stack (prometheus/scylla_servers.yml) to match the Data Center names used in Scylla Cluster.
+   The CQL Optimization Dashboard relies on the definition of nodes per Data Center in the Scylla Monitoring Stack (prometheus/scylla_servers.yml) to match the Data Center names used in Scylla Cluster.
    If this is not the case, you will see the wrong result.
 
 In a typical situation, a client performs a read from the nearest data-center and that query is performed local to the data-center.

--- a/docs/source/docker_compose.rst
+++ b/docs/source/docker_compose.rst
@@ -1,11 +1,11 @@
 Using Docker Compose
 ====================
 
-Scylla-Monitoring is container-based.
-You can start and stop the monitoring stack with the `start-all.sh` and `kill-all.sh` scripts.
+Scylla-Monitoring Stack is container-based.
+You can start and stop the Scylla Monitoring Stack with the `start-all.sh` and `kill-all.sh` scripts.
  
 Docker Compose is an alternative method to start and stop the stack. It requires more manual steps, but once
-set it simplify starting and stopping the monitoring stack.
+configured, it simplifies starting and stopping the stack.
 
 .. warning:: 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,34 +1,34 @@
-Scylla Monitor
-=================
+Scylla Monitoring Stack
+=======================
 
 .. toctree::
    :hidden:
    :maxdepth: 2 
    
-   Install Scylla Monitor Stack <monitoring_stack>
+   Install Scylla Monitoring Stack <monitoring_stack>
    The start-all.sh script <start_all>
    Running using Docker Compose <docker_compose>
-   Scylla Monitor Interfaces <monitoring_apis>
-   Deploy Scylla Monitor Without Docker <monitor_without_docker>
-   Troubleshoot Monitor <monitor_troubleshoot>
+   Scylla Monitoring Stack Interfaces <monitoring_apis>
+   Deploy Scylla Monitoring Stack Without Docker <monitor_without_docker>
+   Troubleshoot the Monitoring Stack <monitor_troubleshoot>
    Troubleshooting Guide for Scylla Manager and Scylla Monitor Integration <https://docs.scylladb.com/troubleshooting/manager_monitoring_integration/>
    Upgrade Guide for Scylla Monitor <https://docs.scylladb.com/upgrade/upgrade-monitor/>
    CQL Optimization Dashboard <cql_optimization>
-   Scylla Monitoring Advisor <advisor>
+   Scylla Monitoring Stack Advisor <advisor>
    Adding and Modifying Dashboards <updating_dashboard>
    Alerting <alerting>
    Using Thanos <thanos>
-   Scylla Monitor Support Matrix <matrix>
+   Scylla Monitoring Stack Support Matrix <matrix>
 
 
 .. include:: /_common/monitor-description.rst
 
-For older versions of Scylla Monitoring see `here <https://docs.scylladb.com/operating-scylla/monitoring/>`_.
+For older versions of Scylla Monitoring Stack see `here <https://docs.scylladb.com/operating-scylla/monitoring/>`_.
 
 .. image:: monitor.png
     :width: 400pt
 
-The Scylla Monitor Stack consists of three components, wrapped in Docker containers:
+The Scylla Monitoring Stack consists of three components, wrapped in Docker containers:
 
 * `prometheus` - collects and stores metrics
 * `alertmanager` - handles alerts
@@ -36,18 +36,18 @@ The Scylla Monitor Stack consists of three components, wrapped in Docker contain
 
 **Choose a topic to get started**:
 
-* :doc:`Install Scylla Monitor Stack <monitoring_stack>`
+* :doc:`Install Scylla Monitoring Stack <monitoring_stack>`
 * :doc:`The start-all.sh script <start_all>`
 * :doc:`Running using Docker Compose <docker_compose>`
-* :doc:`Scylla Monitor Interfaces <monitoring_apis>`
-* :doc:`Deploy Scylla Monitor Without Docker <monitor_without_docker>`
-* :doc:`Troubleshoot Scylla Monitor <monitor_troubleshoot>`
-* `Troubleshooting Guide for Scylla Manager and Scylla Monitor Integration <https://docs.scylladb.com/troubleshooting/manager_monitoring_integration/>`_
-* `Upgrade Guide for Monitoring <https://docs.scylladb.com/upgrade/upgrade-monitor/>`_
-* :doc:`Scylla Monitoring Advisor <advisor>`
+* :doc:`Scylla Monitoring Stack Interfaces <monitoring_apis>`
+* :doc:`Deploy Scylla Monitoring Stack Without Docker <monitor_without_docker>`
+* :doc:`Troubleshoot Scylla Monitoring Stack <monitor_troubleshoot>`
+* `Troubleshooting Guide for Scylla Manager and Scylla Monitoring Stack Integration <https://docs.scylladb.com/troubleshooting/manager_monitoring_integration/>`_
+* `Upgrade Guide for Scylla Monitoring Stack <https://docs.scylladb.com/upgrade/upgrade-monitor/>`_
+* :doc:`Scylla Monitoring Stack Advisor <advisor>`
 * :doc:`Adding and Modifying Dashboards <updating_dashboard>`
 * :doc:`Alerting <alerting>`
 * :doc:`Using Thanos <thanos>`
-* :doc:`Scylla Monitor Support Matrix <matrix>`
-* `Scylla Monitor lesson <https://university.scylladb.com/courses/scylla-operations/lessons/admin-procedures-and-basic-monitoring/>`_ on Scylla University
+* :doc:`Scylla Monitoring Stack Support Matrix <matrix>`
+* `Scylla Monitoring Stack lesson <https://university.scylladb.com/courses/scylla-operations/lessons/admin-procedures-and-basic-monitoring/>`_ on Scylla University
 

--- a/docs/source/matrix.rst
+++ b/docs/source/matrix.rst
@@ -1,15 +1,15 @@
 
-Scylla Monitor Support Matrix
-================================
+Scylla Monitoring Stack Support Matrix
+======================================
 
-The following table shows which version of Scylla Monitor supports dashboards for which versions of Scylla and Scylla Manager.
+The following table shows which version of Scylla Monitoring Stack supports dashboards for which versions of Scylla and Scylla Manager.
 
 
 .. list-table::
    :widths: 25 25 25 25 25
    :header-rows: 1
 
-   * - Scylla Monitor Version
+   * - Scylla Monitoring Stack Version
      - Scylla Open Source Version
      - Scylla Enterprise Version
      - Node_exporter[1] Version

--- a/docs/source/monitor_troubleshoot.rst
+++ b/docs/source/monitor_troubleshoot.rst
@@ -1,5 +1,5 @@
-Troubleshoot Monitoring
-========================
+Troubleshoot Scylla Monitoring Stack
+====================================
 
 
 This document describes steps that need to be done to troubleshoot monitoring problems when using `Grafana/Prometheus`_ monitoring tool.
@@ -21,7 +21,7 @@ Scylla Manager 2.2 change the default metrics (Prometheus) reporting ports:
 * For Manager server: from 56090 to 5090 
 * For Manager Agent: from 56090 to 5090 
 
-For backward compatibility, Scylla Monitoring 3.5 default configuration reads from **both** Manager ports, old and new, so you do not have to update the Prometheus configuration when upgrading to Manager 2.2
+For backward compatibility, Scylla Monitoring Stack 3.5 default configuration reads from **both** Manager ports, old and new, so you do not have to update the Prometheus configuration when upgrading to Manager 2.2
 
   
 
@@ -122,14 +122,14 @@ More on start-all.sh `options`_.
 Grafana Chart Shows Error (!) Sign
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Run this procedure on the Monitoring server.
+Run this procedure on the Scylla Monitoring Stack server.
 
 If the Grafana charts show an error (!) sign, there is a problem with the connection between Grafana and Prometheus. 
 
 Solution
 .........
 
-On the monitoring server:
+On the Scylla Monitoring Stack server:
 
 1. Check Prometheus is running using ``docker ps``.
 
@@ -153,7 +153,7 @@ Prometheus fails to fetch metrics from Scylla servers.
 Solution
 .........
 
-* Use ``curl <scylla_node>:9180/metrics`` to fetch binary metric data from Scylla.  If curl does not return data, the problem is the connectivity between the Monitoring and Scylla server. In that case, check your IPs and firewalls.
+* Use ``curl <scylla_node>:9180/metrics`` to fetch binary metric data from Scylla.  If curl does not return data, the problem is the connectivity between the Scylla Monitoring Stack and Scylla server. In that case, check your IPs and firewalls.
 
 For example
 
@@ -173,7 +173,7 @@ Solution
 1. Make sure that ``node_exporter`` is running on each Scylla server (by login to the machine and running ``ps -ef |gre node_exporter``). ``node_exporter`` is installed with ``scylla_setup``.
 to check that ``node_exporter`` is installed, run ``node_exporter --version``, If it is not, make sure to install and run it.
 
-2. If it is running, use ``curl http://<scylla_node>:9100/metrics`` (where <scylla_node> is a Scylla server IP) to fetch metric data from Scylla.  If curl does not return data, the problem is the connectivity between Scylla Monitoring and Scylla server. Please check your IPs and firewalls.
+2. If it is running, use ``curl http://<scylla_node>:9100/metrics`` (where <scylla_node> is a Scylla server IP) to fetch metric data from Scylla.  If curl does not return data, the problem is the connectivity between Scylla Monitoring Stack and Scylla server. Please check your IPs and firewalls.
 
 Notice to users upgrading to Scylla Open Source 3.0 or Scylla Enterprise 2019.1
 ................................................................................
@@ -192,13 +192,13 @@ in the `upgrade guide`_.
 Working with Wireshark
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-No metrics shown in Scylla Monitoring.
+No metrics shown in the Scylla Monitoring Stack.
 
 1. Install `wireshark`_
 
 ..  _`wireshark`: https://www.wireshark.org/#download
 
-2. Capture the traffic between Scylla Monitoring and Scylla node using the ``tshark`` command.
+2. Capture the traffic between the Scylla Monitoring Stack and Scylla node using the ``tshark`` command.
 ``tshark -i <network interface name> -f "dst port 9180"``
 
 For example:
@@ -207,7 +207,7 @@ For example:
 
    tshark -i eth0 -f "dst port 9180"
 
-Capture from Scylla node towards Scylla Monitor server.
+Capture from Scylla node towards Scylla Monitoring Stack server.
 
 
 In this example, Scylla is running.

--- a/docs/source/monitor_without_docker.rst
+++ b/docs/source/monitor_without_docker.rst
@@ -1,5 +1,5 @@
-Deploying Scylla Monitoring Without Docker
-==========================================
+Deploying Scylla Monitoring Stack Without Docker
+================================================
 
 The following instructions will help to deploy `Scylla Monitoring Stack <monitoring_stack>`_ in cases where you can not use the recommended Docker version.
 
@@ -9,12 +9,12 @@ Please note, Scylla recommends you use the Docker version as it will provide you
 
 The main item to set an alert on is the available disk space in the monitoring system. Data is indefinitely accrued on the Prometheus data directory. The current monitoring solution does not churn data.
 
-Install Scylla Monitor
-----------------------
+Install Scylla Monitoring Stack
+-------------------------------
 
 The following procedure uses a ``CentOS 7`` based instance
 
-1. Download the latest Scylla Monitoring release.
+1. Download the latest Scylla Monitoring Stack release.
 
 ``wget https://github.com/scylladb/scylla-monitoring/archive/scylla-monitoring-3.5.tar.gz``
 

--- a/docs/source/monitoring_apis.rst
+++ b/docs/source/monitoring_apis.rst
@@ -1,6 +1,6 @@
 
-Monitoring Interfaces
-=====================
+Scylla Monitoring Stack Interfaces
+==================================
 
 Scylla exposes two interfaces for online monitoring, as described below
 

--- a/docs/source/monitoring_stack.rst
+++ b/docs/source/monitoring_stack.rst
@@ -8,9 +8,9 @@ Install Scylla Monitoring Stack
 
 This document describes the setup of Scylla Monitoring Stack, based on `Scylla Prometheus API`_.
 
-The Scylla Monitoring stack needs to be installed on a dedicated server, external to the Scylla cluster. Make sure the Scylla Monitoring server has access to the Scylla nodes so that it can pull the metrics over the Prometheus API.
+The Scylla Monitoring Stack needs to be installed on a dedicated server, external to the Scylla cluster. Make sure the Scylla Monitoring Stack server has access to the Scylla nodes so that it can pull the metrics over the Prometheus API.
 
-For evaluation, you can run Scylla Monitoring stack on any server (or laptop) that can handle three Docker instances at the same time. For production, see recommendations below.
+For evaluation, you can run Scylla Monitoring Stack on any server (or laptop) that can handle three Docker instances at the same time. For production, see recommendations below.
 
 .. include:: min-prod-hw.rst
 
@@ -19,7 +19,7 @@ For evaluation, you can run Scylla Monitoring stack on any server (or laptop) th
 Prerequisites
 -------------
 
-* Follow the Installation Guide and install `docker`_ on the Scylla Monitoring Server. This server can be the same server that is running Scylla Manager. Alternatively, you can `Deploy Scylla Monitoring Without Docker <monitor_without_docker>`_ .
+* Follow the Installation Guide and install `docker`_ on the Scylla Monitoring Stack Server. This server can be the same server that is running Scylla Manager. Alternatively, you can `Deploy Scylla Monitoring Stack Without Docker <monitor_without_docker>`_ .
 
 .. _`docker`: https://docs.docker.com/install/
 
@@ -34,7 +34,7 @@ Docker post installation guide can be found `here`_
 
    Avoid running the container as root.
 
-To avoid running docker as root, you should add the user you are going to use for Scylla Monitor to the Docker group.
+To avoid running docker as root, you should add the user you are going to use for Scylla Monitoring Stack to the Docker group.
 
 1. Create the Docker group.
 
@@ -54,8 +54,8 @@ To avoid running docker as root, you should add the user you are going to use fo
 
    sudo systemctl enable docker
 
-Install Scylla Monitoring
--------------------------
+Install Scylla Monitoring Stack
+-------------------------------
 
 **Procedure**
 
@@ -84,10 +84,10 @@ As an alternative, you can clone and use the Git repository directly.
 
    sudo systemctl restart docker
 
-Configure Scylla Monitoring
----------------------------
+Configure Scylla Monitoring Stack
+---------------------------------
 
-To monitor the cluster, Scylla Monitor (Specifically the Prometheus Server) needs to know the IP of all the nodes and the IP of the Scylla Manager Server (if you are using Scylla Manager).
+To monitor the cluster, Scylla Monitoring Stack (Specifically the Prometheus Server) needs to know the IP of all the nodes and the IP of the Scylla Manager Server (if you are using Scylla Manager).
 
 This configuration can be done from files, or using the Consul_ api.
 
@@ -117,7 +117,7 @@ For example:
          cluster: cluster1
          dc: dc1
 
-.. note:: If you want to add your managed cluster to Scylla Monitoring, add the IPs of the nodes as well as the cluster name you used when you `added the cluster`_ to Scylla Manager. It is important that the label ``cluster name`` and the cluster name in Scylla Manager match.
+.. note:: If you want to add your managed cluster to Scylla Monitoring Stack, add the IPs of the nodes as well as the cluster name you used when you `added the cluster`_ to Scylla Manager. It is important that the label ``cluster name`` and the cluster name in Scylla Manager match.
 
 ..  _`added the cluster`: https://scylladb.github.io/scylla-manager/2.2/add-a-cluster.html
 
@@ -291,7 +291,7 @@ Stop
    ./kill-all.sh
 
 
-Start a Specific Scylla Monitoring Stack  Version
+Start a Specific Scylla Monitoring Stack Version
 .................................................
 
 By default, start-all.sh will start with dashboards for the latest Scylla Open source version and the latest Scylla Manager version.
@@ -319,10 +319,10 @@ To do that run ./start-all.sh with the -l flag. For example:
 
 Configure rsyslog on each Scylla node
 .....................................
-generates metrics and alerts from logs. To get full functionality, you should use rsyslog_. Scylla Monitoring will act as an additional rsyslog server.
+generates metrics and alerts from logs. To get full functionality, you should use rsyslog_. Scylla Monitoring Stack will act as an additional rsyslog server.
 Scylla Monitoring Stack collects Scylla logs using Loki and generates metrics and alerts based on these logs. 
 To use this feature, you need to direct logs from each Scylla node to Loki.
-The recommended method to do this is by using rsyslog_, where Scylla Monitoring (Loki) acts as an additional rsyslog server.
+The recommended method to do this is by using rsyslog_, where Scylla Monitoring Stack (Loki) acts as an additional rsyslog server.
 .. note:: Scylla can send logs to more than one log collection service.
 
 .. _rsyslog: https://www.rsyslog.com/
@@ -335,7 +335,7 @@ The recommended method to do this is by using rsyslog_, where Scylla Monitoring 
 
 Add scylla's rsyslog configuration file. Add the file: ``/etc/rsyslog.d/scylla.conf``.
 
-If Scylla monitoring IP is 10.0.0.1, the file should look like
+If Scylla Monitoring Stack IP is 10.0.0.1, the file should look like
 
 .. code-block:: sh
 

--- a/docs/source/start_all.rst
+++ b/docs/source/start_all.rst
@@ -1,7 +1,7 @@
 The start-all.sh command
 ========================
 
-Scylla Monitor is container-based, the simplest way to configure and start the monitoring is with the `start-all.sh` command.
+Scylla Monitoring Stack is container-based, the simplest way to configure and start the monitoring is with the `start-all.sh` command.
 
 The `start-all.sh` script is a small utility that sets the dashboards and starts the containers with the appropriate configuration.
 
@@ -70,7 +70,7 @@ This flag places the Prometheus data directory outside of its container and by d
 
 **-s scylla-target-file** Specify the location of the Scylla target files. This file contains the IP addresses of the Scylla nodes.
 
-**-n node-target-file** Scylla Monitoring collects OS metrics (Disk, network, etc.) using an agent called node_exporter. By default, Scylla Monitoring assumes that there is a node_exporter running beside each Scylla node, for situations that this is not the case, for example, Scylla runs inside a container and the relevant metrics are of the host machine, it is possible to specify a target file for the node_exporter agents. 
+**-n node-target-file** Scylla Monitoring Stack collects OS metrics (Disk, network, etc.) using an agent called node_exporter. By default, Scylla Monitoring Stack assumes that there is a node_exporter running beside each Scylla node, for situations that this is not the case, for example, Scylla runs inside a container and the relevant metrics are of the host machine, it is possible to specify a target file for the node_exporter agents. 
 
 **-N manager target file** Specify the location of the Scylla Manager target file.
 

--- a/docs/source/thanos.rst
+++ b/docs/source/thanos.rst
@@ -1,5 +1,5 @@
-Using Thanos as Data Source With Scylla Monitoring
-==================================================
+Using Thanos as Data Source With Scylla Monitoring Stack
+========================================================
 
 Scylla-Monitoring uses `Prometheus <https://prometheus.io/>`_ for metrics collection, which works out-of-the-box, but Prometheus does have limitations.
 `Thanos <https://thanos.io/>`_  is an opensource solution which when used on top of Prometheus, provides additiuonal functionalities such as:
@@ -53,7 +53,7 @@ After you run the sidecar you should be able to reach it from your browser at: h
 Thanos query
 ^^^^^^^^^^^^
 Thanos query is the aggregator, it expose a Prometheus like API and read from multiple thanos stores (in this case the Thanos stores are the sidecars).
-You run Thanos query together with Scylla Monitoring. Assuming that you have two sidecars running on IP addresses: `ip1` and `ip2`,
+You run Thanos query together with Scylla . Assuming that you have two sidecars running on IP addresses: `ip1` and `ip2`,
 Start the container  by running: 
 
 .. code-block:: shell
@@ -79,5 +79,5 @@ and replace DB_ADDRESS with {ip}:10903 (The IP address could be of the container
 
 The file you edit is a template file that replaces the file Grafana uses, next time you start.
 
-Restart the Scylla Monitoring stack it should now use Thanos.
+Restart the Scylla Monitoring Stack it should now use Thanos.
  

--- a/docs/source/updating_dashboard.rst
+++ b/docs/source/updating_dashboard.rst
@@ -2,9 +2,9 @@
 Adding and Modifying Dashboards
 *******************************
 
-The following document explains how to update or create Grafana dashboards for the Scylla Monitor.
+The following document explains how to update or create Grafana dashboards for the Scylla Monitoring Stack.
 
-It will explain about Scylla Monitor dashboard templates and how to modify them.
+It will explain about Scylla Monitoring Stack dashboard templates and how to modify them.
 
 .. contents::
    :depth: 2
@@ -13,14 +13,14 @@ It will explain about Scylla Monitor dashboard templates and how to modify them.
 
 General Limitations
 ###################
-Scylla Monitor uses Grafana for its dashboards.
+Scylla Monitoring Stack uses Grafana for its dashboards.
 The dashboards are provisioned from files and are stored in Grafana internal storage.
 There are consistency issues here, between restarts and between upgrades.
 
 consistency between restarts
 ****************************
 
-By default, Grafana internal storage is inside the container. That means whenever you restart the Scylla Monitor (explicitly when restarting Grafana) any local changes will be gone.
+By default, Grafana internal storage is inside the container. That means whenever you restart the Scylla Monitoring Stack (explicitly when restarting Grafana) any local changes will be gone.
  If you are doing and saving changes from the GUI make sure to configure an external directory for Grafana.
 
 consistency between upgrades
@@ -136,7 +136,7 @@ To reduce the redundancy of Grafana JSON format, we added dashboard templates.
 The template class system
 ***************************
 
-Scylla Monitor dashboard templates use ``class`` attribute that can be added to any JSON object in a template file.
+Scylla Monitoring Stack dashboard templates use ``class`` attribute that can be added to any JSON object in a template file.
 The different classes are defined in a file.
 
 The ``class`` system resembles CSS classes. It is hierarchical, so a ``class`` type definition can have a ``class`` attribute and


### PR DESCRIPTION
Search and replace
Scylla Monitor and Scylla Monitoring ---> Scylla Monitoring Stack in all places where we are referring to the product. 