### PR TITLE
docs: matrix.rst set the node_exporter dependency to 1.7.0

### DIFF
--- a/docs/source/reference/matrix.rst
+++ b/docs/source/reference/matrix.rst
@@ -17,7 +17,7 @@ The following table shows which version of Scylla Monitoring Stack supports dash
    * - 4.7
      - 5.2, 5.4, 6.0
      - 2022.1, 2022.2, 2023.1, 2024.1
-     - 1.4.1
+     - 1.7.0
      - 3.2
    * - 4.6
      - 5.2, 5.4


### PR DESCRIPTION
Set the node_exporter dependency to 1.7.0. The motivation is to encourage the users to upgrade their node_exporter to a newer version.

Fixes #2265