### PR TITLE
scylla-detailed add bloom filter percentage graph 

### DIFF
--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -1788,7 +1788,7 @@
                 "panels": [
                     {
                         "class": "bytes_panel",
-                        "span": 6,
+                        "span": 4,
                         "targets": [
                             {
                                 "expr": "$func(scylla_lsa_total_space_bytes{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
@@ -1803,7 +1803,7 @@
                     },
                     {
                         "class": "bytes_panel",
-                        "span": 6,
+                        "span": 4,
                         "targets": [
                             {
                                 "expr": "$func(scylla_lsa_non_lsa_used_space_bytes{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
@@ -1815,6 +1815,21 @@
                         ],
                         "description": "scylla_lsa_non_lsa_used_space_bytes",
                         "title": "Non-LSA used memory"
+                    },
+                    {
+                        "class": "percentunit_panel",
+                        "span": 4,
+                        "targets": [
+                            {
+                                "expr": "$func(scylla_sstables_bloom_filter_memory_size{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])/$func(scylla_memory_total_memory{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "description": "Bloom filter should take a small percentage of the total memory.\n\nscylla_sstables_bloom_filter_memory_size",
+                        "title": "Bloom Filter memory usage (percentage)"
                     }
                 ],
                 "title": "New row"

--- a/prometheus/prom_rules/prometheus.rules.yml
+++ b/prometheus/prom_rules/prometheus.rules.yml
@@ -303,3 +303,10 @@ groups:
       severity: "warn"
       description: 'Cluster in a split-brain mode'
       summary: Some nodes the cluster do not see all of the other live nodes
+  - alert: bloomFilterSize
+    expr: scylla_sstables_bloom_filter_memory_size/scylla_memory_total_memory > 0.1
+    for: 10m
+    labels:
+      severity: "warn"
+      description: 'Bloom filter size'
+      summary: The bloom filter takes too much memory, update bloom_filter_fp_chance


### PR DESCRIPTION
This PR adds a bloom filter panel in the detailed dashboard,
When a bloom filter takes too much memory, it can cause out-of-memory crash

![image](https://github.com/scylladb/scylla-monitoring/assets/2118079/6d5bf250-6bd8-4e77-b55d-2bcc38e57674)

Fixes #2219