### PR TITLE
type.json: set the soft-min to zero

### DIFF
--- a/grafana/types.json
+++ b/grafana/types.json
@@ -943,7 +943,8 @@
         },
         "thresholdsStyle": {
           "mode": "off"
-        }
+        },
+        "axisSoftMin": 0
       },
    "fieldConfig_defaults": {
       "custom": {


### PR DESCRIPTION
This patch sets the default soft-min of the graphs to be zero
![image](https://user-images.githubusercontent.com/2118079/153153327-6935c56c-664a-4032-93c7-69da6f8ab5ab.png)

Fixes #1671
