### PR TITLE
Update alternator dashoard

### DIFF
--- a/grafana/alternator.template.json
+++ b/grafana/alternator.template.json
@@ -5,244 +5,178 @@
         "overwrite": true,
         "rows": [
             {
-                "class": "alternator_logo_row"
-            },
-            {
                 "class": "row",
-                "height": "200px",
                 "panels": [
                     {
-                        "class": "single_stat_panel",
-                        "targets": [
-                            {
-                                "expr": "count(scylla_scylladb_current_version{job=\"scylla\", cluster=~\"$cluster|$^\"})",
-                                "intervalFactor": 1,
-                                "legendFormat": "Total Nodes",
-                                "refId": "A",
-                                "step": 40
-                            }
-                        ],
-                        "title": "Total Nodes"
-                    },
-                    {
-                        "class": "single_stat_panel_fail",
-                        "targets": [
-                            {
-                                "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Unreachable",
-                                "refId": "A",
-                                "step": 20
-                            }
-                        ],
-                        "thresholds": "1,2",
-                        "title": "Unreachable"
-                    },
-                    {
-                        "class": "single_stat_panel_fail",
-                        "description": "Number of nodes that reported their status as Starting or Joining",
-                        "targets": [
-                            {
-                                "expr": "count(scylla_node_operation_mode<=2)OR vector(0)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Joining",
-                                "refId": "A",
-                                "step": 20
-                            }
-                        ],
-                        "thresholds": "1,2",
-                        "title": "Joining"
-                    },
-                    {
-                        "class": "single_stat_panel_fail",
-                        "description": "Number of nodes that reported their status as  Leaving, Decommissioned, Draining or Drained",
-                        "targets": [
-                            {
-                                "expr": "count(scylla_node_operation_mode>3)OR vector(0)",
-                                "intervalFactor": 1,
-                                "legendFormat": "Leaving",
-                                "refId": "A",
-                                "step": 20
-                            }
-                        ],
-                        "thresholds": "1,2",
-                        "title": "Leaving"
-                    },
-                    {
-                        "class": "percent_panel",
-                        "description": "The percentage of the time during which Scylla utilized the CPU. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high.",
-                        "span": 4,
-                        "targets": [
-                            {
-                                "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 4
-                            }
-                        ],
-                        "title": "Load"
-                    },
-                    {
-                        "class": "small_nodes_table",
-                        "span": 4,
-                          "transformations":[
-                             {
-                                "id":"filterFieldsByName",
-                                "options":{
-                                   "include":{
-                                      "names":[
-                                         "instance",
-                                         "svr",
-                                         "Value #A",
-                                         "Value #B",
-                                         "Value #C",
-                                         "Value #D"
-                                      ]
-                                   }
-                                }
-                             },
-                             {
-                                "id":"seriesToColumns",
-                                "options":{
-                                   "byField":"instance"
-                                }
-                             },
-                             {
-                                "id":"organize",
-                                "options":{
-                                   "excludeByName":{
-                                   },
-                                   "indexByName":{
-                                      "instance":0,
-                                      "Value #D":1,
-                                      "Value #C":2,
-                                      "svr":3,
-                                      "Value #A":4,
-                                      "Value #B":5
-                                   },
-                                   "renameByName":{
-                                   }
-                                }
-                             }
-                          ]
+                      "collapsed": false,
+                      "datasource": null,
+                      "id": "auto",
+                      "gridPos": {
+                        "h": 1,
+                        "w": 24
+                      },
+                      "panels": [],
+                      "title": "Alternator Cluster overview $cluster",
+                      "type": "row"
                     }
-                ],
-                "title": "New row"
+                ]
+            },
+            {
+                "class": "alternator_small_stat_rows"
             },
             {
                 "class": "row",
                 "panels": [
+                    {
+                        "class": "alert_table",
+                        "span": 4,
+                        "title": "Active Alerts"
+                    },
                     {
                         "class": "bytes_panel",
-                        "span": 4,
+                        "gridPos": {
+                            "w": 3
+                          },
                         "targets": [
                             {
-                                "expr": "sum(node_filesystem_size_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])-sum(node_filesystem_avail_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])",
+                                "expr": "sum(node_filesystem_size_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"})-sum(node_filesystem_avail_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"})",
                                 "intervalFactor": 1,
-                                "legendFormat": "",
+                                "legendFormat": "{{mountpoint}}",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                                "expr": "sum(node_filesystem_size{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])-sum(node_filesystem_avail{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])",
+                                "expr": "sum(node_filesystem_size{mountpoint=\"$mount_point\", instance=~\"$node\"})-sum(node_filesystem_avail{mountpoint=\"$mount_point\", instance=~\"$node\"})",
                                 "intervalFactor": 1,
-                                "legendFormat": "",
+                                "legendFormat": "{{mountpoint}}",
                                 "metric": "",
                                 "refId": "B",
                                 "step": 1
                             }
                         ],
-                        "title": "Disk Size by $by"
+                        "title": "Total Cluster Storage"
                     },
                     {
                         "class": "ops_panel",
-                        "description": "Number of Alternator Actions",
-                        "span": 4,
+                        "description": "Number of Alternator Operations by operation type",
+                        "gridPos": {
+                            "w": 5
+                          },
                         "targets": [
                             {
-                                "expr": "$func(rate(scylla_alternator_total_operations{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                                "expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", op=~\"$ops\"}[60s])>0) by (op)",
                                 "intervalFactor": 1,
-                                "legendFormat": "",
+                                "legendFormat": "{{op}}",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 4
                             }
                         ],
-                        "title": "Total Actions"
+                        "title": "Operations/s"
                     },
                     {
-                        "class": "alert_table",
-                        "span": 4,
-                        "styles": [
+                        "class": "us_panel",
+                        "description": "The P95 Latencies per operation",
+                        "gridPos": {
+                            "w": 4
+                          },
+                        "targets": [
                             {
-                                "alias": "Time",
-                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                                "link": true,
-                                "linkTooltip": "Jump to the see the node",
-                                "linkUrl": "/d/detailed-[[dash_version]]/detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_4}&from=${__cell_0}",
-                                "pattern": "Time",
-                                "type": "date"
-                            },
-                            {
-                                "class": "hidden_column",
-                                "pattern": "severity"
-                            },
-                            {
-                                "class": "hidden_column",
-                                "pattern": "alertname"
-                            },
-                            {
-                                "class": "hidden_column",
-                                "pattern": "cluster"
-                            },
-                            {
-                                "class": "hidden_column",
-                                "pattern": "monitor"
-                            },
-                            {
-                                "class": "hidden_column",
-                                "pattern": "summary"
-                            },
-                            {
-                                "alias": "Instance",
-                                "colorMode": null,
-                                "colors": [
-                                    "rgba(245, 54, 54, 0.9)",
-                                    "rgba(237, 129, 40, 0.89)",
-                                    "rgba(50, 172, 45, 0.97)"
-                                ],
-                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                                "decimals": 2,
-                                "link": true,
-                                "linkTooltip": "Jump to the see the node",
-                                "linkUrl": "/d/detailed-[[dash_version]]/detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__cell}",
-                                "mappingType": 1,
-                                "pattern": "instance",
-                                "thresholds": [],
-                                "type": "string",
-                                "unit": "short"
-                            },
-                            {
-                                "alias": "",
-                                "colorMode": null,
-                                "colors": [
-                                    "rgba(245, 54, 54, 0.9)",
-                                    "rgba(237, 129, 40, 0.89)",
-                                    "rgba(50, 172, 45, 0.97)"
-                                ],
-                                "decimals": 2,
-                                "pattern": "/.*/",
-                                "thresholds": [],
-                                "type": "number",
-                                "unit": "short"
+                                "expr": "histogram_quantile(0.95, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=~\"$ops\"}[60s])>0) by (op, le))",
+
+                                "intervalFactor": 1,
+                                "legendFormat": "{{op}}",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 4
                             }
                         ],
-                        "title": "Active Alerts"
+                        "title": "P95 Latencies"
+                    },
+                    {
+                        "class": "us_panel",
+                        "description": "The P99 Latencies per operation",
+                        "gridPos": {
+                            "w": 4
+                          },
+                        "targets": [
+                            {
+                                "expr": "histogram_quantile(0.99, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=~\"$ops\"}[60s])>0) by (op, le))",
+
+                                "intervalFactor": 1,
+                                "legendFormat": "{{op}}",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 4
+                            }
+                        ],
+                        "title": "P99 Latencies"
                     }
                 ],
                 "title": "New row"
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                      "collapsed": false,
+                      "datasource": null,
+                      "id": "auto",
+                      "gridPos": {
+                        "h": 1,
+                        "w": 24
+                      },
+                      "panels": [],
+                      "title": "",
+                      "repeat": "dc",
+                      "type": "row"
+                    }
+                ]
+            },
+            {
+                "class": "header_row",
+                "panels": [
+                    {
+                        "class": "plain_text",
+                        "content": "<h1 style=\"color:#5780C1; border-bottom: 3px solid #5780C1;\">Information for $dc</h1>"
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "dc_nodes_table"
+                    },
+                    {
+                        "class": "plain_text",
+                        "dashproductreject": "no-version-check",
+                        "gridPos": {
+                            "w": 10,
+                            "x": 14,
+                            "h": 1
+                          },
+                        "options": {
+                            "mode": "html",
+                            "content": "<img src=\"https://repositories.scylladb.com/scylla/imgversion/$all_scyllas_versions/scylla\"></img>"
+                          }
+                        },
+                    {
+                        "class": "plain_text",
+                        "dashproduct": "no-version-check",
+                        "gridPos": {
+                            "w": 10,
+                            "x": 14,
+                            "h": 1
+                          },
+                        "options": {
+                            "mode": "html",
+                            "content": ""
+                          }
+                        }
+                ]
             },
             {
                 "class": "row",
@@ -338,7 +272,6 @@
                     {
                         "class": "ops_panel",
                         "span": 4,
-                        "dashversion":[">4.4", ">2021.1"],
                         "targets": [
                             {
                                 "expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchGetItem\"}[60s])) by ([[by]])",
@@ -997,6 +930,14 @@
                         }
                     ],
                     "query": "GetRecords"
+                },
+                {
+                    "class": "template_variable_all",
+                    "label": "ops",
+                    "name": "ops",
+                    "allValue":".+",
+                    "query": "label_values(scylla_alternator_operation{cluster=~\"$cluster|$\"},op)",
+                    "sort": 3
                 },
                   {
                     "allValue": null,

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -678,6 +678,493 @@
       ],
       "title":"New row"
    },
