### PR TITLE
prometheus.rules.yml warn when a node is in joining mode for a long time

### DIFF
--- a/prometheus/prom_rules/prometheus.rules.yml
+++ b/prometheus/prom_rules/prometheus.rules.yml
@@ -282,3 +282,17 @@ groups:
       severity: "error"
       description: 'Over 40k open files per shard {{ $labels.instance }}'
       summary: There are over 40K open files per shard on Insace {{ $labels.instance }}
+  - alert: nodeInJoinMode
+    expr: scylla_node_operation_mode == 2
+    for: 5h
+    labels:
+      severity: "info"
+      description: 'Node {{ $labels.instance }} in Joining mode for 5 hours'
+      summary: Node {{ $labels.instance }} in Joining mode for 5 hours
+  - alert: nodeInJoinMode
+    expr: scylla_node_operation_mode == 2
+    for: 1d
+    labels:
+      severity: "warn"
+      description: 'Node {{ $labels.instance }} in Joining mode for 1 day'
+      summary: Node {{ $labels.instance }} in Joining mode for 1 day


### PR DESCRIPTION
This PR adds two alerts for a joining node that takes a long time to join.
It adds two levels, one as info after 5 hours and one as warning after a day

Fixes #2076