### PR TITLE
scylla-advanced: switching to a bar chart

### DIFF
--- a/grafana/scylla-advanced.template.json
+++ b/grafana/scylla-advanced.template.json
@@ -36,6 +36,7 @@
                         "class": "percentunit_panel",
                         "dashversion":[">5.4", ">2024.1"],
                         "span": 3,
+                        "type": "barchart",
                         "targets": [
                             {
                                 "expr": "sum(rate(scylla_io_queue_consumption{iogroup=~\"$iogroup\", class=~\"$classes\", instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by ([[by]], class, iogroup)",
@@ -51,18 +52,34 @@
                               "class": "fieldConfig_defaults",
                               "custom": {
                                  "class":"fieldConfig_defaults_custom",
-                                 "axisSoftMax": 1,
-                                 "stacking": {
-                                  "mode": "normal",
-                                  "group": "A"
-                                }
+                                 "fillOpacity": 30,
+                                 "thresholdsStyle": {
+                                    "mode": "line"
+                                 },
+                                 "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                      {
+                                        "color": "green",
+                                        "value": null
+                                      },
+                                      {
+                                        "color": "red",
+                                        "value": 0.8
+                                      }
+                                    ]
+                                  },
+                                 "axisSoftMax": 1
                               },
                               "unit": "percentunit"
                             },
                             "overrides": []
                          },
                         "options": {
-                            "class":"desc_tooltip_options"
+                            "class":"desc_tooltip_options",
+                            "xTickLabelSpacing": 100,
+                            "showValue": "never",
+                            "stacking": "normal"
                         },
                         "description": "This stack graph shows how IO queue consumption is distributed between io-groups and classes. Being a stack graph means the total would reach 100% with a high consumption.\n\nscylla_io_queue_consumption",
                         "title": "I/O Group [[iogroup]] Queue consumption by [[by]]"


### PR DESCRIPTION
the io-queue uses a stack graph, to make it clearer, we switch to a bar graph.
![image](https://github.com/scylladb/scylla-monitoring/assets/2118079/254d0b1a-ed74-479b-b358-4563ddd5b6c8)

Fixes #2293