### PR TITLE
types.json: when user panels are not present add a dummy line

### DIFF
--- a/grafana/types.json
+++ b/grafana/types.json
@@ -1109,10 +1109,15 @@
         "panels": [
             {
                 "class": "collapsible_row_panel",
-                "title": "Your panels"
+                "title": "Your panels",
+                "dashproductreject": "no-your-pannels"
+            },
+            {
+                "class": "collapsible_row_panel",
+                "title": "Versions",
+                "dashproduct": "no-your-pannels"
             }
-        ],
-        "dashproductreject": "no-your-pannels"
+        ]
     },
    "iops_panel":{
       "class":"graph_panel",


### PR DESCRIPTION
This patch adds a dummy before the version row, to prevenet a situation that there are repeated rows at the buttom (like in the detailed dashboard) and the version would be repeated for each of the repeated row

Fixes #1904