### PR TITLE
datadog.rules: add a last manager operation

### DIFF
--- a/docs/source/procedures/datadog/datadog.rules.yml
+++ b/docs/source/procedures/datadog/datadog.rules.yml
@@ -552,3 +552,9 @@ groups:
       by: "cluster"
       level: "1"
       dd: "1"
+  - record: scylla_manager_last_success_ts
+    expr: max(scylla_manager_scheduler_last_success{}) by(cluster, type)
+    labels:
+      by: "cluster"
+      level: "1"
+      dd: "1"


### PR DESCRIPTION
Add a recording rules for the last successful backup, repair, and healthcheck
Relates to #2043