### PR TITLE
Prepare for summaries

### DIFF
--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -1142,10 +1142,17 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "casrlatencyp95{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}",
+                                "expr": "avg(scylla_storage_proxy_coordinator_cas_read_latency_summary{quantile=\"0.95\", by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by (cluster, dc, instance, shard)",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
+                                "step": 10
+                            },
+                            {
+                                "expr": "avg(casrlatencyp95{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by (cluster, dc, instance, shard)",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "B",
                                 "step": 10
                             }
                         ],
@@ -1207,10 +1214,17 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "caswlatencyp95{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}",
+                                "expr": "avg(scylla_storage_proxy_coordinator_cas_write_latency_summary{quantile=\"0.95\",by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by (cluster,dc,instance, shard)",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
+                                "step": 10
+                            },
+                            {
+                                "expr": "avg(caswlatencyp95{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by (cluster,dc,instance, shard)",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "B",
                                 "step": 10
                             }
                         ],
@@ -1693,10 +1707,17 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "wlatencya{by=\"[[by]]\", instance=~\"[[node]]|$^\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$scheduling_group\"} or on() ($func(rate(scylla_storage_proxy_coordinator_write_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])/($func(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]]) + 1))",
+                                "expr": "avg(scylla_storage_proxy_coordinator_write_latency_summary{quantile=\"0.5\",by=\"[[by]]\", instance=~\"[[node]]|$^\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$scheduling_group\"}) by (cluster, dc, instance, shard)",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
+                                "step": 1
+                            },
+                            {
+                                "expr": "avg(wlatencya{by=\"[[by]]\", instance=~\"[[node]]|$^\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$scheduling_group\"}) by (cluster, dc, instance, shard)",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "B",
                                 "step": 1
                             }
                         ],
@@ -1707,11 +1728,19 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "wlatencyp95{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$scheduling_group|$\"}",
+                                "expr": "avg(scylla_storage_proxy_coordinator_write_latency_summary{quantile=\"0.95\",by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$scheduling_group|$\"}) by (cluster, dc, instance, shard)",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
+                                "step": 1
+                            },
+                            {
+                                "expr": "avg(wlatencyp95{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$scheduling_group|$\"}) by (cluster, dc, instance, shard)",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "B",
                                 "step": 1
                             }
                         ],
@@ -1722,11 +1751,19 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "wlatencyp99{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$scheduling_group\"}",
+                                "expr": "avg(scylla_storage_proxy_coordinator_write_latency_summary{quantile=\"0.99\",by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$scheduling_group\"}) by (cluster, dc, instance, shard)",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
+                                "step": 1
+                            },
+                            {
+                                "expr": "avg(wlatencyp99{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$scheduling_group\"}) by (cluster, dc, instance, shard)",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "B",
                                 "step": 1
                             }
                         ],
@@ -1751,10 +1788,17 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "rlatencya{by=\"[[by]]\", instance=~\"[[node]]|$^\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$scheduling_group\"} or on() ($func(rate(scylla_storage_proxy_coordinator_read_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$scheduling_group\"}[60s])) by ([[by]])/($func(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]]) + 1))",
+                                "expr": "avg(scylla_storage_proxy_coordinator_read_latency_summary{quantile=\"0.5\", by=\"[[by]]\", instance=~\"[[node]]|$^\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$scheduling_group\"}) by (cluster,dc,instance,shard)",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
+                                "step": 1
+                            },
+                            {
+                                "expr": "avg(rlatencya{by=\"[[by]]\", instance=~\"[[node]]|$^\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$scheduling_group\"}) by (cluster,dc,instance,shard)",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "B",
                                 "step": 1
                             }
                         ],
@@ -1765,11 +1809,19 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "rlatencyp95{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$scheduling_group\"}",
+                                "expr": "avg(scylla_storage_proxy_coordinator_read_latency_summary{quantile=\"0.95\",by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$scheduling_group\"}) by (cluster,dc,instance,shard)",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
+                                "step": 1
+                            },
+                            {
+                                "expr": "avg(rlatencyp95{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$scheduling_group\"}) by (cluster,dc,instance,shard)",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "B",
                                 "step": 1
                             }
                         ],
