### PR TITLE
Remove cdc

### DIFF
--- a/prometheus-config.sh
+++ b/prometheus-config.sh
@@ -12,6 +12,9 @@ for arg; do
         (--compose) COMPOSE=1
             AM_ADDRESS="aalert:9093"
             ;;
+        (--no-cas-cdc) COMPOSE=1
+            NO_CAS_CDC="1"
+            ;;
         (*) set -- "$@" "$arg"
             ;;
     esac
@@ -54,6 +57,10 @@ fi
 if [[ "$EVALUATION_INTERVAL" != "" ]]; then
     sed -i "s/  evaluation_interval: [[:digit:]]*.*/  evaluation_interval: ${EVALUATION_INTERVAL}/g" $PWD/prometheus/build/prometheus.yml
 fi
+if [[ "$NO_CAS_CDC" = "1" ]]; then
+    sed -i "s/ *# FILTER_METRICS.*/    - source_labels: [__name__]\\n      regex: '(.*_cdc_.*|.*_cas.*)'\\n      action: drop/g" $PWD/prometheus/build/prometheus.yml
+fi
+
 for val in "${PROMETHEUS_TARGETS[@]}"; do
     if [[ ! -f $val ]]; then
         echo "Target file $val does not exists"

--- a/prometheus/prometheus.yml.template
+++ b/prometheus/prometheus.yml.template
@@ -38,6 +38,7 @@ scrape_configs:
       target_label: instance
       replacement: '${1}'
   metric_relabel_configs:
+# FILTER_METRICS
     - source_labels: [version]
       regex:  '(.+)'
       target_label: CPU

--- a/start-all.sh
+++ b/start-all.sh
@@ -227,6 +227,9 @@ for arg; do
                 LIMIT="1"
                 PARAM="evaluation-interval"
                 ;;
+            (--no-cas-cdc)
+                PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-cas-cdc"
+                ;;
             (--archive)
                 PROMETHEUS_COMMAND_LINE_OPTIONS_ARRAY+=(--storage.tsdb.retention.time=100y)
                 ;;


### PR DESCRIPTION
This series adds a command line option to drop cdc and cas metrics while scrapping.

Fixes #1937