### PR TITLE
start-all.sh: add --archive switch to disable Prometheus TTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,11 +190,17 @@ ___
 
 #### Prometheus Command Line Options and Retention Period
 Check the documentation for a full list of command line option for [start-all.sh](https://monitoring.docs.scylladb.com/stable/install/start_all.html)
-Prometheus retention time is set to two weeks by default, you can override it as well as other Prometheus configuration with the `-b` flag.
+Prometheus retention time is set to two weeks by default, you can override it as well as other Prometheus configuration with the `-b` flag. For loading an archive, you can disable Prometheus TTL with `--archive`.
 
 For example:
 ```
 -b "-storage.tsdb.retention.time=30d"
+```
+
+or
+
+```
+--archive -d /path/to/archived/data
 ```
 
 #### connecting Scylla and the Monitoring locally - the local flag

--- a/start-all.sh
+++ b/start-all.sh
@@ -97,6 +97,7 @@ Options:
   --thanos                       - If set, run thanos query as a Grafana datasource.
   --limit container,param        - Allow to set a specific Docker parameter for a container, where container can be:
                                    prometheus, grafana, alertmanager, loki, sidecar, grafanarender
+  --archive                      - Treat data directory as an archive. This disables Prometheus time-to-live (infinite retention).
 The script starts Scylla Monitoring stack.
 "
   echo "$__usage"
@@ -213,6 +214,9 @@ for arg; do
             (--param)
                 LIMIT="1"
                 PARAM="1"
+                ;;
+            (--archive)
+                PROMETHEUS_COMMAND_LINE_OPTIONS_ARRAY+=(--storage.tsdb.retention.time=100y)
                 ;;
             (*) set -- "$@" "$arg"
                 ;;


### PR DESCRIPTION
When loading an old archive, there is a risk that it is older than the retention time and so Prometheus will delete it instantly. This can be worked around with a `-b "-storage.tsdb.retention.time=30y"` switch, but that is too much to remember and to type.

Provide a --archive switch to help out people who mostly work with archives.