### PR TITLE
genconfig.py: handle multi-dc with ipv6 correctly

### DIFF
--- a/genconfig.py
+++ b/genconfig.py
@@ -9,7 +9,7 @@ import sys
 def gen_targets(servers, cluster):
     if ':' not in servers:
         raise Exception('Server list must contain a dc name')
-    dcs = servers.split(':')
+    dcs = servers.split(':', maxsplit=1)
     res = {"labels": {"cluster": cluster, "dc": dcs[0]}}
     res["targets"] = dcs[1].split(',')
     return res;


### PR DESCRIPTION
when passing ipv6 addresses to `genconfig.py` with -dc options, the code was incorrectly picking only part of address, and it failing to collect metrics like that

```bash
❯ python3 genconfig.py -s -n -dc eu-west-1:[2a05:d018:12e3:f000:65d7:d0a7:3871:fca4],[2a05:d018:12e3:f000:be9f:dc4c:b0b2:7a0d],[2a05:d018:12e3:f000:7f60:4628:db83:cac0],[2a05:d018:
12e3:f000:b7a6:2245:2a8f:4e3f],[2a05:d018:12e3:f000:705f:58c0:ee63:9a55],[2a05:d018:12e3:f000:7214:6f2f:35e5:8b60]

❯ cat scylla_servers.yml
- labels:
    cluster: my-cluster
    dc: eu-west-1
  targets:
  - '[2a05'
```