### PR TITLE
scylla-detailed: Add CQL messages size

### DIFF
--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -1824,6 +1824,108 @@
                             }
                         ],
                         "title": "99th percentile read latency by [[by]]"
+                    },
+                    {
+                        "class": "bytes_panel",
+                        "span": 3,
+                        "dashversion":[">5.3", ">2022.1"],
+                        "description": "Bytes received in CQL messages",
+                        "targets": [
+                            {
+                                "expr": "sum(rate(scylla_transport_cql_request_bytes{kind=~\"$kind\",instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$scheduling_group\"}[1m])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Received payload by [[by]]"
+                    },
+                    {
+                        "class": "bytes_panel",
+                        "span": 3,
+                        "dashversion":[">5.3", ">2022.1"],
+                        "description": "Average CQL message size (received)",
+                        "targets": [
+                            {
+                                "expr": "sum(rate(scylla_transport_cql_request_bytes{kind=~\"$kind\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$scheduling_group\"}[1m])) by ([[by]])/sum(rate(scylla_transport_cql_requests_count{kind=~\"$kind\",instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$scheduling_group\"}[1m])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Average received payload size by [[by]]"
+                    },
+                    {
+                        "class": "bytes_panel",
+                        "span": 3,
+                        "dashversion":[">5.3", ">2022.1"],
+                        "description": "Bytes sent in CQL messages",
+                        "targets": [
+                            {
+                                "expr": "sum(rate(scylla_transport_cql_response_bytes{kind=~\"$kind\",instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$scheduling_group\"}[1m])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Response payload by [[by]]"
+                    },
+                    {
+                        "class": "bytes_panel",
+                        "span": 3,
+                        "dashversion":[">5.3", ">2022.1"],
+                        "targets": [
+                            {
+                                "expr": "sum(rate(scylla_transport_cql_response_bytes{kind=~\"$kind\",instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$scheduling_group\"}[1m])) by ([[by]])/sum(rate(scylla_transport_cql_requests_count{kind=~\"$kind\",instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$scheduling_group\"}[1m])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "description": "Average CQL message size (sent)",
+                        "title": "Average response payload size by [[by]]"
+                    },
+                    {
+                        "class": "bytes_panel",
+                        "span": 3,
+                        "dashversion":[">5.3", ">2022.1"],
+                        "targets": [
+                            {
+                                "expr": "sum(rate(scylla_transport_cql_request_bytes{kind=~\"QUERY|EXECUTE\",instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$scheduling_group\"}[1m])) by ([[by]])/sum(rate(scylla_storage_proxy_coordinator_write_latency_summary_count{instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$scheduling_group\"}[1m])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "description": "This is a ballpark estimation of the write-messages size (like insert and update).\n\nIt is based on the assumption that write-messages are responsible for most inwards traffic.",
+                        "title": "Estimated write message size by [[by]]"
+                    },
+                    {
+                        "class": "bytes_panel",
+                        "span": 3,
+                        "dashversion":[">5.3", ">2022.1"],
+                        "targets": [
+                            {
+                                "expr": "sum(rate(scylla_transport_cql_request_bytes{kind=~\"QUERY|EXECUTE\",instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$scheduling_group\"}[1m])) by ([[by]])/sum(rate(scylla_storage_proxy_coordinator_read_latency_summary_count{instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$scheduling_group\"}[1m])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "description": "This is a ballpark estimation of the read-messages size (like select).\n\nIt is based on the assumption that read-messages are responsible for most outbound traffic.",
+                        "title": "Estimated read message size by [[by]]"
                     }
                 ]
             },
@@ -1904,6 +2006,14 @@
                     },
                     "name": "scheduling_group",
                     "query": "label_values(all_scheduling_group{cluster=~\"$cluster|$^\"}, scheduling_group_name)",
+                    "sort": 3
+                },
+                {
+                    "class": "template_variable_all",
+                    "label": "cql_kind",
+                    "dashversion":[">5.3", ">2022.1"],
+                    "name": "kind",
+                    "query": "label_values(scylla_transport_cql_requests_count{cluster=~\"$cluster|$^\"}, kind)",
                     "sort": 3
                 },
                 {


### PR DESCRIPTION
This patch adds 
CQL messages size (sent and received) to the detailed dashboard by scheduling group

![image](https://user-images.githubusercontent.com/2118079/235877091-47c2ba48-040f-444d-aab8-8543eeb7bcc0.png)

Fixes #1928 