### PR TITLE
Datadog deprecate the level label

### DIFF
--- a/docs/source/procedures/datadog/cloud-conf.yaml
+++ b/docs/source/procedures/datadog/cloud-conf.yaml
@@ -5,7 +5,7 @@ instances:
     ## @param prometheus_url - string - required
     ## The URL where your application metrics are exposed by Prometheus.
     #
-  - prometheus_url: https://us-east-1.aws.metrics.cloud.scylladb.com/api/v1/cluster/CLUSTER_ID/proxy/federate?match[]={level=~"1"} 
+  - prometheus_url: https://us-east-1.aws.metrics.cloud.scylladb.com/api/v1/cluster/CLUSTER_ID/proxy/federate?match[]={dd=~"1"} 
 
     ## @param namespace - string - required
     ## The namespace to be appended before all metrics namespace

--- a/docs/source/procedures/datadog/conf.yaml
+++ b/docs/source/procedures/datadog/conf.yaml
@@ -5,7 +5,7 @@ instances:
     ## @param prometheus_url - string - required
     ## The URL where your application metrics are exposed by Prometheus.
     #
-  - prometheus_url: http://IP:9090/federate?match[]={level=~"1"} 
+  - prometheus_url: http://IP:9090/federate?match[]={dd=~"1"} 
 
     ## @param namespace - string - required
     ## The namespace to be appended before all metrics namespace

--- a/docs/source/procedures/datadog/datadog.rules.yml
+++ b/docs/source/procedures/datadog/datadog.rules.yml
@@ -6,279 +6,335 @@ groups:
     labels:
       by: "cluster"
       level: "1"
