### PR TITLE
Datadog no shard metrics

### DIFF
--- a/docs/source/procedures/datadog/datadog.rules-with-shards.yml
+++ b/docs/source/procedures/datadog/datadog.rules-with-shards.yml
@@ -19,6 +19,12 @@ groups:
       by: "instance"
       level: "1"
       dd: "1"
+  - record: scylla_coordinator_read_count
+    expr: sum(rate(scylla_storage_proxy_coordinator_read_latency_count{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, shard, scheduling_group_name)
+    labels:
+      by: "instance,shard"
+      level: "2"
+      dd: "2"
   - record: scylla_total_requests
     expr: sum(rate(scylla_transport_requests_served{}[60s])) by (cluster)
     labels:
@@ -37,6 +43,12 @@ groups:
       by: "instance"
       level: "1"
       dd: "1"
+  - record: scylla_total_requests
+    expr: sum(rate(scylla_transport_requests_served{}[60s])) by (cluster, dc, instance, shard)
+    labels:
+      by: "instance,shard"
+      level: "2"
+      dd: "2"
   - record: scylla_coordinator_write_count
     expr: sum(rate(scylla_storage_proxy_coordinator_write_latency_count{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, scheduling_group_name)
     labels:
@@ -55,6 +67,12 @@ groups:
       by: "instance"
       level: "1"
       dd: "1"
+  - record: scylla_coordinator_write_count
+    expr: sum(rate(scylla_storage_proxy_coordinator_write_latency_count{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, shard, scheduling_group_name)
+    labels:
+      by: "instance,shard"
+      level: "2"
+      dd: "2"
   - record: scylla_ag_cache_row_hits
     expr: sum(rate(scylla_cache_row_hits{}[60s])) by (cluster)
     labels:
@@ -73,6 +91,12 @@ groups:
       by: "instance"
       level: "1"
       dd: "1"
+  - record: scylla_ag_cache_row_hits
+    expr: sum(rate(scylla_cache_row_hits{}[60s])) by (cluster, dc, instance, shard)
+    labels:
+      by: "instance,shard"
+      level: "2"
+      dd: "2"
   - record: scylla_ag_cache_row_misses
     expr: sum(rate(scylla_cache_row_misses{}[60s])) by (cluster)
     labels:
@@ -91,6 +115,12 @@ groups:
       by: "instance"
       level: "1"
       dd: "1"
+  - record: scylla_ag_cache_row_misses
+    expr: sum(rate(scylla_cache_row_misses{}[60s])) by (cluster, dc, instance, shard)
+    labels:
+      by: "instance,shard"
+      level: "2"
+      dd: "2"
   - record: scylla_node_filesystem_avail_bytes
     expr: avg(node_filesystem_avail_bytes) by (cluster, mountpoint)
     labels:
@@ -157,6 +187,12 @@ groups:
       by: "instance"
       level: "1"
       dd: "1"
+  - record: scylla_ag_cache_bytes_used
+    expr: avg(rate(scylla_cache_bytes_used{}[60s])) by (cluster, dc, instance, shard)
+    labels:
+      by: "instance,shard"
+      level: "2"
+      dd: "2"
   - record: scylla_storage_proxy_coordinator_read_timeouts_ag
     expr: avg(rate(scylla_storage_proxy_coordinator_read_timeouts{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (scheduling_group_name, cluster, dc, instance)
     labels:

--- a/docs/source/procedures/datadog/index.rst
+++ b/docs/source/procedures/datadog/index.rst
@@ -6,7 +6,7 @@ The safest way to use Datadog with Scylla is to load the metrics, using a  Datad
 The integration consists of:
 
 1. Installing and configuring the Datadog Agent.
-2. Add datadog recording rules.
+2. Add Datadog recording rules.
 3. Loading Scylla dashboard to Datadog.
 4. Optionally load Monitor (Alerts).
 
@@ -40,7 +40,10 @@ Restart the agent based on your installation. Scylla metrics should be visible i
 
 Add datadog recording rules
 ===========================
-Non cloud users, download the rules configuration file :download:`datadog.rules.yml <datadog.rules.yml>` and place it under prometheus/prom_rules/.
+Non cloud users, download the rules configuration file :download:`datadog.rules.yml <datadog.rules.yml>` if you need per-shard metrics, download :download:`datadog.rules-with-shards.yml <datadog.rules-with-shards.yml>` and place it under prometheus/prom_rules/.
+Per-shards metrics adds load and cost to both the Prometheus server and Datadog agent and server, so only use it if needed.
+
+Cloud users, skip this step, it's been take care for by the cloud.
 
 Upload the Dashboard
 ====================

--- a/docs/source/procedures/datadog/index.rst
+++ b/docs/source/procedures/datadog/index.rst
@@ -40,7 +40,7 @@ Restart the agent based on your installation. Scylla metrics should be visible i
 
 Add datadog recording rules
 ===========================
-Non cloud users, download the rules configuration file :download:`datadog.rules.yml <datadog.rules.yml>` if you need per-shard metrics, download :download:`datadog.rules-with-shards.yml <datadog.rules-with-shards.yml>` and place it under prometheus/prom_rules/.
+Non Scylla Cloud users, download the rules configuration file :download:`datadog.rules.yml <datadog.rules.yml>` if you need per-shard metrics, download :download:`datadog.rules-with-shards.yml <datadog.rules-with-shards.yml>` and place it under prometheus/prom_rules/.
 Per-shards metrics adds load and cost to both the Prometheus server and Datadog agent and server, so only use it if needed.
 
 Cloud users, skip this step, it's been take care for by the cloud.


### PR DESCRIPTION
This series adds an option to install the datadog metrics without generating the per-shard metrics