### PR TITLE
set DOCKER_HOST only if needed

### DIFF
--- a/start-datadog.sh
+++ b/start-datadog.sh
@@ -62,17 +62,19 @@ for val in "${ENV_ARRAY[@]}"; do
         ENV_COMMAND="$ENV_COMMAND -e $val"
 done
 
-if [ ! -z "$is_podman" ]; then
-    if [[ $(uname) == "Linux" ]]; then
-        DOCKER_HOST=$(hostname -I | awk '{print $1}')
-    elif [[ $(uname) == "Darwin" ]]; then
-        DOCKER_HOST=$(ifconfig bridge0 | awk '/inet / {print $2}')
-    fi
-else
-    if [[ $(uname) == "Linux" ]]; then
-        DOCKER_HOST=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+')
-    elif [[ $(uname) == "Darwin" ]]; then
-        DOCKER_HOST=$(ifconfig bridge0 | awk '/inet / {print $2}')
+if [[ -z "${DOCKER_HOST}" ]]; then
+    if [ ! -z "$is_podman" ]; then
+        if [[ $(uname) == "Linux" ]]; then
+            DOCKER_HOST=$(hostname -I | awk '{print $1}')
+        elif [[ $(uname) == "Darwin" ]]; then
+            DOCKER_HOST=$(ifconfig bridge0 | awk '/inet / {print $2}')
+        fi
+    else
+        if [[ $(uname) == "Linux" ]]; then
+            DOCKER_HOST=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+')
+        elif [[ $(uname) == "Darwin" ]]; then
+            DOCKER_HOST=$(ifconfig bridge0 | awk '/inet / {print $2}')
+        fi
     fi
 fi
 

--- a/start-grafana.sh
+++ b/start-grafana.sh
@@ -230,28 +230,30 @@ if [[ "$HOME_DASHBOARD" = "" ]]; then
     HOME_DASHBOARD="/var/lib/grafana/dashboards/ver_$VERSION/scylla-overview.$VERSION.json"
 fi
 
-if [ ! -z "$is_podman" ]; then
-	if [[ $(uname) == "Linux" ]]; then
-		DOCKER_HOST=$(hostname -I | awk '{print $1}')
-	elif [[ $(uname) == "Darwin" ]]; then
-		DOCKER_HOST=$(ifconfig bridge0 | awk '/inet / {print $2}')
-	fi
-else
-	if [[ $(uname) == "Linux" ]]; then
-		DOCKER_HOST=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+')
-	elif [[ $(uname) == "Darwin" ]]; then
-		DOCKER_HOST=$(ifconfig bridge0 | awk '/inet / {print $2}')
-	fi
+if [[ -z "${DOCKER_HOST}" ]]; then
+    if [ ! -z "$is_podman" ]; then
+        if [[ $(uname) == "Linux" ]]; then
+            DOCKER_HOST=$(hostname -I | awk '{print $1}')
+        elif [[ $(uname) == "Darwin" ]]; then
+            DOCKER_HOST=$(ifconfig bridge0 | awk '/inet / {print $2}')
+        fi
+    else
+        if [[ $(uname) == "Linux" ]]; then
+            DOCKER_HOST=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+')
+        elif [[ $(uname) == "Darwin" ]]; then
+            DOCKER_HOST=$(ifconfig bridge0 | awk '/inet / {print $2}')
+        fi
+    fi
 fi
 
 if [ ! -z $RUN_RENDERER ]; then
 	if [ ! -z "$is_podman" ]; then
-		DOCKER_HOST=`hostname -I | awk '{print $1}'`
+		HOST_ADDRESS=`hostname -I | awk '{print $1}'`
 	else
-		DOCKER_HOST=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+')
+		HOST_ADDRESS=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+')
 	fi
     RENDERING_SERVER_URL=`./start-grafana-renderer.sh $LIMITS $VOLUMES $PARAMS  -D "$DOCKER_PARAM"`
-    GRAFANA_ENV_COMMAND="$GRAFANA_ENV_COMMAND -e GF_RENDERING_SERVER_URL=http://$DOCKER_HOST:8081/render -e GF_RENDERING_CALLBACK_URL=http://$DOCKER_HOST:$GRAFANA_PORT/"
+    GRAFANA_ENV_COMMAND="$GRAFANA_ENV_COMMAND -e GF_RENDERING_SERVER_URL=http://$HOST_ADDRESS:8081/render -e GF_RENDERING_CALLBACK_URL=http://$HOST_ADDRESS:$GRAFANA_PORT/"
 fi
 
 docker run -d $DOCKER_PARAM ${DOCKER_LIMITS["grafana"]} -i $USER_PERMISSIONS $PORT_MAPPING \


### PR DESCRIPTION
we have places where we use a specific DOCKER_HOST in order to be able to support case of running the monitoring stack inside a running podman instance via socket, those places changing the DOCKER_HOST are breaking this usage, and were preventing the monitoring stack from starting