### PR TITLE
scylla-os: allow collect by cpu (shard)

### DIFF
--- a/grafana/scylla-os.template.json
+++ b/grafana/scylla-os.template.json
@@ -606,6 +606,11 @@
                             "selected": true,
                             "text": "Instance",
                             "value": "instance"
+                        },
+                        {
+                            "selected": true,
+                            "text": "Shard",
+                            "value": "instance,cpu"
                         }
                     ],
                     "query": "Cluster,DC,Instance",


### PR DESCRIPTION
This patch adds a cpu resolution to the os dashboard.
After this patch you can look at the a cpu level (shard) and not just by node level
![image](https://user-images.githubusercontent.com/2118079/216955525-8c95d177-aa04-435f-8bbb-1c77154deace.png)

Fixes #1878 