### PR TITLE
Fix typo - Avrage -> Average (in LWT panels)

### DIFF
--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -1432,8 +1432,8 @@
                                 "step": 10
                             }
                         ],
-                        "title": "LWT Avrage Read latency",
-                        "description" : "LWT Avrage Read latency."
+                        "title": "LWT Average Read latency",
+                        "description" : "LWT Average Read latency."
                     },
                     {
                         "class": "us_panel",
@@ -1497,8 +1497,8 @@
                                 "step": 10
                             }
                         ],
-                        "title": "LWT Avrage Write latency",
-                        "description" : "LWT Avrage Write latency."
+                        "title": "LWT Average Write latency",
+                        "description" : "LWT Average Write latency."
                     },
                     {
                         "class": "us_panel",


### PR DESCRIPTION
I see that in Scylla we have it quite a lot:
kaul@ykaul:~/github/scylladb$ git grep avrage
api/api-doc/cache_service.json:      "path": "/cache_service/metrics/key/hits_moving_avrage",
api/api-doc/cache_service.json:          "summary": "Get key hits moving avrage",
api/api-doc/cache_service.json:          "nickname": "get_key_hits_moving_avrage",
api/api-doc/cache_service.json:      "path": "/cache_service/metrics/key/requests_moving_avrage",
api/api-doc/cache_service.json:          "summary": "Get key requests moving avrage",
api/api-doc/cache_service.json:          "nickname": "get_key_requests_moving_avrage",
api/api-doc/cache_service.json:      "path": "/cache_service/metrics/row/hits_moving_avrage",
api/api-doc/cache_service.json:          "summary": "Get row hits moving avrage",
api/api-doc/cache_service.json:          "nickname": "get_row_hits_moving_avrage",
api/api-doc/cache_service.json:      "path": "/cache_service/metrics/row/requests_moving_avrage",
api/api-doc/cache_service.json:          "summary": "Get row requests moving avrage",
api/api-doc/cache_service.json:          "nickname": "get_row_requests_moving_avrage",
api/api-doc/cache_service.json:      "path": "/cache_service/metrics/counter/hits_moving_avrage",
api/api-doc/cache_service.json:          "summary": "Get counter hits moving avrage",
api/api-doc/cache_service.json:          "nickname": "get_counter_hits_moving_avrage",
api/api-doc/cache_service.json:      "path": "/cache_service/metrics/counter/requests_moving_avrage",
api/api-doc/cache_service.json:          "summary": "Get counter requests moving avrage",
api/api-doc/cache_service.json:          "nickname": "get_counter_requests_moving_avrage",
api/api-doc/column_family.json:               "summary":"Get read latency moving avrage histogram",
api/api-doc/column_family.json:               "summary":"Get read latency moving avrage histogram from all column family",
api/cache_service.cc:    cs::get_key_hits_moving_avrage.set(r, [] (std::unique_ptr<http::request> req) {
api/cache_service.cc:    cs::get_key_requests_moving_avrage.set(r, [] (std::unique_ptr<http::request> req) {
api/cache_service.cc:    cs::get_row_hits_moving_avrage.set(r, [&ctx] (std::unique_ptr<http::request> req) {
api/cache_service.cc:    cs::get_row_requests_moving_avrage.set(r, [&ctx] (std::unique_ptr<http::request> req) {
api/cache_service.cc:    cs::get_counter_hits_moving_avrage.set(r, [] (std::unique_ptr<http::request> req) {
api/cache_service.cc:    cs::get_counter_requests_moving_avrage.set(r, [] (std::unique_ptr<http::request> req) {
test/nodetool/test_info.py:            expected_request('GET', f'/cache_service/metrics/{name}/hits_moving_avrage',
test/nodetool/test_info.py:            expected_request('GET', f'/cache_service/metrics/{name}/requests_moving_avrage',
tools/scylla-nodetool.cc:    auto res = client.get(fmt::format("/cache_service/metrics/{}/{}_moving_avrage",

But at least in the monitoring UI, it should be correct.