@@ -1780,11 +1832,19 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "rlatencyp99{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$scheduling_group\"}",
+                                "expr": "avg(scylla_storage_proxy_coordinator_read_latency_summary{quantile=\"0.99\",by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$scheduling_group\"}) by (cluster,dc,instance,shard)",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
+                                "step": 1
+                            },
+                            {
+                                "expr": "avg(rlatencyp99{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$scheduling_group\"}) by (cluster,dc,instance,shard)",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "B",
                                 "step": 1
                             }
                         ],
@@ -1856,7 +1916,7 @@
                       ]
                     },
                     "name": "scheduling_group",
-                    "query": "label_values(scylla_storage_proxy_coordinator_read_latency_bucket,scheduling_group_name)",
+                    "query": "label_values(ops_by_scheduling_group{cluster=\"$cluster\"},scheduling_group_name)",
                     "sort": 3
                 },
                 {
@@ -1874,7 +1934,7 @@
                       ]
                     },
                     "name": "scheduling_group",
-                    "query": "label_values(scylla_storage_proxy_coordinator_read_latency_bucket,scheduling_group_name)",
+                    "query": "label_values(ops_by_scheduling_group{cluster=\"$cluster\"},scheduling_group_name)",
                     "sort": 3
                 },
                 {

--- a/grafana/scylla-overview.template.json
+++ b/grafana/scylla-overview.template.json
@@ -37,7 +37,7 @@
                         "span": 2,
                         "targets": [
                             {
-                                "expr": "$func(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m]))",
+                                "expr": "$func(rate(scylla_storage_proxy_coordinator_write_latency_summary_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m])) or on() $func(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m]))",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -52,14 +52,14 @@
                         "span": 2,
                         "targets": [
                             {
-                                "expr": "avg(wlatencyp95{by=\"cluster\", cluster=~\"$cluster|$^\",scheduling_group_name!=\"streaming\"}>0)",
+                                "expr": "avg(scylla_storage_proxy_coordinator_write_latency_summary{quantile=\"0.95\", by=\"cluster\", cluster=~\"$cluster|$^\",scheduling_group_name!=\"streaming\"}>0) or on() avg(wlatencyp95{by=\"cluster\", cluster=~\"$cluster|$^\",scheduling_group_name!=\"streaming\"}>0)",
                                 "intervalFactor": 1,
                                 "legendFormat": "95%",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                                "expr": "avg(wlatencyp99{by=\"cluster\", cluster=~\"$cluster|$^\",scheduling_group_name!=\"streaming\"}>0)",
+                                "expr": "avg(scylla_storage_proxy_coordinator_write_latency_summary{quantile=\"0.99\",by=\"cluster\", cluster=~\"$cluster|$^\",scheduling_group_name!=\"streaming\"}>0) or on() avg(wlatencyp99{by=\"cluster\", cluster=~\"$cluster|$^\",scheduling_group_name!=\"streaming\"}>0)",
                                 "intervalFactor": 1,
                                 "legendFormat": "99%",
                                 "refId": "B",
@@ -76,7 +76,7 @@
                         "span": 2,
                         "targets": [
                             {
-                                "expr": "$func(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m]))",
+                                "expr": "$func(rate(scylla_storage_proxy_coordinator_read_latency_summary_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m])) or on() $func(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m]))",
                                 "intervalFactor": 1,
                                 "legendFormat": "Reads",
                                 "refId": "A",
@@ -91,14 +91,14 @@
                         "span": 2,
                         "targets": [
                             {
-                                "expr": "avg(rlatencyp95{by=\"cluster\", cluster=~\"$cluster|$^\",scheduling_group_name!=\"streaming\"}>0)",
+                                "expr": "avg(scylla_storage_proxy_coordinator_read_latency_summary{quantile=\"0.95\",by=\"cluster\", cluster=~\"$cluster|$^\",scheduling_group_name!=\"streaming\"}>0) or on() avg(rlatencyp95{by=\"cluster\", cluster=~\"$cluster|$^\",scheduling_group_name!=\"streaming\"}>0)",
                                 "intervalFactor": 1,
                                 "legendFormat": "95%",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                                "expr": "avg(rlatencyp99{by=\"cluster\", cluster=~\"$cluster|$^\",scheduling_group_name!=\"streaming\"}>0)",
+                                "expr": "avg(scylla_storage_proxy_coordinator_read_latency_summary{quantile=\"0.99\",by=\"cluster\", cluster=~\"$cluster|$^\",scheduling_group_name!=\"streaming\"}>0) or on() avg(rlatencyp99{by=\"cluster\", cluster=~\"$cluster|$^\",scheduling_group_name!=\"streaming\"}>0)",
                                 "intervalFactor": 1,
                                 "legendFormat": "99%",
                                 "refId": "B",
@@ -252,12 +252,12 @@
                         "title": "Node Latency",
                         "targets": [
                             {
-                              "expr": "((max(wlatencyp99{by=\"instance\", cluster=~\"$cluster|$^\",scheduling_group_name!=\"streaming\"})-scalar(avg(wlatencyp99{by=\"instance\", cluster=~\"$cluster|$^\",scheduling_group_name!=\"streaming\"}>0)))/(scalar(stddev(wlatencyp99{by=\"instance\", cluster=~\"$cluster|$^\",scheduling_group_name!=\"streaming\"}>0))+100)-3)",
+                              "expr": "((max(scylla_storage_proxy_coordinator_write_latency_summary{quantile=\"0.99\",by=\"instance\", cluster=~\"$cluster|$^\",scheduling_group_name!=\"streaming\"})-scalar(avg(cylla_storage_proxy_coordinator_write_latency_summary{quantile=\"0.99\",by=\"instance\", cluster=~\"$cluster|$^\",scheduling_group_name!=\"streaming\"}>0)))/(scalar(stddev(scylla_storage_proxy_coordinator_write_latency_summary{quantile=\"0.99\",by=\"instance\", cluster=~\"$cluster|$^\",scheduling_group_name!=\"streaming\"}>0))+100)-3)",
                               "legendFormat": "",
                               "refId": "A"
                             },
                             {
-                              "expr": "((max(rlatencyp99{by=\"instance\", cluster=~\"$cluster|$^\",scheduling_group_name!=\"streaming\"})-scalar(avg(rlatencyp99{by=\"instance\", cluster=~\"$cluster|$^\",scheduling_group_name!=\"streaming\"}>0)))/(scalar(stddev(rlatencyp99{by=\"instance\", cluster=~\"$cluster|$^\",scheduling_group_name!=\"streaming\"}>0))+100)-3)",
+                              "expr": "((max(scylla_storage_proxy_coordinator_read_latency_summary{quantile=\"0.99\",by=\"instance\", cluster=~\"$cluster|$^\",scheduling_group_name!=\"streaming\"})-scalar(avg(scylla_storage_proxy_coordinator_read_latency_summary{quantile=\"0.99\",by=\"instance\", cluster=~\"$cluster|$^\",scheduling_group_name!=\"streaming\"}>0)))/(scalar(stddev(scylla_storage_proxy_coordinator_read_latency_summary{quantile=\"0.99\",by=\"instance\", cluster=~\"$cluster|$^\",scheduling_group_name!=\"streaming\"}>0))+100)-3)",
                               "legendFormat": "",
                               "refId": "B"
                             }
@@ -441,14 +441,14 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$func(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m])) by ([[by]])",
+                                "expr": "$func(rate(scylla_storage_proxy_coordinator_write_latency_summary_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m])) by ([[by]]) or on() $func(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "Writes",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                              "expr": "$func(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m] offset 1d))",
+                              "expr": "$func(rate(scylla_storage_proxy_coordinator_write_latency_summary_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m] offset 1d)) or on() $func(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m] offset 1d))",
                               "legendFormat": "1 Day Ago",
                               "interval": "",
                               "intervalFactor": 1,
@@ -456,7 +456,7 @@
                               "step": 1
                             },
                             {
-                              "expr": "$func(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m] offset 1w))",
+                              "expr": "$func(rate(scylla_storage_proxy_coordinator_write_latency_summary_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m] offset 1w)) or on() $func(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m] offset 1w))",
                               "legendFormat": "1 Week Ago",
                               "interval": "",
                               "intervalFactor": 1,
@@ -487,14 +487,14 @@
                         "span": 2,
                         "targets": [
                             {
-                                "expr": "avg(wlatencyp95{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name!=\"streaming\"}>0) by ([[by]])",
+                                "expr": "avg(scylla_storage_proxy_coordinator_write_latency_summary{quantile=\"0.95\", by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name!=\"streaming\"}>0) by ([[by]]) or on() avg(wlatencyp95{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name!=\"streaming\"}>0) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "95% {{[[by]]}}",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                                "expr": "avg(wlatencyp99{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name!=\"streaming\"}>0) by ([[by]])",
+                                "expr": "avg(scylla_storage_proxy_coordinator_write_latency_summary{quantile=\"0.99\", by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name!=\"streaming\"}>0) by ([[by]]) or on() avg(wlatencyp99{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name!=\"streaming\"}>0) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "99% {{[[by]]}}",
                                 "refId": "B",
@@ -532,21 +532,21 @@
                         },
                         "targets": [
                             {
-                                "expr": "$func(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name!=\"streaming\"}[1m])) by ([[by]])",
+                                "expr": "$func(rate(scylla_storage_proxy_coordinator_read_latency_summary_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name!=\"streaming\"}[1m])) by ([[by]]) or on() $func(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name!=\"streaming\"}[1m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "Reads",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                                "expr": "$func(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name!=\"streaming\"}[1m] offset 1d))",
+                                "expr": "$func(rate(scylla_storage_proxy_coordinator_read_latency_summary_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name!=\"streaming\"}[1m] offset 1d)) or on() $func(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name!=\"streaming\"}[1m] offset 1d))",
                                 "intervalFactor": 1,
                                 "legendFormat": "1 Day Ago",
                                 "refId": "B",
                                 "step": 1
                             },
                             {
-                                "expr": "$func(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name!=\"streaming\"}[1m] offset 1w))",
+                                "expr": "$func(rate(scylla_storage_proxy_coordinator_read_latency_summary_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name!=\"streaming\"}[1m] offset 1w)) or on() $func(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name!=\"streaming\"}[1m] offset 1w))",
                                 "intervalFactor": 1,
                                 "legendFormat": "1 Week Ago",
                                 "refId": "C",
@@ -579,14 +579,14 @@
                         },
                         "targets": [
                             {
-                                "expr": "avg(rlatencyp95{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name!=\"streaming\"}>0) by([[by]])",
+                                "expr": "avg(scylla_storage_proxy_coordinator_read_latency_summary{quantile=\"0.95\", by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name!=\"streaming\"}>0) by([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "95% {{[[by]]}}",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                                "expr": "avg(rlatencyp99{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name!=\"streaming\"}>0) by([[by]])",
+                                "expr": "avg(cylla_storage_proxy_coordinator_read_latency_summary{quantile=\"0.99\", by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name!=\"streaming\"}>0) by([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "99% {{[[by]]}}",
                                 "refId": "B",

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -422,7 +422,7 @@
             },
             "targets":[
                {
-                  "expr":"avg(wlatencya{by=\"cluster\", cluster=~\"$cluster|^$\",scheduling_group_name!=\"streaming\"}>0) or on() (sum(rate(scylla_storage_proxy_coordinator_write_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s]))/(sum(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) + 1))",
+                  "expr":"avg(scylla_storage_proxy_coordinator_write_latency_summary{quantile=\"0.5\", by=\"cluster\", cluster=~\"$cluster|^$\",scheduling_group_name!=\"streaming\"}>0) or on() avg(wlatencya{by=\"cluster\", cluster=~\"$cluster|^$\",scheduling_group_name!=\"streaming\"}>0)",
                   "intervalFactor":1,
                   "legendFormat":"",
                   "refId":"A",
@@ -460,7 +460,7 @@
             },
             "targets":[
                {
-                  "expr":"avg(wlatencyp99{by=\"cluster\", cluster=~\"$cluster|^$\",scheduling_group_name!=\"streaming\"}>0)",
+                  "expr":"avg(scylla_storage_proxy_coordinator_write_latency_summary{quantile=\"0.95\", by=\"cluster\", cluster=~\"$cluster|^$\",scheduling_group_name!=\"streaming\"}>0) or on() avg(wlatencyp99{by=\"cluster\", cluster=~\"$cluster|^$\",scheduling_group_name!=\"streaming\"}>0)",
                   "intervalFactor":1,
                   "legendFormat":"",
                   "refId":"A",
@@ -498,7 +498,7 @@
             },
             "targets":[
                {
-                  "expr":"avg(rlatencya{by=\"cluster\", cluster=~\"$cluster|^$\",scheduling_group_name!=\"streaming\"}>0) or on() (sum(rate(scylla_storage_proxy_coordinator_read_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s]))/(sum(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) + 1))",
+                  "expr":"avg(scylla_storage_proxy_coordinator_read_latency_summary{quantile=\"0.5\", by=\"cluster\", cluster=~\"$cluster|^$\",scheduling_group_name!=\"streaming\"}>0) or on() avg(rlatencya{by=\"cluster\", cluster=~\"$cluster|^$\",scheduling_group_name!=\"streaming\"}>0)",
                   "intervalFactor":1,
                   "legendFormat":"",
                   "instant":true,
@@ -536,7 +536,7 @@
             },
             "targets":[
                {
-                  "expr":"avg(rlatencyp99{by=\"cluster\", cluster=~\"$cluster|^$\",scheduling_group_name!=\"streaming\"}>0)",
+                  "expr":"avg(scylla_storage_proxy_coordinator_read_latency_summary{quantile=\"0.99\", by=\"cluster\", cluster=~\"$cluster|^$\",scheduling_group_name!=\"streaming\"}>0) or on() avg(rlatencyp99{by=\"cluster\", cluster=~\"$cluster|^$\",scheduling_group_name!=\"streaming\"}>0)",
                   "intervalFactor":1,
                   "legendFormat":"",
                   "refId":"A",

--- a/prometheus/prom_rules/prometheus.rules.shard_latency.yml
+++ b/prometheus/prom_rules/prometheus.rules.shard_latency.yml
@@ -1,0 +1,36 @@
+groups:
+- name: scylla.rules
+  rules:
+  - record: wlatencyp99
+    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{}[60s])) by (cluster, dc, instance, shard, scheduling_group_name, le))
+    labels:
+      by: "instance,shard"
+  - record: rlatencyp99
+    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{}[60s])) by (cluster, dc, instance, shard, scheduling_group_name, le))
+    labels:
+      by: "instance,shard"
+  - record: wlatencyp95
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{}[60s])) by (cluster, dc, instance, shard, scheduling_group_name, le))
+    labels:
+      by: "instance,shard"
+  - record: rlatencyp95
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{}[60s])) by (cluster, dc, instance, shard, scheduling_group_name, le))
+    labels:
+      by: "instance,shard"
+  - record: wlatencya
+    expr: sum(rate(scylla_storage_proxy_coordinator_write_latency_sum{}[60s])) by (cluster, dc, instance,scheduling_group_name, shard)/sum(rate(scylla_storage_proxy_coordinator_write_latency_count{}[60s])) by (cluster, dc, instance, scheduling_group_name, shard)
+    labels:
+      by: "instance,shard"
+  - record: rlatencya
+    expr: sum(rate(scylla_storage_proxy_coordinator_read_latency_sum{}[60s])) by (cluster, dc, instance, shard,scheduling_group_name)/sum(rate(scylla_storage_proxy_coordinator_read_latency_count{}[60s])) by (cluster, dc, instance, shard, scheduling_group_name)
+    labels:
+      by: "instance,shard"
+  - record: casrlatencyp95
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency_bucket{}[60s])) by (cluster, dc, instance, shard, le, scheduling_group_name))
+    labels:
+      by: "instance,shard"
+  - record: caswlatencyp95
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_bucket{}[60s])) by (cluster, dc, instance, shard, le, scheduling_group_name))
+    labels:
+      by: "instance,shard"
+

--- a/prometheus/prom_rules/prometheus.rules.yml
+++ b/prometheus/prom_rules/prometheus.rules.yml
@@ -47,134 +47,128 @@ groups:
     expr: (max(scylla_manager_task_active_count{type="repair"}) by (cluster) >bool 0)*((max(scylla_manager_repair_token_ranges_total) by(cluster)<= 0)*0 or on(cluster) (sum(scylla_manager_repair_token_ranges_success>=0) by (cluster) + sum(scylla_manager_repair_token_ranges_error>=0) by (cluster))/sum(scylla_manager_repair_token_ranges_total>=0) by (cluster))
   - record: manager:backup_progress
     expr: (max(scylla_manager_task_active_count{type="backup"}) by (cluster) >bool 0)*((max(scylla_manager_backup_files_size_bytes) by(cluster)<= 0)*0 or on(cluster) (sum(scylla_manager_backup_files_uploaded_bytes) by (cluster) + sum(scylla_manager_backup_files_skipped_bytes) by (cluster) + sum(scylla_manager_backup_files_failed_bytes)by(cluster))/sum(scylla_manager_backup_files_size_bytes>=0) by (cluster))
-  - record: wlatencyp99
-    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{}[60s])) by (cluster, dc, instance, shard, scheduling_group_name, le))
-    labels:
-      by: "instance,shard"
-  - record: wlatencyp99
+  - record: scylla_storage_proxy_coordinator_write_latency_summary
     expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{}[60s])) by (cluster, dc, instance, scheduling_group_name, le))
     labels:
       by: "instance"
