### PR TITLE
cql: add all columns for the big cell, row, and partition tables

### DIFF
--- a/grafana/scylla-cql.template.json
+++ b/grafana/scylla-cql.template.json
@@ -309,7 +309,7 @@
                         "targets": [
                             {
                               "refId": "A",
-                              "queryText": "select keyspace_name, table_name,partition_key, clustering_key, row_size  from system.large_rows",
+                              "queryText": "select keyspace_name, table_name,partition_key, clustering_key, row_size,compaction_time from system.large_rows",
                               "queryHost": "$node"
                             }
                           ],
@@ -375,7 +375,7 @@
                         "targets": [
                             {
                               "refId": "A",
-                              "queryText": "select keyspace_name, table_name,partition_key, clustering_key,  column_name,cell_size  from system.large_cells",
+                              "queryText": "select keyspace_name, table_name,partition_key, clustering_key, column_name,cell_size, collection_elements, compaction_time from system.large_cells",
                               "queryHost": "$node"
                             }
                           ],
@@ -441,7 +441,7 @@
                         "targets": [
                             {
                               "refId": "A",
-                              "queryText": "select keyspace_name, table_name,partition_key, partition_size  from system.large_partitions",
+                              "queryText": "select keyspace_name, table_name,partition_key, partition_size, compaction_time, rows from system.large_partitions",
                               "queryHost": "$node"
                             }
                           ],


### PR DESCRIPTION
This patch expose all columns of the big cell, row and partition table, after this change the tables look like:

![image](https://github.com/scylladb/scylla-monitoring/assets/2118079/da63733c-dbf0-4dce-ae8f-f8b25581d3a9)

Fixes #1991