+   "alternator_small_stat_rows":{
+      "class":"row",
+      "height":"200px",
+      "panels":[
+         {
+            "class":"text_panel",
+            "dashproductreject": "no-version-check",
+            "gridPos":{
+               "w":6,
+               "h":1
+            },
+            "transparent":false,
+            "options": {
+                "mode": "html",
+                "content": "<img src=\"https://repositories.scylladb.com/scylla/imgversion/$monitoring_version/scylla-monitoring\">"
+              }
+         },
+         {
+            "class":"text_panel",
+            "dashproduct": "no-version-check",
+            "gridPos":{
+               "w":6,
+               "h":1
+            },
+            "transparent":false,
+            "options": {
+                "mode": "html",
+                "content": ""
+              }
+         },
+         {
+            "class":"text_panel",
+            "title":"Manager",
+            "gridPos":{
+               "w":3,
+               "h":1
+            },
+            "transparent":false,
+            "options": {
+                "mode": "html",
+                "content": ""
+              }
+         },
+         {
+            "class":"text_panel",
+            "title":"Average latencies",
+            "gridPos":{
+               "w":4,
+               "h":1
+            },
+            "transparent":false,
+            "options":{
+               "content":""
+            }
+         },
+         {
+            "class":"text_panel",
+            "title":"P99 Latencies",
+            "gridPos":{
+               "w":4,
+               "h":1
+            },
+            "transparent":false,
+            "options":{
+               "content":""
+            }
+         },
+         {
+            "class":"text_panel",
+            "gridPos":{
+               "w":7,
+               "h":1
+            },
+            "transparent":false,
+            "options":{
+               "content":"# "
+            }
+         },
+         {
+            "class":"small_stat",
+            "description":"The number of nodes configured in the cluster.",
+            "targets":[
+               {
+                  "expr":"count(scylla_scylladb_current_version{job=\"scylla\", cluster=\"$cluster\"})",
+                  "intervalFactor":1,
+                  "legendFormat":"Total Nodes",
+                  "refId":"A",
+                  "step":40
+               }
+            ],
+            "title":"# Nodes"
+         },
+         {
+            "class":"small_stat",
+            "description":"The number of unreachable nodes.\nUsually because a machine is down or unreachable.",
+            "targets":[
+               {
+                  "expr":"(count(scrape_samples_scraped{job=\"scylla\", cluster=\"$cluster\"}==0) OR vector(0))",
+                  "intervalFactor":1,
+                  "legendFormat":"Offline ",
+                  "refId":"A",
+                  "step":20
+               }
+            ],
+            "fieldConfig":{
+               "defaults":{
+                  "custom":{
+                  },
+                  "thresholds":{
+                     "mode":"absolute",
+                     "steps":[
+                        {
+                           "color":"green",
+                           "value":null
+                        },
+                        {
+                           "value":0,
+                           "color":"green"
+                        },
+                        {
+                           "value":1,
+                           "color":"red"
+                        }
+                     ]
+                  }
+               }
+            },
+            "title":"Unreachable"
+         },
+         {
+            "class":"small_stat",
+            "description":"The number of joining and leaving nodes.\nThe number of nodes that are up but not actively part of the cluster, either because they are still joining or because they are leaving.",
+            "targets":[
+               {
+                  "expr":"count(scylla_node_operation_mode{cluster=\"$cluster\"}!=3)OR vector(0)",
+                  "intervalFactor":1,
+                  "legendFormat":"Offline ",
+                  "refId":"A",
+                  "step":20
+               }
+            ],
+            "thresholds":"1,2",
+            "fieldConfig":{
+               "defaults":{
+                  "custom":{
+                  },
+                  "thresholds":{
+                     "mode":"absolute",
+                     "steps":[
+                        {
+                           "color":"green",
+                           "value":null
+                        },
+                        {
+                           "value":0,
+                           "color":"green"
+                        },
+                        {
+                           "value":1,
+                           "color":"red"
+                        }
+                     ]
+                  }
+               }
+            },
+            "title":"Inactive"
+         },
+         {
+            "class":"small_stat",
+                "options": {
+                    "reduceOptions": {
+                      "values": false,
+                      "calcs": [
+                        "last"
+                      ],
+                      "fields": ""
+                    },
+                    "orientation": "auto",
+                    "textMode": "value",
+                    "wideLayout": true,
+                    "colorMode": "value",
+                    "graphMode": "none",
+                    "justifyMode": "auto",
+                    "showPercentChange": false
+                  },
+                "fieldConfig":{
+               "defaults":{
+                  "noValue":" Offline",
+                  "thresholds":{
+                     "mode":"absolute",
+                     "steps":[
+                        {
+                           "color":"red",
+                           "value":null
+                        },
+                        {
+                           "color":"green",
+                           "value":0
+                        }
+                     ]
+                  },
+                  "mappings":[
+                     {
+                        "from":"",
+                        "id":0,
+                        "text":"Backup",
+                        "to":"",
+                        "type":1,
+                        "value":"2"
+                     },
+                     {
+                        "from":"",
+                        "id":1,
+                        "text":"Repair",
+                        "to":"",
+                        "type":1,
+                        "value":"1"
+                     },
+                     {
+                        "from":"",
+                        "id":2,
+                        "text":"Online",
+                        "to":"",
+                        "type":1,
+                        "value":"0"
+                     },
+                     {
+                        "from":"",
+                        "id":3,
+                        "text":"Offline",
+                        "to":"",
+                        "type":1,
+                        "value":"-1"
+                     },
+                     {
+                        "from":"",
+                        "id":4,
+                        "text":"Backup Repair",
+                        "to":"",
+                        "type":1,
+                        "value":"3"
+                     }
+                  ]
+               }
+            },
+            "targets":[
+               {
+                  "expr":"(max(scylla_manager_scheduler_run_indicator{type=~\"repair\",cluster=\"$cluster\"}) or on() vector(0)) + (max(scylla_manager_scheduler_run_indicator{type=~\"backup\",cluster=\"$cluster\"})*2 or on() vector(0)) + (sum(scylla_manager_server_current_version{}) or on() vector(-1))",
+                  "intervalFactor":1,
+                  "refId":"A",
+                  "step":40
+               }
+            ],
+            "title":""
+         },
+         {
+            "class":"vertical_lcd",
+            "fieldConfig":{
+               "defaults":{
+                  "custom":{
+                  },
+                  "unit":"percent",
+                  "decimals":0,
+                  "thresholds":{
+                     "mode":"absolute",
+                     "steps":[
+                        {
+                           "color":"green",
+                           "value":null
+                        }
+                     ]
+                  },
+                  "mappings":[]
+               },
+               "overrides":[]
+            },
+            "gridPos":{
+               "w":1,
+               "h":4
+            },
+            "targets":[
+               {
+                  "expr":"(avg(scylla_manager_repair_progress{cluster=\"$cluster\", job=\"scylla_manager\"}) * max(scylla_manager_scheduler_run_indicator{type=\"repair\",cluster=\"$cluster\"})) or on ()  (100*avg(manager:backup_progress{cluster=\"$cluster\"}) * max(scylla_manager_scheduler_run_indicator{type=\"backup\",cluster=\"$cluster\"})) or on () vector(0)",
+                  "legendFormat":"",
+                  "interval":"",
+                  "refId":"A",
+                  "instant":true
+               }
+            ]
+         },
+         {
+            "class":"small_stat",
+            "description":"",
+            "gridPos": {
+                "h": 4,
+                "w": 4
+             },
+            "fieldConfig":{
+               "defaults":{
+                  "custom":{
+                  },
+                  "unit":"\u00b5s",
+                  "decimals":0,
+                  "thresholds":{
+                     "mode":"absolute",
+                     "steps":[
+                        {
+                           "color":"green",
+                           "value":null
+                        },
+                        {
+                           "color":"red",
+                           "value":50000
+                        }
+                     ]
+                  },
+                  "mappings":[]
+               },
+               "overrides":[]
+            },
+            "targets":[
+               {
+                  "expr":"sum(rate(scylla_alternator_op_latency_sum{cluster=~\"$cluster\", op=~\"$ops\"}[1m])) by (op)/sum(rate(scylla_alternator_op_latency_count{cluster=~\"$cluster|^$\", op=~\"$ops\"}[1m])>0) by (op)",
+                  "intervalFactor":1,
+                  "legendFormat": "{{op}}",
+                  "refId":"A",
+                  "instant":true,
+                  "step":4
+               }
+            ],
+            "title":""
+         },
+         {
+            "class":"small_stat",
+            "description":"",
+            "gridPos": {
+                "h": 4,
+                "w": 4
+              },
+            "fieldConfig":{
+               "defaults":{
+                  "custom":{
+                  },
+                  "unit":"\u00b5s",
+                  "decimals":0,
+                  "thresholds":{
+                     "mode":"absolute",
+                     "steps":[
+                        {
+                           "color":"green",
+                           "value":null
+                        },
+                        {
+                           "color":"red",
+                           "value":50000
+                        }
+                     ]
+                  },
+                  "mappings":[]
+               },
+               "overrides":[]
+            },
+            "targets":[
+               {
+                  "expr":"histogram_quantile(0.99, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=~\"$ops\"}[60s])>0) by (op, le))",
+                  "intervalFactor":1,
+                  "legendFormat": "{{op}}",
+                  "refId":"A",
+                  "instant":true,
+                  "step":4
+               }
+            ],
+            "title":""
+         },
+         {
+            "class":"small_stat",
+            "targets":[
+               {
+                  "expr":"sum(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s]))",
+                  "intervalFactor":1,
+                  "refId":"A",
+                  "instant":true,
+                  "step":40
+               }
+            ],
+            "gridPos":{
+               "w":3,
+               "h":4
+            },
+            "fieldConfig":{
+               "defaults":{
+                  "custom":{
+                  },
+                  "unit":"si:",
+                  "decimals":1,
+                  "thresholds":{
+                     "mode":"absolute",
+                     "steps":[
+                        {
+                           "color":"green",
+                           "value":null
+                        }
+                     ]
+                  },
+                  "mappings":[]
+               },
+               "overrides":[]
+            },
+            "description":"Total Operations per seconds",
+            "title":"Total Operations/s"
+         },
+         {
+            "class":"small_stat",
+            "description":"The percentage of the time during which Scylla utilized the CPU. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high.",
+            "fieldConfig":{
+               "defaults":{
+                  "custom":{
+                  },
+                  "decimals":0,
+                  "mappings":[],
+                  "thresholds":{
+                     "mode":"absolute",
+                     "steps":[
+                        {
+                           "color":"green",
+                           "value":null
+                        },
+                        {
+                           "color":"red",
+                           "value":80
+                        }
+                     ]
+                  },
+                  "unit":"percent"
+               },
+               "overrides":[]
+            },
+            "targets":[
+               {
+                  "expr":"avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"} )",
+                  "intervalFactor":1,
+                  "legendFormat":"",
+                  "refId":"A",
+                  "instant":true,
+                  "step":4
+               }
+            ],
+            "title":"Load"
+         },
+         {
+            "class":"small_stat",
+            "fieldConfig":{
+               "defaults":{
+                  "custom":{
+                  },
+                  "thresholds":{
+                     "mode":"absolute",
+                     "steps":[
+                        {
+                           "color":"green",
+                           "value":null
+                        },
+                        {
+                           "color":"red",
+                           "value":1
+                        }
+                     ]
+                  },
+                  "mappings":[]
+               },
+               "overrides":[]
+            },
+            "targets":[
+               {
+                  "expr":"(sum(rate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m])) or on() vector(0)) + (sum(rate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m])) or on() vector(0))",
+                  "intervalFactor":1,
+                  "refId":"A",
+                  "instant":true,
+                  "step":40
+               }
+            ],
+            "description":"The rate of timeouts (read and write).\n\nTimeouts are an indication of an overloaded system",
+            "title":"Timeouts"
+         }
+      ],
+      "title":"New row"
+   },
    "logo_row":{
       "collapse":false,
       "editable":true,
@@ -2235,6 +2722,919 @@
          }
       ],
       "title":"Nodes"
