### PR TITLE
Move to Timeseries panels

### DIFF
--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -1477,23 +1477,6 @@
                                 "step": 1
                             }
                         ],
-                        "yaxes": [
-                            {
-                              "format": "percent",
-                              "logBase": 1,
-                              "max": null,
-                              "min": 0,
-                              "show": true,
-                              "decimals": 0
-                            },
-                            {
-                              "format": "short",
-                              "logBase": 1,
-                              "max": null,
-                              "min": null,
-                              "show": true
-                            }
-                          ],
                         "description": "Percentage of CPU time used by compaction",
                         "title": "Compactions CPU Runtime"
                     },

--- a/grafana/scylla-os.template.json
+++ b/grafana/scylla-os.template.json
@@ -79,7 +79,7 @@
                 "class": "row",
                 "panels": [
                     {
-                        "class": "graph_panel",
+                        "class": "percentunit_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -91,24 +91,8 @@
                                 "step": 1
                             }
                         ],
-                          "yaxes":[
-                             {
-                                "format":"percentunit",
-                                "logBase":1,
-                                "max":1.01,
-                                "min":0,
-                                "show":true
-                             },
-                             {
-                                "format":"short",
-                                "logBase":1,
-                                "max":null,
-                                "min":null,
-                                "show":true
-                             }
-                          ],
                         "title": "Used disk by $by"