-  - record: wlatencyp99
+      quantile: "0.99"
+  - record: scylla_storage_proxy_coordinator_write_latency_summary
     expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{}[60s])) by (cluster, dc, scheduling_group_name, le))
     labels:
       by: "dc"
-  - record: wlatencyp99
+      quantile: "0.99"
+  - record: scylla_storage_proxy_coordinator_write_latency_summary
     expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{}[60s])) by (cluster, scheduling_group_name, le))
     labels:
       by: "cluster"
-  - record: rlatencyp99
-    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{}[60s])) by (cluster, dc, instance, shard, scheduling_group_name, le))
-    labels:
-      by: "instance,shard"
-  - record: rlatencyp99
+      quantile: "0.99"
+  - record: ops_by_scheduling_group
+    expr: sum(scylla_storage_proxy_coordinator_read_latency_count) by (cluster, scheduling_group_name)>0
+  - record: scylla_storage_proxy_coordinator_read_latency_summary
     expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{}[60s])) by (cluster, dc, instance, scheduling_group_name, le))
     labels:
       by: "instance"
-  - record: rlatencyp99
+      quantile: "0.99"
+  - record: scylla_storage_proxy_coordinator_read_latency_summary
     expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{}[60s])) by (cluster, dc, scheduling_group_name, le))
     labels:
       by: "dc"
