### PR TITLE
Fix the `all_scheduling_group` recording rule

### DIFF
--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -1850,7 +1850,7 @@
                       ]
                     },
                     "name": "scheduling_group",
-                    "query": "label_values(all_scheduling_group, scheduling_group_name)",
+                    "query": "label_values(all_scheduling_group{cluster=~\"$cluster|$^\"}, scheduling_group_name)",
                     "sort": 3
                 },
                 {
@@ -1868,7 +1868,7 @@
                       ]
                     },
                     "name": "scheduling_group",
-                    "query": "label_values(all_scheduling_group, scheduling_group_name)",
+                    "query": "label_values(all_scheduling_group{cluster=~\"$cluster|$^\"}, scheduling_group_name)",
                     "sort": 3
                 },
                 {

--- a/prometheus/prom_rules/back_fill/3.8/rules.1.yml
+++ b/prometheus/prom_rules/back_fill/3.8/rules.1.yml
@@ -153,6 +153,8 @@ groups:
     expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_bucket{}[60s])) by (cluster, le, scheduling_group_name))
     labels:
       by: "cluster"
+  - record: all_scheduling_group
+    expr: sum by (cluster, scheduling_group_name) (scylla_storage_proxy_coordinator_write_latency_count + scylla_storage_proxy_coordinator_read_latency_count) > 0
   - record: errors:nodes_total
     expr: sum(rate(scylla_storage_proxy_coordinator_read_errors_local_node[60s])) by (cluster, dc, instance) + sum(rate(scylla_storage_proxy_coordinator_write_errors_local_node[60s])) by (cluster, dc, instance) + sum(rate(scylla_storage_proxy_coordinator_read_unavailable[60s])) by (cluster, dc, instance) + sum(rate(scylla_storage_proxy_coordinator_write_unavailable[60s])) by (cluster, dc, instance) + sum(rate(scylla_storage_proxy_coordinator_range_unavailable[60s])) by (cluster, dc, instance)
   - record: cql:non_system_prepared1m

--- a/prometheus/prom_rules/prometheus.latency.rules.yml
+++ b/prometheus/prom_rules/prometheus.latency.rules.yml
@@ -315,4 +315,4 @@ groups:
       by: "cluster"
       level: "1"
   - record: all_scheduling_group
-    expr: sum(scylla_storage_proxy_coordinator_write_latency_count>0) by (cluster, scheduling_group_name)
+    expr: sum by (cluster, scheduling_group_name) (scylla_storage_proxy_coordinator_write_latency_count + scylla_storage_proxy_coordinator_read_latency_count) > 0


### PR DESCRIPTION
- The rule is supposed to filter out inactive scheduling groups, but it only looks at writes, not reads. In particular, it filters out active read-only groups.
- The rule is missing from the back-fill file.
- The rule does not take `cluster` into account, so it displays scheduling groups from other clusters.

Fix all of the above.