### PR TITLE
Add github-actions workflow for building cloud-images

### DIFF
--- a/.github/workflows/build-cloud-images.yaml
+++ b/.github/workflows/build-cloud-images.yaml
@@ -1,0 +1,75 @@
+name: Build Cloud Images
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      monitor_version:
+        description: 'Git tag to build from'
+        required: true
+
+jobs:
+  build-cloud-images:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: 'write'
+      id-token: 'write'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup Packer
+        uses: hashicorp/setup-packer@v3.0.0
+        with:
+          version: '1.10.0'
+
+      - name: Setup AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.MONITOR_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.MONITOR_AWS_SECRET_ACCESS_KEY }}
+          aws-region: 'us-east-1'
+
+      - name: Setup GCP credentials
+        uses: google-github-actions/auth@v2.1.2
+        with:
+          workload_identity_provider: ${{ secrets.MONITOR_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.MONITOR_GCP_SERVICE_ACCOUNT }}
+
+      - name: Determine Scylla Monitor version
+        run: |
+          if ${{ github.event_name == 'workflow_dispatch' }}; then
+            echo "MONITOR_VERSION=${{ github.event.inputs.monitor_version }}" >> $GITHUB_ENV
+          elif ${{ github.event_name == 'release' }}; then
+            echo "MONITOR_VERSION=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
+          else
+            echo "Missing Scylla Monitor version - Workflow cannot continue"
+            exit 1
+          fi
+
+      - name: Build Images
+        run: |
+          packer plugins install github.com/hashicorp/googlecompute
+          packer plugins install github.com/hashicorp/amazon
+          packer build -var monitor_version="$MONITOR_VERSION" scylla-monitor-template.json
+        working-directory: packer
+
+      - name: Archive Packer manifest
+        uses: actions/upload-artifact@v4
+        with:
+          name: scylla-monitor-cloud-images-${{ env.MONITOR_VERSION }}
+          path: packer/packer-manifest.json
+
+      - name: Upload Packer manifest to the release
+        if: github.event_name == 'release' && github.event.release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: packer/packer-manifest.json
+          asset_name: scylla-monitor-cloud-images-${{ env.MONITOR_VERSION }}.json
+          asset_content_type: application/json


### PR DESCRIPTION
The workflow installs the required packer plugins, authenticate with AWS and GCP and use the packer template to build scylla-monitor cloud-images,

Once done, a file with the cloud-images info will be published to the workflow run, and to the release,

The workflow will auto-trigger following a new release (excluding pre-releases), and can be manually triggered against a specific tag.

Ref: https://github.com/scylladb/scylla-pkg/issues/3268