### PR TITLE
scylla-monitor-template: fix wrong copy to regions parameter

### DIFF
--- a/packer/scylla-monitor-template.json
+++ b/packer/scylla-monitor-template.json
@@ -6,7 +6,7 @@
       "ami_name": "{{ user `monitor_image_name` }}",
       "source_ami": "{{user `aws_source_ami`}}",
       "instance_type": "{{user `aws_instance_type`}}",
-      "aws_regions": "us-west-2,eu-west-2,eu-west-1,eu-central-1,eu-north-1",
+      "ami_regions": "us-west-2,eu-west-2,eu-west-1,eu-central-1,eu-north-1",
       "user_data_file": "files/user_data.txt",
       "subnet_filter": {
         "filters": {


### PR DESCRIPTION
In 90f7fb862d9df7c4fdaf73c09725a98351325f8e i mistakly configured the wrong parameter for copying the ami to different regions

Fixing it