+      dd: "1"
   - record: scylla_coordinator_read_count
     expr: sum(rate(scylla_storage_proxy_coordinator_read_latency_count{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, scheduling_group_name)
     labels:
       by: "dc"
       level: "1"
+      dd: "1"
   - record: scylla_coordinator_read_count
     expr: sum(rate(scylla_storage_proxy_coordinator_read_latency_count{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, scheduling_group_name)
     labels:
       by: "instance"
       level: "1"
+      dd: "1"
   - record: scylla_coordinator_read_count
     expr: sum(rate(scylla_storage_proxy_coordinator_read_latency_count{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, shard, scheduling_group_name)
     labels:
       by: "instance,shard"
       level: "2"
+      dd: "2"
   - record: scylla_total_requests
     expr: sum(rate(scylla_transport_requests_served{}[60s])) by (cluster)
     labels:
       by: "cluster"
       level: "1"
+      dd: "1"
   - record: scylla_total_requests
     expr: sum(rate(scylla_transport_requests_served{}[60s])) by (cluster, dc)
     labels:
       by: "dc"
       level: "1"
+      dd: "1"
   - record: scylla_total_requests
     expr: sum(rate(scylla_transport_requests_served{}[60s])) by (cluster, dc, instance)
     labels:
       by: "instance"
       level: "1"
+      dd: "1"
   - record: scylla_total_requests
     expr: sum(rate(scylla_transport_requests_served{}[60s])) by (cluster, dc, instance, shard)
     labels:
       by: "instance,shard"
       level: "2"
+      dd: "2"
   - record: scylla_coordinator_write_count
     expr: sum(rate(scylla_storage_proxy_coordinator_write_latency_count{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, scheduling_group_name)
     labels:
       by: "cluster"
       level: "1"
+      dd: "1"
   - record: scylla_coordinator_write_count
     expr: sum(rate(scylla_storage_proxy_coordinator_write_latency_count{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, scheduling_group_name)
     labels:
       by: "dc"
       level: "1"
+      dd: "1"
   - record: scylla_coordinator_write_count
     expr: sum(rate(scylla_storage_proxy_coordinator_write_latency_count{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, scheduling_group_name)
     labels:
       by: "instance"
       level: "1"
+      dd: "1"
   - record: scylla_coordinator_write_count
     expr: sum(rate(scylla_storage_proxy_coordinator_write_latency_count{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, shard, scheduling_group_name)
     labels:
       by: "instance,shard"
       level: "2"
+      dd: "2"
   - record: scylla_ag_cache_row_hits
     expr: sum(rate(scylla_cache_row_hits{}[60s])) by (cluster)
     labels:
       by: "cluster"
       level: "1"
+      dd: "1"
   - record: scylla_ag_cache_row_hits
     expr: sum(rate(scylla_cache_row_hits{}[60s])) by (cluster, dc)
     labels:
       by: "dc"
       level: "1"
+      dd: "1"
   - record: scylla_ag_cache_row_hits
     expr: sum(rate(scylla_cache_row_hits{}[60s])) by (cluster, dc, instance)
     labels:
       by: "instance"
       level: "1"
+      dd: "1"
   - record: scylla_ag_cache_row_hits
     expr: sum(rate(scylla_cache_row_hits{}[60s])) by (cluster, dc, instance, shard)
     labels:
       by: "instance,shard"
       level: "2"
+      dd: "2"
   - record: scylla_ag_cache_row_misses
     expr: sum(rate(scylla_cache_row_misses{}[60s])) by (cluster)
     labels:
       by: "cluster"
       level: "1"
+      dd: "1"
   - record: scylla_ag_cache_row_misses
     expr: sum(rate(scylla_cache_row_misses{}[60s])) by (cluster, dc)
     labels:
       by: "dc"
       level: "1"
+      dd: "1"
   - record: scylla_ag_cache_row_misses
     expr: sum(rate(scylla_cache_row_misses{}[60s])) by (cluster, dc, instance)
     labels:
       by: "instance"
       level: "1"
+      dd: "1"
   - record: scylla_ag_cache_row_misses
     expr: sum(rate(scylla_cache_row_misses{}[60s])) by (cluster, dc, instance, shard)
     labels:
       by: "instance,shard"
       level: "2"
+      dd: "2"
   - record: scylla_node_filesystem_avail_bytes
     expr: avg(node_filesystem_avail_bytes) by (cluster, mountpoint)
     labels:
       by: "cluster"
       level: "1"
+      dd: "1"
   - record: scylla_node_filesystem_total_avail_bytes
     expr: sum(node_filesystem_avail_bytes) by (cluster, mountpoint)
     labels:
       by: "cluster"
       level: "1"
+      dd: "1"
   - record: scylla_node_filesystem_avail_bytes
     expr: avg(node_filesystem_avail_bytes) by (cluster, mountpoint, dc)
     labels:
       by: "dc"
       level: "1"
+      dd: "1"
   - record: scylla_node_filesystem_avail_bytes
     expr: avg(node_filesystem_avail_bytes) by (cluster, mountpoint, dc, instance)
     labels:
       by: "instance"
       level: "1"
+      dd: "1"
   - record: scylla_node_filesystem_size_bytes
     expr: avg(node_filesystem_size_bytes) by (cluster, mountpoint)
     labels:
       by: "cluster"
       level: "1"
+      dd: "1"
   - record: scylla_node_filesystem_total_size_bytes
     expr: sum(node_filesystem_size_bytes) by (cluster, mountpoint)
     labels:
       by: "cluster"
       level: "1"
+      dd: "1"
   - record: scylla_node_filesystem_size_bytes
     expr: avg(node_filesystem_size_bytes) by (cluster, mountpoint, dc)
     labels:
       by: "dc"
       level: "1"
+      dd: "1"
   - record: scylla_node_filesystem_size_bytes
     expr: avg(node_filesystem_size_bytes) by (cluster, mountpoint, dc, instance)
     labels:
       by: "instance"
       level: "1"
+      dd: "1"
   - record: scylla_ag_cache_bytes_used
     expr: avg(rate(scylla_cache_bytes_used{}[60s])) by (cluster)
     labels:
       by: "cluster"
       level: "1"
+      dd: "1"
   - record: scylla_ag_cache_bytes_used
     expr: avg(rate(scylla_cache_bytes_used{}[60s])) by (cluster, dc)
     labels:
       by: "dc"
       level: "1"
+      dd: "1"
   - record: scylla_ag_cache_bytes_used
     expr: avg(rate(scylla_cache_bytes_used{}[60s])) by (cluster, dc, instance)
     labels:
       by: "instance"
       level: "1"
+      dd: "1"
   - record: scylla_ag_cache_bytes_used
     expr: avg(rate(scylla_cache_bytes_used{}[60s])) by (cluster, dc, instance, shard)
     labels:
       by: "instance,shard"
       level: "2"
+      dd: "2"
   - record: scylla_storage_proxy_coordinator_read_timeouts_ag
     expr: avg(rate(scylla_storage_proxy_coordinator_read_timeouts{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (scheduling_group_name, cluster, dc, instance)
     labels:
       by: "instance"
       level: "1"
+      dd: "1"
   - record: scylla_reactor_utilization_ag
     expr: avg(scylla_reactor_utilization{}) by (cluster, dc, instance)
     labels:
       by: "instance"
       level: "1"
+      dd: "1"
   - record: scylla_storage_proxy_coordinator_read_unavailable_ag
     expr: avg(rate(scylla_storage_proxy_coordinator_read_unavailable{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (scheduling_group_name, cluster, dc, instance)
     labels:
       by: "instance"
       level: "1"
+      dd: "1"
   - record: scylla_storage_proxy_coordinator_write_timeouts_ag
     expr: avg(rate(scylla_storage_proxy_coordinator_write_timeouts{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (scheduling_group_name, cluster, dc, instance)
     labels:
       by: "instance"
       level: "1"
+      dd: "1"
   - record: scylla_storage_proxy_coordinator_write_unavailable_ag
     expr: avg(rate(scylla_storage_proxy_coordinator_write_unavailable{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, scheduling_group_name, instance)
     labels:
       by: "instance"
       level: "1"
+      dd: "1"
   - record: node_network_receive_packets
     expr: sum(rate(node_network_receive_packets_total{}[2m])) by (device,cluster, dc, instance)
     labels:
       by: "instance"
       level: "1"
+      dd: "1"
   - record: node_network_receive_packets
     expr: sum(rate(node_network_receive_packets_total{}[2m])) by (device,cluster, dc)
     labels:
       by: "dc"
       level: "1"
+      dd: "1"
   - record: node_network_receive_packets
     expr: sum(rate(node_network_receive_packets_total{}[2m])) by (device,cluster)
     labels:
       by: "cluster"
       level: "1"
+      dd: "1"
   - record: node_network_transmit_packets
     expr: sum(rate(node_network_transmit_packets_total{}[2m])) by (device,cluster, dc, instance)
     labels:
       by: "instance"
       level: "1"
+      dd: "1"
   - record: node_network_transmit_packets
     expr: sum(rate(node_network_transmit_packets_total{}[2m])) by (device,cluster, dc)
     labels:
       by: "dc"
       level: "1"
+      dd: "1"
   - record: node_network_transmit_packets
     expr: sum(rate(node_network_transmit_packets_total{}[2m])) by (device,cluster)
     labels:
       by: "cluster"
       level: "1"
+      dd: "1"
   - record: node_network_receive_bytes
     expr: sum(rate(node_network_receive_bytes_total{}[2m])) by (device,cluster, dc, instance)
     labels:
       by: "instance"
       level: "1"
+      dd: "1"
   - record: node_network_receive_bytes
     expr: sum(rate(node_network_receive_bytes_total{}[2m])) by (device,cluster, dc)
     labels:
       by: "dc"
       level: "1"
+      dd: "1"
   - record: node_network_receive_bytes
     expr: sum(rate(node_network_receive_bytes_total{}[2m])) by (device,cluster)
     labels:
       by: "cluster"
       level: "1"
+      dd: "1"
   - record: node_network_transmit_bytes
     expr: sum(rate(node_network_transmit_bytes_total{}[2m])) by (device,cluster, dc, instance)
     labels:
       by: "instance"
       level: "1"
+      dd: "1"
   - record: node_network_transmit_bytes
     expr: sum(rate(node_network_transmit_bytes_total{}[2m])) by (device,cluster, dc)
     labels:
       by: "dc"
       level: "1"
+      dd: "1"
   - record: node_network_transmit_bytes
     expr: sum(rate(node_network_transmit_bytes_total{}[2m])) by (device,cluster)
     labels:
       by: "cluster"
       level: "1"
+      dd: "1"
   - record: scylla_total_connection
     expr: sum(scylla_transport_current_connections) by (cluster)
     labels:
       by: "cluster"
       level: "1"
+      dd: "1"
   - record: scylla_total_nodes
     expr: count(scylla_scylladb_current_version{job="scylla"}) by (cluster)
     labels:
       by: "cluster"
       level: "1"
+      dd: "1"
   - record: scylla_total_unreachable_nodes
     expr: count(scrape_samples_scraped{job="scylla"}==0) by (cluster)
     labels:
       by: "cluster"
       level: "1"
+      dd: "1"
   - record: scylla_total_joining_nodes
     expr: count(scylla_node_operation_mode<3) by (cluster)
     labels:
       by: "cluster"
       level: "1"
+      dd: "1"
   - record: scylla_total_leaving_nodes
     expr: count(scylla_node_operation_mode>3) by (cluster)
     labels:
       by: "cluster"
       level: "1"
+      dd: "1"
   - record: scylla_total_manager_tasks
     expr: sum(scylla_manager_task_active_count{type=~"repair|backup"}) by (cluster, type)
     labels:
       by: "cluster"
       level: "1"
+      dd: "1"
   - record: scylla_total_compactios
     expr: sum(scylla_compaction_manager_completed_compactions) by (cluster)
     labels:
       by: "cluster"
       level: "1"
+      dd: "1"
       

--- a/docs/source/procedures/datadog/index.rst
+++ b/docs/source/procedures/datadog/index.rst
@@ -36,7 +36,7 @@ Post configuration
 Restart the agent based on your installation. Scylla metrics should be visible in Datadog.
 
 
-.. note::  By default, Datadog will not scrap per-shard metrics. To enable per-shard metrics, edit the conf.yaml file and replace level=~"1" with level=~"1|2"
+.. note::  By default, Datadog will not scrap per-shard metrics. To enable per-shard metrics, edit the conf.yaml file and replace dd=~"1" with dd=~"1|2"
 
 Add datadog recording rules
 ===========================

--- a/prometheus/prom_rules/prometheus.latency.rules.yml
+++ b/prometheus/prom_rules/prometheus.latency.rules.yml
@@ -49,6 +49,7 @@ groups:
     expr: sum(manager:repair_progress) by (cluster)
     labels:
       level: "1"
+      dd: "1"
       by: "cluster"
   - record: manager:backup_progress
     expr: (max(scylla_manager_scheduler_run_indicator{type="backup"}) by (cluster) >bool 0)*((max(scylla_manager_backup_files_size_bytes) by(cluster)<= 0)*0 or on(cluster) (sum(scylla_manager_backup_files_uploaded_bytes) by (cluster) + sum(scylla_manager_backup_files_skipped_bytes) by (cluster) + sum(scylla_manager_backup_files_failed_bytes)by(cluster))/sum(scylla_manager_backup_files_size_bytes>=0) by (cluster))
@@ -56,127 +57,152 @@ groups:
     expr: sum(manager:backup_progress) by (cluster)
     labels:
       level: "1"
+      dd: "1"
       by: "cluster"
   - record: wlatencyp99
     expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{shard=~".+", scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, shard, scheduling_group_name, le))
     labels:
       by: "instance,shard"
       level: "2"
+      dd: "2"
   - record: wlatencyp99
     expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, scheduling_group_name, le))
     labels:
       by: "instance"
       level: "1"
+      dd: "1"
   - record: wlatencyp99
     expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, scheduling_group_name, le))
     labels:
       by: "dc"
       level: "1"
+      dd: "1"
   - record: wlatencyp99
     expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, scheduling_group_name, le))
     labels:
       by: "cluster"
       level: "1"
+      dd: "1"
   - record: rlatencyp99
     expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{shard=~".+", scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, shard, scheduling_group_name, le))
     labels:
       by: "instance,shard"
       level: "2"
+      dd: "2"
   - record: rlatencyp99
     expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, scheduling_group_name, le))
     labels:
       by: "instance"
       level: "1"
+      dd: "1"
   - record: rlatencyp99
     expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, scheduling_group_name, le))
     labels:
       by: "dc"
       level: "1"
+      dd: "1"
   - record: rlatencyp99
     expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, scheduling_group_name, le))
     labels:
       by: "cluster"
       level: "1"
+      dd: "1"
   - record: wlatencyp95
     expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{shard=~".+", scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, shard, scheduling_group_name, le))
     labels:
       by: "instance,shard"
       level: "2"
+      dd: "2"
   - record: wlatencyp95
     expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, scheduling_group_name, le))
     labels:
       by: "instance"
       level: "1"
+      dd: "1"
   - record: wlatencyp95
     expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, scheduling_group_name, le))
     labels:
       by: "dc"
       level: "1"
+      dd: "1"
   - record: wlatencyp95
     expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, scheduling_group_name, le))
     labels:
       by: "cluster"
       level: "1"
+      dd: "1"
   - record: rlatencyp95
     expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{shard=~".+", scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, shard, scheduling_group_name, le))
     labels:
       by: "instance,shard"
       level: "2"
+      dd: "2"
   - record: rlatencyp95
     expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, scheduling_group_name, le))
     labels:
       by: "instance"
       level: "1"
+      dd: "1"
   - record: rlatencyp95
     expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, scheduling_group_name, le))
     labels:
       by: "dc"
       level: "1"
