### PR TITLE
User recording rules for Latencies

### DIFF
--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -124,7 +124,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$func(rate(scylla_storage_proxy_coordinator_write_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])/($func(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]]) + 1)",
+                                "expr": "wlatencya{by=\"[[by]]\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -138,7 +138,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$func(rate(scylla_storage_proxy_coordinator_read_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])/($func(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]]) + 1)",
+                                "expr": "rlatencya{by=\"[[by]]\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -152,7 +152,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]], le))",
+                                "expr": "wlatencyp95{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"statement|$\"}",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -167,7 +167,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]], le))",
+                                "expr": "wlatencyp99{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -182,7 +182,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]], le))",
+                                "expr": "rlatencyp95{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -197,7 +197,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]], le))",
+                                "expr": "rlatencyp99{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -1019,7 +1019,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"statement|$\"}[$__rate_interval])) by ([[by]], le))",
+                                "expr": "casrlatencyp95{by=\"[[by]]\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -1084,7 +1084,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"statement|$\"}[$__rate_interval])) by ([[by]], le))",
+                                "expr": "caswlatencyp95{by=\"[[by]]\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",

--- a/grafana/scylla-overview.template.json
+++ b/grafana/scylla-overview.template.json
@@ -51,14 +51,14 @@
                         "span": 2,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"statement|$\"}[$__rate_interval])) by (le))",
+                                "expr": "wlatencyp95{by=\"cluster\", cluster=~\"$cluster|$^\"}",
                                 "intervalFactor": 1,
                                 "legendFormat": "95%",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"statement|$\"}[$__rate_interval])) by (le))",
+                                "expr": "wlatencyp99{by=\"cluster\", cluster=~\"$cluster|$^\"}",
                                 "intervalFactor": 1,
                                 "legendFormat": "99%",
                                 "refId": "B",
@@ -89,14 +89,14 @@
                         "span": 2,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"statement|$\"}[$__rate_interval])) by (le))",
+                                "expr": "rlatencyp95{by=\"cluster\", cluster=~\"$cluster|$^\"}",
                                 "intervalFactor": 1,
                                 "legendFormat": "95%",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"statement|$\"}[$__rate_interval])) by (le))",
+                                "expr": "rlatencyp99{by=\"cluster\", cluster=~\"$cluster|$^\"}",
                                 "intervalFactor": 1,
                                 "legendFormat": "99%",
                                 "refId": "B",
