### PR TITLE
Take the scylla username and password from environment variables

### DIFF
--- a/grafana-datasource.sh
+++ b/grafana-datasource.sh
@@ -36,3 +36,8 @@ else
 fi
 mkdir -p grafana/provisioning/datasources
 sed "s/DB_ADDRESS/$DB_ADDRESS/" grafana/datasource.yml | sed "s/AM_ADDRESS/$ALERT_MANAGER_ADDRESS/" | sed "s/LOKI_ADDRESS/$LOKI_ADDRESS/" > grafana/provisioning/datasources/datasource.yaml
+if [ -z "$SCYLLA_USER" ] || [ -z "$SCYLLA_PSSWD" ]; then
+    cp grafana/datasource.scylla.yml grafana/provisioning/datasources/datasource.scylla.yml
+else
+    sed "s/SCYLLA_USER/$SCYLLA_USER/" grafana/datasource.psswd.scylla.yml |sed "s/SCYLLA_PSSWD/$SCYLLA_PSSWD/">grafana/provisioning/datasources/datasource.scylla.yml
+fi

--- a/grafana/datasource.psswd.scylla.yml
+++ b/grafana/datasource.psswd.scylla.yml
@@ -1,0 +1,12 @@
+# config file version
+apiVersion: 1
+datasources:
+- name: scylla-datasource
+  type: scylladb-scylla-datasource
+  orgId: 1
+  isDefault:
+  jsonData:
+    host: ''
+  secureJsonData:
+    user: 'SCYLLA_USER'
+    password: 'SCYLLA_PSSWD'

--- a/grafana/datasource.scylla.yml
+++ b/grafana/datasource.scylla.yml
@@ -1,0 +1,12 @@
+# config file version
+apiVersion: 1
+datasources:
+- name: scylla-datasource
+  type: scylladb-scylla-datasource
+  orgId: 1
+  isDefault:
+  jsonData:
+    host: ''
+#  secureJsonData:
+#    user: 'Scylla-User'
+#    password: 'Scylla-Password'

--- a/grafana/datasource.yml
+++ b/grafana/datasource.yml
@@ -6,16 +6,6 @@ datasources:
   url: http://DB_ADDRESS
   access: proxy
   basicAuth: false
-- name: scylla-datasource
-  type: scylladb-scylla-datasource
-  orgId: 1
-  isDefault:
-  jsonData:
-    host: ''
-#  secureJsonData:
-#    user: 'Scylla-User'
-#    password: 'Scylla-Password'
-
 - name: alertmanager
   type: camptocamp-prometheus-alertmanager-datasource
   orgId: 1


### PR DESCRIPTION
Set scylla username/password from the environment variables.
This patch makes it easier to configure the username/password for the scylla datasource.
1. It splits the datasource files into two, so scylla configuration will have its own file.
2. It uses two aletnatives for the configuration, by default it would use `grafana/datasource.scylla.yml` that file can be updated if needed.
3. It would look at  `SCYLLA_USER` and `SCYLLA_PSSWD` environment variables if they exists it would take the configuration from `datasource.psswd.scylla.yml` and replace the username and password.

Fixes #1748