### PR TITLE
alternator: Add BatchWriteItem,BatchGetItem

### DIFF
--- a/grafana/alternator.template.json
+++ b/grafana/alternator.template.json
@@ -873,6 +873,56 @@
                 {
                     "class": "template_variable_custom",
                     "name": "alternator_latency_ops",
+                    "dashversion":[">6.0", ">2024.1"],
+                    "multi": true,
+                    "includeAll": true,
+                    "current": {
+                        "text": "All",
+                        "value": "$__all"
+                    },
+                    "options": [
+                        {
+                            "selected": true,
+                            "text": "All",
+                            "value": "$__all"
+                        },
+                        {
+                            "selected": false,
+                            "text": "GetItem",
+                            "value": "GetItem"
+                        },
+                        {
+                            "selected": false,
+                            "text": "PutItem",
+                            "value": "PutItem"
+                        },
+                        {
+                            "selected": false,
+                            "text": "UpdateItem",
+                            "value": "UpdateItem"
+                        },
+                        {
+                            "selected": false,
+                            "text": "DeleteItem",
+                            "value": "DeleteItem"
+                        },
+                        {
+                            "selected": false,
+                            "text": "BatchWriteItem",
+                            "value": "BatchWriteItem"
+                        },
+                        {
+                            "selected": false,
+                            "text": "BatchGetItem",
+                            "value": "BatchGetItem"
+                        }
+                    ],
+                    "query": "GetItem,PutItem,UpdateItem,DeleteItem,BatchWriteItem,BatchGetItem"
+                },
+                {
+                    "class": "template_variable_custom",
+                    "name": "alternator_latency_ops",
+                    "dashversion":["<6.0", "<2024.1"],
                     "multi": true,
                     "includeAll": true,
                     "current": {

--- a/grafana/alternator.template.json
+++ b/grafana/alternator.template.json
@@ -260,34 +260,6 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchWriteItem\"}[$__rate_interval])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "BatchWriteItem by [[by]]"
-                    },
-                    {
-                        "class": "ops_panel",
-                        "span": 4,
-                        "targets": [
-                            {
-                                "expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchGetItem\"}[$__rate_interval])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "BatchGetItem by [[by]]"
-                    },
-                    {
-                        "class": "ops_panel",
-                        "span": 4,
-                        "targets": [
-                            {
                                 "expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"Query\"}[$__rate_interval])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
@@ -310,6 +282,94 @@
                             }
                         ],
                         "title": "Scan by [[by]]"
+                    },
+                    {
+                        "class": "ops_panel",
+                        "span": 4,
+                        "targets": [
+                            {
+                                "expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchWriteItem\"}[$__rate_interval])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "BatchWriteItem by [[by]]"
+                    },
+                    {
+                        "class": "ops_panel",
+                        "span": 4,
+                        "targets": [
+                            {
+                                "expr": "$func(rate(scylla_alternator_batch_item_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchWriteItem\"}[$__rate_interval])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "description": "The number of items processed as a result of BatchWriteItem",
+                        "title": "Operations from BatchWriteItem by [[by]]"
+                    },
+                    {
+                        "class": "ops_panel",
+                        "span": 4,
+                        "targets": [
+                            {
+                                "expr": "$func(rate(scylla_alternator_batch_item_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchWriteItem\"}[$__rate_interval])) by ([[by]])/$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchWriteItem\"}[$__rate_interval])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "description": "The avarage batch size of BatchWriteItem",
+                        "title": "Average Batch size of BatchWriteItem by [[by]]"
+                    },
+                    {
+                        "class": "ops_panel",
+                        "span": 4,
+                        "targets": [
+                            {
+                                "expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchGetItem\"}[$__rate_interval])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "BatchGetItem by [[by]]"
+                    },
+                    {
+                        "class": "ops_panel",
+                        "span": 4,
+                        "targets": [
+                            {
+                                "expr": "$func(rate(scylla_alternator_batch_item_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchGetItem\"}[$__rate_interval])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "description": "The number of items processed as a result of BatchGetItem",
+                        "title": "Operations from BatchGetItem by [[by]]"
+                    },
+                    {
+                        "class": "ops_panel",
+                        "span": 4,
+                        "targets": [
+                            {
+                                "expr": "$func(rate(scylla_alternator_batch_item_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchGetItem\"}[$__rate_interval])) by ([[by]])/$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchGetItem\"}[$__rate_interval])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "description": "The avarage batch size of BatchGetItem",
+                        "title": "Average Batch size of BatchGetItem by [[by]]"
                     }
                     ]
             },

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -1074,7 +1074,7 @@
             "class":"small_stat",
             "targets":[
                {
-                  "expr":"sum(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval]))",
+                  "expr":"sum(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\", op !~\"Batch.*\"}[$__rate_interval]))+sum(rate(scylla_alternator_batch_item_count{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval]))",
                   "intervalFactor":1,
                   "refId":"A",
                   "instant":true,


### PR DESCRIPTION
This series adds support to Alternator batches.
The total ops panel now takes into account the ops that are inside of batches.
There are panels that show the number of batch operations, the number of operations that came from batches, and the average batch size.

Fixes #2380 
