### PR TITLE
Fix malformed types in Prometheus rules

### DIFF
--- a/prometheus/prom_rules/prometheus.rules.yml
+++ b/prometheus/prom_rules/prometheus.rules.yml
@@ -192,7 +192,7 @@ groups:
       severity: "1"
       advisor: "cqlOptimization"
       dashboard: "cql"
-      status: 1
+      status: "1"
     annotations:
       description: 'Some SELECT queries are non-paged'
       summary: non paged statments
@@ -251,7 +251,7 @@ groups:
     for: 10s
     labels:
       severity: "1"
-      status: 1
+      status: "1"
       advisor: "balanced"
       dashboard: "cql"
     annotations:


### PR DESCRIPTION
At the moment, trying to install `prometheus-community/kube-prometheus-stack` Helm chart with additional Prometheus rules defined by Scylla Monitoring results in the following validation error:

```
Error: PrometheusRule.monitoring.coreos.com "kube-prometheus-stack-prometheus.rules" is invalid: spec.groups.rules.labels.status: Invalid value: "integer": spec.groups.rules.labels.status in body must be of type string: "integer"
```

This pull request changes the ill-formed values from integers to strings in order to pass validation.

To give you some context: using the `prometheus-community/kube-prometheus-stack` Helm chart is a recommended way of deploying Scylla Monitoring stack in K8s with Scylla Operator (see [Setting up Monitoring](https://operator.docs.scylladb.com/stable/monitoring.html)). Introducing this change lets us avoid formatting these rules before deploying them. 

Required by [scylladb/scylla-operator#1001](https://github.com/scylladb/scylla-operator/pull/1001).