+      dd: "1"
   - record: rlatencyp95
     expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, scheduling_group_name, le))
     labels:
       by: "cluster"
       level: "1"
+      dd: "1"
   - record: wlatencya
     expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{shard=~".+", scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, shard, scheduling_group_name, le))
     labels:
       by: "instance,shard"
       level: "2"
+      dd: "2"
   - record: wlatencya
     expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, scheduling_group_name, le))
     labels:
       by: "instance"
       level: "1"
+      dd: "1"
   - record: wlatencya
     expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, scheduling_group_name, le))
     labels:
       by: "dc"
       level: "1"
+      dd: "1"
   - record: wlatencya
     expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, scheduling_group_name, le))
     labels:
       by: "cluster"
       level: "1"
+      dd: "1"
   - record: rlatencya
     expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{shard=~".+", scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, shard, scheduling_group_name, le))
     labels:
       by: "instance,shard"
       level: "2"
+      dd: "2"
   - record: rlatencya
     expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, scheduling_group_name, le))
     labels:
       by: "instance"
       level: "1"
+      dd: "1"
   - record: rlatencya
     expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, scheduling_group_name, le))
     labels:
       by: "dc"
       level: "1"
+      dd: "1"
   - record: rlatencya
     expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, scheduling_group_name, le))
     labels:
       by: "cluster"
       level: "1"
