### PR TITLE
Larger node table

### DIFF
--- a/grafana/scylla-overview.template.json
+++ b/grafana/scylla-overview.template.json
@@ -388,6 +388,53 @@
                         "title": "Disk Size by $by"
                     },
                     {
+                        "class": "graph_panel_int",
+                        "span": 2,
+                        "targets": [
+                            {
+                                "expr": "$func(scylla_compaction_manager_compactions{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Running Compactions"
+                    },
+                    {
+                        "class": "ops_panel",
+                        "description": "The Hits and Misses",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$func(rate(scylla_cache_row_hits{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "Hit {{[[by]]}}",
+                                "refId": "A",
+                                "step": 10
+                            },
+                            {
+                                "expr": "$func(rate(scylla_cache_row_misses{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "Misses {{[[by]]}}",
+                                "refId": "B",
+                                "step": 10
+                            }
+                        ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
+                        "title": "Cache Hits/Misses"
+                    },
+                    {
+                      "class":"small_nodes_table",
+                      "gridPos": {
+                        "h": 18,
+                        "w": 10
+                      }
+                    },
+                    {
                         "class": "ops_panel",
                         "span": 3,
                         "targets": [
@@ -458,7 +505,28 @@
                     },
                     {
                         "class": "ops_panel",
+                        "description": "Requests that Scylla tried to write but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas.",
+                        "span": 2,
+                        "targets": [
+                            {
+                                "expr": "$func(rate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[$__rate_interval])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "Writes {{[[by]]}}",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "legend": {
+                            "class": "show_legend"
+                        },
+                        "title": "Write Timeouts by [[by]]"
+                    },
+                    {
+                        "class": "ops_panel",
                         "span": 3,
+                        "gridPos": {
+                            "x": 0
+                        },
                         "targets": [
                             {
                                 "expr": "$func(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name!=\"streaming\"}[$__rate_interval])) by ([[by]])",
@@ -502,6 +570,9 @@
                     {
                         "class": "us_panel",
                         "span": 2,
+                        "gridPos": {
+                            "x": 6
+                        },
                         "targets": [
                             {
                                 "expr": "avg(rlatencyp95{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name!=\"streaming\"}>0) by([[by]]) or on() (histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name!=\"streaming\"}[$__rate_interval])) by ([[by]], le)))",
@@ -522,82 +593,28 @@
                             "class": "show_legend"
                         },
                         "title": "Read Latencies"
-                    }
-                ]
-            },
-            {
-                "class": "row",
-                "panels": [
-                    {
-                      "class":"small_nodes_table",
-                      "span":5
-                    },
-                    {
-                        "class": "graph_panel_int",
-                        "span": 2,
-                        "targets": [
-                            {
-                                "expr": "$func(scylla_compaction_manager_compactions{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "Running Compactions"
                     },
                     {
                         "class": "ops_panel",
-                        "description": "The Hits and Misses",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(rate(scylla_cache_row_hits{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "Hit {{[[by]]}}",
-                                "refId": "A",
-                                "step": 10
-                            },
-                            {
-                                "expr": "$func(rate(scylla_cache_row_misses{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "Misses {{[[by]]}}",
-                                "refId": "B",
-                                "step": 10
-                            }
-                        ],
-                        "legend": {
-                            "class": "show_legend"
+                        "description": "Requests that Scylla tried to read but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas.",
+                        "span": 2,
+                        "gridPos": {
+                            "x": 10
                         },
-                        "title": "Cache Hits/Misses"
-                    },
-                    {
-                        "class": "ops_panel",
-                        "description": "Requests that Scylla tried to write but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas.",
-                        "span": 2,
                         "targets": [
-                            {
-                                "expr": "$func(rate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[$__rate_interval])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "Writes {{[[by]]}}",
-                                "refId": "A",
-                                "step": 10
-                            },
                             {
                                 "expr": "$func(rate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])+rate(scylla_storage_proxy_coordinator_cas_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])+rate(scylla_storage_proxy_coordinator_range_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "Read  {{[[by]]}}",
-                                "refId": "B",
+                                "refId": "A",
                                 "step": 10
                             }
                         ],
                         "legend": {
                             "class": "show_legend"
                         },
-                        "title": "Read/Write Timeouts by [[by]]"
+                        "title": "Read Timeouts by [[by]]"
                     }
-
                 ]
             },
             {

--- a/grafana/scylla-overview.template.json
+++ b/grafana/scylla-overview.template.json
@@ -430,7 +430,7 @@
                     {
                       "class":"small_nodes_table",
                       "gridPos": {
-                        "h": 18,
+                        "h": 17,
                         "w": 10
                       }
                     },
@@ -614,7 +614,19 @@
                             "class": "show_legend"
                         },
                         "title": "Read Timeouts by [[by]]"
-                    }
+                    },
+                    {
+                        "class": "plain_text",
+                        "gridPos": {
+                            "w": 10,
+                            "x": 14,
+                            "h": 1
+                          },
+                        "options": {
+                            "mode": "html",
+                            "content": "<img src=\"https://repositories.scylladb.com/scylla/imgversion/$all_scyllas_versions/scylla\"></img>"
+                          }
+                        }
                 ]
             },
             {


### PR DESCRIPTION
This series address two issues:
The node table in the dc section is too small, need to add a warning when a newer version of scylla is available.
## Scylla OS
![image](https://user-images.githubusercontent.com/2118079/130434824-8b33bc37-49cb-4d4b-8200-185a192a26c9.png)

## Scylla Enterprise
![image](https://user-images.githubusercontent.com/2118079/130435924-0feec882-62e6-4baa-bd28-c5b3be4019c8.png)

The red text at the bottom is an image created by an AWS lambda function and its formatting is done there.

Fixes #1522
Relates to #294 