### PR TITLE
Show the scheduler time to be reported as percent

### DIFF
--- a/grafana/scylla-advanced.template.json
+++ b/grafana/scylla-advanced.template.json
@@ -139,12 +139,12 @@
                 "class": "row",
                 "panels": [
                     {
-                        "class": "ms_panel",
+                        "class": "percentunit_panel",
                         "span":4,
                         "pointradius": 1,
                         "targets": [
                             {
-                                "expr": "$func(rate(scylla_scheduler_runtime_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])",
+                                "expr": "$func(rate(scylla_scheduler_runtime_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[$__rate_interval])/1000) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -156,12 +156,12 @@
                         "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. This graph shows how much time was spent in $group group"
                     },
                     {
-                        "class": "ms_panel",
+                        "class": "percentunit_panel",
                         "span":4,
                         "pointradius": 1,
                         "targets": [
                             {
-                                "expr": "$func(rate(scylla_scheduler_time_spent_on_task_quota_violations_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])",
+                                "expr": "$func(rate(scylla_scheduler_time_spent_on_task_quota_violations_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[$__rate_interval])/1000) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -917,8 +917,7 @@
          "rgba(255, 0, 0, 0.9)"
       ]
    },
-   "fieldConfig_defaults": {
-      "custom": {
+   "fieldConfig_defaults_custom": {
         "drawStyle": "line",
         "lineInterpolation": "linear",
         "barAlignment": 0,
@@ -945,6 +944,10 @@
         "thresholdsStyle": {
           "mode": "off"
         }
+      },
+   "fieldConfig_defaults": {
+      "custom": {
+         "class":"fieldConfig_defaults_custom"
       },
       "color": {
         "mode": "palette-classic"
@@ -1013,6 +1016,10 @@
      "fieldConfig": {
         "defaults": {
           "class": "fieldConfig_defaults",
+          "custom": {
+             "class":"fieldConfig_defaults_custom",
+             "axisSoftMax": 1
+          },
           "unit": "percentunit"
         },
         "overrides": []


### PR DESCRIPTION
This patch change how the scylla_scheduler reported runtime and violation time are shown, instead of ms/s it's now shown as percent.

Instead of looking at the `rate(scylla_scheduler time)` we now look at the rate/1000 
The panel type is now percentunit (to show 0-1 range as percent).

![image](https://user-images.githubusercontent.com/2118079/143062261-3f46d3f8-8296-4fab-93ce-fd5450a6bad7.png)

Fixes #1573

