### PR TITLE
Remove your panels

### DIFF
--- a/grafana/scylla-advanced.template.json
+++ b/grafana/scylla-advanced.template.json
@@ -569,13 +569,7 @@
                  ]
             },
             {
-                "class": "row",
-                "panels": [
-                    {
-                        "class": "collapsible_row_panel",
-                        "title": "Your panels"
-                    }
-                ]
+                "class": "user_panels_collapse"
             },
             {
                 "class": "user_panel_row_header"

--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -1793,13 +1793,7 @@
                 ]
             },
             {
-                "class": "row",
-                "panels": [
-                    {
-                        "class": "collapsible_row_panel",
-                        "title": ""
-                    }
-                ]
+                "class": "user_panels_collapse"
             },
             {
                 "class": "user_panel_row_header"

--- a/grafana/scylla-overview.template.json
+++ b/grafana/scylla-overview.template.json
@@ -648,13 +648,7 @@
                 ]
             },
             {
-                "class": "row",
-                "panels": [
-                    {
-                        "class": "collapsible_row_panel",
-                        "title": "Your panels"
-                    }
-                ]
+                "class": "user_panels_collapse"
             },
             {
                 "class": "user_panel_row_header"

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -1072,6 +1072,7 @@
             }
          }
       ],
+      "dashproductreject": "no-your-pannels",
       "title":"New row"
    },
    "monitoring_version_row":{
@@ -1100,8 +1101,19 @@
             "class":"user_panel"
          }
       ],
+      "dashproductreject": "no-your-pannels",
       "title":"New row"
    },
+   "user_panels_collapse" : {
+        "class": "row",
+        "panels": [
+            {
+                "class": "collapsible_row_panel",
+                "title": "Your panels"
+            }
+        ],
+        "dashproductreject": "no-your-pannels"
+    },
    "iops_panel":{
       "class":"graph_panel",
       "fieldConfig": {


### PR DESCRIPTION
This series makes the your-panels section optional.
To remove it from the dashboard:
`./generate-dashboards.sh -F -P "no-your-pannels"`

Fixes #1828