### PR TITLE
prometheus.rules.yml: Set the DiskFull severity level in the right order

### DIFF
--- a/prometheus/prom_rules/prometheus.rules.yml
+++ b/prometheus/prom_rules/prometheus.rules.yml
@@ -158,7 +158,7 @@ groups:
       * 100 < 35
     for: 30s
     labels:
-      severity: "error"
+      severity: "info"
     annotations:
       description: '{{ $labels.instance }} has less than 35% free disk space.'
       summary: Instance {{ $labels.instance }} low disk space
@@ -176,7 +176,7 @@ groups:
       * 100 < 15
     for: 30s
     labels:
-      severity: "info"
+      severity: "error"
     annotations:
       description: '{{ $labels.instance }} has less than 15% free disk space.'
       summary: Instance {{ $labels.instance }} low disk space


### PR DESCRIPTION
This patch fixes the DiskFull severity level to be order correctly from info to error

Fixes #2029