### PR TITLE
Scylla manager 2.4

### DIFF
--- a/grafana/scylla-manager.template.json
+++ b/grafana/scylla-manager.template.json
@@ -5,7 +5,27 @@
         "originalTitle": "Scylla Manager Metrics",
         "rows": [
             {
-                "class": "logo_row"
+                "class": "logo_row",
+                "panels":[
+                     {
+                        "class":"text_panel",
+                        "options":{
+                           "content":"<div>\n<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPoAAAA6CAYAAACZBESJAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAGm9JREFUeNrsXQd8VFXWP+9NTe+NEOmgSIdFiuxSIqB0krCssrCI0sKGLnVZV/qCCqx0ERdQ+ehFCKEtCAuCCAkdQkkhlPQ2yfT5znkzwWTyJslMJqDfd//8zo+ZVydz5//+55x777kADAwMDAwMDL99cC/yZjKpUtqxWUQbvUFbD982Q9OjKdE6oz1Gu4HGo6VzHPdzsabw+uU7h4tYMzEw/IqJLpUouE7NIwL1Bl0kvh1gIbQr8DzIgvyA9/EGMJnKnGPSG0CXnAYmjQY/HWfATTeR9HuL1Pknr9w9cpo1GQPDr4ToUomc79g88jWDQTcf3w7ipFJwad8SFE0agLxuKMgb1wcwGGxfAMlvKCgE3b1kKLp0DTR37oP+cboBJPx1juPXFKnzNiHpDaz5GBheAtGlEhnXsVnkqwajfgGq8WBZaBB4Rb4DyhavAaeQl1PvKgPP0yY9grxdh0FzIxEdfsP9Ik3eR1fuxu1hTcjA8AKJLpHIZJ2aRY4zmAxLkeBKIrhrh9aCK+5M6NMzIe+7g6A6+5OeVypjVcU5Y+ITjz5hTcnAUMNER5K7IMm3GnlThHuPzuD1p/7AyWSOK3iFn5gjRQd1wk3I+moHmLLzbqi0+SOQ7D+z5mRgsMHRal+Alyo7NY/aZpRyEX7Rw8Gzbw8zGWsSPAfSkEBwaf066J88C+TS8/v5+YRdepp9P5k1KQODk4lOJO/YPHKLScpH+o4bBm4d2oDJ8OJyZBIvD1A2awLa1DQPPr2gB5L9FJL9KWtWBgYnue5IchmSfIZJws33Hf9nJDnG4wajeSf+r752G1RnLoLm7gMwZOc9V3lOKgEFktO1fStw7dSm+i4+z+P1cyFr9RbQXL3zs8pQ0Dsh8Vgma1oGhmoSHUnOd2wW2dEkgbNeUX3Bc0C4OemGhNU9fgZZa78BQ1IqNG3RGP7Qoz00a9UEDKj0RqMRUpOfwMXzV+H44bPgEhoM5AkomzasXtIOHyLahymQuWyjIf/xw+0JD04OY03LwFBNovMUl7eIOi1t+Er74E+mgkmnE0iuufMAMpeshXp1Q2DuognQ+NV6Nq/x9EkGfLpwE5z+4TL49Q8H7+ERYFJrHCY69csX/XgFMv+5Ia1IqnkXVf0H1rwMDA7G6Dwv4Ts1i+ppkvDT/SeMAImPF6BUo4v+ELKWroMWLRrB+q0LICDQt9y5pOp3bj2EtNRn4O3jCX0GdgM3pRxObN4HMpkUlM2bVDyQpiJgSMC7uYLhyTNPVVJyg2d5SV+z5mVgcJDoHMfLw4Kbfa1o1jjUa2BPgZgmrRYyl2+EZvVDYeWmeSCVSsudp9XqYOc3h2F69BKI+/4H+H7vSUHx3xnYFVzlMjjx9T5wf60hSAP9hQeH/TABr1QC5+4GutOXpX7+dX56lv0ghTUxA4N5Aok9as6hmtc3cdDerUt7MBEhDUYoPH0BJJnZMHthtCjJCepiDez69gjIkNQcutoF+Sr4eOZKuHguASLfewfaNm8AGVv3AIcK7xBM+BCS8CAPq0WeQZBJp/+QNS8DgwNEFzwADgbyHm7g1uV3AslNej0UHTwBfSPDIbR2kM0T9XoD3LubDBIJb/EMiOxFsGr5FnBxVcL4Se9BQWIKqBNuAWfjYVEp142o6vjZlG+0lLpLPVq2bBjOWpiBwQGi88jQPyjQxQYklZBlz8gCyM2HLt1+V4nLz4E7ktBUpivNBFkZOXABVb1+wzCoGxYEhZeuCvG2Y0w3AeeiBEWjepTF98QtLVkTMzA4RvSW8jqh5r5vInpyGkjlUmjXoXmFJ8oVMniza1tB2cvE7hodxP98S3gIdO7SCoofZwDH8w7/QRzPgcTbE6ShQW4mg/F11sQMDPYS3US5OD5Y8WpD5LhRcJX1KY8hJDSw0lPd3Fxg/rLJMHrCUPDx8QQjnsvhP8rEU1cbZxnDrk99LAyCcRgUq6PrL/UVbtKxJr60Pn36yNEzaYc2FW0r2lm002ixaCvRInbt2uVRE/eOiYlxweu/iTYRbTPaf9FOoR1H24Q2asmSJbXtve6iRYvq47k90bqWsu50rylTpvhXdv66deukeGwLtHCra7yF1mD48OGVumn4ncnw2NZoPazOr9uvXz/emd/jhQsXAvG6ndC6lbpXz1atWrm/aBKmp6d3tvrOG3p7ezv1761yMMxzEq5T86i6RqNB1CWvqtq6e7haue+lY2wjGIuKqzVWnq7Nofcgqx0MpnjnDsft3bu3JDY2tivxAq29rcOIjxEREQVExJ07dy4fMmRIanXvHR0dXfeLL76Yji/fRfOu4ND3Z8yYoUOLXbx48d9nz54dX8VbvIn2BVq5B9Snn366xGg0zlqxYkVF51NRkbVor4nsm4S2sgqfwQftX5ZrlcYnaEvQip3YnN3R6A+yTiy1Rot/gSRvGRAQcAhfepXajPEw1EfLfxmKTuyrSySUBPiYlZPc5LAQSLz9sNKTi4vUsOTjdfDpok2Qm1uAos3hJUyCm+7h7mq+gVwG8iYNHO9Lr0H07NnTH0n+Ob48XgHJS4MIExMVFfWf7du393T0vuPGjePwgfEXJPlP+HZ8JSQvgQyt/6xZsy7guZMWLFhQlVttQfvWxr7h9BXYOnHNmjUwZsyYsTZIfnDEiBH7t2zZwvxncfwVqOpSWfjl5OQM8vT0lL4Mootl2EDq7wtGdLkfpVY8l0St1sKRg2eEgTFlYnckd6u2TaGwQAX/PRMPLrUCzN12vy6Su8TFxY21NIq9KERzaL48kkeGJCI124zm78AlqK9y6Zw5cyZ98sknFR6Iyg/oAWy2oWa1Pv/888hJkybZcmvHofUT2Z41cuTIVUjyJMbn8nj69KkXqvkgy4O5XJSGpngZRDcKPwIq85SRY9Z3JLq8bm0wenrAzm2HK3WpicxcGbecg4AgX+jeqyPcT0yBpJQn4Nq00a9R0duizXfgvPvous8YOnToNXtP/PDDD2UY987Fl3Or+dnvL1y48Mq8efMqPRDJfmHp0qUbwVy00xpRFnfXWs3D0OugmoBi8Ru58qcYpW1igoial6BNXl5eW1R1/oUS3WgywLlrO3N53iqnIpGAokNrOLTnBOTlFdpOBkgl0LBxHeSw8Tnx3d1d4P2xUaDVaGHLl/vAo1EdcO3YBkw6fTWcDAwJNDrQPXqq5ySSasc44eHhfqjm79rYnYu23aJoRIStaKqS8AtJPh/j8zgHSA4bNmygiTkVsZPm3q+zxOwRxDm0O9ZuM5K8/9y5c+0pqrnR8jdZwxtV/f2YmJjniT4MJyi0iBZ7ABDBUc23ff3113rGZ1E1h6CgoBFgroJsC05TdfueFhwl241PNbfvUfrdvAkJ7PF2V9AplTBn0jLbPiS66F26tQO9Xi+Q3MVFCcM/HAQ9UM3/Z8v3cPr8VQgQJrZoq/1HCUm9YnURfsgbTviO/NDEBgncO3jw4AB8sPwJbR3aLrThgwcPpn7GNbt3716MJP+3g/ekWHeEjX15aDNXrFhRH+83Du07tD1o0dOnT2+F+/4GQgYFNqErHoUkv2fPjWfOnKlDVV+NLxNEdg9YuXJlXyR7yfsuNlx2zQcffPAZkvwOo7RN9BNJBFojAlU9wMOj+h049gb79ANKMhYVB5cRdR8v8P3rSLi+fD2sWLIZoqcME4a6lobSRSFsr1MvFFSqYug3uDt4eLjBvh3HYMPGveDfpxsoXm8M+vQs0D9JB3n9MOAUCvvnqpOiF6tBm/hQz8klzshakmsVar3x0KFDd/r3719uhtzevXsfEukcvdmoUaNIzbviyz+I7H60atWqmIkTJ+4VO3f58uVqiUSybMmSJWuR5Cp0xR2aDohk/xGv8+W0adM+F/mNDEtLSzv98ccf34qOjh6D75uKXOJTtFjG5QpBIVlVGDwRbRaa9kUS3YjES9Amp3Wgck5g+IVcikZ1weMvkbDnq51w9/ZDmLMgutyQWLlCDoOH9hJeZyChVyzdDNu/iwP/gW+Bz4hIMOQVgOrUecjdtg+ULV4F/4/GAO/iYtckF4ua02eihR+u11Qr9enTx+fAgQNuSHaVky9dC62rjX0UGuyt6GRUYw2ZEz7HerSOltCgNDrv2rXr92DujhNT89Oo5ls3bdrEXHYbePz4cXN02xtB+WniFI6FWXnawy0hXLWIbn+gbzLlGTKzy39GCQ9undqB/4yxcD0tE97tNxH+MWsVnDhyDpIeppkD2px8OH/2CiyatwaGvDMR9sddgOBRQ8B72CAwqtXCQBlpcABIawWC9n4KFHx/EniFHZNcSM21WozPn1DugAiY5IR20YF4f2anfv36HUeyt3Xy74AaWmyY4X9Xr179b1TzF/JjxDBAhx4C9atfFRN9MPdte1q77KNHj/4MSX6b0blCzBFR82MWlbceK+Cfn58/Et33anW12XuyAYl+Sp+R/ZFoyQpUeXmT+hCydCYq84/ww6VrEDf1U+AkkjLHyEICwbVfD3AL7wwSL0+h4ITm9n3I2xUrlJ5yfaM1uPfoBOqbiTYH19gkukYL+rR0KNTk6K+lnXVK3gTtJFoTkX0dkOzn8TNewtf70W2Pwxi9uoMtPG3EbrdFkm01jfNo+9BaWG2va+N4cvUPMx5XqOaeISEh3UW49x3aTssDtJ5IUu4rEO8NqakYnUuiCS2aW/dBju66mFtNQ1Ddw98UjPbrktLMii2VgLxObeCU5kQikbLg8ElQnbmEx6SConkTCF4yQziGikwqmjayu+oMlaQyZudo0Ds454yGOX78eFavXr3+HRcX92d8K9aPLLO4uB0HDRq0GEl/H19/sXv37nWRkZGOuNCvoFlX7dCjmt+aMGHCC/1Roqrj18h/PmXKFCL6wEoOv4Rq/j8bN25kLrv9ag4BAQH7MzMzNVlZWft9fX2joWzfeiNU9e7u7u6HVSqVQ4NM7HLdjUaD6dy1nUk8x4Oe3PeqjFSlddbqhwmklTeoIyyvlL//GGQsXgNpY2ZD0Y5D0NQX+ePtBcELp4OsdojDlWQ5i6JrU59q0ItIdWLjXEabXIUnKn0jDdFWRERE3NuxY0eEk+6PT0lQvYxf5dSpU3M/++wzysInVnIodfXFMx7bxqNHjwDVnNYgtO5S22JpY8K/Sr0Gq1hd9qIUnX7KlJC7qEtJa891bgumX54CUHzlBmT8cz3IwoJB4uvzPGNOxNWiB0BxPLnxktBgkOblw3vD3hG62LZ+uQ8up6YDVHe9B87sJWCMXoT3uemsBjp69KgOVf1LVHVy0Smj3L0Kp9WOiopajWR3r0Y3268FNOyX+tb/ZmP/2rFjx25HNWdsrhiU2Kwlsv2Lktjcz8/vQU5OzmVvb+8uVkIcVVhY+A9U9Zuo6nYzxZFRN0aT0RivTU4rO/kElduldTNBlWkxRcBYe1TvN2BEj3ZQePsBeEW9AyHL50DYthUQNPevwDd4BX46ewV+PBsP33wbC96d2ghFLKoDmk1nVBWRu1+EpHdqxh3JTh5D/Ntvv90DzF1KpHLPKjktCMn+wfbt2wOqeXsKGQJf1q8TVR1WrFjxGb48IJY7GD9+/Lb169erGI8rRbRI+JcQGBh4F9320uRdZUPVRzgkzg4S3YRKnawTiM6XT8Y1rAOeA3uBEfcl3X8Ebdu/jq85cPldC5ojLqg7r5SDW3gXuJOYAvNmrBQSeN5/7CeoseNqXibjTl1rSTXRUkeOHCHC30Kb0L9/f8qQv4G2Ac3WOu60DnyUHbegOnfZ5X4h0dGNaSTay8LkyZNzkewPRHZlgHkQD0PFbnvn0NDQ16B8wLtVhNQHLN+rNWJQ1QNcqMv5RSg6Uj2BlFOflS06pVTq5wM+00dD7PdnYMyIeeDVvDEohKWSjc/Vnyq+hq5dAMGLPoKAGeOeF7KoFtGLNaC7lwIqXd7DhHvHa7zxDh48qEPCX0QbM3DgwMZgzpqKqXGIHZfFGAbECEWj3rowyvyfUnMC9WqUSdr6+Pjoc3NzabvO6ljKYlNSVFLjRDcaDcZz13ee4jkJGDLEiU7KTuWmQlZ/AoFzJoD/5FFgtM6e43m8hzvG8yEOVn0Vic/R9TdQxp3jU190K+7fvz9t8ODBS/HlfZE8SCM7LkWfXWwSzOuo6sNWrlzJKPMbQ2pqqjuqeXeRZNpBdNvTMzLExFtIyom5uH93JCnn4MwYDoNhYzp1sXG2ikTQvHUksuLVBsA7MpTVbp6T666jjHsBJ+XPO/v6NFXVZDL9MTY2drIDp1d5muqmTZuyR48efcTG7pExMTGzKiL7jBkz6uLnPIa2b9GiRT6MZr8KzIayhSVKu+2ixTRQ1e/n5+f/DOZZo6URWFRU1A3dd7u46+hoGwP+kOK1KWk9ywyFfZmwxOj6R09UoJBcdzLJIS4ujgovbO/du3cx/u21Dh06NLtv377PXasBAwYE7NmzhwpDNLA6vQjsn49OI312oA2x2k5P8oVI9oZGo3EGxs3P15ibNm0aLFu2rBO+XA7mfn2YNWvWCTxu7Ny5cy/+xolS58CBA7+3kMLWD1zRo0ePiydPnsypzo2uXLnSDsxTbmW2fUcoatKkSfzdu3crHSeBag61a9cWm6WWFxwc/B9U84oy0JSUowlV1kE5DY88AXYMi3WU6EYwmhJ0RPSaXiK5iiSnATm0WgxIpUgsvdOIHh4eTiSnutElJVLoS5/Wp0+fcUj4HyxudlNL/Cz21E62ELfK2Lhx42P876sNGzbQfX1FfmjvT5o06U9o1N13BsxVZ94C84iq0m3aes6cOUfRPpo/f/6GqsxJ/5ViBNiezVca1CNyspr3qkofIY0p6IaWVoVjqWCJ2OSVbVB5aSxKytHDPMxqey9U9Qao6rfVanWVXGWHXHfOPBT2tB5jdGECyUsnOghz0Gnoq0qbm5GQeEzvLJIfO3aMfjy7ofy4bnrqv432EVpfGyQn0GAbR0bp0Tx2Gvpo6wt2sTxcyC0cb8kDiD246XNRzbbfMw/6pYDqCogl4baA7Z4ac8N5eenQfaeknN5GrF71mo8OKzqNgqLhrdTNxvMvnekWt10DvFPddpqO+xcRklcVF3fu3Dlv6NCh9svKxo0wduzYb/Dl6ArIXhWQe0fdf2zRyReM5OTk3ui2N4XyXWpn0W2/8+zZs6qo8SobLvqA4uJiX6VSWXNENxj1cO76rhwe+AwhIce/XPddGPpKiTgaESflnUb048ePP33rrbcmWb5se/EfJPl7Q4YMeeDo/devXw/jx4+nhA3lBy45cInbCxcu7Infz4rfsNv+W8Z7NtS8Km57iarfKygouAzlk3JKiwhJaozov8TpxiRtisjAmZfhupOipz4pBonkhjMvbZnUQskPGviyq5LD6QlN3Wvjdu/e3R1Jfq+691+7di09yM5MmDCBEm00//tYZS6fJXactXjx4q52lpFicJ6a13rllVcox2Kd1MuvVavWHlRze0aH2VL1iVV13x2WYp6Xyjq3iFrM1wqYGvLZ34Shp4UnzoFnn27CDLKSSi852/aC3/jhAhEt8gvG/ELIXLUZ/Ea/C5KgUqunGoygvnkXVGcvQcCUD36J/zE0MGTlQP7+o+A37s/m7UgpmlijfZgCrh1aQ+Gxs5D9xdZ7RRJ1B4zRs2qqAXv37u0WGxtLo+FozjgNbTVYLG3v3r1nBg8efLemf0QxMTG+K1eupPu/ZknUUPafJu5T4u/k0qVLH86cOZPNImN4Docns3PCmHdT/POEHJK78MgpcGnVFKQhAQIRTTodFJ39CfxjRiLRrbXPJCzWIKUHQokq0zZVsfCAKJPNNxhAl/YU1Am38fmIH1nNCdemOezqhJvC/HVzIi6v6OqjH7Jq8gs7cuSIChWWMrsnX1ajrVq1KhuNlJqpNUPNxegl9ENynn6ekJPwIPH1Bm3yo+eFI4msnFwOmlv3hP2V+98iK7XQgwCJbswrABmt+UbDaOlQtQZ0D5KFijQmjUZIxHESyTnWpAwMTiQ6JeTOX9uVTQk5LSorFZugVUw1NxJ/ITXNRQ8LEdx6rgpRArn8tJabdRafyj9rU5+UelhYJrA8yQBZoL8wvJYScbj/OmtSBgbnKrpZ1UumrCI5qXJM2emrpMbiXXBUxFGPcTdUJWNPMTwSm1aFodclWXZ9eibI6tYWJrPoU58UMkVnYKgZolMRiqu6lDShvjupty7p0fNlj6nbTervAwZUdCi7QItAWKHIZGUj6yxVYzT3U0AW5C/E8bSSqyG/UDDew02I1c0j4oApOgNDTSi6ySgUiwQjkpFiaIqndSWqjoSnmu9aJw+qMWn1oEt9DLyLEqTouuuSH1MiLiM+8aiONSkDQ0247hwkmCwJOYm7m1CemfrWS1S9RLk5R8fEW8pDaR+goterTbl+cyLuYSq+DxPGuOvThEQcU3MGhpog+vOEnInP1JrdZ5DWDgEtuu8Ue5M7TwUn9M8yqxaL6ynp9hg4kQw9PTiExRyowA3G5yWJOCK9FuNzkPAsPmdgqCFFN6u60XhafesecDIJyGsHC/XYy7jqQkKuVDadut1kMlDT8NmSmu+cOXFHq7XIKQSgBBxtQyJT0UlK9En8zQUnhVFw6Zl4XC0wZOWC/tHTYqboDAw1S3S9QPTrd6DoQjy4tGsB2jsPoGD/MYGcitcbAeeigKyN35qXQ0aiEkkpaae+ehsKT54DTi4TBskUxJ4SYm81egeGXPPiKOQd0Hb5K7WEElX6zBzI3mRe7JNG1eVuP4DXV9KQzyusORkYbEbA1YdEInPp1CxyK0p7hJB5x/iZFmsQusNQpfUl2XVUb1loEJHcgOpOc3qpRE0f3s1ViO31GdmF6OLvQe/8j5xCppBjDK6+kSiEAEKZaF8vMOSrBEXnXV2Ea6Pi31apc6PjE4+eZM3JwFCDRLeQXYJkD8e4nRbfo8obNLmkDZinWFKlRprFNQpNgY77LbVOdeDKnSOGN1sO7aU3aDtxHJdXrCncnZB49B5uC9PpNVSwnvx6KuxAJKbVRTug0SLstExSXY7jk1TFOfuR5FmsKRkYGBgY/l/jfwUYAPw0FqsWp2FrAAAAAElFTkSuQmCC\" style=\"margin-top:-20px\" height=\"55\">\n<span style=\"font-size:40px\">  [[cluster_name]]</span><span style=\"padding-top: 25px;float:right\"></span><hr style=\"border-top: 3px solid #5780c1;\"></div>",
+                           "mode":"html"
+                        },
+                        "gridPos":{
+                           "x":0,
+                           "y":1,
+                           "w":24,
+                           "h":3
+                        }
+                     }
+                 ],
+                "dashversion": ">2.4"
+            },
+            {
+                "class": "logo_row",
+                "dashversion":"<2.4"
             },
             {
                 "class": "row",
@@ -116,9 +136,17 @@
                         "span": 2,
                          "targets": [
                             {
+                              "expr": "manager:repair_progress{cluster=~\"[[cluster]]\"}",
+                              "format": "time_series",
+                              "intervalFactor": 2,
+                              "dashversion":">2.4",
+                              "refId": "A"
+                            },
+                            {
                               "expr": "sum(avg(scylla_manager_repair_progress{cluster=~\"[[cluster]]\", instance=\"\", keyspace=\"\"}) by (task) * sum(scylla_manager_task_active_count{cluster=~\"[[cluster]]\", type=\"repair\"}) by (task))  or vector(0)",
                               "format": "time_series",
                               "intervalFactor": 2,
+                              "dashversion":"<2.4",
                               "refId": "A"
                             }
                           ],
@@ -222,9 +250,17 @@
                         "span": 2,
                         "targets": [
                             {
+                              "expr": "manager:backup_progress{cluster=~\"[[cluster]]\"}",
+                              "format": "time_series",
+                              "intervalFactor": 2,
+                              "dashversion":">2.4",
+                              "refId": "A"
+                            },
+                            {
                               "expr": "sum(avg(scylla_manager_backup_percent_progress{cluster=~\"[[cluster]]\", instance=\"\", keyspace=\"\"}) by (task) * sum(scylla_manager_task_active_count{cluster=~\"[[cluster]]\", type=\"backup\"}) by (task)) or vector(0)",
                               "format": "time_series",
                               "intervalFactor": 2,
+                              "dashversion":"<2.4",
                               "refId": "A"
                             }
                           ],
@@ -329,6 +365,40 @@
             {
                 "class": "row",
                 "panels": [
+                   {
+                        "class": "percentunit_panel",
+                        "targets": [
+                            {
+                              "expr": "manager:repair_progress{cluster=~\"[[cluster]]\"}",
+                              "format": "time_series",
+                              "intervalFactor": 2,
+                              "refId": "A"
+                            }
+                        ],
+                        "span":2,
+                        "dashversion":">2.4",
+                        "title": "Repair Progress"
+                    },
+                    {
+                        "class": "ops_panel",
+                        "fieldConfig": {
+                            "defaults": {
+                              "links": [],
+                              "unit": "si:tr/s"
+                            },
+                            "overrides": []
+                          },
+                        "targets": [
+                            {
+                                "expr": "sum(rate(scylla_manager_repair_token_ranges_success{cluster=~\"[[cluster]]\", instance=~\"$instance\", shard=~\"$shard\"}[60s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "refId": "A",
+                                "step": 4
+                            }
+                        ],
+                        "dashversion":">2.4",
+                        "title": "Repair Token-Range Rate"
+                    },
                     {
                         "class": "ops_panel",
                         "targets": [
@@ -339,7 +409,28 @@
                                 "step": 4
                             }
                         ],
+                        "dashversion":"<2.4",
                         "title": "Repair Segments Rate"
+                    },
+                    {
+                        "class": "ops_panel",
+                        "fieldConfig": {
+                            "defaults": {
+                              "links": [],
+                              "unit": "si:tr/s"
+                            },
+                            "overrides": []
+                          },
+                        "targets": [
+                            {
+                                "expr": "sum(rate(scylla_manager_repair_token_ranges_error{cluster=~\"[[cluster]]\", instance=~\"$instance\", shard=~\"$shard\"}[60s])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "refId": "A",
+                                "step": 4
+                            }
+                        ],
+                        "dashversion":">2.4",
+                        "title": "Repair Token-Range Error Rate"
                     },
                     {
                         "class": "ops_panel",
@@ -351,8 +442,90 @@
                                 "step": 4
                             }
                         ],
+                        "dashversion":"<2.4",
                         "title": "Repair Segments Error Rate"
-                    }],
+                    }
+                    ],
+                "title": "Repair rate Row"
+            },
+            {
+                "class": "row",
+                "dashversion":">2.4",
+                "panels": [
+                   {
+                        "class": "percentunit_panel",
+                        "targets": [
+                            {
+                              "expr": "manager:backup_progress{cluster=~\"[[cluster]]\"}",
+                              "format": "time_series",
+                              "intervalFactor": 2,
+                              "refId": "A"
+                            }
+                        ],
+                        "span":2,
+                        "title": "Backup Progress"
+                    },
+                    {
+                        "class": "ops_panel",
+                        "fieldConfig": {
+                            "defaults": {
+                              "links": [],
+                              "unit": "decbytes"
+                            },
+                            "overrides": []
+                          },
+                        "targets": [
+                            {
+                                "expr": "sum(scylla_manager_backup_files_uploaded_bytes{cluster=~\"[[cluster]]\", instance=~\"$instance\", shard=~\"$shard\"}) by ([[by]])",
+                                "intervalFactor": 1,
+                                "refId": "A",
+                                "step": 4
+                            }
+                        ],
+                        "span":3,
+                        "title": "Uploaded bytes"
+                    },
+                    {
+                        "class": "ops_panel",
+                        "fieldConfig": {
+                            "defaults": {
+                              "links": [],
+                              "unit": "decbytes"
+                            },
+                            "overrides": []
+                          },
+                        "targets": [
+                            {
+                                "expr": "sum(scylla_manager_backup_files_skipped_bytes{cluster=~\"[[cluster]]\", instance=~\"$instance\", shard=~\"$shard\"}) by ([[by]])",
+                                "intervalFactor": 1,
+                                "refId": "A",
+                                "step": 4
+                            }
+                        ],
+                        "span":3,
+                        "title": "Uploaded skipped"
+                    },
+                    {
+                        "class": "ops_panel",
+                        "fieldConfig": {
+                            "defaults": {
+                              "links": [],
+                              "unit": "decbytes"
+                            },
+                            "overrides": []
+                          },
+                        "targets": [
+                            {
+                                "expr": "sum(scylla_manager_backup_files_failed_bytes{cluster=~\"[[cluster]]\", instance=~\"$instance\", shard=~\"$shard\"}) by ([[by]])",
+                                "intervalFactor": 1,
+                                "refId": "A",
+                                "step": 4
+                            }
+                        ],
+                        "span":3,
+                        "title": "Uploaded Failed"
+                    }
+                    ],
                 "title": "Repair rate Row"
             },
             {
@@ -369,6 +542,7 @@
                             }
                         ],
                         "description": "The number of SSH connection used by the manager",
