### PR TITLE
scylla-overview: Add explenation that reads and writes graphs are attempted

### DIFF
--- a/grafana/scylla-overview.template.json
+++ b/grafana/scylla-overview.template.json
@@ -44,6 +44,7 @@
                                 "step": 1
                             }
                         ],
+                        "description": "Write attempts - include all writes that reached the coordinator node, even if they will eventually fail",
                         "title": "Writes"
                     },
                     {
@@ -82,6 +83,7 @@
                                 "step": 1
                             }
                         ],
+                        "description": "Read attempts - include all reads that reached the coordinator node, even if they will eventually fail",
                         "title": "Reads"
                     },
                     {
@@ -477,6 +479,7 @@
                               "dashLength": 2
                             }
                           ],
+                        "description": "Write attempts - include all writes that reached the coordinator node, even if they will eventually fail",
                         "title": "Writes"
                     },
                     {
@@ -565,6 +568,7 @@
                               "dashLength": 2
                             }
                           ],
+                        "description": "Read attempts - include all reads that reached the coordinator node, even if they will eventually fail",
                         "title": "Reads"
                     },
                     {


### PR DESCRIPTION
The overview dashboard has graphs for read and writes, those graphs are the attempted read and writes.
This patch adds an explentation about it
Fixes #1486