### PR TITLE
prometheus.yml.template: Drop internal histograms

### DIFF
--- a/prometheus/prometheus.yml.template
+++ b/prometheus/prometheus.yml.template
@@ -39,6 +39,9 @@ scrape_configs:
       replacement: '${1}'
   metric_relabel_configs:
 # FILTER_METRICS
+    - source_labels: [__name__, scheduling_group_name]
+      regex: '(scylla_storage_proxy_coordinator_.*_bucket;)(atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache)'
+      action: drop
     - source_labels: [version]
       regex:  '(.+)'
       target_label: CPU


### PR DESCRIPTION
Histograms are currently the most resource consuming metrics. Scylla reports many of its internal scheduling groups histogram.

This patch drop those metrics while scrapping them, improving the overall performance.

The following scheduling group will be dropped:
atexit|gossip|mem_compaction|memtable|streaming|background_reclaim| compaction|main|memtable_to_cache

Fixes #1971