### PR TITLE
add the "_common" folders to the exclude patterns

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -46,7 +46,7 @@ project = u'Scylla Monitoring'
 copyright = str(date.today().year) + ', ScyllaDB. All rights reserved.'
 author = u'Scylla Project Contributors'
 
-exclude_patterns = ['_build', '_utils']
+exclude_patterns = ['_build', '_utils', '**/_common/*']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'


### PR DESCRIPTION
I've added the __common_ folders to the exclude patterns so that they are skipped by search.