### PR TITLE
doc: add redirections to fix the broken links

### DIFF
--- a/docs/_utils/redirects.yaml
+++ b/docs/_utils/redirects.yaml
@@ -1,0 +1,8 @@
+/stable/install/docker_compose.html:/stable/install/docker-compose
+/stable/install/monitor_without_docker.html:/stable/install/monitor-without-docker
+/stable/install/monitoring_stack.html:/stable/install/monitoring-stack
+/stable/install/start_all.html:/stable/install/start-all
+/stable/procedures/updating_dashboard.html:/stable/procedures/updating-dashboard
+/stable/reference/monitoring_apis.html:/stable/reference/monitoring-apis
+/stable/troubleshooting/monitor_troubleshoot.html:/stable/troubleshooting/monitor-troubleshoot
+/stable/use-monitoring/cql_optimization.html:/stable/use-monitoring/cql-optimization


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylla-enterprise/issues/2973

This commit adds redirections for files that have been renamed (i.e. in which the underscore was replaced with a dash).

This commit must be backported to branch-4.4 to fix the links in the already published docs.