### PR TITLE
monitoring_stack.rst: change to relative path in a link to support versions

### DIFF
--- a/docs/source/install/monitoring_stack.rst
+++ b/docs/source/install/monitoring_stack.rst
@@ -2,7 +2,7 @@
 Install Scylla Monitoring Stack
 ===============================
 
-This document describes the setup of Scylla Monitoring Stack, based on `Scylla Prometheus API </reference/monitoring_apis/#prometheus>`_
+This document describes the setup of Scylla Monitoring Stack, based on `Scylla Prometheus API <../../reference/monitoring_apis/#prometheus>`_
 
 The Scylla Monitoring Stack needs to be installed on a dedicated server, external to the Scylla cluster. Make sure the Scylla Monitoring Stack server has access to the Scylla nodes so that it can pull the metrics over the Prometheus API.
 


### PR DESCRIPTION
This patch moves to use a relative link to support versioning

Fixes #1792