### PR TITLE
types.json: disable the default annotation

### DIFF
--- a/grafana/types.json
+++ b/grafana/types.json
@@ -3021,13 +3021,16 @@
    "default_annotations":{
       "list":[
          {
-            "builtIn":1,
-            "datasource":"-- Grafana --",
-            "enable":true,
-            "hide":true,
-            "iconColor":"rgba(0, 211, 255, 1)",
-            "name":"Annotations & Alerts",
-            "type":"dashboard"
+            "builtIn": 1,
+            "datasource": {
+              "type": "datasource",
+              "uid": "grafana"
+            },
+            "enable": false,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
          },
          {
             "class":"annotation_restart"


### PR DESCRIPTION
Remove the annotation warning in the overview dashboard