-  - record: rlatencyp99
+      quantile: "0.99"
+  - record: scylla_storage_proxy_coordinator_read_latency_summary
     expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{}[60s])) by (cluster, scheduling_group_name, le))
     labels:
       by: "cluster"
-  - record: wlatencyp95
-    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{}[60s])) by (cluster, dc, instance, shard, scheduling_group_name, le))
-    labels:
-      by: "instance,shard"
-  - record: wlatencyp95
+      quantile: "0.99"
+  - record: scylla_storage_proxy_coordinator_write_latency_summary
     expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{}[60s])) by (cluster, dc, instance, scheduling_group_name, le))
     labels:
       by: "instance"
-  - record: wlatencyp95
+      quantile: "0.95"
+  - record: scylla_storage_proxy_coordinator_write_latency_summary
     expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{}[60s])) by (cluster, dc, scheduling_group_name, le))
     labels:
       by: "dc"
-  - record: wlatencyp95
+      quantile: "0.95"
+  - record: scylla_storage_proxy_coordinator_write_latency_summary
     expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{}[60s])) by (cluster, scheduling_group_name, le))
     labels:
       by: "cluster"
-  - record: rlatencyp95
-    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{}[60s])) by (cluster, dc, instance, shard, scheduling_group_name, le))
-    labels:
-      by: "instance,shard"
-  - record: rlatencyp95
+      quantile: "0.95"
+  - record: scylla_storage_proxy_coordinator_read_latency_summary
     expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{}[60s])) by (cluster, dc, instance, scheduling_group_name, le))
     labels:
       by: "instance"