+      dd: "1"
   - record: wlatencyp99
     expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{shard=~".+", scheduling_group_name=~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, shard, scheduling_group_name, le))
     labels:
@@ -279,40 +305,48 @@ groups:
     labels:
       by: "instance,shard"
       level: "2"
+      dd: "2"
   - record: casrlatencyp95
     expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, le, scheduling_group_name))
     labels:
       by: "instance"
       level: "1"
+      dd: "1"
   - record: casrlatencyp95
     expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, le, scheduling_group_name))
     labels:
       by: "dc"
       level: "1"
+      dd: "1"
   - record: casrlatencyp95
     expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, le, scheduling_group_name))
     labels:
       by: "cluster"
       level: "1"
+      dd: "1"
   - record: caswlatencyp95
     expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_bucket{shard=~".+", scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, shard, le, scheduling_group_name))
     labels:
       by: "instance,shard"
       level: "2"
+      dd: "2"
   - record: caswlatencyp95
     expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, le, scheduling_group_name))
     labels:
       by: "instance"
       level: "1"
+      dd: "1"
   - record: caswlatencyp95
     expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, le, scheduling_group_name))
     labels:
       by: "dc"
       level: "1"
+      dd: "1"
   - record: caswlatencyp95
     expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, le, scheduling_group_name))
     labels:
       by: "cluster"
       level: "1"
