### PR TITLE
Ipv6 safe

### DIFF
--- a/docs/source/install/monitoring-stack.rst
+++ b/docs/source/install/monitoring-stack.rst
@@ -175,15 +175,15 @@ For example:
 
 *Using IPV6*
 
-To use IPv6 inside scylla_server.yml, add the IPv6 addresses with their square brackets and the port numbers.
+To use IPv6 inside scylla_server.yml, add the IPv6 addresses with their square brackets.
 
 For example:
 
 .. code-block:: yaml
 
    - targets:
-         - "[2600:1f18:26b1:3a00:fac8:118e:9199:67b9]:9180"
-         - "[2600:1f18:26b1:3a00:fac8:118e:9199:67ba]:9180"
+         - "[2600:1f18:26b1:3a00:fac8:118e:9199:67b9]"
+         - "[2600:1f18:26b1:3a00:fac8:118e:9199:67ba]"
      labels:
          cluster: cluster1
          dc: dc1

--- a/prometheus/prometheus.yml.template
+++ b/prometheus/prometheus.yml.template
@@ -29,12 +29,16 @@ scrape_configs:
       - /etc/scylla.d/prometheus/targets/scylla_servers.yml
   relabel_configs:
     - source_labels: [__address__]
-      regex:  '([^:]+)'
+      regex:  '(.+)([:]\d+)$'
+      target_label: __port__
+      replacement: '::'
+    - source_labels: [__address__, __port__]
+      regex:  '(.+);$'
       target_label: __address__
       replacement: '${1}:9180'
 
     - source_labels: [__address__]
-      regex:  '(.*):.+'
+      regex:  '(.*):.+$'
       target_label: instance
       replacement: '${1}'
   metric_relabel_configs:
@@ -154,7 +158,11 @@ scrape_configs:
   relabel_configs:
 # NODE_EXPORTER_PORT_MAPPING
     - source_labels: [__address__]
-      regex:  '([^:]+)'
+      regex:  '(.+)([:]\d+)$'
+      target_label: __port__
+      replacement: '::'
+    - source_labels: [__address__, __port__]
+      regex:  '(.+);$'
       target_label: __address__
       replacement: '${1}:9100'
     - source_labels: [__address__]
@@ -175,7 +183,11 @@ scrape_configs:
   relabel_configs:
 # MANAGER_AGENT_PORT_MAPPING
     - source_labels: [__address__]
-      regex:  '([^:]+)'
+      regex:  '(.+)([:]\d+)$'
+      target_label: __port__
+      replacement: '::'
+    - source_labels: [__address__, __port__]
+      regex:  '(.+);$'
       target_label: __address__
       replacement: '${1}:5090'
     - source_labels: [__address__]

--- a/start-all.sh
+++ b/start-all.sh
@@ -428,12 +428,12 @@ if [ -z "$TARGET_DIRECTORY" ] && [ -z "$CONSUL_ADDRESS" ]; then
     fi
 
     if [ -z $NODE_TARGET_FILE ]; then
-       PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-manager-agent-file"
+       PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-node-exporter-file"
        NODE_TARGET_FILE=$SCYLLA_TARGET_FILE
     fi
 
     if [ -z $SCYLLA_MANGER_AGENT_TARGET_FILE ]; then
-       PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-node-exporter-file"
+       PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-manager-agent-file"
        SCYLLA_MANGER_AGENT_TARGET_FILE=$SCYLLA_TARGET_FILE
     fi
     if [ ! -f $NODE_TARGET_FILE ]; then


### PR DESCRIPTION
This series applies the same logic of targets in an IPv4 format to IPv6 format. Meaning, if no ports will be given the default one will be used.
if node_exporter or manager-agents files are not supported, the scylla server files will be used with the default ports.
Fixes #2136