+   },
+    "dc_nodes_table":{
+      "datasource":"prometheus",
+      "id":"auto",
+      "gridPos": {
+        "h": 14,
+        "w": 24
+      },
+      "targets":[
+         {
+            "expr":"0*scylla_scylladb_current_version{cluster=\"$cluster\", dc=~\"$dc\"} + on (instance) group_left() scylla_node_operation_mode{cluster=\"$cluster\", dc=~\"$dc\"}",
+            "legendFormat":"",
+            "interval":"",
+            "format":"table",
+            "instant":true,
+            "intervalFactor":1,
+            "refId":"A",
+            "hide":false
+         },
+         {
+            "expr":"avg(scylla_reactor_utilization{cluster=~\"$cluster\", dc=~\"$dc\"} ) by (instance)",
+            "legendFormat":"",
+            "interval":"",
+            "refId":"B",
+            "instant":true,
+            "format":"table"
+         },
+         {
+            "expr":"sum(rate(scylla_reactor_aio_errors{cluster=~\"$cluster\", dc=~\"$dc\"}[1m])) by (instance)",
+            "legendFormat":"",
+            "interval":"",
+            "refId":"C",
+            "instant":true,
+            "format":"table"
+         },
+         {
+            "expr":"sum(scylla_errors:nodes_total{cluster=~\"$cluster\", dc=~\"$dc\"}) by (instance) >bool 0",
+            "legendFormat":"",
+            "interval":"",
+            "refId":"D",
+            "instant":true,
+            "format":"table"
+         },
+         {
+            "expr":"(sum(scylla_cql:non_system_prepared1m{cluster=~\"$cluster\", dc=~\"$dc\"}) by (instance) >bool 1) + (sum(rate(scylla_cql_reverse_queries{cluster=~\"$cluster\", dc=~\"$dc\"}[60s])) by(instance) >bool 1) + (sum(scylla_cql:non_paged_no_system1m{cluster=~\"$cluster\", dc=~\"$dc\"}) by (instance) >bool 1)",
+            "legendFormat":"",
+            "interval":"",
+            "refId":"E",
+            "instant":true,
+            "format":"table"
+         },
+         {
+            "expr":"sum(scylla_gossip_live{cluster=\"$cluster\"})by (instance)",
+            "legendFormat":"",
+            "interval":"",
+            "refId":"F",
+            "instant":true,
+            "dashversion":[">5.1", ">2022.2"],
+            "format":"table"
+         },
+         {
+            "expr":"(min(scylla_streaming_finished_percentage{cluster=\"$cluster\", dc=~\"$dc\"}*100) by (instance) < 100) or on (instance)  0*sum(scylla_scylladb_current_version{cluster=\"$cluster\", dc=~\"$dc\"}) by (instance)",
+            "legendFormat":"",
+            "interval":"",
+            "refId":"G",
+            "instant":true,
+            "dashversion":[">5.2", ">2023.1"],
+            "format":"table"
+         },
+         {
+            "expr":"100-100*node_filesystem_avail_bytes{mountpoint=\"$mount_point\",  dc=~\"$dc\", instance=~\"$node\"}/node_filesystem_size_bytes{mountpoint=\"$mount_point\", dc=~\"$dc\", instance=~\"$node\"}",
+            "legendFormat":"",
+            "interval":"",
+            "refId":"H",
+            "instant":true,
+            "format":"table"
+         },
+         {
+            "expr":"sum(scylla_compaction_manager_compactions{dc=~\"$dc\", instance=~\"$node\"}) by (instance)",
+            "legendFormat":"",
+            "interval":"",
+            "refId":"I",
+            "instant":true,
+            "format":"table"
+         },
+         {
+            "expr":"100*sum(rate(scylla_cache_row_misses{dc=~\"$dc\"}[1m])) by (instance)/(sum(rate(scylla_cache_row_hits{dc=~\"$dc\"}[1m])) by (instance) + sum(rate(scylla_cache_row_misses{dc=~\"$dc\"}[1m])) by (instance))",
+            "legendFormat":"",
+            "interval":"",
+            "refId":"J",
+            "instant":true,
+            "format":"table"
+         },
+         {
+            "expr":"histogram_quantile(0.5, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\"}[60s])>0) by (le, instance))",
+            "legendFormat":"",
+            "interval":"",
+            "refId":"K",
+            "instant":true,
+            "format":"table"
+         },
+         {
+            "expr":"histogram_quantile(0.9, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\"}[60s])>0) by (le, instance))",
+            "legendFormat":"",
+            "interval":"",
+            "refId":"L",
+            "instant":true,
+            "format":"table"
+         },
+         {
+            "expr":"histogram_quantile(0.99, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\"}[60s])>0) by (le, instance))",
+            "legendFormat":"",
+            "interval":"",
+            "refId":"M",
+            "instant":true,
+            "format":"table"
+         }
+      ],
+      "type":"table",
+      "title":"Nodes",
+      "fieldConfig":{
+         "defaults":{
+            "custom":{
+               "align":null,
+               "filterable":true
+            },
+            "color":{
+               "mode":"thresholds"
+            },
+            "thresholds":{
+               "mode":"absolute",
+               "steps":[
+                  {
+                     "color":"green",
+                     "value":null
+                  },
+                  {
+                     "color":"orange",
+                     "value":85
+                  }
+               ]
+            }
+         },
+         "overrides":[
+            {
+               "matcher":{
+                  "id":"byName",
+                  "options":"Value #B"
+               },
+               "properties":[
+                  {
+                     "id":"custom.displayMode",
+                     "value":"lcd-gauge"
+                  },
+                  {
+                     "id":"min",
+                     "value":0
+                  },
+                  {
+                     "id":"max",
+                     "value":101
+                  },
+                  {
+                     "id":"displayName",
+                     "value":"Load"
+                  },
+                  {
+                     "id":"custom.width",
+                     "value":120
+                  },
+                  {
+                     "id":"custom.filterable",
+                     "value":false
+                  },
+                  {
+                     "id":"decimals",
+                     "value":0
+                  }
+               ]
+            },
+            {
+               "matcher":{
+                  "id":"byName",
+                  "options":"svr"
+               },
+               "properties":[
+                  {
+                     "id":"custom.width",
+                     "value":90
+                  },
+                  {
+                     "id":"displayName",
+                     "value":"Version"
+                  }
+               ]
+            },
+            {
+               "matcher":{
+                  "id":"byName",
+                  "options":"instance"
+               },
+               "properties":[
+                  {
+                     "id":"custom.width",
+                     "value":105
+                  }
+               ]
+            },
+            {
+               "matcher":{
+                  "id":"byName",
+                  "options":"Value #A"
+               },
+               "properties":[
+                  {
+                     "id":"custom.width",
+                     "value":105
+                  },
+                  {
+                     "id":"displayName",
+                     "value":"Status"
+                  },
+                  {
+                     "id":"custom.displayMode",
+                     "value":"color-text"
+                  },
+                  {
+                     "id":"thresholds",
+                     "value":{
+                        "mode":"absolute",
+                        "steps":[
+                           {
+                              "color":"yellow",
+                              "value":null
+                           },
+                           {
+                              "value":3,
+                              "color":"rgb(87, 128, 193)"
+                           },
+                           {
+                              "color":"red",
+                              "value":4
+                           }
+                        ]
+                     }
+                  },
+                  {
+                     "id":"custom.align",
+                     "value":"center"
+                  },
+                  {
+                     "id":"mappings",
+                     "value":[
+                        {
+                           "id":1,
+                           "type":1,
+                           "from":"",
+                           "to":"",
+                           "text":"Starting",
+                           "value":"1"
+                        },
+                        {
+                           "id":2,
+                           "type":1,
+                           "from":"",
+                           "to":"",
+                           "text":"Joining",
+                           "value":"2"
+                        },
+                        {
+                           "id":3,
+                           "type":1,
+                           "from":"",
+                           "to":"",
+                           "text":"Normal",
+                           "value":"3"
+                        },
+                        {
+                           "id":4,
+                           "type":1,
+                           "from":"",
+                           "to":"",
+                           "text":"Leaving",
+                           "value":"4"
+                        },
+                        {
+                           "id":5,
+                           "type":1,
+                           "from":"",
+                           "to":"",
+                           "text":"Decommissioned",
+                           "value":"5"
+                        },
+                        {
+                           "id":6,
+                           "type":1,
+                           "from":"",
+                           "to":"",
+                           "text":"Draining",
+                           "value":"6"
+                        },
+                        {
+                           "id":7,
+                           "type":1,
+                           "from":"",
+                           "to":"",
+                           "text":"Drained",
+                           "value":"7"
+                        },
+                        {
+                           "id":8,
+                           "type":1,
+                           "from":"",
+                           "to":"",
+                           "text":"Moving",
+                           "value":"8"
+                        }
+                     ]
+                  }
+               ]
+            },
+            {
+               "matcher":{
+                  "id":"byName",
+                  "options":"Value #E"
+               },
+               "properties":[
+                  {
+                     "id":"links",
+                     "value":[
+                        {
+                           "title":"CQL Information Dashboard. Warning indicates that there are potential issues in the CQL Optimization",
+                           "url":"/d/cql-[[dash_version]]/scylla-cql?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}&from=${__from}&to=${__to}"
+                        }
+                     ]
+                  },
+                  {
+                     "id":"custom.width",
+                     "value":90
+                  },
+                  {
+                     "id":"custom.filterable",
+                     "value":false
+                  },
+                  {
+                     "id":"mappings",
+                     "value":[
+                        {
+                           "id":1,
+                           "type":1,
+                           "from":"",
+                           "to":"",
+                           "text":"CQL Info",
+                           "value":"0"
+                        },
+                        {
+                           "id":1,
+                           "type":2,
+                           "from":"1",
+                           "to":"20",
+                           "text":"CQL Warnings",
+                           "value":""
+                        }
+                     ]
+                  },
+                  {
+                     "id":"thresholds",
+                     "value":{
+                        "mode":"absolute",
+                        "steps":[
+                           {
+                              "color":"rgb(87, 128, 193)",
+                              "value":null
+                           },
+                           {
+                              "color":"dark-orange",
+                              "value":1
+                           }
+                        ]
+                     }
+                  },
+                  {
+                     "id":"custom.displayMode",
+                     "value":"color-text"
+                  },
+                  {
+                     "id":"custom.align",
+                     "value":"left"
+                  },
+                  {
+                     "id":"displayName",
+                     "value":"CQL"
+                  }
+               ]
+            },
+            {
+               "matcher":{
+                  "id":"byName",
+                  "options":"Value #C"
+               },
+               "properties":[
+                  {
+                     "id":"links",
+                     "value":[
+                        {
+                           "title":"OS Information Dashboard, an Error indicates there are OS related errors",
+                           "url":"/d/OS-[[dash_version]]/os-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}&from=${__from}&to=${__to}"
+                        }
+                     ]
+                  },
+                  {
+                     "id":"custom.width",
+                     "value":90
+                  },
+                  {
+                     "id":"custom.filterable",
+                     "value":true
+                  },
+                  {
+                     "id":"mappings",
+                     "value":[
+                        {
+                           "from":"",
+                           "id":1,
+                           "text":"OS Info",
+                           "to":"",
+                           "type":1,
+                           "value":"0"
+                        },
+                        {
+                           "id":2,
+                           "type":2,
+                           "from":"0",
+                           "to":"100000",
+                           "text":"OS Errors",
+                           "value":"0"
+                        }
+                     ]
+                  },
+                  {
+                     "id":"thresholds",
+                     "value":{
+                        "mode":"absolute",
+                        "steps":[
+                           {
+                              "color":"rgb(87, 128, 193)",
+                              "value":null
+                           },
+                           {
+                              "color":"dark-orange",
+                              "value":0.001
+                           }
+                        ]
+                     }
+                  },
+                  {
+                     "id":"custom.displayMode",
+                     "value":"color-text"
+                  },
+                  {
+                     "id":"custom.align",
+                     "value":"left"
+                  },
+                  {
+                     "id":"displayName",
+                     "value":"OS"
+                  }
+               ]
+            },
+            {
+               "matcher":{
+                  "id":"byName",
+                  "options":"Value #D"
+               },
+               "properties":[
+                  {
+                     "id":"links",
+                     "value":[
+                        {
+                           "title":"Cordinator and Replica node errors",
+                           "url":"/d/detailed-[[dash_version]]/detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}&from=${__from}&to=${__to}"
+                        }
+                     ]
+                  },
+                  {
+                     "id":"custom.width",
+                     "value":80
+                  },
+                  {
+                     "id":"custom.filterable",
+                     "value":true
+                  },
+                  {
+                     "id":"mappings",
+                     "value":[
+                        {
+                           "from":"",
+                           "id":1,
+                           "text":"",
+                           "to":"",
+                           "type":1,
+                           "value":"0"
+                        },
+                        {
+                           "id":2,
+                           "type":1,
+                           "from":"",
+                           "to":"",
+                           "text":"Errors",
+                           "value":"1"
+                        }
+                     ]
+                  },
+                  {
+                     "id":"thresholds",
+                     "value":{
+                        "mode":"absolute",
+                        "steps":[
+                           {
+                              "color":"rgb(87, 128, 193)",
+                              "value":null
+                           },
+                           {
+                              "color":"dark-orange",
+                              "value":0.001
+                           }
+                        ]
+                     }
+                  },
+                  {
+                     "id":"custom.displayMode",
+                     "value":"color-text"
+                  },
+                  {
+                     "id":"custom.align",
+                     "value":"left"
+                  },
+                  {
+                     "id":"displayName",
+                     "value":" "
+                  }
+               ]
+            },
+            {
+               "matcher":{
+                  "id":"byName",
+                  "options":"Value #F"
+               },
+               "dashversion":[">5.1", ">2022.2"],
+               "properties":[
+                  {
+                     "id":"links",
+                     "value":[
+                        {
+                           "title":"How many live nodes this node sees",
+                           "url":"/d/detailed-[[dash_version]]/detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}&from=${__from}&to=${__to}"
+                        }
+                     ]
+                  },
+                  {
+                     "id":"custom.width",
+                     "value":80
+                  },
+                  {
+                     "id":"custom.filterable",
+                     "value":true
+                  },
+                  {
+                     "id":"custom.displayMode",
+                     "value":"color-text"
+                  },
+                  {
+                     "id":"custom.align",
+                     "value":"left"
+                  },
+                  {
+                     "id":"displayName",
+                     "value":"Live"
+                  }
+               ]
+            },
+            {
+               "matcher":{
+                  "id":"byName",
+                  "options":"instance"
+               },
+               "properties":[
+                  {
+                     "id":"links",
+                     "value":[
+                        {
+                           "title":"Detailed view",
+                           "url":"/d/detailed-[[dash_version]]/detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}&from=${__from}&to=${__to}"
+                        }
+                     ]
+                  }
+               ]
+            },
+            {
+               "matcher":{
+                  "id":"byName",
+                  "options":"Value #G"
+               },
+               "dashversion":[">5.2", ">2023.1"],
+               "properties":[
+                  {
+                     "id":"custom.displayMode",
+                     "value":"lcd-gauge"
+                  },
+                  {
+                     "id":"min",
+                     "value":0
+                  },
+                  {
+                     "id":"max",
+                     "value":101
+                  },
+                  {
+                     "id":"displayName",
+                     "value":"Streaming"
+                  },
+                  {
+                     "id":"custom.width",
+                     "value":90
+                  },
+                  {
+                     "id":"custom.filterable",
+                     "value":false
+                  },
+                  {
+                     "id":"decimals",
+                     "value":0
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        }
+                      ]
+                    }
+                  }
+               ]
+            },
+            {
+               "matcher":{
+                  "id":"byName",
+                  "options":"Value #H"
+               },
+               "properties":[
+                  {
+                     "id":"custom.displayMode",
+                     "value":"lcd-gauge"
+                  },
+                  {
+                     "id":"min",
+                     "value":0
+                  },
+                  {
+                     "id":"max",
+                     "value":101
+                  },
+                  {
+                     "id":"displayName",
+                     "value":"Disk Usage"
+                  },
+                  {
+                     "id":"custom.width",
+                     "value":120
+                  },
+                  {
+                     "id":"custom.filterable",
+                     "value":false
+                  },
+                  {
+                     "id":"decimals",
+                     "value":0
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        }
+                      ]
+                    }
+                  }
+               ]
+            },
+            {
+               "matcher":{
+                  "id":"byName",
+                  "options":"Value #I"
+               },
+               "properties":[
+                  {
+                     "id":"displayName",
+                     "value":"Compaction"
+                  },
+                  {
+                     "id":"custom.width",
+                     "value":100
+                  },
+                  {
+                     "id":"custom.filterable",
+                     "value":false
+                  },
+                  {
+                     "id":"decimals",
+                     "value":0
+                  }
+               ]
+            },
+            {
+               "matcher":{
+                  "id":"byName",
+                  "options":"Value #J"
+               },
+               "properties":[
+                  {
+                     "id":"custom.displayMode",
+                     "value":"lcd-gauge"
+                  },
+                  {
+                     "id":"min",
+                     "value":0
+                  },
+                  {
+                     "id":"max",
+                     "value":101
+                  },
+                  {
+                     "id":"displayName",
+                     "value":"Cache Misses"
+                  },
+                  {
+                     "id":"custom.width",
+                     "value":120
+                  },
+                  {
+                     "id":"custom.filterable",
+                     "value":false
+                  },
+                  {
+                     "id":"decimals",
+                     "value":0
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        }
+                      ]
+                    }
+                  }
+               ]
+            },
+            {
+               "matcher":{
+                  "id":"byName",
+                  "options":"Value #K"
+               },
+               "properties":[
+                  {
+                     "id":"displayName",
+                     "value":"P50"
+                  },
+                  {
+                     "id":"custom.width",
+                     "value":100
+                  },
+                  {
+                     "id":"custom.filterable",
+                     "value":false
+                  },
+                  {
+                     "id":"decimals",
+                     "value":0
+                  },
+                  {
+                    "id": "unit",
+                    "value": "µs"
+                  }
+               ]
+            },
+            {
+               "matcher":{
+                  "id":"byName",
+                  "options":"Value #L"
+               },
+               "properties":[
+                  {
+                     "id":"displayName",
+                     "value":"P95"
+                  },
+                  {
+                     "id":"custom.width",
+                     "value":100
+                  },
+                  {
+                     "id":"custom.filterable",
+                     "value":false
+                  },
+                  {
+                     "id":"decimals",
+                     "value":0
+                  },
+                  {
+                    "id": "unit",
+                    "value": "µs"
+                  }
+               ]
+            },
+            {
+               "matcher":{
+                  "id":"byName",
+                  "options":"Value #M"
+               },
+               "properties":[
+                  {
+                     "id":"displayName",
+                     "value":"P99"
+                  },
+                  {
+                     "id":"custom.width",
+                     "value":100
+                  },
+                  {
+                     "id":"custom.filterable",
+                     "value":false
+                  },
+                  {
+                     "id":"decimals",
+                     "value":0
+                  },
+                  {
+                    "id": "unit",
+                    "value": "µs"
+                  }
+               ]
+            }
+         ]
+      },
+      "scopedVars":{
+         "dc":{
+            "text":"datacenter1",
+            "value":"datacenter1",
+            "selected":false
+         }
+      },
+      "transformations":[
+         {
+            "id":"filterFieldsByName",
+            "options":{
+               "include":{
+                  "names":[
+                     "instance",
+                     "svr",
+                     "Value #A",
+                     "Value #B",
+                     "Value #C",
+                     "Value #D",
+                     "Value #E",
+                     "Value #F",
+                     "Value #G",
+                     "Value #H",
+                     "Value #I",
+                     "Value #J",
+                     "Value #K",
+                     "Value #L",
+                     "Value #M"
+                  ]
+               }
+            }
+         },
+         {
+            "id":"seriesToColumns",
+            "options":{
+               "byField":"instance"
+            }
+         },
+         {
+            "id":"organize",
+            "options":{
+               "excludeByName":{
+               },
+               "indexByName":{
+                  "instance":0,
+                  "Value #D":1,
+                  "Value #E":2,
+                  "Value #C":3,
+                  "svr":4,
+                  "Value #A":5,
+                  "Value #F":6,
+                  "Value #H":7,
+                  "Value #G":9,
+                  "Value #B":8
+               },
+               "renameByName":{
+               }
+            }
+         }
+      ]
    },
    "small_nodes_table":{
       "datasource":"prometheus",

--- a/start-all.sh
+++ b/start-all.sh
@@ -241,6 +241,9 @@ for arg; do
             (--enable-protobuf)
                 PROMETHEUS_COMMAND_LINE_OPTIONS_ARRAY+=(--enable-feature=native-histograms)
                 ;;
+            (--alternator)
+                RUN_ALTERNATOR="1"
+                ;;
             (--limit)
                 LIMIT="1"
                 ;;
@@ -761,5 +764,8 @@ for val in "${GRAFANA_DASHBOARD_ARRAY[@]}"; do
 done
 if [ ! -z "$DATDOGPARAM" ]; then
    ./start-datadog.sh $DATDOGPARAM -p $DB_ADDRESS
+fi
+if [ "$RUN_ALTERNATOR" = 1 ]; then
+    GRAFANA_ENV_COMMAND="$GRAFANA_ENV_COMMAND --alternator"
 fi
 ./start-grafana.sh $LDAP_FILE $LOKI_ADDRESS $LIMITS $VOLUMES $PARAMS $BIND_ADDRESS_CONFIG $RUN_RENDERER $SPECIFIC_SOLUTION -p $DB_ADDRESS $GRAFNA_ANONYMOUS_ROLE -D "$DOCKER_PARAM" $GRAFANA_PORT $EXTERNAL_VOLUME -m $AM_ADDRESS -M $MANAGER_VERSION -v $VERSIONS $GRAFANA_ENV_COMMAND $GRAFANA_DASHBOARD_COMMAND $GRAFANA_ADMIN_PASSWORD $STACK_CMD

--- a/start-all.sh
+++ b/start-all.sh
@@ -661,6 +661,9 @@ if [ "$DATA_DIR" != "" ] && [ "$ARCHIVE" != "1" ]; then
     echo MONITORING_VERSION='"'"$CURRENT_VERSION"'"' >> $DATA_DIR/scylla.txt
     echo PROMETHEUS_VERSION='"'"$PROMETHEUS_VERSION"'"' >> $DATA_DIR/scylla.txt
     echo LAST_RUN='"'"$DATE"'"' >> $DATA_DIR/scylla.txt
+    if [ "$RUN_ALTERNATOR" = "1" ]; then
+        echo RUN_ALTERNATOR=1 >> $DATA_DIR/scylla.txt
+    fi
 fi
 if [ -z $HOST_NETWORK ]; then
     PORT_MAPPING="-p $BIND_ADDRESS$PROMETHEUS_PORT:9090"

--- a/start-grafana.sh
+++ b/start-grafana.sh
@@ -49,6 +49,9 @@ for arg; do
             (--limit)
                 LIMIT="1"
                 ;;
+            (--alternator)
+                RUN_ALTERNATOR="1"
+                ;;
             (--volume)
                 LIMIT="1"
                 VOLUME="1"
@@ -245,7 +248,11 @@ if [[ ! $DOCKER_PARAM = *"--net=host"* ]]; then
 fi
 
 if [[ "$HOME_DASHBOARD" = "" ]]; then
-    HOME_DASHBOARD="/var/lib/grafana/dashboards/ver_$VERSION/scylla-overview.$VERSION.json"
+    if [ "$RUN_ALTERNATOR" = "1" ]; then
+        HOME_DASHBOARD="/var/lib/grafana/dashboards/ver_$VERSION/alternator.$VERSION.json"
+    else
+        HOME_DASHBOARD="/var/lib/grafana/dashboards/ver_$VERSION/scylla-overview.$VERSION.json"
+    fi
 fi
 
 if [[ -z "${DOCKER_HOST}" ]]; then


### PR DESCRIPTION
This series addresses multiple issues with the alternator dashboard.
1. It adds a command line option to start the monitoring stack with the alternator dashboard as the default.
2. It updates the alternator dashboard with newer functionality from the overview dashboard.
3. A per-DC section now holds extended node tables that combine the relevant information

![image](https://github.com/scylladb/scylla-monitoring/assets/2118079/aa9cb4bc-7684-45b6-84ab-c66f7c2f1ded)

