### PR TITLE
datadog.rules.yml: Add a recording rules for sums without rate

### DIFF
--- a/docs/source/procedures/datadog/datadog.rules.yml
+++ b/docs/source/procedures/datadog/datadog.rules.yml
@@ -1,6 +1,12 @@
 groups:
 - name: scylla.rules
   rules:
+  - record: scylla_coordinator_read_count_total
+    expr: sum(scylla_storage_proxy_coordinator_read_latency_count{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}) by (cluster)
+    labels:
+      by: "cluster"
+      level: "1"
+      dd: "1"
   - record: scylla_coordinator_read_count
     expr: sum(rate(scylla_storage_proxy_coordinator_read_latency_count{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, scheduling_group_name)
     labels:
@@ -19,6 +25,12 @@ groups:
       by: "instance"
       level: "1"
       dd: "1"
+  - record: scylla_total_requests_total
+    expr: sum(scylla_transport_requests_served{}) by (cluster)
+    labels:
+      by: "cluster"
+      level: "1"
+      dd: "1"
   - record: scylla_total_requests
     expr: sum(rate(scylla_transport_requests_served{}[60s])) by (cluster)
     labels:
@@ -35,6 +47,12 @@ groups:
     expr: sum(rate(scylla_transport_requests_served{}[60s])) by (cluster, dc, instance)
     labels:
       by: "instance"
+      level: "1"
+      dd: "1"
+  - record: scylla_coordinator_write_count_total
+    expr: sum(scylla_storage_proxy_coordinator_write_latency_count{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}) by (cluster)
+    labels:
+      by: "cluster"
       level: "1"
       dd: "1"
   - record: scylla_coordinator_write_count
@@ -145,14 +163,14 @@ groups:
       by: "instance"
       level: "1"
       dd: "1"
-  - record: scylla_node_network_receive_bytes
-    expr: sum(rate(node_network_receive_bytes_total[2m])) by (cluster)
+  - record: scylla_node_network_receive_bytes_total
+    expr: sum(node_network_receive_bytes_total) by (cluster)
     labels:
       by: "cluster"
       level: "1"
       dd: "1"
-  - record: scylla_node_network_transmit_bytes
-    expr: sum(rate(node_network_transmit_bytes_total[2m])) by (cluster)
+  - record: scylla_node_network_transmit_bytes_total
+    expr: sum(node_network_transmit_bytes_total) by (cluster)
     labels:
       by: "cluster"
       level: "1"
@@ -163,8 +181,20 @@ groups:
       by: "cluster"
       level: "1"
       dd: "1"
+  - record: scylla_node_disk_read_bytes_total
+    expr: sum(node_disk_read_bytes_total) by (cluster, device)
+    labels:
+      by: "cluster"
+      level: "1"
+      dd: "1"
   - record: scylla_node_disk_written_bytes
     expr: sum(rate(node_disk_written_bytes_total[2m])) by (cluster, device)
+    labels:
+      by: "cluster"
+      level: "1"
+      dd: "1"
+  - record: scylla_node_disk_written_bytes_total
+    expr: sum(node_disk_written_bytes_total) by (cluster, device)
     labels:
       by: "cluster"
       level: "1"
@@ -194,9 +224,21 @@ groups:
       level: "1"
       dd: "1"
   - record: scylla_storage_proxy_coordinator_read_timeouts_ag
-    expr: avg(rate(scylla_storage_proxy_coordinator_read_timeouts{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (scheduling_group_name, cluster, dc, instance)
+    expr: sum(rate(scylla_storage_proxy_coordinator_read_timeouts{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (scheduling_group_name, cluster, dc, instance)
     labels:
       by: "instance"
+      level: "1"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_read_timeouts_ag
+    expr: sum(rate(scylla_storage_proxy_coordinator_read_timeouts{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (scheduling_group_name, cluster)
+    labels:
+      by: "cluster"
+      level: "1"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_read_timeouts_total
+    expr: sum(scylla_storage_proxy_coordinator_read_timeouts{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}) by (cluster)
+    labels:
+      by: "cluster"
       level: "1"
       dd: "1"
   - record: scylla_reactor_utilization_ag
@@ -211,21 +253,57 @@ groups:
       by: "cluster"
       dd: "1"
   - record: scylla_storage_proxy_coordinator_read_unavailable_ag
-    expr: avg(rate(scylla_storage_proxy_coordinator_read_unavailable{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (scheduling_group_name, cluster, dc, instance)
+    expr: sum(rate(scylla_storage_proxy_coordinator_read_unavailable{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (scheduling_group_name, cluster, dc, instance)
+    labels:
+      by: "instance"
+      level: "1"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_read_unavailable_ag
+    expr: sum(rate(scylla_storage_proxy_coordinator_read_unavailable{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (scheduling_group_name, cluster)
+    labels:
+      by: "cluster"
+      level: "1"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_read_unavailable_total
+    expr: sum(scylla_storage_proxy_coordinator_read_unavailable{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}) by (cluster)
+    labels:
+      by: "cluster"
+      level: "1"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_write_timeouts_ag
+    expr: sum(rate(scylla_storage_proxy_coordinator_write_timeouts{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (scheduling_group_name, cluster, dc, instance)
     labels:
       by: "instance"
       level: "1"
       dd: "1"
   - record: scylla_storage_proxy_coordinator_write_timeouts_ag
-    expr: avg(rate(scylla_storage_proxy_coordinator_write_timeouts{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (scheduling_group_name, cluster, dc, instance)
+    expr: sum(rate(scylla_storage_proxy_coordinator_write_timeouts{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (scheduling_group_name, cluster)
+    labels:
+      by: "cluster"
+      level: "1"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_write_timeouts_total
+    expr: sum(scylla_storage_proxy_coordinator_write_timeouts{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}) by (cluster)
+    labels:
+      by: "cluster"
+      level: "1"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_write_unavailable_ag
+    expr: sum(rate(scylla_storage_proxy_coordinator_write_unavailable{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, scheduling_group_name, instance)
     labels:
       by: "instance"
       level: "1"
       dd: "1"
   - record: scylla_storage_proxy_coordinator_write_unavailable_ag
-    expr: avg(rate(scylla_storage_proxy_coordinator_write_unavailable{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, scheduling_group_name, instance)
+    expr: sum(rate(scylla_storage_proxy_coordinator_write_unavailable{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, scheduling_group_name)
     labels:
-      by: "instance"
+      by: "cluster"
+      level: "1"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_write_unavailable_total
+    expr: sum(scylla_storage_proxy_coordinator_write_unavailable{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}) by (cluster)
+    labels:
+      by: "cluster"
       level: "1"
       dd: "1"
   - record: node_network_receive_packets
@@ -246,6 +324,12 @@ groups:
       by: "cluster"
       level: "1"
       dd: "1"
+  - record: scylla_node_network_receive_packets_total
+    expr: sum(node_network_receive_packets_total) by (device,cluster)
+    labels:
+      by: "cluster"
+      level: "1"
+      dd: "1"
   - record: node_network_transmit_packets
     expr: sum(rate(node_network_transmit_packets_total{}[2m])) by (device,cluster, dc, instance)
     labels:
@@ -258,8 +342,8 @@ groups:
       by: "dc"
       level: "1"
       dd: "1"
-  - record: node_network_transmit_packets
-    expr: sum(rate(node_network_transmit_packets_total{}[2m])) by (device,cluster)
+  - record: scylla_node_network_transmit_packets_total
+    expr: sum(node_network_transmit_packets_total) by (device,cluster)
     labels:
       by: "cluster"
       level: "1"


### PR DESCRIPTION
Recording rules that collect metrics accross all nodes without a rate function.
That gives an option to get a cluster view when scraping the prometheus sparesly.
