### PR TITLE
scylla-os: fix number of files

### DIFF
--- a/grafana/scylla-os.template.json
+++ b/grafana/scylla-os.template.json
@@ -136,7 +136,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(node_filesystem_files{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])",
+                                "expr": "sum(node_filesystem_files{mountpoint=\"$mount_point\", instance=~\"$node\"}- node_filesystem_files_free{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",


### PR DESCRIPTION
This patch fix the number of files panel in the os dashboard
Fixes #1684