### PR TITLE
Update redirects.yaml

### DIFF
--- a/docs/_utils/redirects.yaml
+++ b/docs/_utils/redirects.yaml
@@ -1,8 +1,8 @@
-/stable/install/docker_compose.html:/stable/install/docker-compose
-/stable/install/monitor_without_docker.html:/stable/install/monitor-without-docker
-/stable/install/monitoring_stack.html:/stable/install/monitoring-stack
-/stable/install/start_all.html:/stable/install/start-all
-/stable/procedures/updating_dashboard.html:/stable/procedures/updating-dashboard
-/stable/reference/monitoring_apis.html:/stable/reference/monitoring-apis
-/stable/troubleshooting/monitor_troubleshoot.html:/stable/troubleshooting/monitor-troubleshoot
-/stable/use-monitoring/cql_optimization.html:/stable/use-monitoring/cql-optimization
+/stable/install/docker_compose.html: /stable/install/docker-compose
+/stable/install/monitor_without_docker.html: /stable/install/monitor-without-docker
+/stable/install/monitoring_stack.html: /stable/install/monitoring-stack
+/stable/install/start_all.html: /stable/install/start-all
+/stable/procedures/updating_dashboard.html: /stable/procedures/updating-dashboard
+/stable/reference/monitoring_apis.html: /stable/reference/monitoring-apis
+/stable/troubleshooting/monitor_troubleshoot.html: /stable/troubleshooting/monitor-troubleshoot
+/stable/use-monitoring/cql_optimization.html: /stable/use-monitoring/cql-optimization


### PR DESCRIPTION
Fix for https://github.com/scylladb/scylla-monitoring/pull/1990

It's not necessary to backport this change to the branch-4.4, redirections are generated from the master branch.