### PR TITLE
scylla-manager: use percentunit for 0-1 range

### DIFF
--- a/grafana/scylla-manager.template.json
+++ b/grafana/scylla-manager.template.json
@@ -154,7 +154,7 @@
                            "defaults":{
                               "custom":{
                               },
-                              "unit":"percent",
+                              "unit":"percentunit",
                               "decimals":0,
                               "thresholds":{
                                  "mode":"absolute",


### PR DESCRIPTION
Fixes #1687