### PR TITLE
doc: update the project name for the docs with ScyllaDB

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,7 +42,7 @@ source_suffix = [".rst", ".md"]
 master_doc = 'index'
 
 # General information about the project.
-project = u'Scylla Monitoring'
+project = u'ScyllaDB Monitoring'
 copyright = str(date.today().year) + ', ScyllaDB. All rights reserved.'
 author = u'Scylla Project Contributors'
 


### PR DESCRIPTION
This PR replaces  "Scylla" with "ScyllaDB" in the project name displayed in the documentation.