### PR TITLE
scylla-os: Check all disks, clean cpu&memory

### DIFF
--- a/grafana/scylla-os.template.json
+++ b/grafana/scylla-os.template.json
@@ -34,7 +34,7 @@
                         "repeat": "node",
                         "targets": [
                             {
-                                "expr": "sum(node_filesystem_avail_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"})",
+                                "expr": "sum(node_filesystem_avail_bytes{mountpoint=~\"$mount_point\", instance=~\"$node\"})",
                                 "interval": "",
                                 "intervalFactor": 1,
                                 "legendFormat": "Free",
@@ -44,7 +44,7 @@
                                 "step": 7200
                             },
                             {
-                                "expr": "(sum(node_filesystem_size_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"})-sum(node_filesystem_avail_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}))",
+                                "expr": "(sum(node_filesystem_size_bytes{mountpoint=~\"$mount_point\", instance=~\"$node\"})-sum(node_filesystem_avail_bytes{mountpoint=~\"$mount_point\", instance=~\"$node\"}))",
                                 "intervalFactor": 1,
                                 "legendFormat": "Used",
                                 "refId": "B",
@@ -462,9 +462,24 @@
             },
             {
                 "class": "row",
+                "gridPos": {
+                    "h": 2
+                },
+                "height": "25px",
                 "panels": [
                     {
-                        "class": "bps_panel",
+                        "class": "text_panel",
+                        "content": "<h1 style=\"color:#5780C1; border-bottom: 3px solid #5780C1;\">CPU and Memory</h1>",
+                        "style": {}
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "bytes_panel",
                         "span": 3,
                         "description": "The available memory, note that in a production environment we expect this to be low, Scylla would use most of the available memory when possible",
                         "targets": [
@@ -493,7 +508,7 @@
                                 "step": 1
                             }
                         ],
-                        "title": "Available memory"
+                        "title": "Percent of Available memory"
                     },
                     {
                         "class": "percentunit_panel",
@@ -617,28 +632,11 @@
                     "type": "custom"
                 },
                 {
-                    "allValue": null,
-                    "current": {
-                        "isNone": true,
-                        "text": "None",
-                        "value": ""
-                    },
-                    "datasource": "prometheus",
-                    "hide": 0,
-                    "includeAll": false,
+                    "class": "template_variable_all",
                     "label": null,
-                    "multi": true,
                     "name": "monitor_disk",
-                    "options": [],
                     "query": "node_disk_read_bytes_total",
-                    "refresh": 2,
-                    "regex": "/.*device=\"([^\\\"]*)\".*/",
-                    "sort": 0,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
+                    "regex": "/.*device=\"([^\\\"]*)\".*/"
                 },
                 {
                     "allValue": null,


### PR DESCRIPTION
This patch addresses a few issues with the OS dashboard
1. it has a clearer separation for the cpu&memory section
2. it better supports multiple mount points in the pie-chart disk section
3. by default, all disks are picked.
![image](https://github.com/scylladb/scylla-monitoring/assets/2118079/6c7c9fcf-3f78-47fa-af15-d6d8b1cc490b)

Fixes #2142 
Fixes #2141