### PR TITLE
Reciprocal miss rate

### DIFF
--- a/grafana/build/ver_2020.1/scylla-detailed.2020.1.json
+++ b/grafana/build/ver_2020.1/scylla-detailed.2020.1.json
@@ -2952,32 +2952,107 @@
             }
         },
         {
-            "class": "text_panel",
-            "content": "",
-            "datasource": null,
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Reciprocal Miss Rate is a score in the range of 1 to 100 that is used to decide the fraction of read requests to send to each replica - a replica with twice the RMR value of another replica will serve twice the number of read requests.\n\nRMR is calculated on a table level, this is an aggregate estimation of that score.",
             "editable": true,
             "error": false,
             "fieldConfig": {
                 "defaults": {
-                    "custom": {}
+                    "custom": {},
+                    "links": []
                 },
                 "overrides": []
             },
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
             "gridPos": {
                 "h": 6,
                 "w": 6,
                 "x": 0,
                 "y": 51
             },
+            "hiddenSeries": false,
             "id": 31,
             "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
             "links": [],
-            "mode": "markdown",
-            "options": {},
+            "nullPointMode": "connected",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
             "span": 3,
-            "title": "",
-            "transparent": true,
-            "type": "text"
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "clamp_max(1 + sum(rate(scylla_cache_row_hits[1m])) by ([[by]])/(sum(rate(scylla_cache_row_misses[1m])) by ([[by]]) + 0.00001),100)",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Reciprocal Miss Rate (HWLB)",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
         },
         {
             "aliasColors": {},

--- a/grafana/build/ver_2021.1/scylla-detailed.2021.1.json
+++ b/grafana/build/ver_2021.1/scylla-detailed.2021.1.json
@@ -2952,32 +2952,107 @@
             }
         },
         {
-            "class": "text_panel",
-            "content": "",
-            "datasource": null,
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Reciprocal Miss Rate is a score in the range of 1 to 100 that is used to decide the fraction of read requests to send to each replica - a replica with twice the RMR value of another replica will serve twice the number of read requests.\n\nRMR is calculated on a table level, this is an aggregate estimation of that score.",
             "editable": true,
             "error": false,
             "fieldConfig": {
                 "defaults": {
-                    "custom": {}
+                    "custom": {},
+                    "links": []
                 },
                 "overrides": []
             },
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
             "gridPos": {
                 "h": 6,
                 "w": 6,
                 "x": 0,
                 "y": 51
             },
+            "hiddenSeries": false,
             "id": 31,
             "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
             "links": [],
-            "mode": "markdown",
-            "options": {},
+            "nullPointMode": "connected",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
             "span": 3,
-            "title": "",
-            "transparent": true,
-            "type": "text"
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "clamp_max(1 + sum(rate(scylla_cache_row_hits[1m])) by ([[by]])/(sum(rate(scylla_cache_row_misses[1m])) by ([[by]]) + 0.00001),100)",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Reciprocal Miss Rate (HWLB)",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
         },
         {
             "aliasColors": {},

--- a/grafana/build/ver_4.2/scylla-detailed.4.2.json
+++ b/grafana/build/ver_4.2/scylla-detailed.4.2.json
@@ -2952,32 +2952,107 @@
             }
         },
         {
-            "class": "text_panel",
-            "content": "",
-            "datasource": null,
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Reciprocal Miss Rate is a score in the range of 1 to 100 that is used to decide the fraction of read requests to send to each replica - a replica with twice the RMR value of another replica will serve twice the number of read requests.\n\nRMR is calculated on a table level, this is an aggregate estimation of that score.",
             "editable": true,
             "error": false,
             "fieldConfig": {
                 "defaults": {
-                    "custom": {}
+                    "custom": {},
+                    "links": []
                 },
                 "overrides": []
             },
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
             "gridPos": {
                 "h": 6,
                 "w": 6,
                 "x": 0,
                 "y": 51
             },
+            "hiddenSeries": false,
             "id": 31,
             "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
             "links": [],
-            "mode": "markdown",
-            "options": {},
+            "nullPointMode": "connected",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
             "span": 3,
-            "title": "",
-            "transparent": true,
-            "type": "text"
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "clamp_max(1 + sum(rate(scylla_cache_row_hits[1m])) by ([[by]])/(sum(rate(scylla_cache_row_misses[1m])) by ([[by]]) + 0.00001),100)",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Reciprocal Miss Rate (HWLB)",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
         },
         {
             "aliasColors": {},

--- a/grafana/build/ver_4.3/scylla-detailed.4.3.json
+++ b/grafana/build/ver_4.3/scylla-detailed.4.3.json
@@ -2952,32 +2952,107 @@
             }
         },
         {
-            "class": "text_panel",
-            "content": "",
-            "datasource": null,
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Reciprocal Miss Rate is a score in the range of 1 to 100 that is used to decide the fraction of read requests to send to each replica - a replica with twice the RMR value of another replica will serve twice the number of read requests.\n\nRMR is calculated on a table level, this is an aggregate estimation of that score.",
             "editable": true,
             "error": false,
             "fieldConfig": {
                 "defaults": {
-                    "custom": {}
+                    "custom": {},
+                    "links": []
                 },
                 "overrides": []
             },
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
             "gridPos": {
                 "h": 6,
                 "w": 6,
                 "x": 0,
                 "y": 51
             },
+            "hiddenSeries": false,
             "id": 31,
             "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
             "links": [],
-            "mode": "markdown",
-            "options": {},
+            "nullPointMode": "connected",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
             "span": 3,
-            "title": "",
-            "transparent": true,
-            "type": "text"
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "clamp_max(1 + sum(rate(scylla_cache_row_hits[1m])) by ([[by]])/(sum(rate(scylla_cache_row_misses[1m])) by ([[by]]) + 0.00001),100)",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Reciprocal Miss Rate (HWLB)",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
         },
         {
             "aliasColors": {},

--- a/grafana/build/ver_4.4/scylla-detailed.4.4.json
+++ b/grafana/build/ver_4.4/scylla-detailed.4.4.json
@@ -2952,32 +2952,107 @@
             }
         },
         {
-            "class": "text_panel",
-            "content": "",
-            "datasource": null,
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Reciprocal Miss Rate is a score in the range of 1 to 100 that is used to decide the fraction of read requests to send to each replica - a replica with twice the RMR value of another replica will serve twice the number of read requests.\n\nRMR is calculated on a table level, this is an aggregate estimation of that score.",
             "editable": true,
             "error": false,
             "fieldConfig": {
                 "defaults": {
-                    "custom": {}
+                    "custom": {},
+                    "links": []
                 },
                 "overrides": []
             },
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
             "gridPos": {
                 "h": 6,
                 "w": 6,
                 "x": 0,
                 "y": 51
             },
+            "hiddenSeries": false,
             "id": 31,
             "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
             "links": [],
-            "mode": "markdown",
-            "options": {},
+            "nullPointMode": "connected",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
             "span": 3,
-            "title": "",
-            "transparent": true,
-            "type": "text"
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "clamp_max(1 + sum(rate(scylla_cache_row_hits[1m])) by ([[by]])/(sum(rate(scylla_cache_row_misses[1m])) by ([[by]]) + 0.00001),100)",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Reciprocal Miss Rate (HWLB)",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
         },
         {
             "aliasColors": {},

--- a/grafana/build/ver_master/scylla-detailed.master.json
+++ b/grafana/build/ver_master/scylla-detailed.master.json
@@ -2952,32 +2952,107 @@
             }
         },
         {
-            "class": "text_panel",
-            "content": "",
-            "datasource": null,
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Reciprocal Miss Rate is a score in the range of 1 to 100 that is used to decide the fraction of read requests to send to each replica - a replica with twice the RMR value of another replica will serve twice the number of read requests.\n\nRMR is calculated on a table level, this is an aggregate estimation of that score.",
             "editable": true,
             "error": false,
             "fieldConfig": {
                 "defaults": {
-                    "custom": {}
+                    "custom": {},
+                    "links": []
                 },
                 "overrides": []
             },
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
             "gridPos": {
                 "h": 6,
                 "w": 6,
                 "x": 0,
                 "y": 51
             },
+            "hiddenSeries": false,
             "id": 31,
             "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
             "links": [],
-            "mode": "markdown",
-            "options": {},
+            "nullPointMode": "connected",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
             "span": 3,
-            "title": "",
-            "transparent": true,
-            "type": "text"
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "clamp_max(1 + sum(rate(scylla_cache_row_hits[1m])) by ([[by]])/(sum(rate(scylla_cache_row_misses[1m])) by ([[by]]) + 0.00001),100)",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Reciprocal Miss Rate (HWLB)",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
         },
         {
             "aliasColors": {},

--- a/grafana/scylla-detailed.2020.1.template.json
+++ b/grafana/scylla-detailed.2020.1.template.json
@@ -465,10 +465,19 @@
                         "title": "Writes currently blocked on commitlog"
                     },
                     {
-                        "class": "text_panel",
-                        "content": "",
-                        "mode": "markdown",
-                        "span": 3
+                        "class": "graph_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "clamp_max(1 + sum(rate(scylla_cache_row_hits[1m])) by ([[by]])/(sum(rate(scylla_cache_row_misses[1m])) by ([[by]]) + 0.00001),100)",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "description" :"Reciprocal Miss Rate is a score in the range of 1 to 100 that is used to decide the fraction of read requests to send to each replica - a replica with twice the RMR value of another replica will serve twice the number of read requests.\n\nRMR is calculated on a table level, this is an aggregate estimation of that score.",
+                        "title": "Reciprocal Miss Rate (HWLB)"
                     },
                     {
                         "class": "rps_panel",

--- a/grafana/scylla-detailed.2021.1.template.json
+++ b/grafana/scylla-detailed.2021.1.template.json
@@ -465,10 +465,19 @@
                         "title": "Writes currently blocked on commitlog"
                     },
                     {
-                        "class": "text_panel",
-                        "content": "",
-                        "mode": "markdown",
-                        "span": 3
+                        "class": "graph_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "clamp_max(1 + sum(rate(scylla_cache_row_hits[1m])) by ([[by]])/(sum(rate(scylla_cache_row_misses[1m])) by ([[by]]) + 0.00001),100)",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "description" :"Reciprocal Miss Rate is a score in the range of 1 to 100 that is used to decide the fraction of read requests to send to each replica - a replica with twice the RMR value of another replica will serve twice the number of read requests.\n\nRMR is calculated on a table level, this is an aggregate estimation of that score.",
+                        "title": "Reciprocal Miss Rate (HWLB)"
                     },
                     {
                         "class": "rps_panel",

--- a/grafana/scylla-detailed.4.2.template.json
+++ b/grafana/scylla-detailed.4.2.template.json
@@ -465,10 +465,19 @@
                         "title": "Writes currently blocked on commitlog"
                     },
                     {
-                        "class": "text_panel",
-                        "content": "",
-                        "mode": "markdown",
-                        "span": 3
+                        "class": "graph_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "clamp_max(1 + sum(rate(scylla_cache_row_hits[1m])) by ([[by]])/(sum(rate(scylla_cache_row_misses[1m])) by ([[by]]) + 0.00001),100)",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "description" :"Reciprocal Miss Rate is a score in the range of 1 to 100 that is used to decide the fraction of read requests to send to each replica - a replica with twice the RMR value of another replica will serve twice the number of read requests.\n\nRMR is calculated on a table level, this is an aggregate estimation of that score.",
+                        "title": "Reciprocal Miss Rate (HWLB)"
                     },
                     {
                         "class": "rps_panel",

--- a/grafana/scylla-detailed.4.3.template.json
+++ b/grafana/scylla-detailed.4.3.template.json
@@ -465,10 +465,19 @@
                         "title": "Writes currently blocked on commitlog"
                     },
                     {
-                        "class": "text_panel",
-                        "content": "",
-                        "mode": "markdown",
-                        "span": 3
+                        "class": "graph_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "clamp_max(1 + sum(rate(scylla_cache_row_hits[1m])) by ([[by]])/(sum(rate(scylla_cache_row_misses[1m])) by ([[by]]) + 0.00001),100)",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "description" :"Reciprocal Miss Rate is a score in the range of 1 to 100 that is used to decide the fraction of read requests to send to each replica - a replica with twice the RMR value of another replica will serve twice the number of read requests.\n\nRMR is calculated on a table level, this is an aggregate estimation of that score.",
+                        "title": "Reciprocal Miss Rate (HWLB)"
                     },
                     {
                         "class": "rps_panel",

--- a/grafana/scylla-detailed.4.4.template.json
+++ b/grafana/scylla-detailed.4.4.template.json
@@ -465,10 +465,19 @@
                         "title": "Writes currently blocked on commitlog"
                     },
                     {
-                        "class": "text_panel",
-                        "content": "",
-                        "mode": "markdown",
-                        "span": 3
+                        "class": "graph_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "clamp_max(1 + sum(rate(scylla_cache_row_hits[1m])) by ([[by]])/(sum(rate(scylla_cache_row_misses[1m])) by ([[by]]) + 0.00001),100)",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "description" :"Reciprocal Miss Rate is a score in the range of 1 to 100 that is used to decide the fraction of read requests to send to each replica - a replica with twice the RMR value of another replica will serve twice the number of read requests.\n\nRMR is calculated on a table level, this is an aggregate estimation of that score.",
+                        "title": "Reciprocal Miss Rate (HWLB)"
                     },
                     {
                         "class": "rps_panel",

--- a/grafana/scylla-detailed.master.template.json
+++ b/grafana/scylla-detailed.master.template.json
@@ -465,10 +465,19 @@
                         "title": "Writes currently blocked on commitlog"
                     },
                     {
-                        "class": "text_panel",
-                        "content": "",
-                        "mode": "markdown",
-                        "span": 3
+                        "class": "graph_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "clamp_max(1 + sum(rate(scylla_cache_row_hits[1m])) by ([[by]])/(sum(rate(scylla_cache_row_misses[1m])) by ([[by]]) + 0.00001),100)",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "description" :"Reciprocal Miss Rate is a score in the range of 1 to 100 that is used to decide the fraction of read requests to send to each replica - a replica with twice the RMR value of another replica will serve twice the number of read requests.\n\nRMR is calculated on a table level, this is an aggregate estimation of that score.",
+                        "title": "Reciprocal Miss Rate (HWLB)"
                     },
                     {
                         "class": "rps_panel",


### PR DESCRIPTION
The Reciprocal miss-rate is an indication to the Heat Weighted Load balancing (HWLB).

This series adds a panel to the detailed dashboard with a node/shard level estimation of that score.
The values are in a range of 1-100 and are an indication of how likely a query will be served from the cache.

![Screenshot from 2021-03-17 13-46-51](https://user-images.githubusercontent.com/2118079/111468579-63f24800-872e-11eb-9921-dc57883c3e20.png)

Fixes #907

Replaces #1321 