### PR TITLE
scylla-cql.template.json: Add an explenation about the CQL connectivity

### DIFF
--- a/grafana/scylla-cql.template.json
+++ b/grafana/scylla-cql.template.json
@@ -231,6 +231,24 @@
             },
             {
                 "class": "row",
+                "height": "25px",
+                "gridPos": {"h": 3},
+                "dashproductreject": "no-cql-connection",
+                "panels": [
+                    {
+                        "class": "text_panel",
+                        "options": {
+                            "content": "<span style=\"color:#5881c2;font-size: 2rem;\">CQL System tables</span></br><span style=\"\">The following information is based on Scylla Plugin configuration, check the </span><a target=\"_blank\" herf=\"https://monitoring.docs.scylladb.com/latest/install/monitor_without_docker.html#using-scylla-plugin-with-grafana\" onclick=\"window.open('https://monitoring.docs.scylladb.com/latest/install/monitor_without_docker.html#using-scylla-plugin-with-grafana', '_blank')\">documentation</a><span> for more details on how to enable it.</span>",
+                            "mode": "html"
+                        },
+                        "style": {}
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "class": "row",
+                "dashproductreject": "no-cql-connection",
                 "panels": [
                     {
                         "class": "collapsible_row_panel",
@@ -241,6 +259,7 @@
             },
             {
                 "class": "row",
+                "dashproductreject": "no-cql-connection",
                 "panels": [
                     {
                         "class": "single_value_table",
@@ -267,6 +286,7 @@
             },
             {
                 "class": "row",
+                "dashproductreject": "no-cql-connection",
                 "panels": [
                     {
                         "class": "collapsible_row_panel",
@@ -277,6 +297,7 @@
             },
             {
                 "class": "row",
+                "dashproductreject": "no-cql-connection",
                 "panels": [
                     {
                         "class": "single_value_table",
@@ -331,6 +352,7 @@
             },
             {
                 "class": "row",
+                "dashproductreject": "no-cql-connection",
                 "panels": [
                     {
                         "class": "collapsible_row_panel",
@@ -341,6 +363,7 @@
             },
             {
                 "class": "row",
+                "dashproductreject": "no-cql-connection",
                 "panels": [
                     {
                         "class": "single_value_table",
@@ -395,6 +418,7 @@
             },
             {
                 "class": "row",
+                "dashproductreject": "no-cql-connection",
                 "panels": [
                     {
                         "class": "collapsible_row_panel",
@@ -405,6 +429,7 @@
             },
             {
                 "class": "row",
+                "dashproductreject": "no-cql-connection",
                 "panels": [
                     {
                         "class": "single_value_table",


### PR DESCRIPTION
This patch address two issues in the cql dashbaord:
1. Add an explenation that the Scylla CQL plugin needs to be configure for the cql table to show data
![image](https://user-images.githubusercontent.com/2118079/148073346-5dfae439-340e-4e47-8afd-4d5f414c1fd3.png)

2. Support an option to remove the related CQL connection section alltogether if needed
![image](https://user-images.githubusercontent.com/2118079/148074351-ca5884a9-446e-47f7-b122-4d1e7b0ee2e9.png)

Fixes #1636 