### PR TITLE
scylla-cql: Add a panel for new connections

### DIFF
--- a/grafana/scylla-cql.template.json
+++ b/grafana/scylla-cql.template.json
@@ -134,6 +134,23 @@
                         "pointradius": 1,
                         "targets": [
                             {
+                                "expr": "sum(rate(scylla_transport_cql_connections{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "title": "Client CQL new connections by [[by]]",
+                        "description": "Rate of CQL connections created"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span": 3,
+                        "pointradius": 1,
+                        "targets": [
+                            {
                                 "expr": "sum(rate(scylla_cql_batches{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",


### PR DESCRIPTION
This patch adds a panel with the number of new connections.

![image](https://github.com/scylladb/scylla-monitoring/assets/2118079/f1630137-6470-4fb0-b22a-1a4b0d666d6f)

Fixes #2053