### PR TITLE
scylla-overview: Make the disk usage clearer

### DIFF
--- a/grafana/scylla-overview.template.json
+++ b/grafana/scylla-overview.template.json
@@ -387,7 +387,41 @@
                               "refId": "B"
                             }
                         ],
-                        "title": "Disk Size by $by"
+                        "fieldConfig": {
+                            "defaults": {
+                              "class": "fieldConfig_defaults",
+                              "unit": "bytes"
+                            },
+                            "overrides": [
+                              {
+                                "matcher": {
+                                  "id": "byFrameRefID",
+                                  "options": "B"
+                                },
+                                "properties": [
+                                  {
+                                    "id": "custom.lineStyle",
+                                    "value": {
+                                      "fill": "dash",
+                                      "dash": [
+                                        10,
+                                        10
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "id": "custom.lineWidth",
+                                    "value": 2
+                                  }
+                                ]
+                              }
+                            ]
+                        },
+                        "options": {
+                            "class":"desc_tooltip_options"
+                        },
+                        "description": "The average Disk usage per [[by]].\n\n The dashed line represent the total size.",
+                        "title": "Average Disk Usage"
                     },
                     {
                         "class": "graph_panel_int",


### PR DESCRIPTION
This patch makes the disk usage panel clearer

![Screenshot from 2023-04-25 12-34-04](https://user-images.githubusercontent.com/2118079/234236607-c2248a15-7579-482b-8a47-6c60311ddace.png)

Fixes #1958