### PR TITLE
docs: refactor and simplify advisor index

### DIFF
--- a/docs/source/advisor/index.rst
+++ b/docs/source/advisor/index.rst
@@ -2,13 +2,6 @@
 Scylla Monitoring Stack Advisor
 ===============================
 
-.. toctree::
-   :glob:
-   :maxdepth: 2
-   :hidden:
-
-   *
-
 The Scylla Monitoring Stack Advisor is an element of the Scylla Monitoring Stack that recognize bad practices, bad configurations, and potential problems and advises on how to solve them.
 
 The Advisor section
@@ -29,14 +22,8 @@ For example, when a single, hot partition gets most of the requests, making one 
 
 Each Advisor issue is explained in detail:
 
-* :doc:`Some queries use ALLOW FILTERING <cqlAllowFiltering>`
-* :doc:`Some queries use Consistency Level: ALL <cqlCLAll>`
-* :doc:`Some queries use Consistency Level: ANY <cqlCLAny>`
-* :doc:`Some queries are not token-aware <cqlNoTokenAware>`
-* :doc:`Some SELECT queries are non-paged <cqlNonPaged>`
-* :doc:`Some queries are non-prepared <cqlNonPrepared>`
-* :doc:`Some queries use reverse order <cqlReverseOrder>`
-* :doc:`Some operation failed due to unsatisfied consistency level <nodeCLErrors>`
-* :doc:`I/O Errors can indicate a node with a faulty disk <nodeIOErrors>`
-* :doc:`Some operations failed on the replica side <nodeLocalErrors>`
-* :doc:`CQL queries are not balanced among shards  <nonBalancedcqlTraffic>`
+.. toctree::
+   :glob:
+   :maxdepth: 1
+              
+   *


### PR DESCRIPTION
This PR simplify the Advisor index by using the automatically generated ToC tree in the doc itself.
The end result (below) looks exactly the same, but  shorter, and easier to maintain.

![image](https://user-images.githubusercontent.com/170200/113296613-5ded9100-9302-11eb-96b4-9eb29291e2a0.png)
