### PR TITLE
scylla-overview: Add SCT test support

### DIFF
--- a/grafana/scylla-overview.template.json
+++ b/grafana/scylla-overview.template.json
@@ -116,6 +116,143 @@
                 "class": "row",
                 "panels": [
                     {
+                        "class": "collapsible_row_panel",
+                        "title": "SCT Information",
+                        "dashproduct": "sct-tests"
+                    }
+                ]
+            },
+            {
+                "class": "row",
+                "dashproduct": "sct-tests",
+                "panels": [
+                    {
+                      "datasource": {
+                        "type": "datasource",
+                        "uid": "grafana"
+                      },
+                      "gridPos": {
+                        "h": 13,
+                        "w": 24
+                      },
+                      "links": [],
+                      "options": {
+                        "onlyFromThisDashboard": false,
+                        "onlyInTimeRange": true,
+                        "limit": 1000,
+                        "showUser": true,
+                        "showTime": true,
+                        "showTags": true,
+                        "navigateToPanel": true,
+                        "navigateBefore": "10m",
+                        "navigateAfter": "10m"
+                      },
+                      "repeat": "cluster",
+                      "repeatDirection": "v",
+                      "title": "SCT Events",
+                      "type": "annolist",
+                      "id": "auto",
+                      "scopedVars": {
+                        "cluster": {
+                          "text": "None",
+                          "value": "",
+                          "isNone": true,
+                          "selected": true
+                        }
+                      }
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                              "expr": "sct_cassandra_stress_write_gauge{type=\"lat_perc_95\"}",
+                              "interval": "",
+                              "legendFormat": "",
+                              "instant": true,
+                              "refId": "A"
+                            },
+                            {
+                              "expr": "sct_cassandra_stress_counter_write_gauge{type=\"lat_perc_95\"}",
+                              "interval": "",
+                              "legendFormat": "",
+                              "instant": true,
+                              "refId": "B"
+                            }
+                          ],
+                          "title": "C-S stress tools write latency 95%"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                              "expr": "sct_cassandra_stress_write_gauge{type=\"lat_perc_95\"}",
+                              "interval": "",
+                              "legendFormat": "",
+                              "instant": true,
+                              "refId": "A"
+                            },
+                            {
+                              "expr": "sct_cassandra_stress_counter_write_gauge{type=\"lat_perc_95\"}",
+                              "interval": "",
+                              "legendFormat": "",
+                              "instant": true,
+                              "refId": "B"
+                            }
+                          ],
+                          "title": "C-S stress tools write latency 95% histogram",
+                          "type": "histogram"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                              "expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"lat_perc_95\"}",
+                              "interval": "",
+                              "legendFormat": "",
+                              "instant": true,
+                              "refId": "A"
+                            },
+                            {
+                              "expr": "sct_cql_stress_cassandra_stress_counter_write_gauge{type=\"lat_perc_95\"}",
+                              "interval": "",
+                              "legendFormat": "",
+                              "instant": true,
+                              "refId": "B"
+                            }
+                          ],
+                          "title": "cql-stress C-S write latency 95%"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                              "expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"lat_perc_95\"}",
+                              "interval": "",
+                              "legendFormat": "",
+                              "instant": true,
+                              "refId": "A"
+                            },
+                            {
+                              "expr": "sct_cql_stress_cassandra_stress_counter_write_gauge{type=\"lat_perc_95\"}",
+                              "interval": "",
+                              "legendFormat": "",
+                              "instant": true,
+                              "refId": "B"
+                            }
+                          ],
+                          "title": "cql-stress C-S write latency 95% histogram",
+                          "type": "histogram"
+                    }
+                ]
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
                       "collapsed": false,
                       "datasource": null,
                       "id": "auto",


### PR DESCRIPTION
This is a work in progress to place sct related panels inside the overview dashboard.

This is an example of how to generate the dashboard for 6.1 release:
```
./generate-dashboards.sh -F -v 6.1 -P "sct-tests"
```