### PR TITLE
start-all.sh support both shot and long command line format

### DIFF
--- a/start-all.sh
+++ b/start-all.sh
@@ -355,7 +355,12 @@ then
 fi
 
 for val in "${PROMETHEUS_COMMAND_LINE_OPTIONS_ARRAY[@]}"; do
-    PROMETHEUS_COMMAND_LINE_OPTIONS+=" -$val"
+    if [[ $val = "--"* ]]; then
+        PROMETHEUS_COMMAND_LINE_OPTIONS+=" $val"
+    else
+        echo "Using single hyphen is depricated and will be removed in future version use -$val instead"
+        PROMETHEUS_COMMAND_LINE_OPTIONS+=" -$val"
+    fi
 done
 
 ./prometheus-config.sh -m $AM_ADDRESS $CONSUL_ADDRESS $PROMETHEUS_TARGETS


### PR DESCRIPTION
A long time ago prometheus moved from short to long command line options, for backwards compatibility start-all.sh adds a hyphen.

This patch test first and does not add that hyphen if it's not needed, it also warn that the short format is depericated and will be removed in a future release.
Fixes #1507 