### PR TITLE
Add upload data to query

### DIFF
--- a/grafana/build/ver_2020.1/scylla-overview.2020.1.json
+++ b/grafana/build/ver_2020.1/scylla-overview.2020.1.json
@@ -1713,7 +1713,7 @@
                                     {
                                         "targetBlank": true,
                                         "title": "Open an issue",
-                                        "url": "https://github.com/scylladb/scylla/issues/new?body=description%3D${__data.fields[4]}%0ASource%3DAdvisor%0AScylla-versions%3D${all_scyllas_versions}%0Ascylla-monitoring%3D${monitoring_version}%0Acluster%3D${count_dc}%0Aname%3D${cluster}"
+                                        "url": "https://github.com/scylladb/scylla/issues/new?body=description%3D${__data.fields[4]}%0ASource%3DAdvisor%0AScylla-versions%3D${all_scyllas_versions}%0Ascylla-monitoring%3D${monitoring_version}%0Acluster%3D${count_dc}%0Aname%3D${cluster}%0A%0A<!--%0ATo help us understand the issue, please upload a copy of your metrics to our secure location.%0AYou can read about it here: https://docs.scylladb.com/troubleshooting/report_scylla_problem/%0A%0AYou can use the upload_report.sh utility that is part of scylla-monitoring stack.%0AMake sure to include the UUID you got from the utility in this issue.%0A-->"
                                     }
                                 ]
                             },

--- a/grafana/build/ver_2021.1/scylla-overview.2021.1.json
+++ b/grafana/build/ver_2021.1/scylla-overview.2021.1.json
@@ -1713,7 +1713,7 @@
                                     {
                                         "targetBlank": true,
                                         "title": "Open an issue",
-                                        "url": "https://github.com/scylladb/scylla/issues/new?body=description%3D${__data.fields[4]}%0ASource%3DAdvisor%0AScylla-versions%3D${all_scyllas_versions}%0Ascylla-monitoring%3D${monitoring_version}%0Acluster%3D${count_dc}%0Aname%3D${cluster}"
+                                        "url": "https://github.com/scylladb/scylla/issues/new?body=description%3D${__data.fields[4]}%0ASource%3DAdvisor%0AScylla-versions%3D${all_scyllas_versions}%0Ascylla-monitoring%3D${monitoring_version}%0Acluster%3D${count_dc}%0Aname%3D${cluster}%0A%0A<!--%0ATo help us understand the issue, please upload a copy of your metrics to our secure location.%0AYou can read about it here: https://docs.scylladb.com/troubleshooting/report_scylla_problem/%0A%0AYou can use the upload_report.sh utility that is part of scylla-monitoring stack.%0AMake sure to include the UUID you got from the utility in this issue.%0A-->"
                                     }
                                 ]
                             },

--- a/grafana/build/ver_4.2/scylla-overview.4.2.json
+++ b/grafana/build/ver_4.2/scylla-overview.4.2.json
@@ -1713,7 +1713,7 @@
                                     {
                                         "targetBlank": true,
                                         "title": "Open an issue",
-                                        "url": "https://github.com/scylladb/scylla/issues/new?body=description%3D${__data.fields[4]}%0ASource%3DAdvisor%0AScylla-versions%3D${all_scyllas_versions}%0Ascylla-monitoring%3D${monitoring_version}%0Acluster%3D${count_dc}%0Aname%3D${cluster}"
+                                        "url": "https://github.com/scylladb/scylla/issues/new?body=description%3D${__data.fields[4]}%0ASource%3DAdvisor%0AScylla-versions%3D${all_scyllas_versions}%0Ascylla-monitoring%3D${monitoring_version}%0Acluster%3D${count_dc}%0Aname%3D${cluster}%0A%0A<!--%0ATo help us understand the issue, please upload a copy of your metrics to our secure location.%0AYou can read about it here: https://docs.scylladb.com/troubleshooting/report_scylla_problem/%0A%0AYou can use the upload_report.sh utility that is part of scylla-monitoring stack.%0AMake sure to include the UUID you got from the utility in this issue.%0A-->"
                                     }
                                 ]
                             },

--- a/grafana/build/ver_4.3/scylla-overview.4.3.json
+++ b/grafana/build/ver_4.3/scylla-overview.4.3.json
@@ -1713,7 +1713,7 @@
                                     {
                                         "targetBlank": true,
                                         "title": "Open an issue",
-                                        "url": "https://github.com/scylladb/scylla/issues/new?body=description%3D${__data.fields[4]}%0ASource%3DAdvisor%0AScylla-versions%3D${all_scyllas_versions}%0Ascylla-monitoring%3D${monitoring_version}%0Acluster%3D${count_dc}%0Aname%3D${cluster}"
+                                        "url": "https://github.com/scylladb/scylla/issues/new?body=description%3D${__data.fields[4]}%0ASource%3DAdvisor%0AScylla-versions%3D${all_scyllas_versions}%0Ascylla-monitoring%3D${monitoring_version}%0Acluster%3D${count_dc}%0Aname%3D${cluster}%0A%0A<!--%0ATo help us understand the issue, please upload a copy of your metrics to our secure location.%0AYou can read about it here: https://docs.scylladb.com/troubleshooting/report_scylla_problem/%0A%0AYou can use the upload_report.sh utility that is part of scylla-monitoring stack.%0AMake sure to include the UUID you got from the utility in this issue.%0A-->"
                                     }
                                 ]
                             },

