### PR TITLE
prometheus.rules.yml: increase a BF alert threshold to 0.2

### DIFF
--- a/prometheus/prom_rules/prometheus.rules.yml
+++ b/prometheus/prom_rules/prometheus.rules.yml
@@ -304,7 +304,7 @@ groups:
       description: 'Cluster in a split-brain mode'
       summary: Some nodes in the cluster do not see all of the other live nodes
   - alert: bloomFilterSize
-    expr: scylla_sstables_bloom_filter_memory_size/scylla_memory_total_memory > 0.1
+    expr: scylla_sstables_bloom_filter_memory_size/scylla_memory_total_memory > 0.2
     for: 10m
     labels:
       severity: "warn"


### PR DESCRIPTION
0.1 was too low and created too many false alarms.
Fixes #2263 2263