### PR TITLE
Fixes Compatibility Matrix link 

### DIFF
--- a/docs/source/install/monitor_without_docker.rst
+++ b/docs/source/install/monitor_without_docker.rst
@@ -10,7 +10,7 @@ Please note, Scylla recommends you use the Docker version as it will provide you
 The main item to set an alert on is the available disk space in the monitoring system. Data is indefinitely accrued on the Prometheus data directory.
 The current monitoring solution does not churn data.
 
-.. note:: Confirm before beginning that your Grafana and Prometheus versions are supported by the Monitoring Stack version you want to install. See the `Scylla Monitoring Stack Compatibility Matrix </install/monitoring_stack/#prerequisites>`_.
+.. note:: Confirm before beginning that your Grafana and Prometheus versions are supported by the Monitoring Stack version you want to install. See the :ref:`Scylla Monitoring Stack Compatibility Matrix <Monitoring_Stack_Compatibility_Matrix>`.
 
 Install Scylla Monitoring Stack
 -------------------------------

--- a/docs/source/install/monitoring_stack.rst
+++ b/docs/source/install/monitoring_stack.rst
@@ -21,7 +21,10 @@ Prerequisites
 
 * Follow the Installation Guide and install `docker`_ on the Scylla Monitoring Stack Server. This server can be the same server that is running Scylla Manager. Alternatively, you can `Deploy Scylla Monitoring Stack Without Docker <monitor_without_docker>`_ .
 * If you have Prometheus or Grafana installed, confirm that your version is supported by the Scylla Monitoring Stack version you want to install. Refer to the table below.
+
 .. _`docker`: https://docs.docker.com/install/
+
+.. _Monitoring_Stack_Compatibility_Matrix:
 
 .. list-table:: Scylla Monitoring Stack Compatibility Matrix
    :widths: 33 33 33


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylla-monitoring/issues/1433

Cross-references between sections in restructuredText are defined explicitly using the [ref keyword](https://docs.readthedocs.io/en/stable/guides/cross-referencing-with-sphinx.html#explicit-targets).

Once this PR is merged, the change will be visible on the site on the [next documentation build](https://sphinx-theme.scylladb.com/stable/github-pages.html#github-pages).

## What's next?

For the next release, I recommend moving the Compatibility Table to a separate page, like you are already doing with this other [Matrix](https://monitoring.docs.scylladb.com/stable/reference/matrix.html). Then, you will be able to redirect users from both guides to the same table with an [Internal Docs](https://sphinx-theme.scylladb.com/stable/examples/links.html) link. 

If you prefer to keep the table where it is, please apply these changes to the ``master`` branch as well.