### PR TITLE
scylla-detailed: reorganized the rows and partition panels

### DIFF
--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -793,21 +793,6 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$func(rate(scylla_cache_partition_hits{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "description": "scylla_cache_partition_hits",
-                        "title": "Partition Hits"
-                    },
-                    {
-                        "class": "rps_panel",
-                        "span": 3,
-                        "targets": [
-                            {
                                 "expr": "$func(rate(scylla_cache_row_misses{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
@@ -817,6 +802,21 @@
                         ],
                         "description": "scylla_cache_row_misses",
                         "title": "Row Misses"
+                    },
+                    {
+                        "class": "rps_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$func(rate(scylla_cache_partition_hits{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "description": "scylla_cache_partition_hits",
+                        "title": "Partition Hits"
                     },
                     {
                         "class": "rps_panel",
@@ -855,21 +855,6 @@
                         "title": "Row Insertions"
                     },
                     {
-                        "class": "rps_panel",
-                        "span": 3,
-                        "targets": [
-                            {
-                                "expr": "$func(rate(scylla_cache_partition_insertions{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "description": "scylla_cache_partition_insertions",
-                        "title": "Partition Insertions"
-                    },
-                    {
                         "class": "ops_panel",
                         "span": 3,
                         "targets": [
@@ -883,6 +868,21 @@
                         ],
                         "description": "scylla_cache_row_evictions",
                         "title": "Row Evictions"
+                    },
+                    {
+                        "class": "rps_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$func(rate(scylla_cache_partition_insertions{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "description": "scylla_cache_partition_insertions",
+                        "title": "Partition Insertions"
                     },
                     {
                         "class": "ops_panel",
@@ -924,21 +924,6 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$func(rate(scylla_cache_partition_merges{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "description": "scylla_cache_partition_merges",
-                        "title": "Partition Merges"
-                    },
-                    {
-                        "class": "ops_panel",
-                        "span": 3,
-                        "targets": [
-                            {
                                 "expr": "$func(rate(scylla_cache_row_removals{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
@@ -948,6 +933,21 @@
                         ],
                         "description": "scylla_cache_row_removals",
                         "title": "Row Removals"
+                    },
+                    {
+                        "class": "ops_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$func(rate(scylla_cache_partition_merges{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "description": "scylla_cache_partition_merges",
+                        "title": "Partition Merges"
                     },
                     {
                         "class": "ops_panel",


### PR DESCRIPTION
This patch reorganized the panel so that the partition would be next to the partitions and rows next to rows.

![image](https://github.com/scylladb/scylla-monitoring/assets/2118079/b01cbd50-4748-41df-880a-f3029135f553)

Fixes #2084 