### PR TITLE
min-prod-hw.rst: Add a js in-page calculator

### DIFF
--- a/docs/source/install/min-prod-hw.rst
+++ b/docs/source/install/min-prod-hw.rst
@@ -30,3 +30,46 @@ Prometheus uses more memory when querying over a longer duration (e.g. looking a
 
 For Prometheus alone, you should have 60MB of memory per core in the cluster and it would use about 600MB of virtual memory per core.
 Because Prometheus is so memory demanding, it is a good idea to add swap, so queries with a longer duration would not crash the server.
+
+.. raw:: html
+
+    <script>
+        function myFunction() {
+            const hosts = parseInt(document.getElementById('hosts').value);
+            const shards = parseInt(document.getElementById('shards').value);
+            const retention = parseInt(document.getElementById('retention').value);
+            let memory= (hosts*shards*60);
+            let disk = (hosts*shards*retention*12);
+
+            if (!Number.isNaN(disk)) {
+                disk = (disk > 1024)?((disk/1024).toFixed(2) + "GB") : disk.toString() + "MB";
+            } else {
+               disk = "0";
+            }
+            document.getElementById('disk').textContent = disk;
+            if (!Number.isNaN(memory)) {
+                memory = (memory > 1024)?((memory/1024).toFixed(2) + "GB") : memory.toString() + "MB";
+            } else {
+                memory = "0";
+            }
+            document.getElementById('memory').textContent = memory;
+        }
+    </script>
+    <div>
+    <table>
+    <colgroup>
+    <col style="width: 20%">
+    <col style="width: 20%">
+    <col style="width: 20%">
+    <col style="width: 20%;text-align: center;">
+    <col style="width: 20%;text-align: center;">
+    </colgroup>
+    <tr><th># ScyllaDB Nodes</th><th># Cores Per ScyllaDB Node</th><th>Prometheus Retention in Days</th><th>Prometheus RAM</th><th>Prometheus Storage</th></tr>
+    <tr><td><input type="number" id="hosts" onchange="myFunction()" value="3" placeholder="# Nodes" min="1"></td><td><input type="number" id="shards" onchange="myFunction()" value="16" placeholder="# Cores" min="1"></td><td><input type="number" id="retention" placeholder="# Days" onchange="myFunction()" value="15" min="1"></td><td style="text-align:center"><span id="memory" style="text-align:center">0</span></td><td style="text-align: center"><span id="disk">0</span></td></tr>
+
+    </table>
+
+    </div>
+    <script>
+    myFunction();
+    </script>


### PR DESCRIPTION
This is RFC for an in page calculator,
This is how it looks like inside the page:
![image](https://user-images.githubusercontent.com/2118079/203494509-39aad0cb-7094-4343-a662-1899245f3072.png)

Newer Scylla versions would have different parameters and we shell take that into concideration
Fixes #1817