### PR TITLE
Do not avg p95,p99 of scheduling group

### DIFF
--- a/grafana/scylla-overview.template.json
+++ b/grafana/scylla-overview.template.json
@@ -52,16 +52,16 @@
                         "span": 2,
                         "targets": [
                             {
-                                "expr": "avg(wlatencyp95{by=\"cluster\", cluster=~\"$cluster|$^\",scheduling_group_name=~\"$sg\"}>0)",
+                                "expr": "wlatencyp95{by=\"cluster\", cluster=~\"$cluster|$^\",scheduling_group_name=~\"$sg\"}>0",
                                 "intervalFactor": 1,
-                                "legendFormat": "95%",
+                                "legendFormat": "{{scheduling_group_name}} 95%",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                                "expr": "avg(wlatencyp99{by=\"cluster\", cluster=~\"$cluster|$^\",scheduling_group_name=~\"$sg\"}>0)",
+                                "expr": "wlatencyp99{by=\"cluster\", cluster=~\"$cluster|$^\",scheduling_group_name=~\"$sg\"}>0",
                                 "intervalFactor": 1,
-                                "legendFormat": "99%",
+                                "legendFormat": "{{scheduling_group_name}} 99%",
                                 "refId": "B",
                                 "step": 1
                             }
@@ -91,16 +91,16 @@
                         "span": 2,
                         "targets": [
                             {
-                                "expr": "avg(rlatencyp95{by=\"cluster\", cluster=~\"$cluster|$^\",scheduling_group_name=~\"$sg\"}>0)",
+                                "expr": "rlatencyp95{by=\"cluster\", cluster=~\"$cluster|$^\",scheduling_group_name=~\"$sg\"}>0",
                                 "intervalFactor": 1,
-                                "legendFormat": "95%",
+                                "legendFormat": "{{scheduling_group_name}} 95%",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                                "expr": "avg(rlatencyp99{by=\"cluster\", cluster=~\"$cluster|$^\",scheduling_group_name=~\"$sg\"}>0)",
+                                "expr": "rlatencyp99{by=\"cluster\", cluster=~\"$cluster|$^\",scheduling_group_name=~\"$sg\"}>0",
                                 "intervalFactor": 1,
-                                "legendFormat": "99%",
+                                "legendFormat": "{{scheduling_group_name}} 99%",
                                 "refId": "B",
                                 "step": 1
                             }
@@ -312,16 +312,16 @@
                         "span": 2,
                         "targets": [
                             {
-                                "expr": "avg(wlatencyp95{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}>0) by ([[by]],sg)",
+                                "expr": "avg(wlatencyp95{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}>0) by (scheduling_group_name, [[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "95% {{[[by]]}}",
+                                "legendFormat": "{{scheduling_group_name}} 95% {{[[by]]}}",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                                "expr": "avg(wlatencyp99{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}>0) by ([[by]],sg)",
+                                "expr": "avg(wlatencyp99{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}>0) by (scheduling_group_name, [[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "99% {{[[by]]}}",
+                                "legendFormat": "{{scheduling_group_name}} 99% {{[[by]]}}",
                                 "refId": "B",
                                 "step": 1
                             }
@@ -404,16 +404,16 @@
                         },
                         "targets": [
                             {
-                                "expr": "avg(rlatencyp95{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}>0) by([[by]])",
+                                "expr": "avg(rlatencyp95{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}>0) by(scheduling_group_name, [[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "95% {{[[by]]}}",
+                                "legendFormat": "{{scheduling_group_name}} 95% {{[[by]]}}",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                                "expr": "avg(rlatencyp99{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}>0) by([[by]])",
+                                "expr": "avg(rlatencyp99{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}>0) by(scheduling_group_name, [[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "99% {{[[by]]}}",
+                                "legendFormat": "{{scheduling_group_name}} 99% {{[[by]]}}",
                                 "refId": "B",
                                 "step": 1
                             }

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -472,9 +472,9 @@
             },
             "targets":[
                {
-                  "expr":"avg(wlatencyp99{by=\"cluster\", cluster=~\"$cluster|^$\",scheduling_group_name=~\"$sg\"}>0)",
+                  "expr":"wlatencyp99{by=\"cluster\", cluster=~\"$cluster|^$\",scheduling_group_name=~\"$sg\"}>0",
                   "intervalFactor":1,
-                  "legendFormat":"",
+                  "legendFormat":"{{scheduling_group_name}}",
                   "refId":"A",
                   "instant":true,
                   "step":4
@@ -548,9 +548,9 @@
             },
             "targets":[
                {
-                  "expr":"avg(rlatencyp99{by=\"cluster\", cluster=~\"$cluster|^$\",scheduling_group_name=~\"$sg\"}>0)",
+                  "expr":"rlatencyp99{by=\"cluster\", cluster=~\"$cluster|^$\",scheduling_group_name=~\"$sg\"}>0",
                   "intervalFactor":1,
-                  "legendFormat":"",
+                  "legendFormat":"{{scheduling_group_name}}",
                   "refId":"A",
                   "instant":true,
                   "step":4


### PR DESCRIPTION
This series fix an issue with showing multiple scheduling group in the overview dashboard.
Instead of avg over them 

Fixes #1989