### PR TITLE
fix using GF_USERS_DEFAULT_THEME to set the default theme

### DIFF
--- a/start-grafana.sh
+++ b/start-grafana.sh
@@ -195,7 +195,7 @@ fi
 
 for val in "${GRAFANA_ENV_ARRAY[@]}"; do
         GRAFANA_ENV_COMMAND="$GRAFANA_ENV_COMMAND -e $val"
-        if [[ $val = "GF_USERS_DEFAULT_THEME=.*" ]]; then
+        if [[ $val =~ GF_USERS_DEFAULT_THEME=.* ]]; then
             DEFAULT_THEME=""
         fi
 done


### PR DESCRIPTION
`GF_USERS_DEFAULT_THEME=.*` was insted quotes, hence wasn't
treated by bash as regex