### PR TITLE
Drop cas cdc while scrapping

### DIFF
--- a/docs/source/install/start-all.rst
+++ b/docs/source/install/start-all.rst
@@ -80,6 +80,9 @@ This flag places the Prometheus data directory outside of its container and by d
 
 **--evaluation-interval duration** Override the default recording rules evaluation-interval.
 
+**--no-cas** An optimization for users who do not use cas, Prometheus will drop all cas related metrics while scrapping
+**--no-cdc** An optimization for users who do not use cdc, Prometheus will drop all cdc related metrics while scrapping
+
 Prometheus Retention Period
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Prometheus retention period is set for two weeks by default. A common request is how to set it to something else.

--- a/start-all.sh
+++ b/start-all.sh
@@ -238,6 +238,8 @@ for arg; do
             (--no-cdc)
                 PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-cdc"
                 ;;
+            (--help) usage
+                ;;
             (--archive)
                 PROMETHEUS_COMMAND_LINE_OPTIONS_ARRAY+=(--storage.tsdb.retention.time=100y)
                 ;;

--- a/start-all.sh
+++ b/start-all.sh
@@ -91,6 +91,8 @@ Options:
   -T path/to/prometheus-targets  - Adds additional Prometheus target files.
   -k path/to/loki/storage        - When set, will use the given directory for Loki's data
   --no-loki                      - If set, do not run Loki and promtail.
+  --no-cas                       - If set, Prometheus will drop all cas related metrics while scrapping
+  --no-cdc                       - If set, Prometheus will drop all cdc related metrics while scrapping
   --auto-restart                 - If set, auto restarts the containers on failure.
   --no-renderer                  - If set, do not run the Grafana renderer container.
   --thanos-sc                    - If set, run thanos side car with the Prometheus server.
@@ -229,6 +231,12 @@ for arg; do
                 ;;
             (--no-cas-cdc)
                 PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-cas-cdc"
+                ;;
+            (--no-cas)
+                PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-cas"
+                ;;
+            (--no-cdc)
+                PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-cdc"
                 ;;
             (--archive)
                 PROMETHEUS_COMMAND_LINE_OPTIONS_ARRAY+=(--storage.tsdb.retention.time=100y)


### PR DESCRIPTION
The following new start-all.sh command line flags are supported
```
--help     - same as -h
--no-cas -  drop all cas related metrics while scrapping
--no-cdc -  drop all cdc related metrics while scrapping
```
Fixes #1948