### PR TITLE
scylla-detailed change cache panels units to ops

### DIFF
--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -1062,7 +1062,7 @@
                 "class" : "row",
                 "panels": [
                     {
-                        "class": "rps_panel",
+                        "class": "ops_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -1077,7 +1077,7 @@
                         "title": "Row Hits"
                     },
                     {
-                        "class": "rps_panel",
+                        "class": "ops_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -1092,7 +1092,7 @@
                         "title": "Row Misses"
                     },
                     {
-                        "class": "rps_panel",
+                        "class": "ops_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -1107,7 +1107,7 @@
                         "title": "Partition Hits"
                     },
                     {
-                        "class": "rps_panel",
+                        "class": "ops_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -1128,7 +1128,7 @@
                 "class": "row",
                 "panels": [
                     {
-                        "class": "rps_panel",
+                        "class": "ops_panel",
                         "span": 3,
                         "targets": [
                             {
@@ -1158,7 +1158,7 @@
                         "title": "Row Evictions"
                     },
                     {
-                        "class": "rps_panel",
+                        "class": "ops_panel",
                         "span": 3,
                         "targets": [
                             {


### PR DESCRIPTION
This patch changes cache panels to be ops instead of reads/s
![image](https://github.com/user-attachments/assets/089e1e6e-a169-499d-8aa3-6d0aeaf7bbfe)

Fixes #2386