### PR TITLE
scylla-cql: list all nodes in the all option

### DIFF
--- a/grafana/scylla-cql.template.json
+++ b/grafana/scylla-cql.template.json
@@ -1147,7 +1147,18 @@
                     "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster\"}, dc)"
                 },
                 {
-                    "class": "template_variable_all",
+                    "class":"template_variable_single",
+                    "current":{
+                       "selected":true,
+                       "text":[
+                          "All"
+                       ],
+                       "value":[
+                          "$__all"
+                       ]
+                    },
+                    "includeAll":true,
+                    "multi":true,
                     "label": "node",
                     "name": "node",
                     "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster|$^\", dc=~\"$dc\"}, instance)"


### PR DESCRIPTION
Scylla Plugin uses the nodes list to know what nodes it should connect to. This patch revert the ```all``` change for the cql dashboard so that the node parameters ```all``` would hold all the node values and not simply ```.*```.

Fixes #1895 