### PR TITLE
Preparing for lantencies metric rename

### DIFF
--- a/prometheus/prom_rules/prometheus.latency.rules.yml
+++ b/prometheus/prom_rules/prometheus.latency.rules.yml
@@ -64,302 +64,185 @@ groups:
     labels:
       dd: "1"
       by: "cluster"
-  - record: wlatencyp99
-    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{shard=~".+", scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, shard, scheduling_group_name, le))
-    labels:
-      by: "instance,shard"
-      dd: "2"
-  - record: wlatencyp99
-    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, scheduling_group_name, le))
+  - record: scylla_storage_proxy_coordinator_write_latency_summary
+    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket[60s])) by (cluster, dc, instance, scheduling_group_name, le))
     labels:
       by: "instance"
+      quantile: "0.99"
       dd: "1"
-  - record: wlatencyp99
-    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, scheduling_group_name, le))
+  - record: scylla_storage_proxy_coordinator_write_latency_summary
+    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket[60s])) by (cluster, dc, scheduling_group_name, le))
     labels:
       by: "dc"
+      quantile: "0.99"
       dd: "1"
-  - record: wlatencyp99
-    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, scheduling_group_name, le))
+  - record: scylla_storage_proxy_coordinator_write_latency_summary
+    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket[60s])) by (cluster, scheduling_group_name, le))
     labels:
       by: "cluster"
+      quantile: "0.99"
       dd: "1"
-  - record: rlatencyp99
-    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{shard=~".+", scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, shard, scheduling_group_name, le))
-    labels:
-      by: "instance,shard"
-      dd: "2"
-  - record: rlatencyp99
-    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, scheduling_group_name, le))
+  - record: scylla_storage_proxy_coordinator_read_latency_summary
+    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket[60s])) by (cluster, dc, instance, scheduling_group_name, le))
     labels:
       by: "instance"
+      quantile: "0.99"
       dd: "1"
-  - record: rlatencyp99
-    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, scheduling_group_name, le))
+  - record: scylla_storage_proxy_coordinator_read_latency_summary
+    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket[60s])) by (cluster, dc, scheduling_group_name, le))
     labels:
       by: "dc"
+      quantile: "0.99"
       dd: "1"
-  - record: rlatencyp99
-    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, scheduling_group_name, le))
+  - record: scylla_storage_proxy_coordinator_read_latency_summary
+    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket[60s])) by (cluster, scheduling_group_name, le))
     labels:
       by: "cluster"
+      quantile: "0.99"
       dd: "1"
-  - record: wlatencyp95
-    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{shard=~".+", scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, shard, scheduling_group_name, le))
-    labels:
-      by: "instance,shard"
-      dd: "2"
-  - record: wlatencyp95
-    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, scheduling_group_name, le))
+  - record: scylla_storage_proxy_coordinator_write_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket[60s])) by (cluster, dc, instance, scheduling_group_name, le))
     labels:
       by: "instance"
+      quantile: "0.95"
       dd: "1"
-  - record: wlatencyp95
-    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, scheduling_group_name, le))
+  - record: scylla_storage_proxy_coordinator_write_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket[60s])) by (cluster, dc, scheduling_group_name, le))
     labels:
       by: "dc"
+      quantile: "0.95"
       dd: "1"
-  - record: wlatencyp95
-    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, scheduling_group_name, le))
+  - record: scylla_storage_proxy_coordinator_write_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket[60s])) by (cluster, scheduling_group_name, le))
     labels:
       by: "cluster"
+      quantile: "0.95"
       dd: "1"
-  - record: rlatencyp95
-    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{shard=~".+", scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, shard, scheduling_group_name, le))
-    labels:
-      by: "instance,shard"
-      dd: "2"
-  - record: rlatencyp95
-    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, scheduling_group_name, le))
+  - record: scylla_storage_proxy_coordinator_read_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket[60s])) by (cluster, dc, instance, scheduling_group_name, le))
     labels:
       by: "instance"
+      quantile: "0.95"
       dd: "1"
-  - record: rlatencyp95
-    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, scheduling_group_name, le))
+  - record: scylla_storage_proxy_coordinator_read_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket[60s])) by (cluster, dc, scheduling_group_name, le))
     labels:
       by: "dc"
+      quantile: "0.95"
       dd: "1"
-  - record: rlatencyp95
-    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, scheduling_group_name, le))
+  - record: scylla_storage_proxy_coordinator_read_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket[60s])) by (cluster, scheduling_group_name, le))
     labels:
       by: "cluster"
+      quantile: "0.95"
       dd: "1"
