### PR TITLE
scylla-detailed: add tombstone section in the detailed dashboard

### DIFF
--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -925,6 +925,68 @@
                     {
                         "class": "collapsible_row_panel",
                         "collapsed": true,
+                        "dashversion":[">4.6", ">2021.1"],
+                        "title": "Tombstones"
+                    }
+                ]
+            },
+            {
+                "class": "row",
+                "dashversion":[">4.6", ">2021.1"],
+                "panels": [
+                    {
+                        "class": "rps_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$func(rate(scylla_cache_range_tombstone_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[$__rate_interval]))  by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Cache Range Tombstones",
+                        "description" : "Amount of range tombstones processed during read."
+                    },
+                    {
+                        "class": "rps_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$func(rate(scylla_sstables_range_tombstone_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[$__rate_interval]))  by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Range Tombstones reads",
+                        "description" : "Amount of range tombstones processed during read."
+                    },
+                    {
+                        "class": "wps_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$func(rate(scylla_sstables_tombstone_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[$__rate_interval]))  by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Range Tombstones writes",
+                        "description" : "Amount of range tombstones writes."
+                    }
+                 ]
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "collapsible_row_panel",
+                        "collapsed": true,
                         "title": "LWT"
                     }
                 ]


### PR DESCRIPTION
This patch adds tombstone section in the detailed dashboard.

It contains graphs for range tombstone reads and cache reads
![image](https://user-images.githubusercontent.com/2118079/145181812-008b5c15-059b-49d6-983a-34415e2d2ab6.png)

Fixes #1585 