### PR TITLE
scylla-advanced: set the flow_ratio unit to numbers

### DIFF
--- a/grafana/scylla-advanced.template.json
+++ b/grafana/scylla-advanced.template.json
@@ -48,7 +48,7 @@
                         "title": "I/O Group consumption by instance"
                     },
                     {
-                        "class": "percentunit_panel",
+                        "class": "graph_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -59,6 +59,17 @@
                                 "step": 30
                             }
                         ],
+                        "fieldConfig": {
+                            "defaults": {
+                              "class": "fieldConfig_defaults",
+                              "custom": {
+                                 "class":"fieldConfig_defaults_custom",
+                                 "axisSoftMax": 1.15,
+                                 "axisSoftMin": 0.85
+                              }
+                            },
+                            "overrides": []
+                         },
                         "description": "This graph shows the ratio of dispatch rate to completion rate. It is expected to be 1.0, growing larger on reactor stalls or disk problems.\n\nscylla_io_queue_flow_ratio",
                         "title": "I/O Group Queue flow ratio"
                     }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e4b0ac25-e4d6-4fd4-948a-8b6c9d488f3c)

Fixes #2382

@vladzcloudius can you also take a look