-  - record: wlatencya
-    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{shard=~".+", scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, shard, scheduling_group_name, le))
-    labels:
-      by: "instance,shard"
-      dd: "2"
-  - record: wlatencya
-    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, scheduling_group_name, le))
+  - record: scylla_storage_proxy_coordinator_write_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket[60s])) by (cluster, dc, instance, scheduling_group_name, le))
     labels:
       by: "instance"
+      quantile: "0.5"
       dd: "1"
-  - record: wlatencya
-    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, scheduling_group_name, le))
+  - record: scylla_storage_proxy_coordinator_write_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket[60s])) by (cluster, dc, scheduling_group_name, le))
     labels:
       by: "dc"
+      quantile: "0.5"
       dd: "1"
-  - record: wlatencya
-    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, scheduling_group_name, le))
+  - record: scylla_storage_proxy_coordinator_write_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket[60s])) by (cluster, scheduling_group_name, le))
     labels:
       by: "cluster"
+      quantile: "0.5"
       dd: "1"
-  - record: rlatencya
-    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{shard=~".+", scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, shard, scheduling_group_name, le))
-    labels:
-      by: "instance,shard"
-      dd: "2"
-  - record: rlatencya
-    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, scheduling_group_name, le))
+  - record: scylla_storage_proxy_coordinator_read_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket[60s])) by (cluster, dc, instance, scheduling_group_name, le))
     labels:
       by: "instance"
+      quantile: "0.5"
       dd: "1"
-  - record: rlatencya
-    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, scheduling_group_name, le))
+  - record: scylla_storage_proxy_coordinator_read_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket[60s])) by (cluster, dc, scheduling_group_name, le))
     labels:
       by: "dc"
+      quantile: "0.5"
       dd: "1"
-  - record: rlatencya
-    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, scheduling_group_name, le))
+  - record: scylla_storage_proxy_coordinator_read_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket[60s])) by (cluster, scheduling_group_name, le))
     labels:
       by: "cluster"
+      quantile: "0.5"
       dd: "1"
-  - record: wlatencyp99
-    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{shard=~".+", scheduling_group_name=~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, shard, scheduling_group_name, le))
-    labels:
-      by: "instance,shard"
-  - record: wlatencyp99
-    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name=~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, scheduling_group_name, le))
+  - record: scylla_storage_proxy_coordinator_cas_read_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency_bucket[60s])) by (cluster, dc, instance, le, scheduling_group_name))
     labels:
       by: "instance"
-
-  - record: wlatencyp99
-    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name=~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, scheduling_group_name, le))
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_cas_read_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency_bucket[60s])) by (cluster, dc, le, scheduling_group_name))
     labels:
       by: "dc"
-  - record: wlatencyp99
-    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name=~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, scheduling_group_name, le))
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_cas_read_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency_bucket[60s])) by (cluster, le, scheduling_group_name))
     labels:
       by: "cluster"
-  - record: rlatencyp99
-    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{shard=~".+", scheduling_group_name=~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, shard, scheduling_group_name, le))
-    labels:
-      by: "instance,shard"
-  - record: rlatencyp99
-    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name=~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, scheduling_group_name, le))
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_cas_write_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_bucket[60s])) by (cluster, dc, instance, le, scheduling_group_name))
     labels:
       by: "instance"
-  - record: rlatencyp99
-    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name=~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, scheduling_group_name, le))
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_cas_write_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_bucket[60s])) by (cluster, dc, le, scheduling_group_name))
     labels:
       by: "dc"
-  - record: rlatencyp99
-    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name=~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, scheduling_group_name, le))
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_cas_write_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_bucket[60s])) by (cluster, le, scheduling_group_name))
     labels:
       by: "cluster"
-  - record: wlatencyp95
-    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{shard=~".+", scheduling_group_name=~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, shard, scheduling_group_name, le))
-    labels:
-      by: "instance,shard"
-  - record: wlatencyp95
-    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name=~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, scheduling_group_name, le))
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_cas_read_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency_bucket[60s])) by (cluster, dc, instance, le, scheduling_group_name))
     labels:
       by: "instance"
-  - record: wlatencyp95
-    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name=~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, scheduling_group_name, le))
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_cas_read_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency_bucket[60s])) by (cluster, dc, le, scheduling_group_name))
     labels:
       by: "dc"
-  - record: wlatencyp95
-    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name=~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, scheduling_group_name, le))
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_cas_read_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency_bucket[60s])) by (cluster, le, scheduling_group_name))
     labels:
       by: "cluster"
-  - record: rlatencyp95
-    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{shard=~".+", scheduling_group_name=~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, shard, scheduling_group_name, le))
-    labels:
-      by: "instance,shard"
-  - record: rlatencyp95
-    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name=~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, scheduling_group_name, le))
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_cas_write_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_bucket[60s])) by (cluster, dc, instance, le, scheduling_group_name))
     labels:
       by: "instance"
