### PR TITLE
Qualify docker image names with registry name

### DIFF
--- a/start-alertmanager.sh
+++ b/start-alertmanager.sh
@@ -117,7 +117,7 @@ fi
 docker run ${DOCKER_LIMITS["alertmanager"]} -d $DOCKER_PARAM -i $PORT_MAPPING \
 	 -v $RULE_FILE:/etc/alertmanager/config.yml:z \
 	 $ALERT_MANAGER_DIR \
-     --name $ALERTMANAGER_NAME prom/alertmanager:$ALERT_MANAGER_VERSION \
+     --name $ALERTMANAGER_NAME docker.io/prom/alertmanager:$ALERT_MANAGER_VERSION \
      $ALERTMANAGER_COMMANDS --log.level=debug --config.file=/etc/alertmanager/config.yml ${DOCKER_PARAMS["alertmanager"]}  >& /dev/null
 
 

--- a/start-all.sh
+++ b/start-all.sh
@@ -469,7 +469,7 @@ docker run -d $DOCKER_PARAM ${DOCKER_LIMITS["prometheus"]} $USER_PERMISSIONS \
      $SCYLLA_TARGET_FILE \
      $SCYLLA_MANGER_TARGET_FILE \
      $NODE_TARGET_FILE \
-     $PORT_MAPPING --name $PROMETHEUS_NAME prom/prometheus:$PROMETHEUS_VERSION \
+     $PORT_MAPPING --name $PROMETHEUS_NAME docker.io/prom/prometheus:$PROMETHEUS_VERSION \
      --web.enable-lifecycle --config.file=/etc/prometheus/prometheus.yml $PROMETHEUS_COMMAND_LINE_OPTIONS \
      ${DOCKER_PARAMS["prometheus"]}
 

--- a/start-grafana-renderer.sh
+++ b/start-grafana-renderer.sh
@@ -93,5 +93,5 @@ if [[ ! $DOCKER_PARAM = *"--net=host"* ]]; then
 fi
 
 docker run ${DOCKER_LIMITS["grafanarender"]} -d $DOCKER_PARAM -i $USER_PERMISSIONS $PORT_MAPPING \
-     --name $GRAFANA_NAME grafana/grafana-image-renderer:$VERSION \
+     --name $GRAFANA_NAME docker.io/grafana/grafana-image-renderer:$VERSION \
      ${DOCKER_PARAMS["grafanarender"]}

--- a/start-grafana.sh
+++ b/start-grafana.sh
@@ -234,7 +234,7 @@ docker run -d $DOCKER_PARAM ${DOCKER_LIMITS["grafana"]} -i $USER_PERMISSIONS $PO
      -e "GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/var/lib/grafana/dashboards/ver_$VERSION/scylla-overview.$VERSION.json" \
      $GRAFANA_ENV_COMMAND \
      "${proxy_args[@]}" \
-     --name $GRAFANA_NAME grafana/grafana:$GRAFANA_VERSION ${DOCKER_PARAMS["grafana"]} >& /dev/null
+     --name $GRAFANA_NAME docker.io/grafana/grafana:$GRAFANA_VERSION ${DOCKER_PARAMS["grafana"]} >& /dev/null
 
 if [ $? -ne 0 ]; then
     echo "Error: Grafana container failed to start"

--- a/start-loki.sh
+++ b/start-loki.sh
@@ -137,7 +137,7 @@ docker run ${DOCKER_LIMITS["loki"]} -d $DOCKER_PARAM -i $PORT_MAPPING \
 	 -v $LOKI_RULE_DIR:/etc/loki/rules:z \
 	 -v $LOKI_CONF_DIR:/mnt/config:z \
 	 $LOKI_DIR \
-     --name $LOKI_NAME grafana/loki:$LOKI_VERSION $LOKI_COMMANDS --config.file=/mnt/config/loki-config.yaml ${DOCKER_PARAMS["loki"]} >& /dev/null
+     --name $LOKI_NAME docker.io/grafana/loki:$LOKI_VERSION $LOKI_COMMANDS --config.file=/mnt/config/loki-config.yaml ${DOCKER_PARAMS["loki"]} >& /dev/null
 
 if [ $? -ne 0 ]; then
     echo "Error: Loki container failed to start"
@@ -186,7 +186,7 @@ sed "s/LOKI_IP/$LOKI_ADDRESS/" loki/promtail/promtail_config.template.yml > loki
 
 docker run ${DOCKER_LIMITS["promtail"]}  -d $DOCKER_PARAM -i $PROMTAIL_PORT_MAPPING \
 	 -v $PROMTAIL_CONFIG:/etc/promtail/config.yml:z \
-     --name $PROMTAIL_NAME grafana/promtail:$LOKI_VERSION --config.file=/etc/promtail/config.yml ${DOCKER_PARAMS["promtail"]} >& /dev/null
+     --name $PROMTAIL_NAME docker.io/grafana/promtail:$LOKI_VERSION --config.file=/etc/promtail/config.yml ${DOCKER_PARAMS["promtail"]} >& /dev/null
 
 if [ $? -ne 0 ]; then
     echo "Error: Promtail container failed to start"

--- a/start-thanos-sc.sh
+++ b/start-thanos-sc.sh
@@ -137,7 +137,7 @@ fi
 echo "Starting Thanos sidecar"
 docker run ${DOCKER_LIMITS["sidecar"]} -d $DOCKER_PARAM $USER_PERMISSIONS \
      $DATA_DIR \
-     -i $PORT_MAPPING --name sidecar$NAME thanosio/thanos:$THANOS_VERSION \
+     -i $PORT_MAPPING --name sidecar$NAME docker.io/thanosio/thanos:$THANOS_VERSION \
         "sidecar" \
        "--debug.name=$NAME" \
        ${DOCKER_PARAMS["sidecar"]} \

--- a/start-thanos.sh
+++ b/start-thanos.sh
@@ -106,7 +106,7 @@ while getopts ':hl:p:S:' option; do
   esac
 done
 
-docker run ${DOCKER_LIMITS["thanos"]} -d $DOCKER_PARAM -i --name thanos -- thanosio/thanos:$THANOS_VERSION \
+docker run ${DOCKER_LIMITS["thanos"]} -d $DOCKER_PARAM -i --name thanos -- docker.io/thanosio/thanos:$THANOS_VERSION \
        query \
       "--debug.name=query0" \
       "--grpc-address=0.0.0.0:10903" \


### PR DESCRIPTION
Prefix docker image names so that container runtimes that support
multiple registries don't stop to ask which registry to use.