### PR TITLE
scylla-overview: Do not rely on recording rules for picking the scheduling group

### DIFF
--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -2002,7 +2002,7 @@
                       ]
                     },
                     "name": "scheduling_group",
-                    "query": "label_values(all_scheduling_group{cluster=~\"$cluster|$^\"}, scheduling_group_name)",
+                    "query": "label_values(scylla_scheduler_runtime_ms{cluster=~\"$cluster|$^\"}, group)",
                     "sort": 3
                 },
                 {
@@ -2020,7 +2020,7 @@
                       ]
                     },
                     "name": "scheduling_group",
-                    "query": "label_values(all_scheduling_group{cluster=~\"$cluster|$^\"}, scheduling_group_name)",
+                    "query": "label_values(scylla_scheduler_runtime_ms{cluster=~\"$cluster|$^\"}, group)",
                     "sort": 3
                 },
                 {

--- a/grafana/scylla-overview.template.json
+++ b/grafana/scylla-overview.template.json
@@ -599,41 +599,12 @@
                     "sort": 0
                 },
                 {
-                    "class": "template_variable_single",
-                    "current": {
-                      "selected": true,
-                      "text": [
-                        "statement"
-                      ],
-                      "value": [
-                        "statement"
-                      ]
-                    },
+                    "class": "template_variable_all",
                     "label": "SG",
                     "name": "sg",
                     "includeAll":true,
                     "multi":true,
-                    "dashversion":[">4.3"],
-                    "query": "label_values(rlatencyp99{cluster=~\"$cluster\", scheduling_group_name!~\"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache\"},scheduling_group_name)",
-                    "sort": 3
-                },
-                {
-                    "class": "template_variable_single",
-                    "dashversion":[">2019.1"],
-                    "current": {
-                      "selected": true,
-                      "text": [
-                        "sl:default"
-                      ],
-                      "value": [
-                        "sl:default"
-                      ]
-                    },
-                    "label": "SG",
-                    "name": "sg",
-                    "includeAll":true,
-                    "multi":true,
-                    "query": "label_values(rlatencyp99{cluster=~\"$cluster\", scheduling_group_name!~\"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache\"},scheduling_group_name)",
+                    "query": "label_values(scylla_scheduler_runtime_ms{cluster=~\"$cluster\", group!~\"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache\"},group)",
                     "sort": 3
                 },
                 {


### PR DESCRIPTION
This patch change the scheduling group filter to be based on scylla_scheduler_runtime_ms