### PR TITLE
scylla-detailed rename the active and queued read correctly

### DIFF
--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -349,7 +349,7 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Active sstable reads"
+                        "title": "Active reads"
                     },
                     {
                         "class": "reads_panel",
@@ -364,7 +364,7 @@
                             }
                         ],
                         "description": "number of currently queued read operations",
-                        "title": "Queued sstable reads"
+                        "title": "Queued reads"
                     },
                     {
                         "class": "writes_panel",


### PR DESCRIPTION
Currently the sstable reads panels is missleading.
This patch rename the panels to refelect what they show.
![image](https://user-images.githubusercontent.com/2118079/215729639-4da2cdaa-17ce-4ae3-8417-ed19c8918ea3.png)

Relates to #1839 
