### PR TITLE
docs: build branches (docs)

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -178,15 +178,17 @@ redirects_file = "_utils/redirections.yaml"
 # -- Options for multiversion --------------------------------------------
 
 # Whitelist pattern for tags (set to None to ignore all tags)
-TAGS = ['scylla-monitoring-3.4.2', 'scylla-monitoring-3.5', 'scylla-monitoring-3.5.\d+', 'scylla-monitoring-3.6.0', 'scylla-monitoring-3.6.3', 'scylla-monitoring-3.7.0']
+TAGS = []
 smv_tag_whitelist = multiversion_regex_builder(TAGS)
+# Whitelist pattern for branches (set to None to ignore all branches)
+BRANCHES = ['branch-3.4', 'branch-3.5', 'branch-3.6', 'branch-3.7']
+smv_branch_whitelist = multiversion_regex_builder(BRANCHES)
 # Defines which version is considered to be the latest stable version.
 # Must be listed in smv_tag_whitelist or smv_branch_whitelist.
-smv_latest_version = 'scylla-monitoring-3.6.3'
+smv_latest_version = 'branch-3.6'
 smv_rename_latest_version = 'stable'
-# Whitelist pattern for branches (set to None to ignore all branches)
-BRANCHES = []
-smv_branch_whitelist = multiversion_regex_builder(BRANCHES)
+# Part of the branch name to skip.
+branch_substring_removed = 'branch-'
 # Whitelist pattern for remotes (set to None to use local branches only)
 smv_remote_whitelist = r"^origin$"
 # Pattern for released versions


### PR DESCRIPTION
This PR builds docs for branches instead of using tags.

## Motivation

- **Better navigation**: The users will have fewer options to choose from the dropdown (4 vs 8). This is especially relevant when the doc changes between versions are minimal.

- **Less maintenance**: As a maintainer, you would have to update ``docs/source/conf.py`` only when the minor version increases, and not for every patch.

- **Content control**: It is possible to apply fixes to branches without having to update the tag's references.

## Downsides

- The theme does not support redirections when the version changes (only when the contents within a version changes). For this reason, if a user accesses the URL ``scylla-monitoring-3.6.0`` instead of ``branch-3.6``, they will get a 404 error. Note that the error will not be raised when accessing the new latest version, since the URL is labeled as ``stable``.

- @amnonh Docs for ``branch-3.4`` are not building with this new setup. This is because the doc folder organization of ``branch-3.4`` differs from the one used in the tag ``scylla-monitoring-3.4.2``. To fix this, please update ``branch-3.4`` to include the commits available in ``scylla-monitoring-3.4.2``.

- Branches are sorted in ASC order, whereas tags were sorted in DESC order. The [next theme release](https://github.com/scylladb/sphinx-scylladb-theme/issues/154) will automatically fix this issue.

## How to test this PR

1. Within the docs folder run make ``multiversionpreview``.
2. Open https://0.0.0.0:5500. You should see the following dropdown:

![image](https://user-images.githubusercontent.com/9107969/115273838-f45de700-a137-11eb-9aee-1ac4ed641453.png)
