### PR TITLE
grafana: fix by variable

### DIFF
--- a/grafana/scylla-advanced.template.json
+++ b/grafana/scylla-advanced.template.json
@@ -829,7 +829,7 @@
                             "value": "instance,shard"
                         }
                     ],
-                    "query": "Cluster,DC,Instance,Shard",
+                    "query": "Instance : instance,Cluster : cluster,DC : dc,Shard : instance\\,shard",
                     "type": "custom"
                 },
                 {

--- a/grafana/scylla-os.template.json
+++ b/grafana/scylla-os.template.json
@@ -613,7 +613,7 @@
                             "value": "instance,cpu"
                         }
                     ],
-                    "query": "Cluster,DC,Instance",
+                    "query": "Instance : instance,Cluster : cluster,DC : dc,Shard : instance\\,cpu",
                     "type": "custom"
                 },
                 {

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -3094,11 +3094,11 @@
          },
          {
             "selected":false,
-            "text":"instance,shard",
+            "text":"Shard",
             "value":"instance,shard"
          }
       ],
-      "query":"Cluster,DC,Instance,Shard",
+      "query":"Cluster : cluster,DC : dc, Instance : instance, Shard : instance\\,shard",
       "skipUrlSync":false,
       "type":"custom"
    }


### PR DESCRIPTION
seems like custom variable is not full controlled by the query paramter, and you need to feed it a comma seperated with `key : value` for it to work as expectred, and the rest of the data we feed in `option` does not really work anymore

Closes: #2138