### PR TITLE
Shed requests

### DIFF
--- a/docs/source/use-monitoring/advisor/systemOverload.rst
+++ b/docs/source/use-monitoring/advisor/systemOverload.rst
@@ -4,7 +4,7 @@ System Overload
 There could be multiple indications that a system is overloaded:
 
 * Timeouts
-* Requests shed - Requests are shed when the system cannot process the requests fast enough.
+* Requests shed - Requests are shed (dropped) when the system cannot process requests fast enough.
 * CPU at 100% when no background process (like compaction or repair) is running.
 * Ques are getting filled.
 

--- a/docs/source/use-monitoring/advisor/systemOverload.rst
+++ b/docs/source/use-monitoring/advisor/systemOverload.rst
@@ -5,7 +5,7 @@ There could be multiple indications that a system is overloaded:
 
 * Timeouts
 * Requests shed - Requests are shed (dropped) when the system cannot process requests fast enough.
-* CPU at 100% when no background process (like compaction or repair) is running.
+* CPU at 100% when no background process (like compaction or repair) runs.
 * Ques are getting filled.
 
 If you ruled out data-model problems and hardware failure, this could be an indication that you need to rescale the system.

--- a/docs/source/use-monitoring/advisor/systemOverload.rst
+++ b/docs/source/use-monitoring/advisor/systemOverload.rst
@@ -8,5 +8,5 @@ There could be multiple indications that a system is overloaded:
 * CPU at 100% when no background process (like compaction or repair) runs.
 * Ques are getting filled.
 
-If you ruled out data-model problems and hardware failure, this could be an indication that you need to rescale the system.
+If you ruled out data-model problems and hardware failure, this could indicate you need to scale the system.
 

--- a/docs/source/use-monitoring/advisor/systemOverload.rst
+++ b/docs/source/use-monitoring/advisor/systemOverload.rst
@@ -1,0 +1,12 @@
+System Overload
+---------------
+
+There could be multiple indications that a system is overloaded:
+
+* Timeouts
+* Requests shed - Requests are shed when the system cannot process the requests fast enough.
+* CPU at 100% when no background process (like compaction or repair) is running.
+* Ques are getting filled.
+
+If you ruled out data-model problems and hardware failure, this could be an indication that you need to rescale the system.
+

--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -454,10 +454,18 @@
                         "title": "Writes blocked on commitlog"
                     },
                     {
-                        "class": "text_panel",
-                        "content": "",
-                        "mode": "markdown",
-                        "span": 3
+                        "class": "requestsps_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$func(rate(scylla_transport_requests_shed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Requests Shed"
                     },
                     {
                         "class": "text_panel",

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -1167,6 +1167,16 @@
         "overrides": []
       }
    },
+   "requestsps_panel":{
+      "class":"iops_panel",
+      "fieldConfig": {
+        "defaults": {
+          "class": "fieldConfig_defaults",
+          "unit": "si:requests/s"
+        },
+        "overrides": []
+      }
+   },
    "wpm_panel":{
       "class":"iops_panel",
       "fieldConfig": {

--- a/prometheus/prom_rules/prometheus.rules.yml
+++ b/prometheus/prom_rules/prometheus.rules.yml
@@ -307,6 +307,17 @@ groups:
     annotations:
       description: 'Compaction load increases to a level it can interfere with the system behaviour. If this persists set the compaction share to a static level.'
       summary: Heavy compaction load
+  - alert: heavyCompaction
+    expr: max(sum(rate(scylla_transport_requests_shed[60s])) by (instance,cluster)/sum(rate(scylla_transport_requests_served{}[60s])) by (instance, cluster)) by(cluster) > 0.1
+    for: 5m
+    labels:
+      severity: "1"
+      advisor: "systemOverload"
+      dashboard: "scylla-detailed"
+    annotations:
+      description: 'More than 1% of the requests got shed, this is an indication of an overload, consider system resize.'
+      summary: System is overloaded
+
   - alert: InstanceDown
     expr: up{job="scylla"} == 0
     for: 30s


### PR DESCRIPTION
This series handles requests shed.
It adds an advisor warning when the percentage of shed reqeusts is above 1% and a documentation for the the advisor warning
It adds a panel in the detailed dashboard under the replica section with the number of shed requests

Fixes #1580