### PR TITLE
share scylla-monitor aws ami

### DIFF
--- a/packer/scylla-monitor-template.json
+++ b/packer/scylla-monitor-template.json
@@ -28,6 +28,13 @@
           "delete_on_termination": true
         }
       ],
+      "ami_org_arns": [
+        "arn:aws:organizations::978072043225:organization/o-o561yy1rs6"
+      ],
+      "snapshot_users": [
+        "797456418907",
+        "734708892259"
+      ],
       "tags": {
         "Name": "{{ user `monitor_image_name` }}",
         "scylladb-monitor-version": "{{ user `monitor_version`| clean_resource_name }}"


### PR DESCRIPTION
sharing scylla-monitor aws AMIs with organization path and snapshot with relevant account IDs

Fixes: https://github.com/scylladb/scylla-monitoring/issues/2375 

(cherry picked from commit 9f386486390be435f1579bc8551e72c7e20d9786)