### PR TITLE
prometheus.rules: fix summary typos and query expressions syntax

### DIFF
--- a/prometheus/prometheus.rules.yml
+++ b/prometheus/prometheus.rules.yml
@@ -8,19 +8,19 @@ groups:
   - record: cql:all_rate1m
     expr: sum(cql:all_shardrate1m) by (cluster, dc, instance)
   - record: cql:non_token_aware
-    expr: (sum(cql:all_rate1m) by (cluster) >bool 10) * (1-(sum(rate(scylla_storage_proxy_coordinator_reads_local_node{}[60s]))  by (cluster)+ sum(rate(scylla_storage_proxy_coordinator_total_write_attempts_local_node{}[60s]))  by (cluster)) / sum(cql:all_rate1m)  by (cluster))
+    expr: (sum(cql:all_rate1m) by (cluster) >bool 10) * (1-(sum(rate(scylla_storage_proxy_coordinator_reads_local_node{}[60s])) by (cluster) + sum(rate(scylla_storage_proxy_coordinator_total_write_attempts_local_node{}[60s])) by (cluster)) / sum(cql:all_rate1m) by (cluster))
   - record: cql:non_system_prepared1m
     expr: clamp_min(sum(rate(scylla_query_processor_statements_prepared[1m])) by (cluster, dc, instance, shard) - cql:all_system_shardrate1m, 0)
   - record: cql:non_prepared
-    expr: (sum(cql:non_system_prepared1m) by (cluster) >bool 10) * (sum(cql:non_system_prepared1m)  by (cluster) / clamp_min(sum(cql:all_rate1m) - sum(cql:all_system_shardrate1m) by (cluster), 0.001))
+    expr: (sum(cql:non_system_prepared1m) by (cluster) >bool 10) * (sum(cql:non_system_prepared1m) by (cluster) / clamp_min(sum(cql:all_rate1m) - sum(cql:all_system_shardrate1m) by (cluster), 0.001))
   - record: cql:non_paged_no_system
     expr: clamp_min(sum(rate(scylla_cql_unpaged_select_queries[60s])) by (cluster, dc, instance) - sum(rate(scylla_cql_unpaged_select_queries_per_ks{ks="system"}[60s])) by (cluster, dc, instance), 0)
   - record: cql:non_paged
     expr: sum(rate(scylla_cql_unpaged_select_queries[60s])) by (cluster)/sum(rate(scylla_cql_reads{}[60s])) by (cluster)
   - record: cql:reverse_queries
-    expr: sum(rate(scylla_cql_reverse_queries[60s])) by  (cluster)/ sum(rate(scylla_cql_reads[60s])) by  (cluster)
+    expr: sum(rate(scylla_cql_reverse_queries[60s])) by (cluster)/ sum(rate(scylla_cql_reads[60s])) by (cluster)
   - record: cql:allow_filtering
-    expr: sum(rate(scylla_cql_filtered_read_requests[60s])) by  (cluster)/ sum(rate(scylla_cql_reads[60s])) by  (cluster)
+    expr: sum(rate(scylla_cql_filtered_read_requests[60s])) by (cluster)/ sum(rate(scylla_cql_reads[60s])) by (cluster)
   - record: cql:any_queries
     expr: sum(rate(scylla_query_processor_queries{consistency_level="ANY"}[60s])) by (cluster) >bool 0
   - record: cql:all_queries
@@ -121,7 +121,7 @@ groups:
       dashboard: "cql"
     annotations:
       description: 'CQL queries are not balanced among shards {{ $labels.instance }} shard {{ $labels.shard }}'
-      summary: cql queries are not balanced
+      summary: CQL queries are not balanced
   - alert: nodeLocalErrors
     expr: sum(errors:local_failed) by (cluster, instance) > 0
     for: 10s
@@ -218,8 +218,8 @@ groups:
     labels:
       severity: "2"
     annotations:
-      description: '{{ $labels.host }} has denied cql connection for more than 30 seconds.'
-      summary: Instance {{ $labels.host }} no cql connection
+      description: '{{ $labels.host }} has denied CQL connection for more than 30 seconds.'
+      summary: Instance {{ $labels.host }} no CQL connection
   - alert: HighLatencies
     expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name=~"statement|$"}[300s])) by (instance, le)) > 100000
     for: 5m
@@ -227,7 +227,7 @@ groups:
       severity: "1"
     annotations:
       description: '{{ $labels.instance }} has 95% high latency for more than 5 minutes.'
-      summary: Instance {{ $labels.instance }} Hight Write Latency
+      summary: Instance {{ $labels.instance }} High Write Latency
   - alert: HighLatencies
     expr: sum(rate(scylla_storage_proxy_coordinator_write_latency_sum[60s]))by (instance)/sum(rate(scylla_storage_proxy_coordinator_write_latency_count[60s]))by (instance) >10000
     for: 5m
@@ -235,7 +235,7 @@ groups:
       severity: "1"
     annotations:
       description: '{{ $labels.instance }} has average high latency for more than 5 minutes.'
-      summary: Instance {{ $labels.instance }} Hight Write  Latency
+      summary: Instance {{ $labels.instance }} High Write Latency
   - alert: HighLatencies
     expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name=~"statement|$"}[300s])) by (instance, le)) > 100000
     for: 5m
@@ -243,7 +243,7 @@ groups:
       severity: "1"
     annotations:
       description: '{{ $labels.instance }} has 95% high latency for more than 5 minutes.'
-      summary: Instance {{ $labels.instance }} Hight Read Latency
+      summary: Instance {{ $labels.instance }} High Read Latency
   - alert: HighLatencies
     expr: sum(rate(scylla_storage_proxy_coordinator_read_latency_sum[60s]))by (instance)/sum(rate(scylla_storage_proxy_coordinator_read_latency_count[60s]))by (instance) >10000
     for: 5m
@@ -251,7 +251,7 @@ groups:
       severity: "1"
     annotations:
       description: '{{ $labels.instance }} has average high latency for more than 5 minutes.'
-      summary: Instance {{ $labels.instance }} Hight Read  Latency
+      summary: Instance {{ $labels.instance }} High Read Latency
   - alert: BackupFailed
     expr: (sum(scylla_manager_task_run_total{type=~"backup", status="ERROR"}) or vector(0)) - (sum(scylla_manager_task_run_total{type=~"backup", status="ERROR"} offset 3m) or vector(0)) > 0
     for: 10s
@@ -274,7 +274,7 @@ groups:
     labels:
       severity: "1"
     annotations:
-      description: 'node restarted'
+      description: 'Node restarted'
       summary: Instance {{ $labels.instance }} restarted
   - alert: oomKill
     expr: changes(node_vmstat_oom_kill[1h])>0
@@ -283,4 +283,4 @@ groups:
       severity: "2"
     annotations:
       description: 'OOM Kill on {{ $labels.instance }}'
-      summary: A process was terminate on Instance {{ $labels.instance }}
+      summary: A process was terminated on Instance {{ $labels.instance }}


### PR DESCRIPTION
with this commit we:

- fix some English typos
- normalize CQL term in upper case
- normalize query expression spaces / syntax