-                    },                   
+                    },
                     {
                         "class": "bytes_panel",
                         "span": 3,
@@ -496,16 +480,9 @@
                         "title": "Available memory"
                     },
                     {
-                        "class": "graph_panel",
+                        "class": "percentunit_panel",
                         "span": 3,
                         "description": "Percent of available memory, note that in a production environment we expect this to be low, Scylla would use most of the available memory when possible",
-                        "fieldConfig": {
-                            "defaults": {
-                              "links": [],
-                              "unit": "percentunit"
-                            },
-                            "overrides": []
-                        },
                         "targets": [
                             {
                                 "expr": "sum(node_memory_MemAvailable_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\"}) by ([[by]])/sum(node_memory_MemTotal_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\"}) by ([[by]])",
@@ -519,16 +496,9 @@
                         "title": "Available memory"
                     },
                     {
-                        "class": "graph_panel",
+                        "class": "percentunit_panel",
                         "span": 3,
                         "description": "Percent of CPU used, note that in production Scylla would try to use most of the CPU and this is not a problem",
-                        "fieldConfig": {
-                            "defaults": {
-                              "links": [],
-                              "unit": "percentunit"
-                            },
-                            "overrides": []
-                        },
                         "targets": [
                             {
                                 "expr": "1-sum(rate(node_cpu_seconds_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", mode=\"idle\"}[3m])) by ([[by]])/count(node_cpu_seconds_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", mode=\"idle\"}) by ([[by]])",

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -916,88 +916,61 @@
          "rgba(255, 0, 0, 0.9)"
       ]
    },
+   "fieldConfig_defaults": {
+      "custom": {
+        "drawStyle": "line",
+        "lineInterpolation": "linear",
+        "barAlignment": 0,
+        "lineWidth": 1,
+        "fillOpacity": 0,
+        "gradientMode": "none",
+        "spanNulls": false,
+        "showPoints": "never",
+        "pointSize": 5,
+        "stacking": {
+          "mode": "none",
+          "group": "A"
+        },
+        "axisPlacement": "auto",
+        "axisLabel": "",
+        "scaleDistribution": {
+          "type": "linear"
+        },
+        "hideFrom": {
+          "tooltip": false,
+          "viz": false,
+          "legend": false
+        },
+        "thresholdsStyle": {
+          "mode": "off"
+        }
+      },
+      "color": {
+        "mode": "palette-classic"
+      },
+      "mappings": []
+    },
    "graph_panel":{
       "class":"base_panel",
-      "aliasColors":{
-      },
+      "type":"timeseries",
       "span":5,
-      "bars":false,
-      "lines":true,
-      "nullPointMode":"connected",
-      "fill":0,
-      "hiddenSeries":false,
-      "dashLength":10,
-      "spaceLength":10,
-      "options":{
-         "alertThreshold":true
+      "fieldConfig": {
+        "defaults": {
+          "class": "fieldConfig_defaults",
+          "unit": "short"
+        },
+        "overrides": []
       },
-      "dashes":false,
-      "fieldConfig":{
-         "defaults":{
-            "custom":{
-            },
-            "links":[]
-         },
-         "overrides":[]
-      },
-      "fillGradient":0,
-      "thresholds":[],
-      "timeRegions":[],
-      "grid":{
-      },
-      "legend":{
-         "avg":false,
-         "current":false,
-         "max":false,
-         "min":false,
-         "show":false,
-         "total":false,
-         "values":false
-      },
-      "linewidth":2,
-      "percentage":false,
-      "pointradius":5,
-      "points":false,
-      "renderer":"flot",
-      "seriesOverrides":[],
-      "stack":false,
-      "steppedLine":false,
-      "timeFrom":null,
-      "timeShift":null,
-      "tooltip":{
-         "msResolution":false,
-         "shared":true,
-         "sort":2,
-         "value_type":"cumulative"
-      },
-      "type":"graph",
-      "xaxis":{
-         "buckets":null,
-         "mode":"time",
-         "name":null,
-         "show":true,
-         "values":[]
-      },
-      "yaxis":{
-         "align":false,
-         "alignLevel":null
-      },
-      "yaxes":[
-         {
-            "format":"short",
-            "logBase":1,
-            "max":null,
-            "min":0,
-            "show":true
-         },
-         {
-            "format":"short",
-            "logBase":1,
-            "max":null,
-            "min":null,
-            "show":true
-         }
-      ]
+      "options": {
+        "tooltip": {
+          "mode": "single"
+        },
+        "legend": {
+          "displayMode": "hidden",
+          "placement": "bottom",
+          "calcs": []
+        }
+      }
    },
    "show_legend":{
       "avg":false,
@@ -1012,23 +985,13 @@
    },
    "graph_panel_int":{
       "class":"graph_panel",
-      "yaxes":[
-         {
-            "format":"short",
-            "logBase":1,
-            "max":null,
-            "min":0,
-            "decimals":0,
-            "show":true
-         },
-         {
-            "format":"short",
-            "logBase":1,
-            "max":null,
-            "min":null,
-            "show":true
-         }
-      ]
+      "fieldConfig": {
+        "defaults": {
+          "class": "fieldConfig_defaults",
+          "unit": "short"
+        },
+        "overrides": []
+      }
    },
    "percent_panel":{
       "class":"graph_panel",
@@ -1036,78 +999,37 @@
          {
          }
       ],
-      "yaxes":[
-         {
-            "format":"percent",
-            "logBase":1,
-            "max":101,
-            "min":0,
-            "show":true
-         },
-         {
-            "format":"short",
-            "logBase":1,
-            "max":null,
-            "min":null,
-            "show":true
-         }
-      ]
+      "fieldConfig": {
+        "defaults": {
+          "class": "fieldConfig_defaults",
+          "unit": "percent"
+        },
+        "overrides": []
+     }
    },
    "percentunit_panel": {
      "class":"graph_panel",
      "fieldConfig": {
         "defaults": {
-          "links": [],
+          "class": "fieldConfig_defaults",
           "unit": "percentunit"
         },
         "overrides": []
-     },
-     "yaxes": [
-        {
-          "format": "percentunit",
-          "logBase": 1,
-          "max": "1.01",
-          "min": 0,
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ]
+     }
    },
-   "fieldConfig": {
-    "defaults": {
-      "links": [],
-      "unit": "percentunit"
-    },
-    "overrides": []
-  },
    "ops_panel":{
       "class":"graph_panel",
       "seriesOverrides":[
          {
          }
       ],
-      "yaxes":[
-         {
-            "format":"si:ops/s",
-            "logBase":1,
-            "max":null,
-            "min":0,
-            "show":true
-         },
-         {
-            "format":"short",
-            "logBase":1,
-            "max":null,
-            "min":null,
-            "show":true
-         }
-      ]
+      "fieldConfig": {
+        "defaults": {
+          "class": "fieldConfig_defaults",
+          "unit": "si:ops/s"
+        },
+        "overrides": []
+      }
    },
    "user_panel":{
       "class":"ops_panel",
@@ -1155,22 +1077,13 @@
    },
    "iops_panel":{
       "class":"graph_panel",
-      "yaxes":[
-         {
-            "format":"iops",
-            "logBase":1,
-            "max":null,
-            "min":0,
-            "show":true
-         },
-         {
-            "format":"short",
-            "logBase":1,
-            "max":null,
-            "min":null,
-            "show":true
-         }
-      ]
+      "fieldConfig": {
+        "defaults": {
+          "class": "fieldConfig_defaults",
+          "unit": "iops"
+        },
+        "overrides": []
+     }
    },
    "us_panel":{
       "class":"graph_panel",
@@ -1178,265 +1091,143 @@
          {
          }
       ],
-      "yaxes":[
-         {
-            "format":"\u00b5s",
-            "logBase":1,
-            "max":null,
-            "min":0,
-            "show":true
-         },
-         {
-            "format":"short",
-            "logBase":1,
-            "max":null,
-            "min":null,
-            "show":true
-         }
-      ]
+      "fieldConfig": {
+        "defaults": {
+          "class": "fieldConfig_defaults",
+          "unit": "\u00b5s"
+        },
+        "overrides": []
+      }
    },
    "ns_panel":{
       "class":"iops_panel",
-      "yaxes":[
-         {
-            "format":"ns",
-            "logBase":1,
-            "max":null,
-            "min":0,
-            "show":true
-         },
-         {
-            "format":"short",
-            "logBase":1,
-            "max":null,
-            "min":null,
-            "show":true
-         }
-      ]
+      "fieldConfig": {
+        "defaults": {
+          "class": "fieldConfig_defaults",
+          "unit": "ns"
+        },
+        "overrides": []
+      }
    },
    "ms_panel":{
       "class":"iops_panel",
-      "yaxes":[
-         {
-            "format":"ms",
-            "logBase":1,
-            "max":null,
-            "min":0,
-            "show":true
-         },
-         {
-            "format":"short",
-            "logBase":1,
-            "max":null,
-            "min":null,
-            "show":true
-         }
-      ]
+      "fieldConfig": {
+        "defaults": {
+          "class": "fieldConfig_defaults",
+          "unit": "ms"
+        },
+        "overrides": []
+      }
    },
    "seconds_panel": {
      "class":"graph_panel",
      "fieldConfig": {
         "defaults": {
-        "links": [],
-        "unit": "s"
-     },
-     "overrides": []
-  }
+            "class": "fieldConfig_defaults",
+            "unit": "s"
+         },
+         "overrides": []
+      }
    },
    "bps_panel":{
       "class":"iops_panel",
-      "yaxes":[
-         {
-            "format":"Bps",
-            "logBase":1,
-            "max":null,
-            "min":0,
-            "show":true
-         },
-         {
-            "format":"short",
-            "logBase":1,
-            "max":null,
-            "min":null,
-            "show":true
-         }
-      ]
+      "fieldConfig": {
+        "defaults": {
+          "class": "fieldConfig_defaults",
+          "unit": "Bps"
+        },
+        "overrides": []
+      }
    },
    "wps_panel":{
       "class":"iops_panel",
-      "yaxes":[
-         {
-            "format":"si:writes/s",
-            "logBase":1,
-            "max":null,
-            "min":0,
-            "show":true
-         },
-         {
-            "format":"short",
-            "logBase":1,
-            "max":null,
-            "min":null,
-            "show":true
-         }
-      ]
+      "fieldConfig": {
+        "defaults": {
+          "class": "fieldConfig_defaults",
+          "unit": "si:writes/s"
+        },
+        "overrides": []
+     }
    },
    "rps_panel":{
       "class":"iops_panel",
-      "yaxes":[
-         {
-            "format":"si:reads/s",
-            "logBase":1,
-            "max":null,
-            "min":0,
-            "show":true
-         },
-         {
-            "format":"short",
-            "logBase":1,
-            "max":null,
-            "min":null,
-            "show":true
-         }
-      ]
+      "fieldConfig": {
+        "defaults": {
+          "class": "fieldConfig_defaults",
+          "unit": "si:reads/s"
+        },
+        "overrides": []
+      }
    },
    "wpm_panel":{
       "class":"iops_panel",
-      "yaxes":[
-         {
-            "format":"si:writes/m",
-            "logBase":1,
-            "max":null,
-            "min":0,
-            "decimals":0,
-            "show":true
-         },
-         {
-            "format":"short",
-            "logBase":1,
-            "max":null,
-            "min":null,
-            "show":true
-         }
-      ]
+      "fieldConfig": {
+        "defaults": {
+          "class": "fieldConfig_defaults",
+          "unit": "si:writes/s"
+        },
+        "overrides": []
+      }
    },
    "rpm_panel":{
       "class":"iops_panel",
-      "yaxes":[
-         {
-            "format":"si:reads/m",
-            "logBase":1,
-            "max":null,
-            "min":0,
-            "decimals":0,
-            "show":true
-         },
-         {
-            "format":"short",
-            "logBase":1,
-            "max":null,
-            "min":null,
-            "show":true
-         }
-      ]
+      "fieldConfig": {
+        "defaults": {
+          "class": "fieldConfig_defaults",
+          "unit": "si:reads/m"
+        },
+        "overrides": []
+     }
    },
    "reads_panel":{
       "class":"iops_panel",
-      "yaxes":[
-         {
-            "format":"si:reads",
-            "logBase":1,
-            "max":null,
-            "min":0,
-            "decimals":0,
-            "show":true
-         },
-         {
-            "format":"short",
-            "logBase":1,
-            "max":null,
-            "min":null,
-            "show":true
-         }
-      ]
+      "fieldConfig": {
+        "defaults": {
+          "class": "fieldConfig_defaults",
+          "unit": "si:reads"
+        },
+        "overrides": []
+      }
    },
    "writes_panel":{
       "class":"iops_panel",
-      "yaxes":[
-         {
-            "format":"si:writes",
-            "logBase":1,
-            "max":null,
-            "min":0,
-            "decimals":0,
-            "show":true
-         },
-         {
-            "format":"short",
-            "logBase":1,
-            "max":null,
-            "min":null,
-            "show":true
-         }
-      ]
+      "fieldConfig": {
+        "defaults": {
+          "class": "fieldConfig_defaults",
+          "unit": "si:writes/s"
+        },
+        "overrides": []
+      }
    },
    "queue_lenght_panel":{
       "class":"iops_panel",
-      "yaxes":[
-         {
-            "format":"short",
-            "label":"Queue Length",
-            "logBase":1,
-            "max":null,
-            "min":0,
-            "show":true
-         },
-         {
-            "format":"short",
-            "logBase":1,
-            "max":null,
-            "min":null,
-            "show":true
-         }
-      ]
+      "fieldConfig": {
+        "defaults": {
+          "class": "fieldConfig_defaults",
+          "unit": "short"
+        },
+        "overrides": []
+      }
    },
    "bytes_panel":{
       "class":"iops_panel",
-      "yaxes":[
-         {
-            "format":"bytes",
-            "logBase":1,
-            "max":null,
-            "min":0,
-            "show":true
-         },
-         {
-            "format":"short",
-            "logBase":1,
-            "max":null,
-            "min":null,
-            "show":true
-         }
-      ]
+      "fieldConfig": {
+        "defaults": {
+          "class": "fieldConfig_defaults",
+          "unit": "bytes"
+        },
+        "overrides": []
+      }
    },
    "pps_panel":{
       "class":"iops_panel",
-      "yaxes":[
-         {
-            "format":"pps",
-            "logBase":1,
-            "max":null,
-            "min":0,
-            "show":true
-         },
-         {
-            "format":"short",
-            "logBase":1,
-            "max":null,
-            "min":null,
-            "show":true
-         }
-      ]
+      "fieldConfig": {
+        "defaults": {
+          "class": "fieldConfig_defaults",
+          "unit": "pps"
+        },
+        "overrides": []
+      }
    },
    "pie_chart_panel":{
       "class":"base_panel",


### PR DESCRIPTION
In grafana 8 timeseries replaces the graph panels.
This series replaces the template to use the new panels

Fixes #1322