### PR TITLE
scylla-os.template add a panel for disk used

### DIFF
--- a/grafana/scylla-os.template.json
+++ b/grafana/scylla-os.template.json
@@ -79,6 +79,37 @@
                 "class": "row",
                 "panels": [
                     {
+                        "class": "graph_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "1-sum(node_filesystem_avail_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])/sum(node_filesystem_size_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                          "yaxes":[
+                             {
+                                "format":"percentunit",
+                                "logBase":1,
+                                "max":1.01,
+                                "min":0,
+                                "show":true
+                             },
+                             {
+                                "format":"short",
+                                "logBase":1,
+                                "max":null,
+                                "min":null,
+                                "show":true
+                             }
+                          ],
+                        "title": "Used disk by $by"
+                    },                   
+                    {
                         "class": "bytes_panel",
                         "span": 3,
                         "targets": [


### PR DESCRIPTION
This patch adds a panel with the percentage of disk usage
![image](https://user-images.githubusercontent.com/2118079/120324037-d23ab580-c2ee-11eb-8308-b1666922fd8b.png)
Fixes #1408 