+      dd: "1"
   - record: all_scheduling_group
     expr: sum by (cluster, scheduling_group_name) (scylla_storage_proxy_coordinator_write_latency_count + scylla_storage_proxy_coordinator_read_latency_count) > 0

--- a/prometheus/prometheus.yml.template
+++ b/prometheus/prometheus.yml.template
@@ -113,13 +113,25 @@ scrape_configs:
       replacement: '2'
       target_label: level
     - source_labels: [__name__]
+      regex: '(scylla_storage_proxy_coordinator_read_timeouts|scylla_reactor_utilization|scylla_storage_proxy_coordinator_read_timeouts|scylla_storage_proxy_coordinator_read_unavailable|scylla_storage_proxy_coordinator_write_timeouts|scylla_storage_proxy_coordinator_write_unavailable|.latency..?.?)'
+      replacement: '2'
+      target_label: dd
+    - source_labels: [__name__]
       regex: '(scylla_node_operation_mode)'
       replacement: '1'
       target_label: level
+    - source_labels: [__name__]
+      regex: '(scylla_node_operation_mode)'
+      replacement: '1'
+      target_label: dd
     - source_labels: [scheduling_group_name]
       regex: '(atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache)'
       replacement: ''
       target_label: level
+    - source_labels: [scheduling_group_name]
+      regex: '(atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache)'
+      replacement: ''
+      target_label: dd
 - job_name: node_exporter
   honor_labels: false
   scrape_interval: 1m # By default, scrape targets every 20 second.


### PR DESCRIPTION
This series deprecates the ```level``` datadog label and replace it with ```dd```.

the ```level``` label can still be used but it will be removed in future releases