### PR TITLE
Scylla-cql: Add the number of range queries without BYPASS CACHE

### DIFF
--- a/grafana/scylla-cql.template.json
+++ b/grafana/scylla-cql.template.json
@@ -894,6 +894,38 @@
                 "panels": [
                     {
                         "class": "gauge_errors_panel",
+                        "description": "Range scans should typically by pass the cache.\n\n Add BYPASS CACHE to your select queries.",
+                        "targets": [
+                            {
+                                "expr": "floor(100 *sum(rate(scylla_cql_select_partition_range_scan_no_bypass_cache{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval]))/(sum(rate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) - sum(rate(scylla_cql_reads_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[$__rate_interval])) )) OR vector(0)",
+                                "format": "time_series",
+                                "hide": false,
+                                "instant": false,
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A"
+                            }
+                        ],
+                        "title": "Range Scans"
+                    },
+                    {
+                        "class": "ops_panel",
+                        "description": "Range scans should typically by pass the cache.\n\n Add BYPASS CACHE to your select queries.",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "sum(rate(scylla_cql_select_partition_range_scan_no_bypass_cache{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])",
+                                "format": "time_series",
+                                "hide": false,
+                                "intervalFactor": 2,
+                                "refId": "A"
+                            }
+                        ],
+                        "title": "Range Scans Without BYPASS CACHE "
+                    },
+                    {
+                        "class": "gauge_errors_panel",
                         "description": "Using consistency level ANY in a query may hurt persistency, if the node receiving the request will fail the data may be lost",
                         "targets": [
                             {


### PR DESCRIPTION
Range queries should typically use BYPASS CACHE.
This patch adds a gauge and a graph that show how many such queries exists

![image](https://user-images.githubusercontent.com/2118079/144745848-52abc9e4-d1a8-4686-9b26-fd40dfab4068.png)

Fixes #1584