-  - record: rlatencyp95
+      quantile: "0.95"
+  - record: scylla_storage_proxy_coordinator_read_latency_summary
     expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{}[60s])) by (cluster, dc, scheduling_group_name, le))
     labels:
       by: "dc"
-  - record: rlatencyp95
+      quantile: "0.95"
+  - record: scylla_storage_proxy_coordinator_read_latency_summary
     expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{}[60s])) by (cluster, scheduling_group_name, le))
     labels:
       by: "cluster"
-  - record: wlatencya
-    expr: sum(rate(scylla_storage_proxy_coordinator_write_latency_sum{}[60s])) by (cluster, dc, instance,scheduling_group_name, shard)/sum(rate(scylla_storage_proxy_coordinator_write_latency_count{}[60s])) by (cluster, dc, instance, scheduling_group_name, shard)
-    labels:
-      by: "instance,shard"
-  - record: wlatencya
-    expr: sum(rate(scylla_storage_proxy_coordinator_write_latency_sum{}[60s])) by (cluster, dc, instance,scheduling_group_name)/sum(rate(scylla_storage_proxy_coordinator_write_latency_count{}[60s])) by (cluster, dc, scheduling_group_name, instance)
+      quantile: "0.95"
+  - record: scylla_storage_proxy_coordinator_write_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{}[60s])) by (cluster, dc, instance, scheduling_group_name, le))
     labels:
       by: "instance"
