### PR TITLE
scylla-detailed: keep the latency panels open but don't show empty ones

### DIFF
--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -1666,7 +1666,7 @@
                     {
                         "class": "collapsible_row_panel",
                         "repeat":"scheduling_group",
-                        "collapsed": true,
+                        "collapsed": false,
                         "title": "Latencies - $scheduling_group"
                     }
                 ]
@@ -1850,7 +1850,7 @@
                       ]
                     },
                     "name": "scheduling_group",
-                    "query": "label_values(scylla_storage_proxy_coordinator_read_latency_bucket,scheduling_group_name)",
+                    "query": "label_values(all_scheduling_group, scheduling_group_name)",
                     "sort": 3
                 },
                 {
@@ -1868,7 +1868,7 @@
                       ]
                     },
                     "name": "scheduling_group",
-                    "query": "label_values(scylla_storage_proxy_coordinator_read_latency_bucket,scheduling_group_name)",
+                    "query": "label_values(all_scheduling_group, scheduling_group_name)",
                     "sort": 3
                 },
                 {


### PR DESCRIPTION
Grafana didn't fix their issue with panels that collapse on each time change.
This workaround show the panels open and remove empty latency graphs.
Fixes #1790