### PR TITLE
allow setting node_exporter ports from their configuration file

### DIFF
--- a/prometheus-config.sh
+++ b/prometheus-config.sh
@@ -26,6 +26,9 @@ for arg; do
         (--no-cdc)
             NO_CDC="1"
             ;;
+        (--no-node-exporter-file)
+            NO_NODE_EXPORTER_FILE="1"
+            ;;
         (--no-manager-agent-file)
             NO_MANAGER_AGENT_FILE="1"
             ;;
@@ -77,6 +80,9 @@ elif [ "$NO_CAS" = "1" ]; then
     sed -i "s/ *# FILTER_METRICS.*/    - source_labels: [__name__]\\n      regex: '(.*_cas.*)'\\n      action: drop/g" $PWD/prometheus/build/prometheus.yml
 elif [ "$NO_CDC" = "1" ]; then
     sed -i "s/ *# FILTER_METRICS.*/    - source_labels: [__name__]\\n      regex: '(.*_cdc_.*)'\\n      action: drop/g" $PWD/prometheus/build/prometheus.yml
+fi
+if [ "$NO_NODE_EXPORTER_FILE" = "1" ]; then
+    sed -i "s/ *# NODE_EXPORTER_PORT_MAPPING.*/    - source_labels: [__address__]\\n      regex:  '(.*):\\\\d+'\\n      target_label: __address__\\n      replacement: '\$\{1\}'\\n/g" $PWD/prometheus/build/prometheus.yml
 fi
 if [ "$NO_MANAGER_AGENT_FILE" = "1" ]; then
     sed -i "s/ *# MANAGER_AGENT_PORT_MAPPING.*/    - source_labels: [__address__]\\n      regex:  '(.*):\\\\d+'\\n      target_label: __address__\\n      replacement: \'\$\{1\}\'\\n/g" $PWD/prometheus/build/prometheus.yml

--- a/prometheus/prometheus.yml.template
+++ b/prometheus/prometheus.yml.template
@@ -152,18 +152,15 @@ scrape_configs:
     - files:
       - /etc/scylla.d/prometheus/targets/node_exporter_servers.yml
   relabel_configs:
-    - source_labels: [__address__]
-      regex:  '(.*):\d+'
-      target_label: instance
-      replacement: '${1}'
+# NODE_EXPORTER_PORT_MAPPING
     - source_labels: [__address__]
       regex:  '([^:]+)'
-      target_label: instance
-      replacement: '${1}'
-    - source_labels: [instance]
-      regex:  '(.*)'
       target_label: __address__
       replacement: '${1}:9100'
+    - source_labels: [__address__]
+      regex:  '(.*):.+'
+      target_label: instance
+      replacement: '${1}'
   metric_relabel_configs:
     - source_labels: [__name__]
       regex: '(node_filesystem_size_bytes|node_filesystem_avail_bytes|node_network_receive_packets_total|node_network_transmit_packets_total|node_network_receive_bytes_total|node_network_transmit_bytes_total)'

--- a/start-all.sh
+++ b/start-all.sh
@@ -428,11 +428,12 @@ if [ -z "$TARGET_DIRECTORY" ] && [ -z "$CONSUL_ADDRESS" ]; then
     fi
 
     if [ -z $NODE_TARGET_FILE ]; then
+       PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-manager-agent-file"
        NODE_TARGET_FILE=$SCYLLA_TARGET_FILE
     fi
 
     if [ -z $SCYLLA_MANGER_AGENT_TARGET_FILE ]; then
-       PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-manager-agent-file"
+       PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-node-exporter-file"
        SCYLLA_MANGER_AGENT_TARGET_FILE=$SCYLLA_TARGET_FILE
     fi
     if [ ! -f $NODE_TARGET_FILE ]; then


### PR DESCRIPTION
This patch allows specifying specific ports for node_exporter, if the node_exporter file is explicitely supplied, the ports will be taken from the file instead of the default ones.

Fixes #2092