### PR TITLE
Optionally remove manager-agent port from target file

### DIFF
--- a/prometheus-config.sh
+++ b/prometheus-config.sh
@@ -26,6 +26,9 @@ for arg; do
         (--no-cdc)
             NO_CDC="1"
             ;;
+        (--no-manager-agent-file)
+            NO_MANAGER_AGENT_FILE="1"
+            ;;
         (*) set -- "$@" "$arg"
             ;;
     esac
@@ -74,6 +77,9 @@ elif [ "$NO_CAS" = "1" ]; then
     sed -i "s/ *# FILTER_METRICS.*/    - source_labels: [__name__]\\n      regex: '(.*_cas.*)'\\n      action: drop/g" $PWD/prometheus/build/prometheus.yml
 elif [ "$NO_CDC" = "1" ]; then
     sed -i "s/ *# FILTER_METRICS.*/    - source_labels: [__name__]\\n      regex: '(.*_cdc_.*)'\\n      action: drop/g" $PWD/prometheus/build/prometheus.yml
+fi
+if [ "$NO_MANAGER_AGENT_FILE" = "1" ]; then
+    sed -i "s/ *# MANAGER_AGENT_PORT_MAPPING.*/    - source_labels: [__address__]\\n      regex:  '(.*):\\\\d+'\\n      target_label: __address__\\n      replacement: \'\$\{1\}\'\\n/g" $PWD/prometheus/build/prometheus.yml
 fi
 
 for val in "${PROMETHEUS_TARGETS[@]}"; do

--- a/prometheus/prometheus.yml.template
+++ b/prometheus/prometheus.yml.template
@@ -176,6 +176,7 @@ scrape_configs:
     - files:
       - /etc/scylla.d/prometheus/targets/scylla_manager_agents.yml
   relabel_configs:
+# MANAGER_AGENT_PORT_MAPPING
     - source_labels: [__address__]
       regex:  '([^:]+)'
       target_label: __address__

--- a/start-all.sh
+++ b/start-all.sh
@@ -432,6 +432,7 @@ if [ -z "$TARGET_DIRECTORY" ] && [ -z "$CONSUL_ADDRESS" ]; then
     fi
 
     if [ -z $SCYLLA_MANGER_AGENT_TARGET_FILE ]; then
+       PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-manager-agent-file"
        SCYLLA_MANGER_AGENT_TARGET_FILE=$SCYLLA_TARGET_FILE
     fi
     if [ ! -f $NODE_TARGET_FILE ]; then


### PR DESCRIPTION
For backwords compatibilities reasons, if no manager-agent file is given and the targets are taken from scylla_server file, ports will be removed.