### PR TITLE
Variable the doc version

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.viewcode',
     'sphinx_multiversion',
-    'recommonmark'   
+    'recommonmark'
 ]
 
 # Add Markdown support
@@ -60,12 +60,18 @@ def setup(sphinx):
     }, True)
     sphinx.add_transform(AutoStructify)
 
-
+current_version = "3.1.0"
+res = ""
+if os.path.isfile('../../CURRENT_VERSION.sh'):
+    with open('../../CURRENT_VERSION.sh', 'r') as file:
+        current_version = file.read().replace('\n', '')
+current_branch = 'branch-' + '.'.join(current_version.split('.')[:2])
 # Adds version variables for monitoring and manager versions when used in inline text
 rst_prolog = """
-.. |version| replace:: 3.10.0
+.. |version| replace:: {current_version}
+.. |branch_version| replace:: {current_branch}
 .. |mon_root| replace::  `Scylla Monitoring Stack </>`__
-"""
+""".format(current_version=current_version, current_branch=current_branch)
 
 # -- Options for not found extension -------------------------------------------
 
@@ -143,7 +149,7 @@ html_sidebars = {'**': ['side-nav.html']}
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'ScyllaMonitorDocumentationdoc'
 
-# URL which points to the root of the HTML documentation. 
+# URL which points to the root of the HTML documentation.
 html_baseurl = 'https://monitoring.docs.scylladb.com'
 
 # Dictionary of values to pass into the template engine’s context for all pages

--- a/docs/source/install/monitor_without_docker.rst
+++ b/docs/source/install/monitor_without_docker.rst
@@ -35,7 +35,10 @@ The following procedure uses a ``CentOS 7`` based instance
 
 1. Download the latest Scylla Monitoring Stack release.
 
-``wget https://github.com/scylladb/scylla-monitoring/archive/refs/tags/scylla-monitoring-3.10.0.tar.gz``
+.. code-block:: sh
+   :substitutions:
+
+   wget https://github.com/scylladb/scylla-monitoring/archive/refs/tags/scylla-monitoring-|version|.tar.gz
 
 
 2. Open the tar
@@ -57,13 +60,14 @@ Tested with alertmanager 0.22.2 version
    tar -xvf alertmanager-*.linux-amd64.tar.gz
 
 
-2. Copy the following file: ``rule_config.yml`` from ``scylla-monitoring-scylla-monitoring-3.10.0/prometheus`` directory to ``alertmanager.yml`` in the alertmanager installation directory.
+2. Copy the following file: ``rule_config.yml`` from ``prometheus/`` directory to ``alertmanager.yml`` in the alertmanager installation directory.
 
 For example:
 
 .. code-block:: shell
-
-   cp -p /home/centos/scylla-monitoring-scylla-monitoring-3.10.0/prometheus/rule_config.yml alertmanager-0.22.2.linux-amd64/alertmanager.yml
+   :substitutions:
+   
+   cp -p /home/centos/scylla-monitoring-scylla-monitoring-|version|/prometheus/rule_config.yml alertmanager-0.22.2.linux-amd64/alertmanager.yml
 
 3. Start the Alertmanager
 
@@ -150,16 +154,17 @@ Tested with Prometheus version 2.27.1
    mkdir -p /etc/scylla.d/prometheus/
 
 
-3. Copy the following files: ``scylla_servers.yml``, ``prometheus.rules.yml`` from ``scylla-monitoring-scylla-monitoring-3.10.0/prometheus`` directory to Prometheus installation directory.
+3. Copy the following files: ``scylla_servers.yml``, ``prometheus.rules.yml`` from ``prometheus/`` directory to Prometheus installation directory.
 
 Copy ``prometheus/prometheus.yml.template`` to ``prometheus.yml``
 
 For example:
 
 .. code-block:: shell
+   :substitutions:
 
-   cp scylla-monitoring-scylla-monitoring-3.10.0/prometheus/prom_rules/*.yml/etc/prometheus/prom_rules/
-   cp scylla-monitoring-scylla-monitoring-3.10.0/prometheus/prometheus.yml.template /etc/prometheus/prometheus.yml
+   cp scylla-monitoring-scylla-monitoring-|version|/prometheus/prom_rules/*.yml/etc/prometheus/prom_rules/
+   cp scylla-monitoring-scylla-monitoring-|version|/prometheus/prometheus.yml.template /etc/prometheus/prometheus.yml
 
 
 4. Edit the ``prometheus.yml`` file to point to the correct static data sources.
@@ -270,8 +275,9 @@ For example:
 For example:
 
 .. code-block:: shell
+   :substitutions:
 
-   cd scylla-monitoring-scylla-monitoring-3.10.0/
+   cd scylla-monitoring-scylla-monitoring-|version|/
    ./prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path /prometheus/data
 
 Data should start accumulate on: /prometheus/data
@@ -316,7 +322,10 @@ different in the rest of the steps.
 
 2. Access Scylla-Grafana-monitoring directory
 
-``cd scylla-monitoring-scylla-monitoring-3.10.0/``
+.. code-block:: shell
+   :substitutions:
+
+   cd scylla-monitoring-scylla-monitoring-|version|/
 
 3. Copy the plugins to the grafana plugins directory (by default ``/var/lib/grafana/``)
 

--- a/docs/source/install/monitoring_stack.rst
+++ b/docs/source/install/monitoring_stack.rst
@@ -97,10 +97,11 @@ Install Scylla Monitoring Stack
 As an alternative, you can clone and use the Git repository directly.
 
 .. code-block:: sh
+   :substitutions:
 
    git clone https://github.com/scylladb/scylla-monitoring.git
    cd scylla-monitoring
-   git checkout branch-3.9
+   git checkout |branch_version|
 
 2. Start Docker service if needed
 


### PR DESCRIPTION
This series address two issues:
1. make all the version and branch in the documentation variables.
2. check for the CURREN_VERSION.sh file if it exists take the version from it
Fixes #1633