### PR TITLE
Create Monitoring dockers

### DIFF
--- a/docker-build/alertmanager.Dockerfile
+++ b/docker-build/alertmanager.Dockerfile
@@ -1,0 +1,6 @@
+ARG ALERTMANAGER_VERSION="latest"
+FROM docker.io/prom/alertmanager:${ALERTMANAGER_VERSION}
+
+ARG CURRENT_DIR="./docker-build"
+
+COPY ./prometheus/rule_config.yml /etc/alertmanager/config.yml

--- a/docker-build/build_docker.sh
+++ b/docker-build/build_docker.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+CURRENT_VERSION="master"
+DOCKER_REPO="scylladb"
+
+. versions.sh
+if [ -f  env.sh ]; then
+    . env.sh
+fi
+
+if [ -f CURRENT_VERSION.sh ]; then
+    CURRENT_VERSION=`cat CURRENT_VERSION.sh`
+fi
+
+if [ -z "$BRANCH_VERSION" ]; then
+  BRANCH_VERSION=$CURRENT_VERSION
+fi
+if [ -z ${DEFAULT_VERSION[$CURRENT_VERSION]} ]; then
+    BRANCH_VERSION=`echo $CURRENT_VERSION|cut -d'.' -f1,2`
+fi
+if [ -z "$MANAGER_VERSION" ];then
+  MANAGER_VERSION=${MANAGER_DEFAULT_VERSION[$BRANCH_VERSION]}
+fi
+if [ -z "$VERSIONS" ]; then
+  VERSIONS=${DEFAULT_ENTERPRISE_VERSION[$BRANCH_VERSION]}
+fi
+
+docker build -t $DOCKER_REPO/grafana:$CURRENT_VERSION . -f docker-build/grafana.Dockerfile --build-arg  CURRENT_DIR="./docker-build" \
+--build-arg GRAFANA_VERSION="$GRAFANA_VERSION" \
+--build-arg DEFAULT_VERSION="$VERSIONS" \
+--build-arg MANAGER_VERSION=$MANAGER_VERSION \
+
+docker build -t $DOCKER_REPO/loki:$CURRENT_VERSION . -f docker-build/loki.Dockerfile --build-arg  CURRENT_DIR="./docker-build" \
+--build-arg LOKI_VERSION="$LOKI_VERSION"
+
+docker build -t $DOCKER_REPO/promtail:$CURRENT_VERSION . -f docker-build/promtail.Dockerfile --build-arg  CURRENT_DIR="./docker-build" \
+--build-arg PROMTAIL_VERSION="$LOKI_VERSION"
+
+docker build -t $DOCKER_REPO/prometheus:$CURRENT_VERSION . -f docker-build/prometheus.Dockerfile --build-arg  CURRENT_DIR="./docker-build" \
+--build-arg PROMETHEUS_VERSION="$PROMETHEUS_VERSION"
+
+docker build -t $DOCKER_REPO/alertmanager:$CURRENT_VERSION . -f docker-build/alertmanager.Dockerfile --build-arg  CURRENT_DIR="./docker-build" \
+--build-arg ALERTMANAGER_VERSION="$ALERT_MANAGER_VERSION"

