### PR TITLE
docs: update theme 1.7

### DIFF
--- a/.github/workflows/docs-pages.yaml
+++ b/.github/workflows/docs-pages.yaml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - master
+      - 'branch-**'
     paths:
       - "docs/**"
   workflow_dispatch:
@@ -15,14 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: '3.10'
       - name: Set up env
         run: make -C docs setupenv
       - name: Build docs

--- a/.github/workflows/docs-pr.yaml
+++ b/.github/workflows/docs-pr.yaml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: '3.10'
       - name: Set up env
         run: make -C docs setupenv
       - name: Build docs

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -12,7 +12,7 @@ recommonmark = "0.7.1"
 sphinx-autobuild = "2021.3.14"
 Sphinx = "7.2.6"
 redirects_cli ="~0.1.2"
-sphinx-scylladb-theme = "~1.6.1"
+sphinx-scylladb-theme = "~1.7.2"
 sphinx-multiversion-scylla = "~0.3.1"
 sphinx-sitemap = "2.5.1"
 


### PR DESCRIPTION
Related issue https://github.com/scylladb/sphinx-scylladb-theme/issues/1035

ScyllaDB Sphinx Theme 1.7 is out 🥳 Now, the docs will automatically publish when backporting changes to previous branches. This release also introduces minor style enhancements to the sidebar and homepage.

You can read more about all notable changes [here](https://sphinx-theme.scylladb.com/master/upgrade/CHANGELOG.html#apr-2024).

## How to test this PR

1. Clone this PR. For more information, see [Cloning pull requests locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally).

2. Enter the docs folder, and run:
  
    ```
    make preview
    ````

3. Open http://localhost:5500 with your favorite browser. The doc should render without errors, and the version should be Sphinx Theme version (see the footer) must be ``1.7.x``:

![image](https://github.com/scylladb/scylladb/assets/9107969/36a20719-fb03-42be-a7bc-faa40d67eb91)
