### PR TITLE
scylla-detailed: add enterprise conditional support

### DIFF
--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -8,7 +8,7 @@
             },
             {
                 "class": "row",
-                "dashversion":["<6.0"],
+                "dashversion":["<6.0", "<2024.2"],
                 "panels": [
                     {
                         "class": "percent_panel",
@@ -77,7 +77,7 @@
             },
            {
            "class": "row",
-           "dashversion":[">6.0"],
+           "dashversion":[">6.0", ">2024.2"],
                 "panels": [
                  {
                         "class": "percent_panel",
@@ -170,7 +170,7 @@
          },
          {
                 "class": "row",
-                "dashversion":[">6.0"],
+                "dashversion":[">6.0", ">2024.2"],
                 "panels": [
                     {
                         "class": "collapsible_row_panel",
@@ -181,7 +181,7 @@
             },
             {
             "class": "row",
-            "dashversion":[">6.0"],
+            "dashversion":[">6.0", ">2024.2"],
                  "panels": [
                      {
                      "title": "Tablets over time per [[by]]",


### PR DESCRIPTION
The changes around the top row and tablets are version conditional, because they were not conditional with enterprise, they were not shown.