### PR TITLE
scylla-advanced.template.json: Split the disk and io-queue panels

### DIFF
--- a/grafana/scylla-advanced.template.json
+++ b/grafana/scylla-advanced.template.json
@@ -59,14 +59,6 @@
                                 "metric": "seastar_io_queue_delay",
                                 "refId": "A",
                                 "step": 30
-                            },
-                            {
-                                "expr": "max(rate(scylla_io_queue_total_exec_sec{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])/rate(scylla_io_queue_total_operations{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by ([[by]]) or on() max(scylla_io_queue_delay{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "Disk {{[[by]]}}",
-                                "metric": "scylla_io_queue_total_exec_sec",
-                                "refId": "B",
-                                "step": 30
                             }
                         ],
                         "title": "$classes I/O Queue delay by [[by]]"
@@ -81,14 +73,6 @@
                                 "legendFormat": "queue length {{[[by]]}}",
                                 "metric": "seastar_io_queue_delay",
                                 "refId": "A",
-                                "step": 30
-                            },
-                            {
-                                "expr": "max(scylla_io_queue_disk_queue_length{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "disk queue length {{[[by]]}}",
-                                "metric": "scylla_io_queue_disk_queue_length",
-                                "refId": "B",
                                 "step": 30
                             }
                         ],
@@ -123,7 +107,37 @@
                             }
                         ],
                         "title": "$classes I/O Queue IOPS by [[by]]"
-                    }
+                    },
+                    {
+                        "class": "seconds_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "max(rate(scylla_io_queue_total_exec_sec{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])/rate(scylla_io_queue_total_operations{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by ([[by]]) or on() max(scylla_io_queue_delay{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "Disk {{[[by]]}}",
+                                "metric": "scylla_io_queue_total_exec_sec",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "Disk $classes I/O Queue delay by [[by]]"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "max(scylla_io_queue_disk_queue_length{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "disk queue length {{[[by]]}}",
+                                "metric": "scylla_io_queue_disk_queue_length",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "DISK $classes Queue length by [[by]]"
+                    }                    
                 ],
                 "title": "New row"
             },


### PR DESCRIPTION
This patch split the io ques and disk queues to different panels one above the other instead of two graphs on the same panel.
After the change this is how it looks like
![image](https://user-images.githubusercontent.com/2118079/210753349-08c7adbc-924a-4030-bdc9-17ddd2a469fb.png)

Fixes #1827