### PR TITLE
Alternator recording rules

### DIFF
--- a/prometheus/prom_rules/prometheus.latency.rules.yml
+++ b/prometheus/prom_rules/prometheus.latency.rules.yml
@@ -364,5 +364,59 @@ groups:
     labels:
       by: "cluster"
       dd: "1"
+  - record: scylla_alternator_op_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_alternator_op_latency_bucket[60s])>0) by (cluster, dc, instance, le, op))
+    labels:
+      by: "instance"
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_alternator_op_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_alternator_op_latency_bucket[60s])>0) by (cluster, dc, le, op))
+    labels:
+      by: "dc"
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_alternator_op_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_alternator_op_latency_bucket[60s])>0) by (cluster, op))
+    labels:
+      by: "cluster"
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_alternator_op_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_alternator_op_latency_bucket[60s])>0) by (cluster, dc, instance, le, op))
+    labels:
+      by: "instance"
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_alternator_op_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_alternator_op_latency_bucket[60s])>0) by (cluster, dc, le, op))
+    labels:
+      by: "dc"
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_alternator_op_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_alternator_op_latency_bucket[60s])>0) by (cluster, op))
+    labels:
+      by: "cluster"
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_alternator_op_latency_summary
+    expr: histogram_quantile(0.99, sum(rate(scylla_alternator_op_latency_bucket[60s])>0) by (cluster, dc, instance, le, op))
+    labels:
+      by: "instance"
+      quantile: "0.99"
+      dd: "1"
+  - record: scylla_alternator_op_latency_summary
+    expr: histogram_quantile(0.99, sum(rate(scylla_alternator_op_latency_bucket[60s])>0) by (cluster, dc, le, op))
+    labels:
+      by: "dc"
+      quantile: "0.99"
+      dd: "1"
+  - record: scylla_alternator_op_latency_summary
+    expr: histogram_quantile(0.99, sum(rate(scylla_alternator_op_latency_bucket[60s])>0) by (cluster, op))
+    labels:
+      by: "cluster"
+      quantile: "0.99"
+      dd: "1"
   - record: all_scheduling_group
     expr: sum by (cluster, scheduling_group_name) (scylla_storage_proxy_coordinator_write_latency_count + scylla_storage_proxy_coordinator_read_latency_count) > 0

--- a/prometheus/prometheus.yml.template
+++ b/prometheus/prometheus.yml.template
@@ -120,8 +120,12 @@ scrape_configs:
       regex: '(scylla_storage_proxy_coordinator_cas_read_latency_summary;0.50*)'
       target_label: __name__
       replacement: 'casrlatencya'
+    - source_labels: [quantile]
+      regex: '(0\.[1-9]+)0*'
+      target_label: quantile
+      replacement: '${1}'
     - source_labels: [__name__]
-      regex: '(.latency..?.?|cas.latency..?.?)'
+      regex: '(.latency..?.?|cas.latency..?.?|scylla_.*_summary)'
       target_label: by
       replacement: 'instance,shard'
     - source_labels: [__name__]


### PR DESCRIPTION
This series is a preparation for alternator 6.0, 
It uses recording rules to create unified summary names for the shard, instance, DC, and cluster levels.

The alternator dashboard will use the pre-calculated metrics in future releases for better performance.

Fixes #2214 