### PR TITLE
Show sidebar on index

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -116,7 +116,7 @@ html_theme_options = {
     ('Scylla University', 'https://university.scylladb.com/'),
     ('ScyllaDB Home', 'https://www.scylladb.com/')],
     'github_issues_repository': 'scylladb/scylla-monitoring',
-    'show_sidebar_index': False,
+    'show_sidebar_index': True,
 }
 
 extlinks = {


### PR DESCRIPTION
Docs look broken because the theme option ``show_sidebar_index: False`` affects to previous versions:

![image](https://user-images.githubusercontent.com/9107969/122418578-3661a880-cf82-11eb-8dac-e6dc4ab8193a.png)

This quickfix will show the sidebar always on the main page (for all versions), while we look for a better solution:

![image](https://user-images.githubusercontent.com/9107969/122419385-c4d62a00-cf82-11eb-85a2-94f1d037d299.png)

Note: Icons may look a bit squashed.

@lauranovich As a permanent fix, I'd consider rolling back the changes done for https://github.com/scylladb/scylla-monitoring/pull/1447. I'd  prefer not to apply big design changes to product landings before we roll out the new design. It will be much more challenging to apply the new design in previous versions if the main page is not plain RST text.