-  - record: wlatencya
-    expr: sum(rate(scylla_storage_proxy_coordinator_write_latency_sum{}[60s])) by (cluster, dc,scheduling_group_name)/sum(rate(scylla_storage_proxy_coordinator_write_latency_count{}[60s])) by (cluster, scheduling_group_name, dc)
+      quantile: "0.5"
+  - record: scylla_storage_proxy_coordinator_write_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{}[60s])) by (cluster, dc, scheduling_group_name, le))
     labels:
       by: "dc"
-  - record: wlatencya
-    expr: sum(rate(scylla_storage_proxy_coordinator_write_latency_sum{}[60s])) by (cluster,scheduling_group_name)/sum(rate(scylla_storage_proxy_coordinator_write_latency_count{}[60s])) by (cluster, scheduling_group_name)
+      quantile: "0.5"
+  - record: scylla_storage_proxy_coordinator_write_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{}[60s])) by (cluster, scheduling_group_name, le))
     labels:
       by: "cluster"
-  - record: rlatencya
-    expr: sum(rate(scylla_storage_proxy_coordinator_read_latency_sum{}[60s])) by (cluster, dc, instance, shard,scheduling_group_name)/sum(rate(scylla_storage_proxy_coordinator_read_latency_count{}[60s])) by (cluster, dc, instance, shard, scheduling_group_name)
-    labels:
-      by: "instance,shard"
-  - record: rlatencya
-    expr: sum(rate(scylla_storage_proxy_coordinator_read_latency_sum{}[60s])) by (cluster, dc, instance,scheduling_group_name)/sum(rate(scylla_storage_proxy_coordinator_read_latency_count{}[60s])) by (cluster, dc, instance, scheduling_group_name)
+      quantile: "0.5"
+  - record: scylla_storage_proxy_coordinator_read_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{}[60s])) by (cluster, dc, instance, scheduling_group_name, le))
     labels:
       by: "instance"