--- a/docker-build/grafana.Dockerfile
+++ b/docker-build/grafana.Dockerfile
@@ -1,0 +1,90 @@
+ARG GRAFANA_VERSION="latest"
+FROM docker.io/grafana/grafana:${GRAFANA_VERSION}
+
+ARG DEFAULT_VERSION="2021.1" GF_INSTALL_IMAGE_RENDERER_PLUGIN="false"
+ENV VERSIONS=${DEFAULT_VERSION}
+
+USER root
+
+ARG GF_GID="0"
+ENV GF_PATHS_PLUGINS="/var/lib/grafana-plugins"
+
+RUN mkdir -p "$GF_PATHS_PLUGINS" && \
+    chown -R grafana:${GF_GID} "$GF_PATHS_PLUGINS"
+
+RUN if [ $GF_INSTALL_IMAGE_RENDERER_PLUGIN = "true" ]; then \
+    echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
+    echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
+    echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
+    apk --no-cache  upgrade && \
+    apk add --no-cache udev ttf-opensans chromium && \
+    rm -rf /tmp/* && \
+    rm -rf /usr/share/grafana/tools/phantomjs; \
+fi
+
+USER grafana
+
+ENV GF_PLUGIN_RENDERING_CHROME_BIN="/usr/bin/chromium-browser"
+
+RUN if [ $GF_INSTALL_IMAGE_RENDERER_PLUGIN = "true" ]; then \
+    grafana-cli \
+        --pluginsDir "$GF_PATHS_PLUGINS" \
+        --pluginUrl https://github.com/grafana/grafana-image-renderer/releases/latest/download/plugin-linux-x64-glibc-no-chromium.zip \
+        plugins install grafana-image-renderer; \
+fi
+
+ARG GF_INSTALL_PLUGINS=""
+
+RUN grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install camptocamp-prometheus-alertmanager-datasource
+
+ARG GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=scylladb-scylla-datasource
+ENV GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=${GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS}
+
+RUN if [ ! -z "${GF_INSTALL_PLUGINS}" ]; then \
+    OLDIFS=$IFS; \
+    IFS=','; \
+    for plugin in ${GF_INSTALL_PLUGINS}; do \
+        IFS=$OLDIFS; \
+        if expr match "$plugin" '.*\;.*'; then \
+            pluginUrl=$(echo "$plugin" | cut -d';' -f 1); \
+            pluginInstallFolder=$(echo "$plugin" | cut -d';' -f 2); \
+            grafana-cli --pluginUrl ${pluginUrl} --pluginsDir "${GF_PATHS_PLUGINS}" plugins install "${pluginInstallFolder}"; \
+        else \
+            grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${plugin}; \
+        fi \
+    done \
+fi
+COPY --chown=grafana:${GF_GID} grafana/plugins/scylla-plugin ${GF_PATHS_PLUGINS}/scylla-plugin/
+ARG CURRENT_DIR="./docker-build"
+COPY --chown=grafana:${GF_GID}  $CURRENT_DIR/grafanainit.sh /grafanainit.sh
+
+ARG GRAFANA_AUTH=false
+ENV GF_AUTH_BASIC_ENABLED=${GRAFANA_AUTH}
+ARG GRAFANA_AUTH_ANONYMOUS=true
+ENV GF_AUTH_ANONYMOUS_ENABLED=${GRAFANA_AUTH_ANONYMOUS}
+ENV COMPOSE_DATASOURCE=""
+ARG ANONYMOUS_ROLE="Admin"
+ENV GF_AUTH_ANONYMOUS_ORG_ROLE=${ANONYMOUS_ROLE}
+ARG GRAFANA_ADMIN_PASSWORD="admin"
+ENV GF_PANELS_DISABLE_SANITIZE_HTML=true
+ENV GF_PATHS_PROVISIONING=/var/lib/grafana/provisioning
+ENV GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
+COPY --chown=grafana:${GF_GID}  grafana/build /var/lib/grafana/dashboards/
+RUN mkdir -p "/var/lib/grafana/provisioning/" && \
+    chown -R grafana:${GF_GID} "/var/lib/grafana/provisioning/"
+ARG SPECIFIC_SOLUTION=""
+ENV SPECIFIC_SOLUTION=${SPECIFIC_SOLUTION}
+ARG MANAGER_VERSION="2.6"
+ENV MANAGER_VERSION=${MANAGER_VERSION}
+ARG GRAFANA_DASHBOARD_COMMAND=""
+ENV GRAFANA_DASHBOARD_COMMAND=${GRAFANA_DASHBOARD_COMMAND}
+#ENV GF_RENDERING_SERVER_URL=http://localhost:8081/render
+#ENV GF_RENDERING_CALLBACK_URL=http://localhost:3000/
+COPY --chown=grafana:${GF_GID}  generate-dashboards.sh /generate-dashboards.sh
+COPY --chown=grafana:${GF_GID}  versions.sh /versions.sh
+COPY --chown=grafana:${GF_GID}  dashboards.sh /dashboards.sh
+COPY --chown=grafana:${GF_GID}  CURRENT_VERSION.sh /CURRENT_VERSION.sh
+COPY --chown=grafana:${GF_GID}  grafana/load.yaml /grafana/load.yaml
+COPY --chown=grafana:${GF_GID}  UA.sh /var/lib/grafana/ua/UA.sh
+COPY ./grafana/provisioning/compose-datasources /var/lib/grafana/compose-datasources/
+ENTRYPOINT ["/grafanainit.sh" ]

--- a/docker-build/grafanainit.sh
+++ b/docker-build/grafanainit.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -e
+
+mkdir -p /var/lib/grafana/provisioning/
+if [ ! -d "/var/lib/grafana/provisioning/dashboards/" ]; then
+    echo "No dashboard directory, creating"
+    cd /
+    /generate-dashboards.sh -t $SPECIFIC_SOLUTION -v $VERSIONS -M $MANAGER_VERSION $GRAFANA_DASHBOARD_COMMAND -B /var/lib/grafana/provisioning/dashboards/
+fi
+VERSION=`echo $VERSIONS|cut -d',' -f1`
+if [ -z "$GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH" ]; then
+    export GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH="/var/lib/grafana/dashboards/ver_${VERSION}/scylla-overview.${VERSION}.json"
+fi
+
+
+
+if [ -z "$UA_ANALTYICS" ]; then
+  . /var/lib/grafana/ua/UA.sh
+fi
+if [ -z "$GF_ANALYTICS_GOOGLE_ANALYTICS_UA_ID" ]; then
+    export GF_ANALYTICS_GOOGLE_ANALYTICS_UA_ID="$UA_ANALTYICS"
+fi
+if [ ! -z "$COMPOSE_DATASOURCE" ]; then
+    mkdir -p /var/lib/grafana/provisioning/datasources
+    cp -r /var/lib/grafana/compose-datasources/* /var/lib/grafana/provisioning/datasources
+fi
+/run.sh

--- a/docker-build/loki.Dockerfile
+++ b/docker-build/loki.Dockerfile
@@ -1,0 +1,16 @@
+ARG LOKI_VERSION="latest"
+FROM docker.io/grafana/loki:${LOKI_VERSION}
+
+ARG GF_GID="10001"
+
+USER root
+RUN mkdir -p /data/loki
+RUN chown 10001:10001 /data/loki
+
+USER loki
+ENV ALERT_MANAGER_ADDRESS="aalert:9093"
+ARG CURRENT_DIR="./docker-build"
+COPY --chown=loki:${GF_GID} loki/rules/scylla /etc/loki/rules/fake/
+COPY --chown=loki:${GF_GID} loki/conf /mnt/config/
+COPY --chown=loki:${GF_GID}  $CURRENT_DIR/lokiinit.sh /lokiinit.sh
+ENTRYPOINT ["/lokiinit.sh" ]

--- a/docker-build/lokiinit.sh
+++ b/docker-build/lokiinit.sh
@@ -1,0 +1,10 @@
+#!/bin/sh -e
+echo "running loki init"
+
+if [ -f /mnt/config/loki-config.yaml ]; then
+    echo "Config exsits loki-config.yaml"
+else
+    echo "Setting loki-config.yaml"
+    sed "s/ALERTMANAGER/$ALERT_MANAGER_ADDRESS/" /mnt/config/loki-config.template.yaml > /mnt/config/loki-config.yaml
+fi
+/usr/bin/loki --config.file=/mnt/config/loki-config.yaml --ingester.wal-enabled=false

--- a/docker-build/prometheus.Dockerfile
+++ b/docker-build/prometheus.Dockerfile
@@ -1,0 +1,12 @@
+ARG PROMETHEUS_VERSION="latest"
+FROM docker.io/prom/prometheus:${PROMETHEUS_VERSION}
+
+USER       nobody
+
+ENV ALERT_MANAGER_ADDRESS="aalert:9093" CONSUL_ADDRESS="" PROMETHEUS_TARGETS=""
+ARG CURRENT_DIR="./docker-build"
+COPY --chown=nobody:nobody  prometheus/prom_rules /etc/prometheus/prom_rules/
+COPY --chown=nobody:nobody  $CURRENT_DIR/prometheusinit.sh /prometheusinit.sh
+COPY --chown=nobody:nobody  prometheus/prometheus.yml.template /etc/prometheus/conf/prometheus.yml.template
+COPY --chown=nobody:nobody  prometheus/prometheus.consul.yml.template /etc/prometheus/conf/prometheus.consul.yml.template
+ENTRYPOINT ["/prometheusinit.sh" ]

--- a/docker-build/prometheusinit.sh
+++ b/docker-build/prometheusinit.sh
@@ -1,0 +1,22 @@
+#!/bin/sh -e
+echo "running prometheus init"
+if [ -f /etc/prometheus/conf/prometheus.yml ]; then
+    echo "Config exsits /etc/prometheus/conf/prometheus.yml"
+else
+    echo "Setting prometheus.yml"
+    DST="/etc/prometheus/conf/"
+    SRC="/etc/prometheus/conf"
+    mkdir -p $DST
+    if [ -z $CONSUL_ADDRESS ]; then
+        sed "s/AM_ADDRESS/$AM_ADDRESS/" $SRC/prometheus.yml.template > $DST/prometheus.yml
+    else
+        if [[ ! $CONSUL_ADDRESS = *":"* ]]; then
+            CONSUL_ADDRESS="$CONSUL_ADDRESS:5090"
+        fi
+        sed "s/AM_ADDRESS/$AM_ADDRESS/" $SRC/prometheus.consul.yml.template| sed "s/MANAGER_ADDRESS/$CONSUL_ADDRESS/" > $DST/prometheus.yml
+    fi
+fi
+echo "Starting prometheus"
+/bin/prometheus --config.file=/etc/prometheus/conf/prometheus.yml --storage.tsdb.path=/prometheus \
+             --web.console.libraries=/usr/share/prometheus/console_libraries \
+             --web.console.templates=/usr/share/prometheus/consoles

--- a/docker-build/promtail.Dockerfile
+++ b/docker-build/promtail.Dockerfile
@@ -1,0 +1,9 @@
+ARG PROMTAIL_VERSION="latest"
+FROM docker.io/grafana/promtail:${PROMTAIL_VERSION}
+
+ARG CURRENT_DIR="./docker-build"
+ENV LOKI_ADDRESS="loki:3100"
+
+COPY loki/promtail/promtail_config.template.yml /etc/promtail/promtail_config.template.yml
+COPY $CURRENT_DIR/promtailinit.sh /promtailinit.sh
+ENTRYPOINT ["/promtailinit.sh" ]

--- a/docker-build/promtailinit.sh
+++ b/docker-build/promtailinit.sh
@@ -1,0 +1,10 @@
+#!/bin/sh -e
+echo "running promtail init"
+
+if [ -f /etc/promtail/config.yml ]; then
+    echo "Config exsits promtail-config.yaml"
+else
+    echo "Setting promtail-config.yaml"
+    sed "s/ALERTMANAGER/$ALERT_MANAGER_ADDRESS/" /etc/promtail/promtail-config.template.yaml > /etc/promtail/config.yml
+fi
+/usr/bin/promtail --config.file=/etc/promtail/config.yml /etc/promtail/config.yml


### PR DESCRIPTION
This series adds an option to create monitoring containers that include all the relevant files.
This remove the dependency in syclla-monitoring repository.

For example, the following docker-compose.yml file would create a monitoring stack with the relevant dashboard.
As can be seen, no external volume is needed (besides the scylla configuration).

This would also make it easier to use with kubernetes
```
cat docker-compose.yml
services:
  alertmanager:
    container_name: aalert
    image: scylladb/alertmanager:3.11.0
    ports:
    - 9093:9093
  grafana:
    container_name: agraf
    environment:
    - GF_RENDERING_SERVER_URL=http://renderer:8081/render
    - GF_RENDERING_CALLBACK_URL=http://agraf:3000/
    - COMPOSE_DATASOURCE=true
    image: scylladb/grafana:3.11.0
    ports:
    - 3000:3000
  loki:
    container_name: loki
    image: scylladb/loki:3.11.0
    ports:
    - 3100:3100
  promotheus:
    container_name: aprom
    image: scylladb/prometheus:3.11.0
    ports:
    - 9090:9090
    volumes:
    - ./prometheus/scylla_servers.yml:/etc/scylla.d/prometheus/scylla_servers.yml
    - ./prometheus/scylla_manager_servers.yml:/etc/scylla.d/prometheus/scylla_manager_servers.yml
    - ./prometheus/scylla_servers.yml:/etc/scylla.d/prometheus/node_exporter_servers.yml
    # Uncomment the following line for prometheus persistency 
    # - path/to/data/dir:/prometheus/data
  promtail:
    container_name: promtail
    image: scylladb/promtail:3.11.0
    ports:
    - 1514:1514
    - 9080:9080
  renderer:
    image: grafana/grafana-image-renderer:latest
    ports:
      - 8081
 
version: '3'
```
Fixes #1695