### PR TITLE
prometheus/prom_rules/prometheus.rules.yml: Add a warning about split-brain cluster

### DIFF
--- a/prometheus/prom_rules/prometheus.rules.yml
+++ b/prometheus/prom_rules/prometheus.rules.yml
@@ -296,3 +296,10 @@ groups:
       severity: "warn"
       description: 'Node {{ $labels.instance }} in Joining mode for 1 day'
       summary: Node {{ $labels.instance }} in Joining mode for 1 day
+  - alert: splitBrain
+    expr: sum(scylla_gossip_live) >= (count(scylla_node_operation_mode==3)-1) * count(scylla_gossip_live)
+    for: 10m
+    labels:
+      severity: "warn"
+      description: 'Cluster in a split-brain mode'
+      summary: Some nodes the cluster do not see all of the other live nodes


### PR DESCRIPTION
This patch adds an alert when a cluster is in a split-brain mode, i.e., not all nodes in the cluster see all the other live nodes.
Fixes #1677