-  - record: rlatencya
-    expr: sum(rate(scylla_storage_proxy_coordinator_read_latency_sum{}[60s])) by (cluster, dc,scheduling_group_name)/sum(rate(scylla_storage_proxy_coordinator_read_latency_count{}[60s])) by (cluster, dc, scheduling_group_name)
+      quantile: "0.5"
+  - record: scylla_storage_proxy_coordinator_read_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{}[60s])) by (cluster, dc, scheduling_group_name, le))
     labels:
       by: "dc"
-  - record: rlatencya
-    expr: sum(rate(scylla_storage_proxy_coordinator_read_latency_sum{}[60s])) by (cluster,scheduling_group_name)/sum(rate(scylla_storage_proxy_coordinator_read_latency_count{}[60s])) by (cluster, scheduling_group_name)
+      quantile: "0.5"
+  - record: scylla_storage_proxy_coordinator_read_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{}[60s])) by (cluster, scheduling_group_name, le))
     labels:
       by: "cluster"
-  - record: casrlatencyp95
-    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency_bucket{}[60s])) by (cluster, dc, instance, shard, le, scheduling_group_name))
-    labels:
-      by: "instance,shard"
-  - record: casrlatencyp95
+      quantile: "0.5"
+  - record: scylla_storage_proxy_coordinator_cas_read_latency_summary
     expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency_bucket{}[60s])) by (cluster, dc, instance, le, scheduling_group_name))
     labels:
       by: "instance"
-  - record: casrlatencyp95
+      quantile: "0.95"
+  - record: scylla_storage_proxy_coordinator_cas_read_latency_summary
     expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency_bucket{}[60s])) by (cluster, dc, le, scheduling_group_name))
     labels:
       by: "dc"