--- a/grafana/build/ver_4.4/scylla-overview.4.4.json
+++ b/grafana/build/ver_4.4/scylla-overview.4.4.json
@@ -1713,7 +1713,7 @@
                                     {
                                         "targetBlank": true,
                                         "title": "Open an issue",
-                                        "url": "https://github.com/scylladb/scylla/issues/new?body=description%3D${__data.fields[4]}%0ASource%3DAdvisor%0AScylla-versions%3D${all_scyllas_versions}%0Ascylla-monitoring%3D${monitoring_version}%0Acluster%3D${count_dc}%0Aname%3D${cluster}"
+                                        "url": "https://github.com/scylladb/scylla/issues/new?body=description%3D${__data.fields[4]}%0ASource%3DAdvisor%0AScylla-versions%3D${all_scyllas_versions}%0Ascylla-monitoring%3D${monitoring_version}%0Acluster%3D${count_dc}%0Aname%3D${cluster}%0A%0A<!--%0ATo help us understand the issue, please upload a copy of your metrics to our secure location.%0AYou can read about it here: https://docs.scylladb.com/troubleshooting/report_scylla_problem/%0A%0AYou can use the upload_report.sh utility that is part of scylla-monitoring stack.%0AMake sure to include the UUID you got from the utility in this issue.%0A-->"
                                     }
                                 ]
                             },

--- a/grafana/build/ver_master/scylla-overview.master.json
+++ b/grafana/build/ver_master/scylla-overview.master.json
@@ -1713,7 +1713,7 @@
                                     {
                                         "targetBlank": true,
                                         "title": "Open an issue",
-                                        "url": "https://github.com/scylladb/scylla/issues/new?body=description%3D${__data.fields[4]}%0ASource%3DAdvisor%0AScylla-versions%3D${all_scyllas_versions}%0Ascylla-monitoring%3D${monitoring_version}%0Acluster%3D${count_dc}%0Aname%3D${cluster}"
+                                        "url": "https://github.com/scylladb/scylla/issues/new?body=description%3D${__data.fields[4]}%0ASource%3DAdvisor%0AScylla-versions%3D${all_scyllas_versions}%0Ascylla-monitoring%3D${monitoring_version}%0Acluster%3D${count_dc}%0Aname%3D${cluster}%0A%0A<!--%0ATo help us understand the issue, please upload a copy of your metrics to our secure location.%0AYou can read about it here: https://docs.scylladb.com/troubleshooting/report_scylla_problem/%0A%0AYou can use the upload_report.sh utility that is part of scylla-monitoring stack.%0AMake sure to include the UUID you got from the utility in this issue.%0A-->"
                                     }
                                 ]
                             },

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -1729,7 +1729,7 @@
                 "value": [
                   {
                     "title": "Open an issue",
-                    "url": "https://github.com/scylladb/scylla/issues/new?body=description%3D${__data.fields[4]}%0ASource%3DAdvisor%0AScylla-versions%3D${all_scyllas_versions}%0Ascylla-monitoring%3D${monitoring_version}%0Acluster%3D${count_dc}%0Aname%3D${cluster}",
+                    "url": "https://github.com/scylladb/scylla/issues/new?body=description%3D${__data.fields[4]}%0ASource%3DAdvisor%0AScylla-versions%3D${all_scyllas_versions}%0Ascylla-monitoring%3D${monitoring_version}%0Acluster%3D${count_dc}%0Aname%3D${cluster}%0A%0A<!--%0ATo help us understand the issue, please upload a copy of your metrics to our secure location.%0AYou can read about it here: https://docs.scylladb.com/troubleshooting/report_scylla_problem/%0A%0AYou can use the upload_report.sh utility that is part of scylla-monitoring stack.%0AMake sure to include the UUID you got from the utility in this issue.%0A-->",
                     "targetBlank": true
                   }
                 ]


### PR DESCRIPTION
This patch adds text when opening an issue with description of how to upload Prometheus metrics, this is how it looks like
after a user press the report an issue button.

![image](https://user-images.githubusercontent.com/2118079/115989067-1f778900-a5c5-11eb-84b0-ddc033073483.png)
