### PR TITLE
More granularity to grafana authentication and anonymous login

### DIFF
--- a/start-all.sh
+++ b/start-all.sh
@@ -206,6 +206,12 @@ for arg; do
                 ;;
             (--victoria-metrics) VICTORIA_METRICS="1"
                 ;;
+            (--auth)
+                GRAFANA_ENV_COMMAND="$GRAFANA_ENV_COMMAND --auth"
+                ;;
+            (--disable-anonymous)
+                GRAFANA_ENV_COMMAND="$GRAFANA_ENV_COMMAND --disable-anonymous"
+                ;;
             (--limit)
                 LIMIT="1"
                 ;;

--- a/start-grafana.sh
+++ b/start-grafana.sh
@@ -4,13 +4,21 @@ if [ -f CURRENT_VERSION.sh ]; then
     CURRENT_VERSION=`cat CURRENT_VERSION.sh`
 fi
 LOCAL=""
-GRAFANA_ADMIN_PASSWORD="admin"
-GRAFANA_AUTH=false
-GRAFANA_AUTH_ANONYMOUS=true
+if [ -z "$GRAFANA_ADMIN_PASSWORD" ]; then
+    GRAFANA_ADMIN_PASSWORD="admin"
+fi
+if [ -z "$GRAFANA_AUTH" ]; then
+    GRAFANA_AUTH=false
+fi
+if [ -z "$GRAFANA_AUTH_ANONYMOUS" ]; then
+    GRAFANA_AUTH_ANONYMOUS=true
+fi
 DOCKER_PARAM=""
 EXTERNAL_VOLUME=""
 BIND_ADDRESS=""
-ANONYMOUS_ROLE="Admin"
+if [ -z "$ANONYMOUS_ROLE" ]; then
+    ANONYMOUS_ROLE="Admin"
+fi
 SPECIFIC_SOLUTION=""
 LDAP_FILE=""
 
@@ -48,6 +56,12 @@ for arg; do
             (--param)
                 LIMIT="1"
                 PARAM="1"
+                ;;
+            (--auth)
+                GRAFANA_AUTH=true
+                ;;
+            (--disable-anonymous)
+                GRAFANA_AUTH_ANONYMOUS=false
                 ;;
             (*) set -- "$@" "$arg"
                 ;;
@@ -122,8 +136,6 @@ while getopts ':hlEg:n:p:v:a:x:c:j:m:G:M:D:A:S:P:L:Q:' option; do
     Q) ANONYMOUS_ROLE=$OPTARG
        ;;
     a) GRAFANA_ADMIN_PASSWORD=$OPTARG
-       GRAFANA_AUTH=true
-       GRAFANA_AUTH_ANONYMOUS=false
        ;;
     x) HTTP_PROXY="$OPTARG"
        ;;
@@ -227,7 +239,6 @@ if [ ! -z $RUN_RENDERER ]; then
     RENDERING_SERVER_URL=`./start-grafana-renderer.sh $LIMITS $VOLUMES $PARAMS  -D "$DOCKER_PARAM"`
     GRAFANA_ENV_COMMAND="$GRAFANA_ENV_COMMAND -e GF_RENDERING_SERVER_URL=http://$DOCKER_HOST:8081/render -e GF_RENDERING_CALLBACK_URL=http://$DOCKER_HOST:$GRAFANA_PORT/"
 fi
-
 
 docker run -d $DOCKER_PARAM ${DOCKER_LIMITS["grafana"]} -i $USER_PERMISSIONS $PORT_MAPPING \
      -e "GF_AUTH_BASIC_ENABLED=$GRAFANA_AUTH" \


### PR DESCRIPTION
This patch split between modifying the admin password, forcing authentication and disable anonymous login.

you can set it from the environment or from the command line.
To enable basic authentication (user/password) either use ```--auth``` or set
```GRAFANA_AUTH``` to true.

To disable anonymous login, either use ```--disable-anonymous``` or
set ```GRAFANA_AUTH_ANONYMOUS``` to false

You can also set the admin password by setting ```GRAFANA_ADMIN_PASSWORD```

Fixes #1913