### PR TITLE
Link to specific branch

### DIFF
--- a/grafana/build/ver_2020.1/scylla-overview.2020.1.json
+++ b/grafana/build/ver_2020.1/scylla-overview.2020.1.json
@@ -1752,7 +1752,7 @@
                                     {
                                         "targetBlank": true,
                                         "title": "${__data.fields.description}",
-                                        "url": "http://monitoring.docs.scylladb.com/stable/advisor/${__data.fields.alertname}"
+                                        "url": "http://monitoring.docs.scylladb.com/scylla-monitoring-${monitoring_version}/advisor/${__data.fields.alertname}"
                                     }
                                 ]
                             }

--- a/grafana/build/ver_2021.1/scylla-overview.2021.1.json
+++ b/grafana/build/ver_2021.1/scylla-overview.2021.1.json
@@ -1752,7 +1752,7 @@
                                     {
                                         "targetBlank": true,
                                         "title": "${__data.fields.description}",
-                                        "url": "http://monitoring.docs.scylladb.com/stable/advisor/${__data.fields.alertname}"
+                                        "url": "http://monitoring.docs.scylladb.com/scylla-monitoring-${monitoring_version}/advisor/${__data.fields.alertname}"
                                     }
                                 ]
                             }

--- a/grafana/build/ver_4.2/scylla-overview.4.2.json
+++ b/grafana/build/ver_4.2/scylla-overview.4.2.json
@@ -1752,7 +1752,7 @@
                                     {
                                         "targetBlank": true,
                                         "title": "${__data.fields.description}",
-                                        "url": "http://monitoring.docs.scylladb.com/stable/advisor/${__data.fields.alertname}"
+                                        "url": "http://monitoring.docs.scylladb.com/scylla-monitoring-${monitoring_version}/advisor/${__data.fields.alertname}"
                                     }
                                 ]
                             }

--- a/grafana/build/ver_4.3/scylla-overview.4.3.json
+++ b/grafana/build/ver_4.3/scylla-overview.4.3.json
@@ -1752,7 +1752,7 @@
                                     {
                                         "targetBlank": true,
                                         "title": "${__data.fields.description}",
-                                        "url": "http://monitoring.docs.scylladb.com/stable/advisor/${__data.fields.alertname}"
+                                        "url": "http://monitoring.docs.scylladb.com/scylla-monitoring-${monitoring_version}/advisor/${__data.fields.alertname}"
                                     }
                                 ]
                             }

--- a/grafana/build/ver_4.4/scylla-overview.4.4.json
+++ b/grafana/build/ver_4.4/scylla-overview.4.4.json
@@ -1752,7 +1752,7 @@
                                     {
                                         "targetBlank": true,
                                         "title": "${__data.fields.description}",
-                                        "url": "http://monitoring.docs.scylladb.com/stable/advisor/${__data.fields.alertname}"
+                                        "url": "http://monitoring.docs.scylladb.com/scylla-monitoring-${monitoring_version}/advisor/${__data.fields.alertname}"
                                     }
                                 ]
                             }

--- a/grafana/build/ver_master/scylla-overview.master.json
+++ b/grafana/build/ver_master/scylla-overview.master.json
@@ -1752,7 +1752,7 @@
                                     {
                                         "targetBlank": true,
                                         "title": "${__data.fields.description}",
-                                        "url": "http://monitoring.docs.scylladb.com/stable/advisor/${__data.fields.alertname}"
+                                        "url": "http://monitoring.docs.scylladb.com/scylla-monitoring-${monitoring_version}/advisor/${__data.fields.alertname}"
                                     }
                                 ]
                             }

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -1768,7 +1768,7 @@
                 "value": [
                   {
                     "title": "${__data.fields.description}",
-                    "url": "http://monitoring.docs.scylladb.com/stable/advisor/${__data.fields.alertname}",
+                    "url": "http://monitoring.docs.scylladb.com/scylla-monitoring-${monitoring_version}/advisor/${__data.fields.alertname}",
                     "targetBlank": true
                   }
                 ]


### PR DESCRIPTION
This series change the link from the the advisor documentation so it would point to a specific version instead of to the latest