### PR TITLE
scylla-detailed: split read timeout into multiple graph on the same panel

### DIFF
--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -289,10 +289,24 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$func(rate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m]) + rate(scylla_storage_proxy_coordinator_cas_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])+rate(scylla_storage_proxy_coordinator_range_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by ([[by]])",
+                                "expr": "$func(rate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "legendFormat": "",
+                                "legendFormat": "Read {{dc}} {{instance}} {{shard}}",
                                 "refId": "A",
+                                "step": 1
+                            },
+                            {
+                                "expr": "$func(rate(scylla_storage_proxy_coordinator_cas_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "CAS {{dc}} {{instance}} {{shard}}",
+                                "refId": "B",
+                                "step": 1
+                            },
+                            {
+                                "expr": "$func(rate(scylla_storage_proxy_coordinator_range_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "Range {{dc}} {{instance}} {{shard}}",
+                                "refId": "C",
                                 "step": 1
                             }
                         ],


### PR DESCRIPTION
This patch fixes the read timeout graph by spliting the query into multiple graph on the same panel.

This has two advantages: first, if one metric is missing, ther other would be shown, second it is possible to see which metric is the one that contribute to the timeouts

![Screenshot from 2023-10-17 10-57-29](https://github.com/scylladb/scylla-monitoring/assets/2118079/bd6209c8-9e8e-4491-bed4-1397d63f3d7a)

Fixes #2085