### PR TITLE
doc: remove dead links from upgrade guides

### DIFF
--- a/docs/source/upgrade/upgrade-guide-from-monitoring-1.x-to-monitoring-2.x.rst
+++ b/docs/source/upgrade/upgrade-guide-from-monitoring-1.x-to-monitoring-2.x.rst
@@ -2,9 +2,7 @@
 Upgrade Guide - Scylla Monitoring 1.x to Scylla Monitoring 2.x
 ==============================================================
 
-This document is a step by step procedure for upgrading |mon_root| from version 1.x to 2.x
-
-
+This document is a step by step procedure for upgrading ScyllaDB Monitoring Stack from version 1.x to 2.x
 
 Scylla monitoring stack uses `Prometheus <https://prometheus.io>`_ as its metrics database. The main differences between Scylla Monitoring 1.x and 2.x are moving from Prometheus version 1.x to Prometheus 2.x.
 Since Prometheus is not backward compatible between these two versions, the upgrade procedure consists of running the two monitoring stack, old and new, in **parallel**, allowing the new stack to read metrics from the old one. This procedure will enable you to migrate your Scylla monitoring stack without losing historical metric data in the process.
@@ -98,6 +96,5 @@ In the upgrade procedure, you set up a second monitoring stack. The old monitori
 Related Links
 =============
 
-* |mon_root|
 * :doc:`Upgrade</upgrade/index>`
 * `Prometheus Migration <https://Prometheus.io/docs/Prometheus/latest/migration/>`_

--- a/docs/source/upgrade/upgrade-guide-from-monitoring-2.x-to-monitoring-2.y.rst
+++ b/docs/source/upgrade/upgrade-guide-from-monitoring-2.x-to-monitoring-2.y.rst
@@ -2,7 +2,7 @@
 Upgrade Guide - Scylla Monitoring 2.x to Scylla Monitoring 2.y
 ==============================================================
 
-This document is a step by step procedure for upgrading  |mon_root| from version 2.x to 2.y, for example, between 2.0 to 2.1.
+This document is a step by step procedure for upgrading  ScyllaDB Monitoring Stack from version 2.x to 2.y, for example, between 2.0 to 2.1.
 
 
 
@@ -128,5 +128,4 @@ Run:
 Related Links
 =============
 
-* |mon_root|
 * :doc:`Upgrade</upgrade/index>`

--- a/docs/source/upgrade/upgrade-guide-from-monitoring-2.x-to-monitoring-3.y.rst
+++ b/docs/source/upgrade/upgrade-guide-from-monitoring-2.x-to-monitoring-3.y.rst
@@ -2,7 +2,7 @@
 Upgrade Guide - Scylla Monitoring 2.x to Scylla Monitoring 3.x
 ==============================================================
 
-This document is a step by step procedure for upgrading |mon_root| from version 2.x to 3.x
+This document is a step by step procedure for upgrading ScyllaDB Monitoring Stack from version 2.x to 3.x
 
 Switching from Scylla Monitoring 2.x to Scylla Monitoring 3.x is not fully backward compatible.
 The changes affect dashboards' names and metrics.
@@ -59,5 +59,4 @@ To rollback, simply kill the new stack, change to the old monitoring stack direc
 Related Links
 =============
 
-* |mon_root|
 * :doc:`Upgrade</upgrade/index>`

--- a/docs/source/upgrade/upgrade-guide-from-monitoring-3.x-to-monitoring-3.y.rst
+++ b/docs/source/upgrade/upgrade-guide-from-monitoring-3.x-to-monitoring-3.y.rst
@@ -2,7 +2,7 @@
 Upgrade Guide - Scylla Monitoring 3.x to Scylla Monitoring 3.y
 ==============================================================
 
-This document is a step by step procedure for upgrading `Scylla Monitoring Stack </operating-scylla/monitoring/3.0>`_ from version 3.x to 3.y, for example, between 3.0 to 3.0.1.
+This document is a step by step procedure for upgrading ScyllaDB Monitoring Stack from version 3.x to 3.y, for example, between 3.0 to 3.0.1.
 
 Upgrade Procedure
 =================
@@ -134,5 +134,4 @@ Run:
 Related Links
 =============
 
-* `Scylla Monitoring </operating-scylla/monitoring/>`_
 * :doc:`Upgrade</upgrade/index>`

--- a/docs/source/upgrade/upgrade-guide-from-monitoring-3.x-to-monitoring-4.y.rst
+++ b/docs/source/upgrade/upgrade-guide-from-monitoring-3.x-to-monitoring-4.y.rst
@@ -2,7 +2,7 @@
 Upgrade Guide - Scylla Monitoring 3.x to Scylla Monitoring 4.y
 ==============================================================
 
-This document is a step by step procedure for upgrading `Scylla Monitoring Stack </operating-scylla/monitoring/3.0>`_ from version 3.x to 4.y, for example, between 3.9 to 4.0.0.
+This document is a step by step procedure for upgrading ScyllaDB Monitoring Stack from version 3.x to 4.y, for example, between 3.9 to 4.0.0.
 
 Upgrade Procedure
 =================
@@ -277,5 +277,4 @@ see the latency graphs over your entire retention time.
 Related Links
 =============
 
-* `Scylla Monitoring </operating-scylla/monitoring/>`_
 * :doc:`Upgrade</upgrade/index>`


### PR DESCRIPTION
This PR removes dead links to ScyllaDB Monitoring Stack from upgrade guides.

The links were added when the Monitoring Stack upgrade guides were part of the core ScyllaDB documentation. Now they are both dead and unnecessary, so they were removed.

At a minimum, this PR must be backported to branch-4.5, but it should also be backported to branch-4.4 (to fix the current docs for that version).