@@ -250,12 +250,12 @@
                         "title": "Node Latency",
                         "targets": [
                             {
-                              "expr": "max(histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\",scheduling_group_name=~\"statement|$\"}[$__rate_interval])) by (instance, le)) -scalar(avg(histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\",scheduling_group_name=~\"statement|$\"}[$__rate_interval])) by (instance,le))>0)))/ scalar(stddev(histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\",scheduling_group_name=~\"statement|$\"}[$__rate_interval])) by (instance,le))>0)+100)-3",
+                              "expr": "(max(wlatencyp99{by=\"instance\", cluster=~\"$cluster|$^\"})-scalar(avg(wlatencyp99{by=\"instance\", cluster=~\"$cluster|$^\"})))/(scalar(stddev(wlatencyp99{by=\"instance\", cluster=~\"$cluster|$^\"}))+100)-3",
                               "legendFormat": "",
                               "refId": "A"
                             },
                             {
-                              "expr": "max(histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\",scheduling_group_name=~\"statement|$\"}[$__rate_interval])) by (instance, le)) -scalar(avg(histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\",scheduling_group_name=~\"statement|$\"}[$__rate_interval])) by (instance,le))>0)))/ scalar(stddev(histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\",scheduling_group_name=~\"statement|$\"}[$__rate_interval])) by (instance,le))>0)+100)-3",
+                              "expr": "(max(rlatencyp99{by=\"instance\", cluster=~\"$cluster|$^\"})-scalar(avg(rlatencyp99{by=\"instance\", cluster=~\"$cluster|$^\"})))/(scalar(stddev(rlatencyp99{by=\"instance\", cluster=~\"$cluster|$^\"}))+100)-3",
                               "legendFormat": "",
                               "refId": "B"
                             }
@@ -273,12 +273,12 @@
                         "title": "Shard Latency",
                         "targets": [
                             {
-                              "expr": "max(histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"statement|$\"}[$__rate_interval])) by (instance,shard, le)) -scalar(avg(histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"statement|$\"}[$__rate_interval])) by (instance,shard,le))>0)))/ scalar(stddev(histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"statement|$\"}[$__rate_interval])) by (instance,shard, le))>0)+100)-3",
+                              "expr": "(max(wlatencyp99{by=\"instance,shard\", cluster=~\"$cluster|$^\"})-scalar(avg(wlatencyp99{by=\"instance,shard\", cluster=~\"$cluster|$^\"})))/(scalar(stddev(wlatencyp99{by=\"instance,shard\", cluster=~\"$cluster|$^\"}))+100)-3",
                               "legendFormat": "",
                               "refId": "A"
                             },
                             {
-                              "expr": "max(histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"statement|$\"}[$__rate_interval])) by (instance,shard, le)) -scalar(avg(histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"statement|$\"}[$__rate_interval])) by (instance,shard,le))>0)))/ scalar(stddev(histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"statement|$\"}[$__rate_interval])) by (instance,shard, le))>0)+100)-3",
+                              "expr": "(max(rlatencyp99{by=\"instance,shard\", cluster=~\"$cluster|$^\"})-scalar(avg(rlatencyp99{by=\"instance,shard\", cluster=~\"$cluster|$^\"})))/(scalar(stddev(rlatencyp99{by=\"instance,shard\", cluster=~\"$cluster|$^\"}))+100)-3",
                               "legendFormat": "",
                               "refId": "B"
                             }
@@ -437,14 +437,14 @@
                         "span": 2,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"statement|$\"}[$__rate_interval])) by ([[by]], le))",
+                                "expr": "wlatencyp95{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}",
                                 "intervalFactor": 1,
                                 "legendFormat": "95% {{[[by]]}}",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"statement|$\"}[$__rate_interval])) by ([[by]], le))",
+                                "expr": "wlatencyp99{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}",
                                 "intervalFactor": 1,
                                 "legendFormat": "99% {{[[by]]}}",
                                 "refId": "B",
@@ -504,14 +504,14 @@
                         "span": 2,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"statement|$\"}[$__rate_interval])) by ([[by]], le))",
+                                "expr": "rlatencyp95{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}",
                                 "intervalFactor": 1,
                                 "legendFormat": "95% {{[[by]]}}",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"statement|$\"}[$__rate_interval])) by ([[by]], le))",
+                                "expr": "rlatencyp99{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}",
                                 "intervalFactor": 1,
                                 "legendFormat": "99% {{[[by]]}}",
                                 "refId": "B",

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -407,7 +407,7 @@
             },
             "targets":[
                {
-                  "expr":"sum(rate(scylla_storage_proxy_coordinator_write_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s]))/(sum(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) + 1)",
+                  "expr":"wlatencya{by=\"cluster\", cluster=~\"$cluster|^$\"}",
                   "intervalFactor":1,
                   "legendFormat":"",
                   "refId":"A",
@@ -445,7 +445,7 @@
             },
             "targets":[
                {
-                  "expr":"histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"statement|$\"}[60s])) by (le))",
+                  "expr":"wlatencyp99{by=\"cluster\", cluster=~\"$cluster|^$\"}",
                   "intervalFactor":1,
                   "legendFormat":"",
                   "refId":"A",
@@ -483,7 +483,7 @@
             },
             "targets":[
                {
-                  "expr":"sum(rate(scylla_storage_proxy_coordinator_read_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s]))/(sum(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) + 1)",
+                  "expr":"rlatencya{by=\"cluster\", cluster=~\"$cluster|^$\"}",
                   "intervalFactor":1,
                   "legendFormat":"",
                   "instant":true,
@@ -521,7 +521,7 @@
             },
             "targets":[
                {
-                  "expr":"histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"statement|$\"}[60s])) by (le))",
+                  "expr":"rlatencyp99{by=\"cluster\", cluster=~\"$cluster|^$\"}",
                   "intervalFactor":1,
                   "legendFormat":"",
                   "refId":"A",

--- a/prometheus/prometheus.rules.yml
+++ b/prometheus/prometheus.rules.yml
@@ -41,7 +41,136 @@ groups:
     expr: timestamp(sum(changes(scylla_manager_task_run_total{status="ERROR",type="repair"}[60s])) by (cluster) > 0) or on(cluster) manager:repair_fail_ts
   - record: manager:backup_fail_ts
     expr: timestamp(sum(changes(scylla_manager_task_run_total{status="ERROR",type="backup"}[60s])) by (cluster) > 0) or on(cluster) manager:backup_fail_ts
-
+  - record: manager:repair_progress
+    expr: (sum(scylla_manager_repair_token_ranges_success) by (cluster) + sum(scylla_manager_repair_token_ranges_error) by (cluster))/sum(scylla_manager_repair_token_ranges_total) by (cluster)
+  - record: wlatencyp99
+    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name=~"statement|$"}[60s])) by (cluster, dc, instance, shard, le))
+    labels:
+      by: "instance,shard"
+  - record: wlatencyp99
+    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name=~"statement|$"}[60s])) by (cluster, dc, instance, le))
+    labels:
+      by: "instance"
+  - record: wlatencyp99
+    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name=~"statement|$"}[60s])) by (cluster, dc, le))
+    labels:
+      by: "dc"
+  - record: wlatencyp99
+    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name=~"statement|$"}[60s])) by (cluster, le))
+    labels:
+      by: "cluster"
+  - record: rlatencyp99
+    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name=~"statement|$"}[60s])) by (cluster, dc, instance, shard, le))
+    labels:
+      by: "instance,shard"
+  - record: rlatencyp99
+    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name=~"statement|$"}[60s])) by (cluster, dc, instance, le))
+    labels:
+      by: "instance"
+  - record: rlatencyp99
+    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name=~"statement|$"}[60s])) by (cluster, dc, le))
+    labels:
+      by: "dc"
+  - record: rlatencyp99
+    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name=~"statement|$"}[60s])) by (cluster, le))
+    labels:
+      by: "cluster"
+  - record: wlatencyp95
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name=~"statement|$"}[60s])) by (cluster, dc, instance, shard, le))
+    labels:
+      by: "instance,shard"
+  - record: wlatencyp95
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name=~"statement|$"}[60s])) by (cluster, dc, instance, le))
+    labels:
+      by: "instance"
+  - record: wlatencyp95
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name=~"statement|$"}[60s])) by (cluster, dc, le))
+    labels:
+      by: "dc"
+  - record: wlatencyp95
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name=~"statement|$"}[60s])) by (cluster, le))
+    labels:
+      by: "cluster"
+  - record: rlatencyp95
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name=~"statement|$"}[60s])) by (cluster, dc, instance, shard, le))
+    labels:
+      by: "instance,shard"
+  - record: rlatencyp95
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name=~"statement|$"}[60s])) by (cluster, dc, instance, le))
+    labels:
+      by: "instance"
+  - record: rlatencyp95
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name=~"statement|$"}[60s])) by (cluster, dc, le))
+    labels:
+      by: "dc"
+  - record: rlatencyp95
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name=~"statement|$"}[60s])) by (cluster, le))
+    labels:
+      by: "cluster"
+  - record: wlatencya
+    expr: sum(rate(scylla_storage_proxy_coordinator_write_latency_sum{scheduling_group_name=~"statement|$"}[60s])) by (cluster, dc, instance, shard)/sum(rate(scylla_storage_proxy_coordinator_write_latency_count{scheduling_group_name=~"statement|$"}[60s])) by (cluster, dc, instance, shard)
+    labels:
+      by: "instance,shard"
+  - record: wlatencya
+    expr: sum(rate(scylla_storage_proxy_coordinator_write_latency_sum{scheduling_group_name=~"statement|$"}[60s])) by (cluster, dc, instance)/sum(rate(scylla_storage_proxy_coordinator_write_latency_count{scheduling_group_name=~"statement|$"}[60s])) by (cluster, dc, instance)
+    labels:
+      by: "instance"
+  - record: wlatencya
+    expr: sum(rate(scylla_storage_proxy_coordinator_write_latency_sum{scheduling_group_name=~"statement|$"}[60s])) by (cluster, dc)/sum(rate(scylla_storage_proxy_coordinator_write_latency_count{scheduling_group_name=~"statement|$"}[60s])) by (cluster, dc)
+    labels:
+      by: "dc"
+  - record: wlatencya
+    expr: sum(rate(scylla_storage_proxy_coordinator_write_latency_sum{scheduling_group_name=~"statement|$"}[60s])) by (cluster)/sum(rate(scylla_storage_proxy_coordinator_write_latency_count{scheduling_group_name=~"statement|$"}[60s])) by (cluster)
+    labels:
+      by: "cluster"
+  - record: rlatencya
+    expr: sum(rate(scylla_storage_proxy_coordinator_read_latency_sum{scheduling_group_name=~"statement|$"}[60s])) by (cluster, dc, instance, shard)/sum(rate(scylla_storage_proxy_coordinator_read_latency_count{scheduling_group_name=~"statement|$"}[60s])) by (cluster, dc, instance, shard)
+    labels:
+      by: "instance,shard"
+  - record: rlatencya
+    expr: sum(rate(scylla_storage_proxy_coordinator_read_latency_sum{scheduling_group_name=~"statement|$"}[60s])) by (cluster, dc, instance)/sum(rate(scylla_storage_proxy_coordinator_read_latency_count{scheduling_group_name=~"statement|$"}[60s])) by (cluster, dc, instance)
+    labels:
+      by: "instance"
+  - record: rlatencya
+    expr: sum(rate(scylla_storage_proxy_coordinator_read_latency_sum{scheduling_group_name=~"statement|$"}[60s])) by (cluster, dc)/sum(rate(scylla_storage_proxy_coordinator_read_latency_count{scheduling_group_name=~"statement|$"}[60s])) by (cluster, dc)
+    labels:
+      by: "dc"
+  - record: rlatencya
+    expr: sum(rate(scylla_storage_proxy_coordinator_read_latency_sum{scheduling_group_name=~"statement|$"}[60s])) by (cluster)/sum(rate(scylla_storage_proxy_coordinator_read_latency_count{scheduling_group_name=~"statement|$"}[60s])) by (cluster)
+    labels:
+      by: "cluster"
+  - record: casrlatencyp95
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency_bucket{scheduling_group_name=~"statement|$"}[60s])) by (cluster, dc, instance, shard, le))
+    labels:
+      by: "instance,shard"
+  - record: casrlatencyp95
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency_bucket{scheduling_group_name=~"statement|$"}[60s])) by (cluster, dc, instance, le))
+    labels:
+      by: "instance"
+  - record: casrlatencyp95
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency_bucket{scheduling_group_name=~"statement|$"}[60s])) by (cluster, dc, le))
+    labels:
+      by: "dc"
+  - record: casrlatencyp95
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency_bucket{scheduling_group_name=~"statement|$"}[60s])) by (cluster, le))
+    labels:
+      by: "cluster"
+  - record: caswlatencyp95
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_bucket{scheduling_group_name=~"statement|$"}[60s])) by (cluster, dc, instance, shard, le))
+    labels:
+      by: "instance,shard"
+  - record: caswlatencyp95
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_bucket{scheduling_group_name=~"statement|$"}[60s])) by (cluster, dc, instance, le))
+    labels:
+      by: "instance"
+  - record: caswlatencyp95
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_bucket{scheduling_group_name=~"statement|$"}[60s])) by (cluster, dc, le))
+    labels:
+      by: "dc"
+  - record: caswlatencyp95
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_bucket{scheduling_group_name=~"statement|$"}[60s])) by (cluster, le))
+    labels:
+      by: "cluster"
   - alert: cqlNonPrepared
     expr: cql:non_prepared > 0
     for: 10s
