### PR TITLE
Advisor alert on Prepared cache eviction

### DIFF
--- a/docs/source/use-monitoring/advisor/index.rst
+++ b/docs/source/use-monitoring/advisor/index.rst
@@ -41,3 +41,4 @@ Each Advisor issue is explained in detail:
 * :doc:`I/O Errors can indicate a node with a faulty disk <nodeIOErrors>`
 * :doc:`Some operations failed on the replica side <nodeLocalErrors>`
 * :doc:`CQL queries are not balanced among shards  <nonBalancedcqlTraffic>`
+* :doc:`Prepared statements cache eviction <preparedCacheEviction.rst>`

--- a/docs/source/use-monitoring/advisor/preparedCacheEviction.rst
+++ b/docs/source/use-monitoring/advisor/preparedCacheEviction.rst
@@ -1,0 +1,10 @@
+Prepared statements cache eviction
+---------------------------------------
+
+Typically, prepared statements are prepared once and then used for a long period. Prepared statements are stored in the cache and only get evicted if they are not used.
+If the prepared statements cache does get evicted, it's an indication that something is wrong.
+The two main sources are:
+
+* A prepared statement that contains a field value, creating such a statement will result in a new prepared statement being stored each time, which defies the purpose of it.
+* The prepared statements cache might be too small for the number of prepared statements.
+

--- a/prometheus/prometheus.rules.yml
+++ b/prometheus/prometheus.rules.yml
@@ -152,6 +152,16 @@ groups:
     annotations:
       description: 'Some operation failed due to consistency level'
       summary: Consistency Level error
+  - alert: preparedCacheEviction
+    expr: sum(rate(scylla_cql_prepared_cache_evictions[2m])) by (cluster) + sum(rate(scylla_cql_authorized_prepared_statements_cache_evictions[2m])) by (cluster) > 100
+    for: 5m
+    labels:
+      severity: "1"
+      advisor: "preparedEviction"
+      dashboard: "scylla-detailed"
+    annotations:
+      description: 'The prepared-statement cache is being continuously evicted, which could indicate a problem in your prepared-statement usage logic.'
+      summary: Prepared cache eviction
   - alert: InstanceDown
     expr: up{job="scylla"} == 0
     for: 30s


### PR DESCRIPTION
This series adds an alert to the Advisor when the prepared statements cache is being continuesly evicted.
This is how it looks like during testing.
![Screenshot from 2021-06-02 16-47-38](https://user-images.githubusercontent.com/2118079/120491993-5e69dd00-c3c2-11eb-8e6f-7e6968554843.png)

Fixes #1401
@tzach and @lauranovich I'm adding you as a reviewer because it contains a documention change