### PR TITLE
Support specify volume and specific parameters per container

### DIFF
--- a/start-grafana-renderer.sh
+++ b/start-grafana-renderer.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
 . versions.sh
+if [ -f  env.sh ]; then
+    . env.sh
+fi
+
 VERSION="$GRAFANA_RENDERER_VERSION"
 DOCKER_PARAM=""
 GRAFANA_NAME="agrafrender"
@@ -9,12 +13,22 @@ GRAFANA_RENDPORT="8081"
 
 usage="$(basename "$0") [-h] [-D encapsulate docker param] -- Start the grafana render container"
 LIMITS=""
+VOLUMES=""
+PARAMS=""
 for arg; do
     shift
     if [ -z "$LIMIT" ]; then
         case $arg in
             (--limit)
                 LIMIT="1"
+                ;;
+            (--volume)
+                LIMIT="1"
+                VOLUME="1"
+                ;;
+            (--param)
+                LIMIT="1"
+                PARAM="1"
                 ;;
             (*) set -- "$@" "$arg"
                 ;;
@@ -23,11 +37,29 @@ for arg; do
         DOCR=`echo $arg|cut -d',' -f1`
         VALUE=`echo $arg|cut -d',' -f2-|sed 's/#/ /g'`
         NOSPACE=`echo $arg|sed 's/ /#/g'`
-        if [ -z ${DOCKER_LIMITS[$DOCR]} ]; then
-            DOCKER_LIMITS[$DOCR]=""
+        if [ "$PARAM" = "1" ]; then
+            if [ -z "${DOCKER_PARAMS[$DOCR]}" ]; then
+                DOCKER_PARAMS[$DOCR]=""
+            fi
+            DOCKER_PARAMS[$DOCR]="${DOCKER_PARAMS[$DOCR]} $VALUE"
+            PARAMS="$PARAMS --param $NOSPACE"
+            unset PARAM
+        else
+            if [ -z "${DOCKER_LIMITS[$DOCR]}" ]; then
+                DOCKER_LIMITS[$DOCR]=""
+            fi
+            if [ "$VOLUME" = "1" ]; then
+                SRC=`echo $VALUE|cut -d':' -f1`
+                DST=`echo $VALUE|cut -d':' -f2-`
+                SRC=$(readlink -m $SRC)
+                DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} -v $SRC:$DST"
+                VOLUMES="$VOLUMES --volume $NOSPACE"
+                unset VOLUME
+            else
+                DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} $VALUE"
+                LIMITS="$LIMITS --limit $NOSPACE"
+            fi
         fi
-        DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} $VALUE"
-        LIMITS="$LIMITS --limit $NOSPACE"
         unset LIMIT
     fi
 done
@@ -61,4 +93,5 @@ if [[ ! $DOCKER_PARAM = *"--net=host"* ]]; then
 fi
 
 docker run ${DOCKER_LIMITS["grafanarender"]} -d $DOCKER_PARAM -i $USER_PERMISSIONS $PORT_MAPPING \
-     --name $GRAFANA_NAME grafana/grafana-image-renderer:$VERSION
+     --name $GRAFANA_NAME grafana/grafana-image-renderer:$VERSION \
+     ${DOCKER_PARAMS["grafanarender"]}

--- a/start-thanos-sc.sh
+++ b/start-thanos-sc.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
-
 . versions.sh
+if [ -f  env.sh ]; then
+    . env.sh
+fi
+
 PROM_ADRESS=`docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' aprom`:9090
 DATADIR="/prometheus-data/"
 NAME="1"
@@ -23,19 +26,28 @@ The script starts Thanos sidecart, it will read from Prometheus directory, so th
 "
   echo "$__usage"
 }
-
 group_args=()
 is_podman="$(docker --help | grep -o podman)"
 if [ ! -z "$is_podman" ]; then
     group_args+=(--userns=keep-id)
 fi
 LIMITS=""
+VOLUMES=""
+PARAMS=""
 for arg; do
     shift
     if [ -z "$LIMIT" ]; then
         case $arg in
             (--limit)
                 LIMIT="1"
+                ;;
+            (--volume)
+                LIMIT="1"
+                VOLUME="1"
+                ;;
+            (--param)
+                LIMIT="1"
+                PARAM="1"
                 ;;
             (*) set -- "$@" "$arg"
                 ;;
@@ -44,11 +56,29 @@ for arg; do
         DOCR=`echo $arg|cut -d',' -f1`
         VALUE=`echo $arg|cut -d',' -f2-|sed 's/#/ /g'`
         NOSPACE=`echo $arg|sed 's/ /#/g'`
-        if [ -z ${DOCKER_LIMITS[$DOCR]} ]; then
-            DOCKER_LIMITS[$DOCR]=""
+        if [ "$PARAM" = "1" ]; then
+            if [ -z "${DOCKER_PARAMS[$DOCR]}" ]; then
+                DOCKER_PARAMS[$DOCR]=""
+            fi
+            DOCKER_PARAMS[$DOCR]="${DOCKER_PARAMS[$DOCR]} $VALUE"
+            PARAMS="$PARAMS --param $NOSPACE"
+            unset PARAM
+        else
+            if [ -z "${DOCKER_LIMITS[$DOCR]}" ]; then
+                DOCKER_LIMITS[$DOCR]=""
+            fi
+            if [ "$VOLUME" = "1" ]; then
+                SRC=`echo $VALUE|cut -d':' -f1`
+                DST=`echo $VALUE|cut -d':' -f2-`
+                SRC=$(readlink -m $SRC)
+                DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} -v $SRC:$DST"
+                VOLUMES="$VOLUMES --volume $NOSPACE"
+                unset VOLUME
+            else
+                DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} $VALUE"
+                LIMITS="$LIMITS --limit $NOSPACE"
+            fi
         fi
-        DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} $VALUE"
-        LIMITS="$LIMITS --limit $NOSPACE"
         unset LIMIT
     fi
 done
@@ -109,12 +139,11 @@ docker run ${DOCKER_LIMITS["sidecar"]} -d $DOCKER_PARAM $USER_PERMISSIONS \
      $DATA_DIR \
      -i $PORT_MAPPING --name sidecar$NAME thanosio/thanos:$THANOS_VERSION \
         "sidecar" \
-       "--debug.name=sidecar-$NAME" \
-       "--log.level=debug" \
+       "--debug.name=$NAME" \
+       ${DOCKER_PARAMS["sidecar"]} \
        "--grpc-address=0.0.0.0:10911" \
        "--grpc-grace-period=1s" \
        "--http-address=0.0.0.0:10912" \
        "--http-grace-period=1s" \
        "--prometheus.url=http://$PROM_ADRESS" \
-       "--tsdb.path=/data/prom$NAME" \
-
+       "--tsdb.path=/data/prom$NAME"


### PR DESCRIPTION
This series adds an option to set arbitrary volume mapping to any container, and specify passing any command line to any container.

Currently some of the containers already support this (like prometheus) but this will set it to any container.
for example:

`./start-alls.sh --param sidecar,"--log.level=info"` will set the log level of the side car
`./start-all.sh  --volume sidecar,security:/security:z` will map the relative directory `security/` inside the sidecar container to `/security` path

Parameters can also be read from an optional env.sh file if it exists:
```
$ cat env.sh
DOCKER_LIMITS["sidecar"]="-v /home/centos/scylla-grafana-monitoring/security:/security:z"
DOCKER_PARAMS["sidecar"]="--grpc-server-tls-cert=/security/thanos.crt --grpc-server-tls-key=/security/thanos.key --log.level=info --grpc-server-tls-client-ca=/security/cathanos.crt"
```