### PR TITLE
scylla-detailed payload panels should be show b/s units

### DIFF
--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -1840,7 +1840,7 @@
                         "title": "99th percentile read latency by [[by]]"
                     },
                     {
-                        "class": "bytes_panel",
+                        "class": "bps_panel",
                         "span": 3,
                         "dashversion":[">5.3", ">2022.1"],
                         "description": "Bytes received in CQL messages",
@@ -1857,7 +1857,7 @@
                         "title": "Received payload by [[by]]"
                     },
                     {
-                        "class": "bytes_panel",
+                        "class": "bps_panel",
                         "span": 3,
                         "dashversion":[">5.3", ">2022.1"],
                         "description": "Average CQL message size (received)",
@@ -1874,7 +1874,7 @@
                         "title": "Average received payload size by [[by]]"
                     },
                     {
-                        "class": "bytes_panel",
+                        "class": "bps_panel",
                         "span": 3,
                         "dashversion":[">5.3", ">2022.1"],
                         "description": "Bytes sent in CQL messages",
@@ -1891,7 +1891,7 @@
                         "title": "Response payload by [[by]]"
                     },
                     {
-                        "class": "bytes_panel",
+                        "class": "bps_panel",
                         "span": 3,
                         "dashversion":[">5.3", ">2022.1"],
                         "targets": [


### PR DESCRIPTION
This patch chang the payload panels units to be b/s
![image](https://github.com/scylladb/scylla-monitoring/assets/2118079/4afc3662-239c-4a59-894e-9196c5cf1d25)

Fixes #2083