### PR TITLE
Fix multiple issues with start-all

### DIFF
--- a/start-all.sh
+++ b/start-all.sh
@@ -406,14 +406,6 @@ if [ -z "$VERSIONS" ]; then
   exit 1
 fi
 
-DOCKER_PARAMS_ORIGIN="$DOCKER_PARAM"
-DOCKER_PARAM=""
-for val in $DOCKER_PARAMS_ORIGIN; do
-	if [[ "$DOCKER_PARAM" != *"$val"* ]]; then
-		DOCKER_PARAM="$DOCKER_PARAM $val"
-	fi
-done
-
 if [[ $DOCKER_PARAM = *"--net=host"* ]]; then
     if [ ! -z "$ALERTMANAGER_PORT" ] || [ ! -z "$GRAFANA_PORT" ] || [ ! -z $PROMETHEUS_PORT ]; then
         echo "Port mapping is not supported with host network, remove the -l flag from the command line"

--- a/start-all.sh
+++ b/start-all.sh
@@ -45,6 +45,7 @@ fi
 
 if [ "`id -u`" -eq 0 ]; then
     echo "Running as root is not advised, please check the documentation on how to run as non-root user"
+    USER_PERMISSIONS="-u 0:0"
 else
     GROUPID=`id -g`
     USER_PERMISSIONS="-u $UID:$GROUPID"


### PR DESCRIPTION
This series solves two issues with start-all.sh
1. when running as root (using sudo) and using an external Prometheus directory, Prometheus cannot start.
2. the de-duplication of docker parameters does not work with parameters in a ```--param value``` format.
Fixes #2134 