### PR TITLE
Manager agents

### DIFF
--- a/prometheus/prometheus.yml.template
+++ b/prometheus/prometheus.yml.template
@@ -26,7 +26,7 @@ scrape_configs:
   honor_labels: false
   file_sd_configs:
     - files:
-      - /etc/scylla.d/prometheus/scylla_servers.yml
+      - /etc/scylla.d/prometheus/targets/scylla_servers.yml
   relabel_configs:
     - source_labels: [__address__]
       regex:  '([^:]+)'
@@ -150,7 +150,7 @@ scrape_configs:
   scrape_timeout: 20s # Timeout before trying to scape a target again
   file_sd_configs:
     - files:
-      - /etc/scylla.d/prometheus/node_exporter_servers.yml
+      - /etc/scylla.d/prometheus/targets/node_exporter_servers.yml
   relabel_configs:
     - source_labels: [__address__]
       regex:  '(.*):\d+'
@@ -174,26 +174,22 @@ scrape_configs:
   honor_labels: false
   file_sd_configs:
     - files:
-      - /etc/scylla.d/prometheus/scylla_servers.yml
+      - /etc/scylla.d/prometheus/targets/scylla_manager_agents.yml
   relabel_configs:
     - source_labels: [__address__]
-      regex:  '(.*):\d+'
-      target_label: instance
-      replacement: '${1}'
-    - source_labels: [__address__]
       regex:  '([^:]+)'
-      target_label: instance
-      replacement: '${1}'
-    - source_labels: [instance]
-      regex:  '(.*)'
       target_label: __address__
       replacement: '${1}:5090'
+    - source_labels: [__address__]
+      regex:  '(.*):.+'
+      target_label: instance
+      replacement: '${1}'
 
 - job_name: scylla_manager
   honor_labels: false
   file_sd_configs:
     - files:
-      - /etc/scylla.d/prometheus/scylla_manager_servers.yml
+      - /etc/scylla.d/prometheus/targets/scylla_manager_servers.yml
   metric_relabel_configs:
     - source_labels: [host]
       target_label: instance

--- a/start-all.sh
+++ b/start-all.sh
@@ -247,7 +247,8 @@ for arg; do
                 PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-cdc"
                 ;;
             (--target-directory)
-                TARGET_DIRECTORY="1"
+                LIMIT="1"
+                PARAM="target-directory"
                 ;;
             (--help) usage
                 ;;
@@ -270,6 +271,9 @@ for arg; do
             unset PARAM
         elif [ "$PARAM" = "evaluation-interval" ]; then
             PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS -E $NOSPACE"
+            unset PARAM
+        elif [ "$PARAM" = "target-directory" ]; then
+            TARGET_DIRECTORY="$NOSPACE"
             unset PARAM
         else
             if [ -z "${DOCKER_LIMITS[$DOCR]}" ]; then
@@ -432,8 +436,8 @@ else
     NODE_TARGET_FILE=""
 fi
 
-if [ "$TARGET_DIRECTORY" = "1" ]; then
-    SCYLLA_TARGET_FILE="-v $PWD/prometheus/targets/:/etc/scylla.d/prometheus/targets/"
+if [ "$TARGET_DIRECTORY" != "" ]; then
+    SCYLLA_TARGET_FILE="-v "$($readlink_command $TARGET_DIRECTORY)":/etc/scylla.d/prometheus/targets/"
 fi
 if [ -z $DATA_DIR ]
 then


### PR DESCRIPTION
This series adds the option to override scylla manager agents configuration file.

It requires two changes, one it allows defining a the manager agent file.
Second, it does not replace the ports if they are part of the configuration file.

Note that this could be a breaking changes

Fixes #1992