### PR TITLE
prometheus.rules.yml: A robust node shudting down

### DIFF
--- a/prometheus/prom_rules/prometheus.rules.yml
+++ b/prometheus/prom_rules/prometheus.rules.yml
@@ -162,7 +162,7 @@ groups:
       description: '{{ $labels.instance }} has been down for more than 30 seconds.'
       summary: Instance {{ $labels.instance }} down
   - alert: InstanceDown
-    expr: absent(scylla_transport_requests_served{job="scylla", shard="0"})
+    expr: sum(up{job="scylla"}>0)by(instance) unless sum(scylla_transport_requests_served{shard="0"}) by(instance)
     for: 1m
     labels:
       severity: "2"


### PR DESCRIPTION
Sometimes when a node is overloaded or shutting down it answers Prometheus but it stops to report scylla_transport_requests_served

This patch changes how the alert is created so it will continue to fire even after Prometheus gives up on the metrics

Signed-off-by: Amnon Heiman <amnon@scylladb.com>

Fixes #1877