### PR TITLE
[cloud image] Copy AMI to testing regions

### DIFF
--- a/packer/scylla-monitor-template.json
+++ b/packer/scylla-monitor-template.json
@@ -6,6 +6,7 @@
       "ami_name": "{{ user `monitor_image_name` }}",
       "source_ami": "{{user `aws_source_ami`}}",
       "instance_type": "{{user `aws_instance_type`}}",
+      "aws_regions": "us-west-2,eu-west-2,eu-west-1,eu-central-1,eu-north-1",
       "user_data_file": "files/user_data.txt",
       "subnet_filter": {
         "filters": {


### PR DESCRIPTION
Same has Scylla images, we need monitoring image to be available also in testing regions so QA can use them