+                        "dashversion":"<2.4",
                         "title": "SSH open connections by $by"
                     },
                     {
@@ -500,8 +674,15 @@
                 {
                     "class": "template_variable_single",
                     "label": "cluster",
+                    "name": "cluster_name",
+                    "query": "label_values(scylla_manager_cluster_name,name)"
+                },
+                {
+                    "class": "template_variable_single",
+                    "hide": 2,
+                    "label": "cluster_id",
                     "name": "cluster",
-                    "query": "label_values(scylla_manager_healthcheck_cql_rtt_ms, cluster)"
+                    "query": "label_values(scylla_manager_cluster_name{name=\"$cluster_name\"}, cluster)"
                 },
                 {
                     "class": "template_variable_all",

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -1053,6 +1053,39 @@
          }
       ]
    },
+   "percentunit_panel": {
+     "class":"graph_panel",
+     "fieldConfig": {
+        "defaults": {
+          "links": [],
+          "unit": "percentunit"
+        },
+        "overrides": []
+     },
+     "yaxes": [
+        {
+          "format": "percentunit",
+          "logBase": 1,
+          "max": "1.01",
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+   },
+   "fieldConfig": {
+    "defaults": {
+      "links": [],
+      "unit": "percentunit"
+    },
+    "overrides": []
+  },
    "ops_panel":{
       "class":"graph_panel",
       "seriesOverrides":[

--- a/prometheus/prom_rules/prometheus.rules.yml
+++ b/prometheus/prom_rules/prometheus.rules.yml
@@ -42,7 +42,9 @@ groups:
   - record: manager:backup_fail_ts
     expr: timestamp(sum(changes(scylla_manager_task_run_total{status="ERROR",type="backup"}[60s])) by (cluster) > 0) or on(cluster) manager:backup_fail_ts
   - record: manager:repair_progress
-    expr: (sum(scylla_manager_repair_token_ranges_success) by (cluster) + sum(scylla_manager_repair_token_ranges_error) by (cluster))/sum(scylla_manager_repair_token_ranges_total) by (cluster)
+    expr: (max(scylla_manager_task_active_count{type="repair"}) by (cluster) >bool 0)*((max(scylla_manager_repair_token_ranges_total) by(cluster)<= 0)*0 or on(cluster) (sum(scylla_manager_repair_token_ranges_success>=0) by (cluster) + sum(scylla_manager_repair_token_ranges_error>=0) by (cluster))/sum(scylla_manager_repair_token_ranges_total>=0) by (cluster))
+  - record: manager:backup_progress
+    expr: (max(scylla_manager_task_active_count{type="backup"}) by (cluster) >bool 0)*((max(scylla_manager_backup_files_size_bytes) by(cluster)<= 0)*0 or on(cluster) (sum(scylla_manager_backup_files_uploaded_bytes) by (cluster) + sum(scylla_manager_backup_files_skipped_bytes) by (cluster) + sum(scylla_manager_backup_files_failed_bytes)by(cluster))/sum(scylla_manager_backup_files_size_bytes>=0) by (cluster))
   - record: wlatencyp99
     expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name=~"statement|$"}[60s])) by (cluster, dc, instance, shard, le))
     labels:


### PR DESCRIPTION
This series adds support for scyllas manager 2.4.
This series contains:
1. use cluster name to get the cluster name
2. add backup metrics
3. add recording rules for backup and repair progress
4. remove the ssh connection
![image](https://user-images.githubusercontent.com/2118079/122087876-e2ce4e00-ce0d-11eb-9ff7-13422c2c7dfb.png)

Fixes #1391