### PR TITLE
scylla-advanced: if scylla_io_queue_total_delay_sec is available use it instead of scylla_io_queue_delay

### DIFF
--- a/grafana/scylla-advanced.template.json
+++ b/grafana/scylla-advanced.template.json
@@ -49,11 +49,11 @@
                 "class": "row",
                 "panels": [
                     {
-                        "class": "us_panel",
+                        "class": "seconds_panel",
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "1000000*max(scylla_io_queue_delay{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
+                                "expr": "max(rate(scylla_io_queue_total_delay_sec{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by ([[by]]) or on() max(scylla_io_queue_delay{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "seastar_io_queue_delay",


### PR DESCRIPTION
Starting from Scylla 4.5 there is a new counter scylla_io_queue_total_delay_sec, that can be used to measure scylla_io_queue_delay.

This patch change the advanced dashboard to try and use that metric first and if it's unavailble to fallback to use scylla_io_queue_delay,
This will help during upgrade and will allow backporting the change to scylla-entperprise

Fixes #1570