### PR TITLE
Os fix pie charts

### DIFF
--- a/grafana/scylla-os.template.json
+++ b/grafana/scylla-os.template.json
@@ -32,6 +32,8 @@
                         "class": "piechart_panel_percent",
                         "height": "250px",
                         "repeat": "node",
+                        "maxPerRow": 8,
+                        "repeatDirection": "h",
                         "targets": [
                             {
                                 "expr": "sum(node_filesystem_avail_bytes{mountpoint=~\"$mount_point\", instance=~\"$node\", job=~\"node_exporter.*\"})",

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -1876,7 +1876,8 @@
               "percent"
             ],
             "tooltip": {
-              "mode": "single"
+              "mode": "multi",
+              "sort": "none"
             },
             "legend": {
               "displayMode": "hidden",


### PR DESCRIPTION
Grafana's moves to Scheme-based dashboard is not 100% backward compatible; specifically, repeated panels should be define with their repeat direction

![image](https://github.com/user-attachments/assets/2ecba967-35ea-4d66-bb74-f06512ed78b3)
