### PR TITLE
types.json change the tool tip mode to all

### DIFF
--- a/grafana/types.json
+++ b/grafana/types.json
@@ -967,7 +967,7 @@
       },
       "options": {
         "tooltip": {
-          "mode": "single"
+          "mode": "all"
         },
         "legend": {
           "displayMode": "hidden",


### PR DESCRIPTION
When moving to the new Grafana timeseries panel the tool tip mode was changed to single instead of all.
This patch fixes it
Fixes #1609