### PR TITLE
scylla-detailed: change active reads panel to be non-stacked

### DIFF
--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -707,20 +707,6 @@
                                 "step": 1
                             }
                         ],
-                        "fieldConfig": {
-				        "defaults": {
-				          "class": "fieldConfig_defaults",
-				          "custom": {
-				             "class":"fieldConfig_defaults_custom",
-				             "stacking": {
-					          "mode": "normal",
-					          "group": "A"
-					        }
-				          },
-				          "unit": "si:reads"
-				        },
-				        "overrides": []
-				     },
                         "title": "Active reads"
                     },
                     {


### PR DESCRIPTION
This patch changes the active reads panel to be regular graph instead of a stack graph.

Fixes #2389 