### PR TITLE
prometheus.rules.yml: change repair/backup failures alerts severity to warn

### DIFF
--- a/prometheus/prom_rules/prometheus.rules.yml
+++ b/prometheus/prom_rules/prometheus.rules.yml
@@ -233,7 +233,7 @@ groups:
     expr: (sum(scylla_manager_scheduler_run_total{type=~"backup", status="ERROR"}) or vector(0)) - (sum(scylla_manager_scheduler_run_total{type=~"backup", status="ERROR"} offset 3m) or vector(0)) > 0
     for: 10s
     labels:
-      severity: "info"
+      severity: "warn"
     annotations:
       description: 'Backup failed'
       summary: Backup task failed
@@ -241,7 +241,7 @@ groups:
     expr: (sum(scylla_manager_scheduler_run_total{type=~"repair", status="ERROR"}) or vector(0)) - (sum(scylla_manager_scheduler_run_total{type=~"repair", status="ERROR"} offset 3m) or vector(0)) > 0
     for: 10s
     labels:
-      severity: "info"
+      severity: "warn"
     annotations:
       description: 'Repair failed'
       summary: Repair task failed


### PR DESCRIPTION
Repair and backup failure alerts are more than just info. These need to be attended.
"info" alerts are usually ignored, while severities above "info" automatically create notifications.

Fixes #2151