### PR TITLE
scylla-ks: base the table filtering on scylla_column_family_cache_hit_rate

### DIFF
--- a/grafana/scylla-ks.template.json
+++ b/grafana/scylla-ks.template.json
@@ -320,14 +320,14 @@
                     "class": "template_variable_single",
                     "label": "ks",
                     "name": "ks",
-                    "query": "label_values(scylla_column_family_write_latency_count{cluster=\"$cluster\"},ks)",
+                    "query": "label_values(scylla_column_family_cache_hit_rate{cluster=\"$cluster\"},ks)",
                     "sort": 3
                 },
                 {
                     "class": "template_variable_all",
                     "label": "table",
                     "name": "table",
-                    "query": "label_values(scylla_column_family_write_latency_count{cluster=\"$cluster\", ks=\"$ks\"},cf)",
+                    "query": "label_values(scylla_column_family_cache_hit_rate{cluster=\"$cluster\", ks=\"$ks\"},cf)",
                     "sort": 3
                 },
                 {


### PR DESCRIPTION
This patch fixes an issue with the keyspace dashboard, which didn't show panels for keyspaces without writes.
Fixes #2425