-  - record: casrlatencyp95
+      quantile: "0.95"
+  - record: scylla_storage_proxy_coordinator_cas_read_latency_summary
     expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency_bucket{}[60s])) by (cluster, le, scheduling_group_name))
     labels:
       by: "cluster"
-  - record: caswlatencyp95
-    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_bucket{}[60s])) by (cluster, dc, instance, shard, le, scheduling_group_name))
-    labels:
-      by: "instance,shard"
-  - record: caswlatencyp95
+      quantile: "0.95"
+  - record: scylla_storage_proxy_coordinator_cas_write_latency_summary
     expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_bucket{}[60s])) by (cluster, dc, instance, le, scheduling_group_name))
     labels:
       by: "instance"
-  - record: caswlatencyp95
+      quantile: "0.95"
+  - record: scylla_storage_proxy_coordinator_cas_write_latency_summary
     expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_bucket{}[60s])) by (cluster, dc, le, scheduling_group_name))
     labels:
       by: "dc"
-  - record: caswlatencyp95
+      quantile: "0.95"
+  - record: scylla_storage_proxy_coordinator_cas_write_latency_summary
     expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_bucket{}[60s])) by (cluster, le, scheduling_group_name))
     labels:
       by: "cluster"
+      quantile: "0.95"
   - alert: cqlNonPrepared
     expr: cql:non_prepared > 0
     for: 10s
@@ -396,7 +390,7 @@ groups:
       description: '{{ $labels.host }} has denied CQL connection for more than 30 seconds.'
       summary: Instance {{ $labels.host }} no CQL connection
   - alert: HighLatencies
-    expr: wlatencyp95{by="instance"} > 100000
+    expr: scylla_storage_proxy_coordinator_write_latency_summary{by="instance", quantile="0.95"} > 100000
     for: 5m
     labels:
       severity: "1"
@@ -404,7 +398,7 @@ groups:
       description: '{{ $labels.instance }} has 95% high latency for more than 5 minutes.'
       summary: Instance {{ $labels.instance }} High Write Latency
   - alert: HighLatencies
-    expr: wlatencya{by="instance"} >10000
+    expr: scylla_storage_proxy_coordinator_write_latency_summary{by="instance", quantile="0.5"} >10000
     for: 5m
     labels:
       severity: "1"
@@ -412,7 +406,7 @@ groups:
       description: '{{ $labels.instance }} has average high latency for more than 5 minutes.'
       summary: Instance {{ $labels.instance }} High Write Latency
   - alert: HighLatencies
-    expr: rlatencyp95{by="instance"} > 100000
+    expr: scylla_storage_proxy_coordinator_read_latency_summary{by="instance", quantile="0.95"} > 100000
     for: 5m
     labels:
       severity: "1"
@@ -420,7 +414,7 @@ groups:
       description: '{{ $labels.instance }} has 95% high latency for more than 5 minutes.'
       summary: Instance {{ $labels.instance }} High Read Latency
   - alert: HighLatencies
-    expr: rlatencya{by="instance"} >10000
+    expr: scylla_storage_proxy_coordinator_read_latency_summary{by="instance", quantile="0.5"} >10000
     for: 5m
     labels:
       severity: "1"

--- a/prometheus/prometheus.yml.template
+++ b/prometheus/prometheus.yml.template
@@ -63,6 +63,13 @@ scrape_configs:
       regex: '([0-9]+\.[0-9]+)(\.?[0-9]*).*'
       replacement: '$1$2'
       target_label: svr
+    - source_labels: [quantile]
+      regex: '([0-9]+\.[0-9]*[1-9])0+'
+      replacement: '$1'
+      target_label: quantile
+    - source_labels: [quantile]
+      replacement: 'instance,shard'
+      target_label: by
 
 - job_name: node_exporter
   honor_labels: false


### PR DESCRIPTION
Future Scylla releases will add summaries as a native ScyllaDB metrics.
This patch replaces prometheus summaries like calculations with the
future summaries names.

For example: scylla_storage_proxy_coordinator_write_latency_summary{quantile="0.99"}
will replace wlatencyp99

When scylla would start to report per-shard latencies summaries the
relevant recording rule file will be deleted.

this patch also contains an intermidate solution for hiding empty scheduling group