-  - record: rlatencyp95
-    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name=~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, scheduling_group_name, le))
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_cas_write_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_bucket[60s])) by (cluster, dc, le, scheduling_group_name))
     labels:
       by: "dc"
-  - record: rlatencyp95
-    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name=~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, scheduling_group_name, le))
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_cas_write_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_bucket[60s])) by (cluster, le, scheduling_group_name))
     labels:
       by: "cluster"
-  - record: wlatencya
-    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{shard=~".+", scheduling_group_name=~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, shard, scheduling_group_name, le))
-    labels:
-      by: "instance,shard"
-  - record: wlatencya
-    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name=~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, scheduling_group_name, le))
-    labels:
-      by: "instance"
-  - record: wlatencya
-    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name=~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, scheduling_group_name, le))
-    labels:
-      by: "dc"
-  - record: wlatencya
-    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{scheduling_group_name=~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, scheduling_group_name, le))
-    labels:
-      by: "cluster"
-  - record: rlatencya
-    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{shard=~".+", scheduling_group_name=~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, shard, scheduling_group_name, le))
-    labels:
-      by: "instance,shard"
-  - record: rlatencya
-    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name=~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, scheduling_group_name, le))
-    labels:
-      by: "instance"
-  - record: rlatencya
-    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name=~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, scheduling_group_name, le))
-    labels:
-      by: "dc"
-  - record: rlatencya
-    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{scheduling_group_name=~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, scheduling_group_name, le))
-    labels:
-      by: "cluster"
-  - record: casrlatencyp95
-    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency_bucket{shard=~".+", scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, shard, le, scheduling_group_name))
-    labels:
-      by: "instance,shard"
-      dd: "2"
-  - record: casrlatencyp95
-    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, le, scheduling_group_name))
-    labels:
-      by: "instance"
-      dd: "1"
-  - record: casrlatencyp95
-    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, le, scheduling_group_name))
-    labels:
-      by: "dc"
-      dd: "1"
-  - record: casrlatencyp95
-    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, le, scheduling_group_name))
-    labels:
-      by: "cluster"
-      dd: "1"
-  - record: caswlatencyp95
-    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_bucket{shard=~".+", scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, shard, le, scheduling_group_name))
-    labels:
-      by: "instance,shard"
-      dd: "2"
-  - record: caswlatencyp95
-    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, le, scheduling_group_name))
-    labels:
-      by: "instance"
-      dd: "1"
-  - record: caswlatencyp95
-    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, le, scheduling_group_name))
-    labels:
-      by: "dc"
-      dd: "1"
-  - record: caswlatencyp95
-    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, le, scheduling_group_name))
-    labels:
-      by: "cluster"
-      dd: "1"
-  - record: casrlatencya
-    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency_bucket{shard=~".+", scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, shard, le, scheduling_group_name))
-    labels:
-      by: "instance,shard"
-      dd: "2"
-  - record: casrlatencya
-    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, le, scheduling_group_name))
-    labels:
-      by: "instance"
-      dd: "1"
-  - record: casrlatencya
-    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, le, scheduling_group_name))
-    labels:
-      by: "dc"
-      dd: "1"
-  - record: casrlatencya
-    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, le, scheduling_group_name))
-    labels:
-      by: "cluster"
-      dd: "1"
-  - record: caswlatencya
-    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_bucket{shard=~".+", scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, shard, le, scheduling_group_name))
-    labels:
-      by: "instance,shard"
-      dd: "2"
-  - record: caswlatencya
-    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, instance, le, scheduling_group_name))
-    labels:
-      by: "instance"
-      dd: "1"
-  - record: caswlatencya
-    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, dc, le, scheduling_group_name))
-    labels:
-      by: "dc"
-      dd: "1"
-  - record: caswlatencya
-    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_bucket{scheduling_group_name!~"atexit|gossip|mem_compaction|memtable|streaming|background_reclaim|compaction|main|memtable_to_cache"}[60s])) by (cluster, le, scheduling_group_name))
-    labels:
-      by: "cluster"
+      quantile: "0.5"
       dd: "1"
   - record: scylla_alternator_op_latency_summary
     expr: histogram_quantile(0.5, sum(rate(scylla_alternator_op_latency_bucket[60s])>0) by (cluster, dc, instance, le, op))
@@ -415,5 +298,3 @@ groups:
       by: "cluster"
       quantile: "0.99"
       dd: "1"
-  - record: all_scheduling_group
-    expr: sum by (cluster, scheduling_group_name) (scylla_storage_proxy_coordinator_write_latency_count + scylla_storage_proxy_coordinator_read_latency_count) > 0

--- a/prometheus/prom_rules/prometheus.latency.rules.yml
+++ b/prometheus/prom_rules/prometheus.latency.rules.yml
@@ -298,3 +298,23 @@ groups:
       by: "cluster"
       quantile: "0.99"
       dd: "1"
