### PR TITLE
packer: enable verbose logs by default

### DIFF
--- a/packer/scylla-monitor-template.json
+++ b/packer/scylla-monitor-template.json
@@ -110,7 +110,7 @@
     "aws_source_ami": "ami-02a35bd020554f400",
     "aws_instance_type": "c4.xlarge",
     "aws_ssh_username": "ubuntu",
-    "aws_install_args": "--cloud aws --os ubuntu --version {{ user `monitor_version` }}",
+    "aws_install_args": "--cloud aws --os ubuntu --verbose --version {{ user `monitor_version` }}",
 
     "gcp_project_id": "scylla-images",
     "gcp_zone": "europe-west1-b",
@@ -118,6 +118,6 @@
     "gcp_image_storage_location": "europe-west1",
     "gcp_instance_type": "n1-standard-1",
     "gcp_ssh_username": "ubuntu",
-    "gcp_install_args": "--cloud gce --os ubuntu --version {{ user `monitor_version` }}"
+    "gcp_install_args": "--cloud gce --os ubuntu --verbose --version {{ user `monitor_version` }}"
   }
 }


### PR DESCRIPTION
This is required to help with debug github-action failures


@amnonh following our discussion from last week about release failures - this change enables verbose logs by default so we can track the next triggered-by-release-event failure 