@@ -233,7 +362,7 @@ groups:
       description: '{{ $labels.host }} has denied CQL connection for more than 30 seconds.'
       summary: Instance {{ $labels.host }} no CQL connection
   - alert: HighLatencies
-    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name=~"statement|$"}[300s])) by (instance, le)) > 100000
+    expr: wlatencyp95{by="instance"} > 100000
     for: 5m
     labels:
       severity: "1"
@@ -241,7 +370,7 @@ groups:
       description: '{{ $labels.instance }} has 95% high latency for more than 5 minutes.'
       summary: Instance {{ $labels.instance }} High Write Latency
   - alert: HighLatencies
-    expr: sum(rate(scylla_storage_proxy_coordinator_write_latency_sum[60s]))by (instance)/sum(rate(scylla_storage_proxy_coordinator_write_latency_count[60s]))by (instance) >10000
+    expr: wlatencypa{by="instance"} >10000
     for: 5m
     labels:
       severity: "1"
@@ -249,7 +378,7 @@ groups:
       description: '{{ $labels.instance }} has average high latency for more than 5 minutes.'
       summary: Instance {{ $labels.instance }} High Write Latency
   - alert: HighLatencies
-    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name=~"statement|$"}[300s])) by (instance, le)) > 100000
+    expr: rlatencyp95{by="instance"} > 100000
     for: 5m
     labels:
       severity: "1"
@@ -257,7 +386,7 @@ groups:
       description: '{{ $labels.instance }} has 95% high latency for more than 5 minutes.'
       summary: Instance {{ $labels.instance }} High Read Latency
   - alert: HighLatencies
-    expr: sum(rate(scylla_storage_proxy_coordinator_read_latency_sum[60s]))by (instance)/sum(rate(scylla_storage_proxy_coordinator_read_latency_count[60s]))by (instance) >10000
+    expr: rlatencypa{by="instance"} >10000
     for: 5m
     labels:
       severity: "1"


### PR DESCRIPTION
show Latencies in realtime is computation heavy.
To make the dashboards work faster and to reduce load from the prometheus server this patch adds recording rules
for the p99, p95 and average for read/write latencies.

Fixes #1431