### PR TITLE
prometheus.rules.yml: Add a warning for too many open files per shard

### DIFF
--- a/prometheus/prom_rules/prometheus.rules.yml
+++ b/prometheus/prom_rules/prometheus.rules.yml
@@ -261,3 +261,24 @@ groups:
     annotations:
       description: 'OOM Kill on {{ $labels.instance }}'
       summary: A process was terminated on Instance {{ $labels.instance }}
+  - alert: tooManyFiles
+    expr: (node_filesystem_files - node_filesystem_files_free) / on(instance) group_left count(scylla_reactor_cpu_busy_ms) by (instance)>20000
+    for: 10s
+    labels:
+      severity: "info"
+      description: 'Over 20k open files per shard {{ $labels.instance }}'
+      summary: There are over 20K open files per shard on Insace {{ $labels.instance }}
+  - alert: tooManyFiles
+    expr: (node_filesystem_files - node_filesystem_files_free) / on(instance) group_left count(scylla_reactor_cpu_busy_ms) by (instance)>30000
+    for: 10s
+    labels:
+      severity: "warn"
+      description: 'Over 30k open files per shard {{ $labels.instance }}'
+      summary: There are over 30K open files per shard on Insace {{ $labels.instance }}
+  - alert: tooManyFiles
+    expr: (node_filesystem_files - node_filesystem_files_free) / on(instance) group_left count(scylla_reactor_cpu_busy_ms) by (instance)>40000
+    for: 10s
+    labels:
+      severity: "error"
+      description: 'Over 40k open files per shard {{ $labels.instance }}'
+      summary: There are over 40K open files per shard on Insace {{ $labels.instance }}


### PR DESCRIPTION
This patch adds info, warn and error alerts if there are two many open
files per shard.

The warnnings will be
More than 20k - Info
More than 30k - warn
More than 40k - error

Fixes #2060 