### PR TITLE
docs: build docs from master

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -115,6 +115,7 @@ html_theme_options = {
     ('Scylla Cloud', 'https://docs.scylladb.com/scylla-cloud/'),
     ('Scylla University', 'https://university.scylladb.com/'),
     ('ScyllaDB Home', 'https://www.scylladb.com/')],
+    'hide_version_dropdown': ['master'],
     'github_issues_repository': 'scylladb/scylla-monitoring',
     'show_sidebar_index': True,
 }
@@ -180,7 +181,7 @@ notfound_urls_prefix = ''
 TAGS = []
 smv_tag_whitelist = multiversion_regex_builder(TAGS)
 # Whitelist pattern for branches (set to None to ignore all branches)
-BRANCHES = ['branch-3.4', 'branch-3.5', 'branch-3.6', 'branch-3.7', 'branch-3.8']
+BRANCHES = ['master', 'branch-3.4', 'branch-3.5', 'branch-3.6', 'branch-3.7', 'branch-3.8']
 smv_branch_whitelist = multiversion_regex_builder(BRANCHES)
 # Defines which version is considered to be the latest stable version.
 # Must be listed in smv_tag_whitelist or smv_branch_whitelist.


### PR DESCRIPTION
Related issues https://github.com/scylladb/sphinx-scylladb-theme/issues/157

## Context

Adds the new option ``hide_version_dropdown``, which hides a list of tags and branch names from the multi-version dropdown.

## How to test this PR

1. Run ``make multiversionpreview``.

2. You should be able to preview http://0.0.0.0:5500/master/, but master should not appear as an option in the dropdown located at the right sidebar.

3. The banner at the top of the page should say:

"You are reading an unstable version of this documentation"