### PR TITLE
scylla-detailed: Add graph for prepared statements cache

### DIFF
--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -793,6 +793,34 @@
                             }
                         ],
                         "title": "Total Bytes"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$func(rate(scylla_cql_prepared_cache_evictions{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Prepared Statements Cache Eviction"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$func(rate(scylla_cql_authorized_prepared_statements_cache_evictions{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Authorized Prepared Statements Cache Eviction"
                     }
                 ],
                 "title": "New row"


### PR DESCRIPTION
Add graph for the prepared statements cache eviction under the cach section

![image](https://user-images.githubusercontent.com/2118079/144825791-59899556-9850-4dca-a487-decc31d7fd0c.png)

Fixes #1561