### PR TITLE
types.json: add annotations for repair based ops

### DIFF
--- a/grafana/types.json
+++ b/grafana/types.json
@@ -2822,6 +2822,14 @@
       "name":"MV",
       "titleFormat":"Materialized View built"
    },
+   "ops_annotation":{
+      "class":"annotation_restart",
+      "expr":"10*min(scylla_node_ops_finished_percentage) by (ops, dc,instance) < 10",
+      "iconColor":"rgb(50, 176, 0, 128)",
+      "name":"ops",
+      "tagKeys":"ops,dc,instance",
+      "titleFormat":"Operation"
+   },
    "vertical_lcd":{
       "datasource":"prometheus",
       "fieldConfig":{
@@ -2925,6 +2933,9 @@
          },
          {
             "class":"mv_building"
+         },
+         {
+            "class":"ops_annotation"
          }
       ]
    },


### PR DESCRIPTION
This patch adds an annotation for the repair-based operation, when such an operation is in action it show a range annotations with the details:
![image](https://user-images.githubusercontent.com/2118079/146176209-b3997648-5c79-4be3-a058-e6d557d606d2.png)

Relates to #1053