+  - record: wlatencyp99
+    expr: scylla_storage_proxy_coordinator_write_latency_summary{quantile="0.99"}
+  - record: rlatencyp99
+    expr: scylla_storage_proxy_coordinator_read_latency_summary{quantile="0.99"}
+  - record: wlatencyp95
+    expr: scylla_storage_proxy_coordinator_write_latency_summary{quantile="0.95"}
+  - record: rlatencyp95
+    expr: scylla_storage_proxy_coordinator_read_latency_summary{quantile="0.95"}
+  - record: wlatencya
+    expr: scylla_storage_proxy_coordinator_write_latency_summary{quantile="0.5"}
+  - record: rlatencya
+    expr: scylla_storage_proxy_coordinator_read_latency_summary{quantile="0.5"}
+  - record: casrlatencyp95
+    expr: scylla_storage_proxy_coordinator_cas_read_latency_summary{quantile="0.95"}
+  - record: caswlatencyp95
+    expr: scylla_storage_proxy_coordinator_cas_write_latency_summary{quantile="0.95"}
+  - record: casrlatencya
+    expr: scylla_storage_proxy_coordinator_cas_read_latency_summary{quantile="0.5"}
+  - record: caswlatencya
+    expr: scylla_storage_proxy_coordinator_cas_write_latency_summary{quantile="0.5"}

--- a/prometheus/prometheus.yml.template
+++ b/prometheus/prometheus.yml.template
@@ -76,60 +76,12 @@ scrape_configs:
       regex: '([0-9]+\.[0-9]+)(\.?[0-9]*).*'
       replacement: '$1$2'
       target_label: svr
-    - source_labels: [__name__, quantile]
-      regex: '(scylla_storage_proxy_coordinator_write_latency_summary;0.990*)'
-      target_label: __name__
-      replacement: 'wlatencyp99'
-    - source_labels: [__name__, quantile]
-      regex: '(scylla_storage_proxy_coordinator_write_latency_summary;0.950*)'
-      target_label: __name__
-      replacement: 'wlatencyp95'
-    - source_labels: [__name__, quantile]
-      regex: '(scylla_storage_proxy_coordinator_write_latency_summary;0.50*)'
-      target_label: __name__
-      replacement: 'wlatencya'
-    - source_labels: [__name__, quantile]
-      regex: '(scylla_storage_proxy_coordinator_read_latency_summary;0.990*)'
-      target_label: __name__
-      replacement: 'rlatencyp99'
-    - source_labels: [__name__, quantile]
-      regex: '(scylla_storage_proxy_coordinator_read_latency_summary;0.950*)'
-      target_label: __name__
-      replacement: 'rlatencyp95'
-    - source_labels: [__name__, quantile]
-      regex: '(scylla_storage_proxy_coordinator_read_latency_summary;0.50*)'
-      target_label: __name__
-      replacement: 'rlatencya'
-    - source_labels: [__name__, quantile]
-      regex: '(scylla_storage_proxy_coordinator_cas_write_latency_summary;0.950*)'
-      target_label: __name__
-      replacement: 'caswlatencyp95'
-    - source_labels: [__name__, quantile]
-      regex: '(scylla_storage_proxy_coordinator_cas_write_latency_summary;0.990*)'
-      target_label: __name__
-      replacement: 'caswlatencyp99'
-    - source_labels: [__name__, quantile]
-      regex: '(scylla_storage_proxy_coordinator_cas_write_latency_summary;0.50*)'
-      target_label: __name__
-      replacement: 'caswlatencya'
-    - source_labels: [__name__, quantile]
-      regex: '(scylla_storage_proxy_coordinator_cas_read_latency_summary;0.950*)'
-      target_label: __name__
-      replacement: 'casrlatencyp95'
-    - source_labels: [__name__, quantile]
-      regex: '(scylla_storage_proxy_coordinator_cas_read_latency_summary;0.990*)'
-      target_label: __name__
-      replacement: 'casrlatencyp99'
-    - source_labels: [__name__, quantile]
-      regex: '(scylla_storage_proxy_coordinator_cas_read_latency_summary;0.50*)'
-      target_label: __name__
-      replacement: 'casrlatencya'
     - source_labels: [quantile]
       regex: '(0\.[1-9]+)0*'
       target_label: quantile
       replacement: '${1}'
     - source_labels: [__name__]
-      regex: '(.latency..?.?|cas.latency..?.?|scylla_.*_summary)'
+      regex: '(scylla_.*_summary)'
       target_label: by
       replacement: 'instance,shard'
     - source_labels: [__name__]


### PR DESCRIPTION
This is a preparation step for #2287. It switches the Prometheus config and recording rules to use the summary name and adds recording rules to copy the value to the old format.


Fixes #2331