### PR TITLE
Add Await metrics

### DIFF
--- a/grafana/scylla-os.template.json
+++ b/grafana/scylla-os.template.json
@@ -257,6 +257,36 @@
                             }
                         ],
                         "title": "Disk Read Bps per $by"
+                    },
+                    {
+                        "class": "seconds_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "rate(node_disk_read_time_seconds_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])/rate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "description": "The average read time from disk",
+                        "title": "Read AWait per instance"
+                    },
+                    {
+                        "class": "seconds_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "rate(node_disk_write_time_seconds_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])/rate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[4m])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "description": "The average write time to disk",
+                        "title": "Write AWait per instance"
                     }
                 ],
                 "title": "New row"

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -1200,6 +1200,16 @@
          }
       ]
    },
+   "seconds_panel": {
+     "class":"graph_panel",
+     "fieldConfig": {
+        "defaults": {
+        "links": [],
+        "unit": "s"
+     },
+     "overrides": []
+  }
+   },
    "bps_panel":{
       "class":"iops_panel",
       "yaxes":[


### PR DESCRIPTION
This patch adds the await read and write metrics to the os dashboard
![image](https://user-images.githubusercontent.com/2118079/120311682-723d1280-c2e0-11eb-921a-c3d0cf0d421f.png)

Fixes #1343