### PR TITLE
types.json: set the all option as .*

### DIFF
--- a/grafana/types.json
+++ b/grafana/types.json
@@ -2804,6 +2804,7 @@
    },
    "template_variable_all":{
       "class":"template_variable_single",
+      "allValue":".*",
       "current":{
          "selected":true,
          "text":[


### PR DESCRIPTION
This patch set the all default value as ```.*``` for variables with all option.
Fixes #1840