### PR TITLE
docs: add zendesk tag to index.html

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -117,6 +117,7 @@ html_theme_options = {
     'site_description': 'Scylla Monitoring Stack is a full stack for Scylla monitoring and alerting. The stack contains open source tools including Prometheus and Grafana, as well as custom Scylla dashboards and tooling.',
     'versions_unstable': UNSTABLE_VERSIONS,
     'versions_deprecated': DEPRECATED_VERSIONS,
+    'zendesk_tag': 'pgbgkga1hpa6ug0732m8ae',
 }
 
 html_extra_path = ['robots.txt']


### PR DESCRIPTION
Related: https://github.com/scylladb/sphinx-scylladb-theme/pull/979

Adds the Zendesk tag to index.html page.

## How to test

1. Run `make multiversion`.
1. Open the `_build/dirhtml/index.html` file.
1. Check for the presence of the Zendesk tag associated with this project.