### PR TITLE
scylla-advanced: remove scylla_io_queue_total_delay_sec

### DIFF
--- a/grafana/scylla-advanced.template.json
+++ b/grafana/scylla-advanced.template.json
@@ -51,6 +51,7 @@
                     {
                         "class": "seconds_panel",
                         "span": 3,
+                        "dashversion":[">5.1", ">2023.1"],
                         "targets": [
                             {
                                 "expr": "max(rate(scylla_io_queue_total_delay_sec{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])/rate(scylla_io_queue_total_operations{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by ([[by]]) or on() max(scylla_io_queue_delay{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
@@ -66,6 +67,22 @@
                                 "legendFormat": "Disk {{[[by]]}}",
                                 "metric": "scylla_io_queue_total_exec_sec",
                                 "refId": "B",
+                                "step": 30
+                            }
+                        ],
+                        "title": "$classes I/O Queue delay by [[by]]"
+                    },
+                    {
+                        "class": "seconds_panel",
+                        "span": 3,
+                        "dashversion":["<5.1", "<2023.1"],
+                        "targets": [
+                            {
+                                "expr": "max(scylla_io_queue_delay{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "IO queue {{[[by]]}}",
+                                "metric": "seastar_io_queue_delay",
+                                "refId": "A",
                                 "step": 30
                             }
                         ],


### PR DESCRIPTION
 scylla_io_queue_total_delay_sec only available with versions higher than 5.0 and 2022.1

This patch make it available for those versions and master

Fixes #1736