### PR TITLE
Deprecate the use of latest as a version

### DIFF
--- a/start-all.sh
+++ b/start-all.sh
@@ -346,6 +346,19 @@ else
     DATA_DIR_CMD="-v "$(readlink -m $DATA_DIR)":/prometheus/data:Z"
 fi
 
+if [ "$VERSIONS" = "latest" ]; then
+    if [ -z "$BRANCH_VERSION" ] || [ "$BRANCH_VERSION" = "master" ]; then
+        echo "Default versions (-v latest) is not supported on the master branch, use specific version instead"
+        exit 1
+    fi
+    VERSIONS=${DEFAULT_VERSION[$BRANCH_VERSION]}
+    echo "The use of -v latest is deprecated. Use a specific version instead."
+else
+    if [ "$VERSIONS" = "all" ]; then
+        VERSIONS=$ALL
+    fi
+fi
+
 ALERTMANAGER_COMMAND=""
 for val in "${ALERTMANAGER_COMMANDS[@]}"; do
     ALERTMANAGER_COMMAND="$ALERTMANAGER_COMMAND -C $val"
@@ -417,13 +430,6 @@ if [ $? -ne 0 ]; then
     echo "Error: Prometheus container failed to start"
     echo "For more information use: docker logs $PROMETHEUS_NAME"
     exit 1
-fi
-if [ "$VERSIONS" = "latest" ]; then
-	VERSIONS=$LATEST
-else
-	if [ "$VERSIONS" = "all" ]; then
-		VERSIONS=$ALL
-	fi
 fi
 
 # Number of retries waiting for a Docker container to start

--- a/start-grafana.sh
+++ b/start-grafana.sh
@@ -97,6 +97,14 @@ if [ -z $GRAFANA_PORT ]; then
     fi
 fi
 VERSION=`echo $VERSIONS|cut -d',' -f1`
+if [ "$VERSION" = "latest" ]; then
+    if [ -z "$BRANCH_VERSION" ] || [ "$BRANCH_VERSION" = "master" ]; then
+        echo "Default versions (-v latest) is not supported on the master branch, use specific version instead"
+        exit 1
+    fi
+    VERSION=${DEFAULT_VERSION[$BRANCH_VERSION]}
+    echo "The use of -v latest is deprecated. Use a specific version instead."
+fi
 if [ -z $GRAFANA_NAME ]; then
     GRAFANA_NAME=agraf-$GRAFANA_PORT
 fi


### PR DESCRIPTION
The use of latest as a scylla version is confusing, for example when upgrading the monitoring stack it may endup with using a different scylla version.
It's possible to use the default version, or better to specify what scylla version is being used.

This version does two things, first it fixed the use of latest that got broken and then it add a deprecation warning when using it.

Fixes #1548
Fixes #1547