### PR TITLE
doc: remove refrences to the Monitoring section in the ScyllaDB docs

### DIFF
--- a/docs/source/_common/monitor-description.rst
+++ b/docs/source/_common/monitor-description.rst
@@ -1,1 +1,1 @@
-Scylla Monitoring Stack is a full stack for Scylla monitoring and alerting. The stack contains open source tools including Prometheus and Grafana, as well as custom Scylla dashboards and tooling.
+ScyllaDB Monitoring Stack is a full stack for ScyllaDB monitoring and alerting. The stack contains open source tools including Prometheus and Grafana, as well as custom ScyllaDB dashboards and tooling.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -38,5 +38,3 @@ The ScyllaDB Monitoring Stack consists of three components, wrapped in Docker co
 
 * `ScyllaDB Monitoring Stack lesson <https://university.scylladb.com/courses/scylla-operations/lessons/admin-procedures-and-basic-monitoring/>`_ on Scylla University
 * `ScyllaDB Monitoring Stack GitHub Project <https://github.com/scylladb/scylla-monitoring/>`_
-
-For older versions of Scylla Monitoring Stack Documentation see `here <https://docs.scylladb.com/operating-scylla/monitoring/>`_.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,6 +1,6 @@
-========================
-Scylla Monitoring Stack
-========================
+===========================
+ScyllaDB Monitoring Stack
+===========================
 
 .. toctree::
    :maxdepth: 1
@@ -21,7 +21,7 @@ Scylla Monitoring Stack
 .. image:: monitor.png
     :width: 400pt
 
-The Scylla Monitoring Stack consists of three components, wrapped in Docker containers:
+The ScyllaDB Monitoring Stack consists of three components, wrapped in Docker containers:
 
 * `prometheus` - collects and stores metrics
 * `alertmanager` - handles alerts
@@ -36,7 +36,7 @@ The Scylla Monitoring Stack consists of three components, wrapped in Docker cont
 * :doc:`Reference <reference/index>`
 * :doc:`Upgrade <upgrade/index>`
 
-* `Scylla Monitoring Stack lesson <https://university.scylladb.com/courses/scylla-operations/lessons/admin-procedures-and-basic-monitoring/>`_ on Scylla University
-* `Scylla Monitoring Stack GitHub Project <https://github.com/scylladb/scylla-monitoring/>`_
+* `ScyllaDB Monitoring Stack lesson <https://university.scylladb.com/courses/scylla-operations/lessons/admin-procedures-and-basic-monitoring/>`_ on Scylla University
+* `ScyllaDB Monitoring Stack GitHub Project <https://github.com/scylladb/scylla-monitoring/>`_
 
 For older versions of Scylla Monitoring Stack Documentation see `here <https://docs.scylladb.com/operating-scylla/monitoring/>`_.

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -1,6 +1,6 @@
-=======================
-Scylla Monitoring Stack
-=======================
+==========================
+ScyllaDB Monitoring Stack
+==========================
 
 .. include:: /_common/monitor-description.rst
 
@@ -8,7 +8,7 @@ Scylla Monitoring Stack
 .. image:: monitor.png
     :width: 400pt
 
-The Scylla Monitoring Stack consists of multiple components, wrapped in Docker containers:
+The ScyllaDB Monitoring Stack consists of multiple components, wrapped in Docker containers:
 
 * `prometheus` - Collects and stores metrics
 * `grafan-loki` - Parses logs and generates metrics and alerts 
@@ -26,14 +26,14 @@ High Level Architecture
 .. image:: monitoring_stack.png
     :width: 400pt
 
-We use Prometheus for metrics collection and storage, and to generate alerts. Prometheus collects Scylla’s metrics from Scylla and the
-host metrics from the `node_exporter` agent that runs on the Scylla server.
+We use Prometheus for metrics collection and storage, and to generate alerts. Prometheus collects Scylla’s metrics from ScyllaDB and the
+host metrics from the `node_exporter` agent that runs on the ScyllaDB server.
 
-We use Loki for metrics and alerts generation based on logs, Loki gets the logs from rsyslog agents that run on each of the Scylla servers.
+We use Loki for metrics and alerts generation based on logs, Loki gets the logs from rsyslog agents that run on each of the DB servers.
 
 The alertmanager, receives alerts from Prometheus and Loki and distributes them to other systems like email and slack.
 
-We use Grafana to display the dashboards. Grafana gets its data from Prometheus, the alertmanager and directly from Scylla using CQL.
+We use Grafana to display the dashboards. Grafana gets its data from Prometheus, the alertmanager and directly from ScyllaDB using CQL.
    
 
 **Choose a topic to get started**:
@@ -43,7 +43,7 @@ We use Grafana to display the dashboards. Grafana gets its data from Prometheus,
 * :doc:`Procedures <procedures/index>`
 * :doc:`Troubleshooting <troubleshooting/index>`
 * :doc:`Reference <reference/index>`
-* `Scylla Monitoring Stack lesson <https://university.scylladb.com/courses/scylla-operations/lessons/admin-procedures-and-basic-monitoring/>`_ on Scylla University
+* `ScyllaDB Monitoring Stack lesson <https://university.scylladb.com/courses/scylla-operations/lessons/admin-procedures-and-basic-monitoring/>`_ on ScyllaDB University
 
 
-For older versions of Scylla Monitoring Stack Documentation see `here <https://docs.scylladb.com/operating-scylla/monitoring/>`_.
+For older versions of ScyllaDB Monitoring Stack Documentation see `here <https://docs.scylladb.com/operating-scylla/monitoring/>`_.

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -45,5 +45,3 @@ We use Grafana to display the dashboards. Grafana gets its data from Prometheus,
 * :doc:`Reference <reference/index>`
 * `ScyllaDB Monitoring Stack lesson <https://university.scylladb.com/courses/scylla-operations/lessons/admin-procedures-and-basic-monitoring/>`_ on ScyllaDB University
 
-
-For older versions of ScyllaDB Monitoring Stack Documentation see `here <https://docs.scylladb.com/operating-scylla/monitoring/>`_.

--- a/docs/source/procedures/index.rst
+++ b/docs/source/procedures/index.rst
@@ -9,10 +9,10 @@ Scylla Monitoring Stack Procedures
 
    Alert Manager <alerts/index>
    Adding and Modifying Dashboards <updating_dashboard>
-   Upgrade Guide <https://docs.scylladb.com/upgrade/upgrade-monitor/>
+   Upgrade Guides </upgrade/index>
 
 There are several reference guides available which give additional information. Choose a topic to begin:
 
 * :doc:`Alert Manager <alerts/index>`
 * :doc:`Adding and Modifying Dashboards <updating_dashboard>`
-* `Upgrade Guide <https://docs.scylladb.com/upgrade/upgrade-monitor/>`_
+* :doc:`Upgrade Guides </upgrade/index>`

--- a/docs/source/procedures/index.rst
+++ b/docs/source/procedures/index.rst
@@ -1,5 +1,5 @@
 =========================================
-Scylla Monitoring Stack Procedures
+ScyllaDB Monitoring Stack Procedures
 =========================================
 
 .. toctree::


### PR DESCRIPTION
The Monitoring section in the ScyllaDB docs has been removed; see https://github.com/scylladb/scylladb/pull/11151.
This PR removes or replaces the links to that section.

In addition, I've replaced "Scylla" with "ScyllaDB" on key pages to be in sync with other resources.