### PR TITLE
scylla-os: use cpu_scaling if they are available

### DIFF
--- a/grafana/scylla-os.template.json
+++ b/grafana/scylla-os.template.json
@@ -517,7 +517,7 @@
                         "description": "CPU frequency should be set for performance.\n\n The current frequency should match the max frequency. If that is not the case, check your host configuration.",
                         "targets": [
                             {
-                                "expr": "max(node_cpu_frequency_max_hertz{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\"})",
+                                "expr": "max(node_cpu_scaling_frequency_max_hertz{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\"}) or on() max(node_cpu_frequency_max_hertz{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\"})",
                                 "intervalFactor": 1,
                                 "legendFormat": "Max",
                                 "metric": "",
@@ -525,7 +525,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "min(node_cpu_frequency_hertz{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\"}) by ([[by]])",
+                                "expr": "min(node_cpu_scaling_frequency_hertz{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\"}) by ([[by]]) or on() min(node_cpu_frequency_hertz{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",


### PR DESCRIPTION
node_exporter can report two variants of the the cpu speed, it could be the scaling or the regular.

This fix changes the CPU frequency panel so it will try to read the scaling version of the metric and if it's not available it will use the over version.

Fixes #1499