### PR TITLE
types.json add a warning when a newer scylla monitoring is available

### DIFF
--- a/grafana/types.json
+++ b/grafana/types.json
@@ -154,9 +154,10 @@
                "h":1
             },
             "transparent":false,
-            "options":{
-               "content":"# "
-            }
+            "options": {
+                "mode": "html",
+                "content": "<img src=\"https://repositories.scylladb.com/scylla/imgversion/$monitoring_version/scylla-monitoring\">"
+              }
          },
          {
             "class":"text_panel",


### PR DESCRIPTION
This patch adds a check to see if a newer scylla monitoring version is available, if that is the case it will be shown on the top left corner of the dashboard

The text is an image and it's formating is done in an AWS lambda function

![image](https://user-images.githubusercontent.com/2118079/130454023-d376bb36-5e9a-475b-8f05-ebc4bf63819b.png)
