### PR TITLE
type.json: fix links in node table

### DIFF
--- a/grafana/types.json
+++ b/grafana/types.json
@@ -2362,7 +2362,7 @@
                      "value":[
                         {
                            "title":"CQL Information Dashboard. Warning indicates that there are potential issues in the CQL Optimization",
-                           "url":"./d/cql-[[dash_version]]/scylla-cql?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
+                           "url":"/d/cql-[[dash_version]]/scylla-cql?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
                         }
                      ]
                   },
@@ -2436,7 +2436,7 @@
                      "value":[
                         {
                            "title":"OS Information Dashboard, an Error indicates there are OS related errors",
-                           "url":"./d/OS-[[dash_version]]/OS-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
+                           "url":"/d/OS-[[dash_version]]/os-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
                         }
                      ]
                   },
@@ -2510,7 +2510,7 @@
                      "value":[
                         {
                            "title":"Cordinator and Replica node errors",
-                           "url":"./d/detailed-[[dash_version]]/Detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
+                           "url":"/d/detailed-[[dash_version]]/detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
                         }
                      ]
                   },
@@ -2584,7 +2584,7 @@
                      "value":[
                         {
                            "title":"Detailed view",
-                           "url":"./d/detailed-[[dash_version]]/Detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
+                           "url":"/d/detailed-[[dash_version]]/detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}"
                         }
                      ]
                   }


### PR DESCRIPTION
Grafana has changed their re-direction behaviour. This result that the quick links from the node tables stop to work.

This patch change two things, it update the url to use the lower case name and it remove the leading dot from the link.

Fixes #1637