### PR TITLE
datadog.rules.yml: Add replica failure metrics

### DIFF
--- a/docs/source/procedures/datadog/datadog.rules.yml
+++ b/docs/source/procedures/datadog/datadog.rules.yml
@@ -355,3 +355,75 @@ groups:
       by: "instance"
       level: "1"
       dd: "1"
+  - record: scylla_database_total_writes_failed_ag
+    expr: sum(rate(scylla_database_total_writes_failed[60s])) by (cluster, dc, instance)
+    labels:
+      by: "instance"
+      level: "1"
+      dd: "1"
+  - record: scylla_database_total_writes_failed_ag
+    expr: sum(rate(scylla_database_total_writes_failed[60s])) by (cluster, dc)
+    labels:
+      by: "dc"
+      level: "1"
+      dd: "1"
+  - record: scylla_database_total_writes_failed_ag
+    expr: sum(rate(scylla_database_total_writes_failed[60s])) by (cluster)
+    labels:
+      by: "cluster"
+      level: "1"
+      dd: "1"
+  - record: scylla_database_total_writes_timedout_ag
+    expr: sum(rate(scylla_database_total_writes_timedout[60s])) by (cluster, dc, instance)
+    labels:
+      by: "instance"
+      level: "1"
+      dd: "1"
+  - record: scylla_database_total_writes_timedout_ag
+    expr: sum(rate(scylla_database_total_writes_timedout[60s])) by (cluster, dc)
+    labels:
+      by: "dc"
+      level: "1"
+      dd: "1"
+  - record: scylla_database_total_writes_timedout_ag
+    expr: sum(rate(scylla_database_total_writes_timedout[60s])) by (cluster)
+    labels:
+      by: "cluster"
+      level: "1"
+      dd: "1"
+  - record: scylla_database_total_reads_failed_ag
+    expr: sum(rate(scylla_database_total_reads_failed{class="user"}[60s])) by (cluster, dc, instance)
+    labels:
+      by: "instance"
+      level: "1"
+      dd: "1"
+  - record: scylla_database_total_reads_failed_ag
+    expr: sum(rate(scylla_database_total_reads_failed{class="user"}[60s])) by (cluster, dc)
+    labels:
+      by: "dc"
+      level: "1"
+      dd: "1"
+  - record: scylla_database_total_reads_failed_ag
+    expr: sum(rate(scylla_database_total_reads_failed{class="user"}[60s])) by (cluster)
+    labels:
+      by: "cluster"
+      level: "1"
+      dd: "1"
+  - record: scylla_database_total_reads_rate_limited_ag
+    expr: sum(rate(scylla_database_total_reads_rate_limited[60s])) by (cluster, dc, instance)
+    labels:
+      by: "instance"
+      level: "1"
+      dd: "1"
+  - record: scylla_database_total_reads_rate_limited_ag
+    expr: sum(rate(scylla_database_total_reads_rate_limited[60s])) by (cluster, dc)
+    labels:
+      by: "dc"
+      level: "1"
+      dd: "1"
+  - record: scylla_database_total_reads_rate_limited_ag
+    expr: sum(rate(scylla_database_total_reads_rate_limited[60s])) by (cluster)
+    labels:
+      by: "cluster"
+      level: "1"
+      dd: "1"


### PR DESCRIPTION
The following metrics will be added to the datadog integration: scylla_database_total_reads_failed_ag
scylla_database_total_reads_rate_limited_ag
scylla_database_total_writes_failed_ag
scylla_database_total_writes_timedout_ag

Fixes #2006
Signed-off-by: Amnon Heiman <amnon@scylladb.com>