### PR TITLE
types.json: set the ip column width

### DIFF
--- a/grafana/types.json
+++ b/grafana/types.json
@@ -3788,7 +3788,16 @@
                "properties":[
                   {
                      "id":"custom.width",
-                     "value":105
+                     "value":120
+                  },
+                  {
+                     "id":"links",
+                     "value":[
+                        {
+                           "title":"Detailed view",
+                           "url":"/d/detailed-[[dash_version]]/detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}&from=${__from}&to=${__to}"
+                        }
+                     ]
                   }
                ]
             },
@@ -4162,23 +4171,6 @@
                   {
                      "id":"displayName",
                      "value":"Live"
-                  }
-               ]
-            },
-            {
-               "matcher":{
-                  "id":"byName",
-                  "options":"instance"
-               },
-               "properties":[
-                  {
-                     "id":"links",
-                     "value":[
-                        {
-                           "title":"Detailed view",
-                           "url":"/d/detailed-[[dash_version]]/detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}&from=${__from}&to=${__to}"
-                        }
-                     ]
                   }
                ]
             },


### PR DESCRIPTION
This patch set the ip column in the node tables to 120

Fixes #2302