### PR TITLE
Evaluation interval

### DIFF
--- a/docs/source/install/start_all.rst
+++ b/docs/source/install/start_all.rst
@@ -78,6 +78,8 @@ This flag places the Prometheus data directory outside of its container and by d
 
 **-L manager-address** Using Scylla Manager **Consul** API to resolve the servers' IP address. When using this option, Prometheus will ignore the target files even if they are explicitly passed in the command line.
 
+**--evaluation-interval duration** Override the default recording rules evaluation-interval.
+
 Prometheus Retention Period
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Prometheus retention period is set for two weeks by default. A common request is how to set it to something else.

--- a/prometheus-config.sh
+++ b/prometheus-config.sh
@@ -17,7 +17,7 @@ for arg; do
     esac
 done
 
-while getopts ':hL:m:T:' option; do
+while getopts ':hL:m:T:E:' option; do
   case "$option" in
     h) echo "$usage"
        exit
@@ -27,6 +27,8 @@ while getopts ':hL:m:T:' option; do
     T) PROMETHEUS_TARGETS+=("$OPTARG")
        ;;
     m) AM_ADDRESS="$OPTARG"
+       ;;
+    E) EVALUATION_INTERVAL="$OPTARG"
        ;;
     :) printf "missing argument for -%s\n" "$OPTARG" >&2
        echo "$usage" >&2
@@ -49,6 +51,9 @@ else
     sed "s/AM_ADDRESS/$AM_ADDRESS/" $PWD/prometheus/prometheus.consul.yml.template| sed "s/MANAGER_ADDRESS/$CONSUL_ADDRESS/" > $PWD/prometheus/build/prometheus.yml
 fi
 
+if [[ "$EVALUATION_INTERVAL" != "" ]]; then
+    sed -i "s/  evaluation_interval: [[:digit:]]*.*/  evaluation_interval: ${EVALUATION_INTERVAL}/g" $PWD/prometheus/build/prometheus.yml
+fi
 for val in "${PROMETHEUS_TARGETS[@]}"; do
     if [[ ! -f $val ]]; then
         echo "Target file $val does not exists"

--- a/prometheus/prometheus.yml.template
+++ b/prometheus/prometheus.yml.template
@@ -1,7 +1,7 @@
 global:
   scrape_interval: 20s # By default, scrape targets every 20 second.
-  scrape_timeout: 15s # Timeout before trying to scape a target again
-  evaluation_interval: 20s
+  scrape_timeout: 15s # Timeout before trying to scrape a target again
+  evaluation_interval: 60s
 
   # Attach these labels to any time series or alerts when communicating with
   # external systems (federation, remote storage, Alertmanager).

--- a/start-all.sh
+++ b/start-all.sh
@@ -223,6 +223,10 @@ for arg; do
                 LIMIT="1"
                 PARAM="1"
                 ;;
+            (--evaluation-interval)
+                LIMIT="1"
+                PARAM="evaluation-interval"
+                ;;
             (--archive)
                 PROMETHEUS_COMMAND_LINE_OPTIONS_ARRAY+=(--storage.tsdb.retention.time=100y)
                 ;;
@@ -239,6 +243,9 @@ for arg; do
             fi
             DOCKER_PARAMS[$DOCR]="${DOCKER_PARAMS[$DOCR]} $VALUE"
             PARAMS="$PARAMS --param $NOSPACE"
+            unset PARAM
+        elif [ "$PARAM" = "evaluation-interval" ]; then
+            PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS -E $NOSPACE"
             unset PARAM
         else
             if [ -z "${DOCKER_LIMITS[$DOCR]}" ]; then


### PR DESCRIPTION
Prometheus recording rules evaluation interval affect the recording rules resolution and the prometheus load.

This series revert the evaluation interval to 60s and add command line option to override it.

The following way would work to set it.

```--evaluation-interval 20s``` would it to 20s

Fixes #1935

