### PR TITLE
Format python and bash script codes

### DIFF
--- a/dashboards.sh
+++ b/dashboards.sh
@@ -1,5 +1,5 @@
 if [[ -z "$DASHBOARDS" ]]; then
-    DASHBOARDS=(scylla-overview scylla-detailed scylla-os scylla-cql scylla-advanced alternator scylla-ks)
+	DASHBOARDS=(scylla-overview scylla-detailed scylla-os scylla-cql scylla-advanced alternator scylla-ks)
 else
-    read -ra DASHBOARDS <<< "$DASHBOARDS"
+	read -ra DASHBOARDS <<<"$DASHBOARDS"
 fi

--- a/docker-build/build_docker.sh
+++ b/docker-build/build_docker.sh
@@ -4,40 +4,40 @@ CURRENT_VERSION="master"
 DOCKER_REPO="scylladb"
 
 . versions.sh
-if [ -f  env.sh ]; then
-    . env.sh
+if [ -f env.sh ]; then
+	. env.sh
 fi
 
 if [ -f CURRENT_VERSION.sh ]; then
-    CURRENT_VERSION=`cat CURRENT_VERSION.sh`
+	CURRENT_VERSION=$(cat CURRENT_VERSION.sh)
 fi
 
 if [ -z "$BRANCH_VERSION" ]; then
-  BRANCH_VERSION=$CURRENT_VERSION
+	BRANCH_VERSION=$CURRENT_VERSION
 fi
 if [ -z ${DEFAULT_VERSION[$CURRENT_VERSION]} ]; then
-    BRANCH_VERSION=`echo $CURRENT_VERSION|cut -d'.' -f1,2`
+	BRANCH_VERSION=$(echo $CURRENT_VERSION | cut -d'.' -f1,2)
 fi
-if [ -z "$MANAGER_VERSION" ];then
-  MANAGER_VERSION=${MANAGER_DEFAULT_VERSION[$BRANCH_VERSION]}
+if [ -z "$MANAGER_VERSION" ]; then
+	MANAGER_VERSION=${MANAGER_DEFAULT_VERSION[$BRANCH_VERSION]}
 fi
 if [ -z "$VERSIONS" ]; then
-  VERSIONS=${DEFAULT_ENTERPRISE_VERSION[$BRANCH_VERSION]}
+	VERSIONS=${DEFAULT_ENTERPRISE_VERSION[$BRANCH_VERSION]}
 fi
 
-docker build -t $DOCKER_REPO/grafana:$CURRENT_VERSION . -f docker-build/grafana.Dockerfile --build-arg  CURRENT_DIR="./docker-build" \
---build-arg GRAFANA_VERSION="$GRAFANA_VERSION" \
---build-arg DEFAULT_VERSION="$VERSIONS" \
---build-arg MANAGER_VERSION=$MANAGER_VERSION \
+docker build -t $DOCKER_REPO/grafana:$CURRENT_VERSION . -f docker-build/grafana.Dockerfile --build-arg CURRENT_DIR="./docker-build" \
+	--build-arg GRAFANA_VERSION="$GRAFANA_VERSION" \
+	--build-arg DEFAULT_VERSION="$VERSIONS" \
+	--build-arg MANAGER_VERSION=$MANAGER_VERSION
 
-docker build -t $DOCKER_REPO/loki:$CURRENT_VERSION . -f docker-build/loki.Dockerfile --build-arg  CURRENT_DIR="./docker-build" \
---build-arg LOKI_VERSION="$LOKI_VERSION"
+docker build -t $DOCKER_REPO/loki:$CURRENT_VERSION . -f docker-build/loki.Dockerfile --build-arg CURRENT_DIR="./docker-build" \
+	--build-arg LOKI_VERSION="$LOKI_VERSION"
 
-docker build -t $DOCKER_REPO/promtail:$CURRENT_VERSION . -f docker-build/promtail.Dockerfile --build-arg  CURRENT_DIR="./docker-build" \
---build-arg PROMTAIL_VERSION="$LOKI_VERSION"
+docker build -t $DOCKER_REPO/promtail:$CURRENT_VERSION . -f docker-build/promtail.Dockerfile --build-arg CURRENT_DIR="./docker-build" \
+	--build-arg PROMTAIL_VERSION="$LOKI_VERSION"
 
-docker build -t $DOCKER_REPO/prometheus:$CURRENT_VERSION . -f docker-build/prometheus.Dockerfile --build-arg  CURRENT_DIR="./docker-build" \
---build-arg PROMETHEUS_VERSION="$PROMETHEUS_VERSION"
+docker build -t $DOCKER_REPO/prometheus:$CURRENT_VERSION . -f docker-build/prometheus.Dockerfile --build-arg CURRENT_DIR="./docker-build" \
+	--build-arg PROMETHEUS_VERSION="$PROMETHEUS_VERSION"
 
-docker build -t $DOCKER_REPO/alertmanager:$CURRENT_VERSION . -f docker-build/alertmanager.Dockerfile --build-arg  CURRENT_DIR="./docker-build" \
---build-arg ALERTMANAGER_VERSION="$ALERT_MANAGER_VERSION"
+docker build -t $DOCKER_REPO/alertmanager:$CURRENT_VERSION . -f docker-build/alertmanager.Dockerfile --build-arg CURRENT_DIR="./docker-build" \
+	--build-arg ALERTMANAGER_VERSION="$ALERT_MANAGER_VERSION"

--- a/docker-build/grafanainit.sh
+++ b/docker-build/grafanainit.sh
@@ -2,25 +2,23 @@
 
 mkdir -p /var/lib/grafana/provisioning/
 if [ ! -d "/var/lib/grafana/provisioning/dashboards/" ]; then
-    echo "No dashboard directory, creating"
-    cd /
-    /generate-dashboards.sh -t $SPECIFIC_SOLUTION -v $VERSIONS -M $MANAGER_VERSION $GRAFANA_DASHBOARD_COMMAND -B /var/lib/grafana/provisioning/dashboards/
+	echo "No dashboard directory, creating"
+	cd /
+	/generate-dashboards.sh -t $SPECIFIC_SOLUTION -v $VERSIONS -M $MANAGER_VERSION $GRAFANA_DASHBOARD_COMMAND -B /var/lib/grafana/provisioning/dashboards/
 fi
-VERSION=`echo $VERSIONS|cut -d',' -f1`
+VERSION=$(echo $VERSIONS | cut -d',' -f1)
 if [ -z "$GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH" ]; then
-    export GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH="/var/lib/grafana/dashboards/ver_${VERSION}/scylla-overview.${VERSION}.json"
+	export GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH="/var/lib/grafana/dashboards/ver_${VERSION}/scylla-overview.${VERSION}.json"
 fi
-
-
 
 if [ -z "$UA_ANALTYICS" ]; then
-  . /var/lib/grafana/ua/UA.sh
+	. /var/lib/grafana/ua/UA.sh
 fi
 if [ -z "$GF_ANALYTICS_GOOGLE_ANALYTICS_UA_ID" ]; then
-    export GF_ANALYTICS_GOOGLE_ANALYTICS_UA_ID="$UA_ANALTYICS"
+	export GF_ANALYTICS_GOOGLE_ANALYTICS_UA_ID="$UA_ANALTYICS"
 fi
 if [ ! -z "$COMPOSE_DATASOURCE" ]; then
-    mkdir -p /var/lib/grafana/provisioning/datasources
-    cp -r /var/lib/grafana/compose-datasources/* /var/lib/grafana/provisioning/datasources
+	mkdir -p /var/lib/grafana/provisioning/datasources
+	cp -r /var/lib/grafana/compose-datasources/* /var/lib/grafana/provisioning/datasources
 fi
 /run.sh

--- a/docker-build/lokiinit.sh
+++ b/docker-build/lokiinit.sh
@@ -2,9 +2,9 @@
 echo "running loki init"
 
 if [ -f /mnt/config/loki-config.yaml ]; then
-    echo "Config exists loki-config.yaml"
+	echo "Config exists loki-config.yaml"
 else
-    echo "Setting loki-config.yaml"
-    sed "s/ALERTMANAGER/$ALERT_MANAGER_ADDRESS/" /mnt/config/loki-config.template.yaml > /mnt/config/loki-config.yaml
+	echo "Setting loki-config.yaml"
+	sed "s/ALERTMANAGER/$ALERT_MANAGER_ADDRESS/" /mnt/config/loki-config.template.yaml >/mnt/config/loki-config.yaml
 fi
 /usr/bin/loki --config.file=/mnt/config/loki-config.yaml --ingester.wal-enabled=false

--- a/docker-build/prometheusinit.sh
+++ b/docker-build/prometheusinit.sh
@@ -1,22 +1,22 @@
 #!/bin/sh -e
 echo "running prometheus init"
 if [ -f /etc/prometheus/conf/prometheus.yml ]; then
-    echo "Config exists /etc/prometheus/conf/prometheus.yml"
+	echo "Config exists /etc/prometheus/conf/prometheus.yml"
 else
-    echo "Setting prometheus.yml"
-    DST="/etc/prometheus/conf/"
-    SRC="/etc/prometheus/conf"
-    mkdir -p $DST
-    if [ -z $CONSUL_ADDRESS ]; then
-        sed "s/AM_ADDRESS/$AM_ADDRESS/" $SRC/prometheus.yml.template > $DST/prometheus.yml
-    else
-        if [[ ! $CONSUL_ADDRESS = *":"* ]]; then
-            CONSUL_ADDRESS="$CONSUL_ADDRESS:5090"
-        fi
-        sed "s/AM_ADDRESS/$AM_ADDRESS/" $SRC/prometheus.consul.yml.template| sed "s/MANAGER_ADDRESS/$CONSUL_ADDRESS/" > $DST/prometheus.yml
-    fi
+	echo "Setting prometheus.yml"
+	DST="/etc/prometheus/conf/"
+	SRC="/etc/prometheus/conf"
+	mkdir -p $DST
+	if [ -z $CONSUL_ADDRESS ]; then
+		sed "s/AM_ADDRESS/$AM_ADDRESS/" $SRC/prometheus.yml.template >$DST/prometheus.yml
+	else
+		if [[ ! $CONSUL_ADDRESS = *":"* ]]; then
+			CONSUL_ADDRESS="$CONSUL_ADDRESS:5090"
+		fi
+		sed "s/AM_ADDRESS/$AM_ADDRESS/" $SRC/prometheus.consul.yml.template | sed "s/MANAGER_ADDRESS/$CONSUL_ADDRESS/" >$DST/prometheus.yml
+	fi
 fi
 echo "Starting prometheus"
 /bin/prometheus --config.file=/etc/prometheus/conf/prometheus.yml --storage.tsdb.path=/prometheus \
-             --web.console.libraries=/usr/share/prometheus/console_libraries \
-             --web.console.templates=/usr/share/prometheus/consoles
+	--web.console.libraries=/usr/share/prometheus/console_libraries \
+	--web.console.templates=/usr/share/prometheus/consoles

--- a/docker-build/promtailinit.sh
+++ b/docker-build/promtailinit.sh
@@ -2,9 +2,9 @@
 echo "running promtail init"
 
 if [ -f /etc/promtail/config.yml ]; then
-    echo "Config exists promtail-config.yaml"
+	echo "Config exists promtail-config.yaml"
 else
-    echo "Setting promtail-config.yaml"
-    sed "s/ALERTMANAGER/$ALERT_MANAGER_ADDRESS/" /etc/promtail/promtail-config.template.yaml > /etc/promtail/config.yml
+	echo "Setting promtail-config.yaml"
+	sed "s/ALERTMANAGER/$ALERT_MANAGER_ADDRESS/" /etc/promtail/promtail-config.template.yaml >/etc/promtail/config.yml
 fi
 /usr/bin/promtail --config.file=/etc/promtail/config.yml /etc/promtail/config.yml

--- a/genconfig.py
+++ b/genconfig.py
@@ -12,18 +12,18 @@ def gen_targets(servers, cluster):
     dcs = servers.split(':', maxsplit=1)
     res = {"labels": {"cluster": cluster, "dc": dcs[0]}}
     res["targets"] = dcs[1].split(',')
-    return res;
+    return res
 
 def get_servers_from_nodetool_status():
     res = []
     dc = None
     ips = []
-    for l in sys.stdin:
+    for line in sys.stdin:
         if dc:
-            ip = re.search(r"..  ([\d\.]+)\s", l)
+            ip = re.search(r"..  ([\d\.]+)\s", line)
             if ip:
                 ips.append(ip.group(1))
-        m = re.search(r"Datacenter: ([^\s]+)\s*$", l)
+        m = re.search(r"Datacenter: ([^\s]+)\s*$", line)
         if m:
             if dc:
                 res.append(dc + ":" + ",".join(ips))

--- a/generate-alternator.sh
+++ b/generate-alternator.sh
@@ -2,22 +2,25 @@
 usage="$(basename "$0") [-h] [-v version]"
 VERSIONS="master"
 while getopts ':hv:' option; do
-  case "$option" in
-    h) echo "$usage"
-       exit
-       ;;
-    v) VERSIONS=$OPTARG
-       ;;
-    :) printf "missing argument for -%s\n" "$OPTARG" >&2
-       echo "$usage" >&2
-       exit 1
-       ;;
-   \?) printf "illegal option: -%s\n" "$OPTARG" >&2
-       echo "$usage" >&2
-       exit 1
-       ;;
-  esac
+	case "$option" in
+	h)
+		echo "$usage"
+		exit
+		;;
+	v)
+		VERSIONS=$OPTARG
+		;;
+	:)
+		printf "missing argument for -%s\n" "$OPTARG" >&2
+		echo "$usage" >&2
+		exit 1
+		;;
+	\?)
+		printf "illegal option: -%s\n" "$OPTARG" >&2
+		echo "$usage" >&2
+		exit 1
+		;;
+	esac
 done
-
 
 DASHBOARDS="scylla-io scylla-cpu scylla-os scylla-errors alternator" ./generate-dashboards.sh -v $VERSIONS -S alternator

--- a/generate-dashboards.sh
+++ b/generate-dashboards.sh
@@ -2,18 +2,18 @@
 
 CURRENT_VERSION="master"
 if [ -f CURRENT_VERSION.sh ]; then
-    CURRENT_VERSION=`cat CURRENT_VERSION.sh`
+	CURRENT_VERSION=$(cat CURRENT_VERSION.sh)
 fi
 
 . versions.sh
 VERSION_FOR_DEFAULTS=$CURRENT_VERSION
-BRANCH_VERSION=`echo $CURRENT_VERSION|cut -d'.' -f1,2`
+BRANCH_VERSION=$(echo $CURRENT_VERSION | cut -d'.' -f1,2)
 if [ -z ${DEFAULT_VERSION[$CURRENT_VERSION]} ]; then
-    VERSION_FOR_DEFAULTS=$BRANCH_VERSION
+	VERSION_FOR_DEFAULTS=$BRANCH_VERSION
 fi
 MANAGER_VERSION=${MANAGER_DEFAULT_VERSION[$VERSION_FOR_DEFAULTS]}
 if [ "$1" = "-e" ]; then
-    DEFAULT_VERSION=${DEFAULT_ENTERPRISE_VERSION[$VERSION_FOR_DEFAULTS]}
+	DEFAULT_VERSION=${DEFAULT_ENTERPRISE_VERSION[$VERSION_FOR_DEFAULTS]}
 fi
 
 . dashboards.sh
@@ -23,142 +23,152 @@ FORCEUPDATE=""
 SPECIFIC_SOLUTION=""
 PRODUCTS=()
 if [ -f env.sh ]; then
-    . env.sh
+	. env.sh
 fi
 
 usage="$(basename "$0") [-h] [-v comma separated versions ]  [-D] [-j additional dashboard to load to Grafana, multiple params are supported] [-M scylla-manager version ] [-t] [-F force update] [-S start with a system specific dashboard set] -- Generates the grafana dashboards and their load files"
 BASE_DASHBOARD_DIR="grafana/provisioning/dashboards"
 while getopts ':htDv:j:M:S:B:P:s:R:F' option; do
-  case "$option" in
-    h) echo "$usage"
-       exit
-       ;;
-    t) TEST_ONLY=1
-       ;;
-    v) VERSIONS=$OPTARG
-       FORMAT_COMAND="$FORMAT_COMAND -v $OPTARG"
-       ;;
-    M) MANAGER_VERSION=$OPTARG
-       FORMAT_COMAND="$FORMAT_COMAND -M $OPTARG"
-       ;;
-    F) FORCEUPDATE="1"
-       ;;
-    P) PRODUCTS+=(-P)
-       PRODUCTS+=($OPTARG)
-       ;;
-    S) SPECIFIC_SOLUTION="$OPTARG"
-       ;;
-    s) STACK="$OPTARG"
-       BASE_DASHBOARD_DIR="grafana/stack/$OPTARG/provisioning/dashboards"
-       ;;
-    D) VERSIONS=${SUPPORTED_VERSIONS[$BRANCH_VERSION]}
-       FORMAT_COMAND="$FORMAT_COMAND -v $VERSIONS"
-       MANAGER_VERSION=${MANAGER_SUPPORTED_VERSIONS[$BRANCH_VERSION]}
-       ;;
-    R) DASHBOARD_REFRESH=$OPTARG
-       ;;
-    B) BASE_DASHBOARD_DIR=$OPTARG
-       ;;
-    j) GRAFANA_DASHBOARD_ARRAY+=("$OPTARG")
-       FORMAT_COMAND="$FORMAT_COMAND -j $OPTARG"
-       ;;
-  esac
+	case "$option" in
+	h)
+		echo "$usage"
+		exit
+		;;
+	t)
+		TEST_ONLY=1
+		;;
+	v)
+		VERSIONS=$OPTARG
+		FORMAT_COMAND="$FORMAT_COMAND -v $OPTARG"
+		;;
+	M)
+		MANAGER_VERSION=$OPTARG
+		FORMAT_COMAND="$FORMAT_COMAND -M $OPTARG"
+		;;
+	F)
+		FORCEUPDATE="1"
+		;;
+	P)
+		PRODUCTS+=(-P)
+		PRODUCTS+=($OPTARG)
+		;;
+	S)
+		SPECIFIC_SOLUTION="$OPTARG"
+		;;
+	s)
+		STACK="$OPTARG"
+		BASE_DASHBOARD_DIR="grafana/stack/$OPTARG/provisioning/dashboards"
+		;;
+	D)
+		VERSIONS=${SUPPORTED_VERSIONS[$BRANCH_VERSION]}
+		FORMAT_COMAND="$FORMAT_COMAND -v $VERSIONS"
+		MANAGER_VERSION=${MANAGER_SUPPORTED_VERSIONS[$BRANCH_VERSION]}
+		;;
+	R)
+		DASHBOARD_REFRESH=$OPTARG
+		;;
+	B)
+		BASE_DASHBOARD_DIR=$OPTARG
+		;;
+	j)
+		GRAFANA_DASHBOARD_ARRAY+=("$OPTARG")
+		FORMAT_COMAND="$FORMAT_COMAND -j $OPTARG"
+		;;
+	esac
 done
 if [[ -z "$TEST_ONLY" ]]; then
-    mkdir -p grafana/build
+	mkdir -p grafana/build
 fi
 
 if [[ -z "$DASHBOARD_REFRESH" ]]; then
-    DASHBOARD_REFRESH="30s"
+	DASHBOARD_REFRESH="30s"
 fi
 
 if [ "$DASHBOARD_REFRESH" = "0" ]; then
-    DASHBOARD_REFRESH=""
+	DASHBOARD_REFRESH=""
 fi
 mkdir -p $BASE_DASHBOARD_DIR
 rm -f $BASE_DASHBOARD_DIR/load.*.yaml
 
 function set_loader {
-    sed "s/NAME/$1/" grafana/load.yaml | sed "s/FOLDER/$2/" | sed "s/VERSION/$3/" > "$BASE_DASHBOARD_DIR/load.$1.yaml"
+	sed "s/NAME/$1/" grafana/load.yaml | sed "s/FOLDER/$2/" | sed "s/VERSION/$3/" >"$BASE_DASHBOARD_DIR/load.$1.yaml"
 }
 
-IFS=',' ;for v in $VERSIONS; do
+IFS=','
+for v in $VERSIONS; do
 
-if [ $v = "latest" ]; then
-    if [ -z "$BRANCH_VERSION" ] || [ "$BRANCH_VERSION" = "master" ]; then
-        echo "Default versions (-v latest) is not supported on the master branch, use specific version instead"
-        exit 1
-    fi
-    v=${DEFAULT_VERSION[$BRANCH_VERSION]}
-    echo "The use of -v latest is deprecated. Use a specific version instead."
-fi
-if [[ -z "$SPECIFIC_SOLUTION" ]]; then
-    VERDIR_NAME="ver_$v"
-else
-    VERDIR_NAME=$SPECIFIC_SOLUTION"_$v"
-fi
+	if [ $v = "latest" ]; then
+		if [ -z "$BRANCH_VERSION" ] || [ "$BRANCH_VERSION" = "master" ]; then
+			echo "Default versions (-v latest) is not supported on the master branch, use specific version instead"
+			exit 1
+		fi
+		v=${DEFAULT_VERSION[$BRANCH_VERSION]}
+		echo "The use of -v latest is deprecated. Use a specific version instead."
+	fi
+	if [[ -z "$SPECIFIC_SOLUTION" ]]; then
+		VERDIR_NAME="ver_$v"
+	else
+		VERDIR_NAME=$SPECIFIC_SOLUTION"_$v"
+	fi
 
-VERDIR="grafana/build/$VERDIR_NAME"
-if [[ -z "$TEST_ONLY" ]]; then
-   mkdir -p $VERDIR
-fi
+	VERDIR="grafana/build/$VERDIR_NAME"
+	if [[ -z "$TEST_ONLY" ]]; then
+		mkdir -p $VERDIR
+	fi
 
-if [[ $VERSIONS = *","* ]]; then
-    set_loader $v "$v" "$VERDIR_NAME"
-else
-    set_loader $v "" "$VERDIR_NAME"
-fi
+	if [[ $VERSIONS = *","* ]]; then
+		set_loader $v "$v" "$VERDIR_NAME"
+	else
+		set_loader $v "" "$VERDIR_NAME"
+	fi
 
-    for f in "${DASHBOARDS[@]}"; do
-        if [ -e grafana/$f.template.json ]
-        then
-            if [ ! -f "$VERDIR/$f.$v.json" ] || [ "$VERDIR/$f.$v.json" -ot "grafana/$f.template.json" ] || [ ! -z "$FORCEUPDATE" ]; then
-                if [[ -z "$TEST_ONLY" ]]; then
-                    echo "updating dashboard grafana/$f.$v.template.json"
-                   ./make_dashboards.py ${PRODUCTS[@]} -af $VERDIR -t grafana/types.json -d grafana/$f.template.json -R "__MONITOR_VERSION__=$CURRENT_VERSION"  -R "__SCYLLA_VERSION_DOT__=$v" -R "__MONITOR_BRANCH_VERSION=$BRANCH_VERSION" -R "__REFRESH_INTERVAL__=$DASHBOARD_REFRESH" --replace-file docs/source/reference/metrics.yaml -V $v
-               fi
-            fi
-        else
-            if [ -f grafana/$f.$v.json ]
-            then
-                cp grafana/$f.$v.json $VERDIR
-            fi
-        fi
-    done
+	for f in "${DASHBOARDS[@]}"; do
+		if [ -e grafana/$f.template.json ]; then
+			if [ ! -f "$VERDIR/$f.$v.json" ] || [ "$VERDIR/$f.$v.json" -ot "grafana/$f.template.json" ] || [ ! -z "$FORCEUPDATE" ]; then
+				if [[ -z "$TEST_ONLY" ]]; then
+					echo "updating dashboard grafana/$f.$v.template.json"
+					./make_dashboards.py ${PRODUCTS[@]} -af $VERDIR -t grafana/types.json -d grafana/$f.template.json -R "__MONITOR_VERSION__=$CURRENT_VERSION" -R "__SCYLLA_VERSION_DOT__=$v" -R "__MONITOR_BRANCH_VERSION=$BRANCH_VERSION" -R "__REFRESH_INTERVAL__=$DASHBOARD_REFRESH" --replace-file docs/source/reference/metrics.yaml -V $v
+				fi
+			fi
+		else
+			if [ -f grafana/$f.$v.json ]; then
+				cp grafana/$f.$v.json $VERDIR
+			fi
+		fi
+	done
 done
 
-IFS=',' ;for v in $MANAGER_VERSION; do
-if [ -e grafana/scylla-manager.template.json ]
-then
-    VERDIR="grafana/build/manager_$v"
-    mkdir -p $VERDIR
-    set_loader "manager_$v" "" "manager_$v"
-    if [ ! -f "$VERDIR/scylla-manager.$v.json" ] || [ "$VERDIR/scylla-manager.$v.json" -ot "grafana/scylla-manager.template.json" ] || [ "$VERDIR/scylla-manager.$v.json" -ot "grafana/types.json" ] || [ ! -z "$FORCEUPDATE" ]; then
-        if [[ -z "$TEST_ONLY" ]]; then
-           echo "updating grafana/scylla-manager.$v.template.json"
-           ./make_dashboards.py ${PRODUCTS[@]}  -af $VERDIR -t grafana/types.json -d grafana/scylla-manager.template.json -R "__MONITOR_VERSION__=$CURRENT_VERSION" -R "__SCYLLA_VERSION_DOT__=$v" -R "__MONITOR_BRANCH_VERSION=$BRANCH_VERSION" -R "__REFRESH_INTERVAL__=$DASHBOARD_REFRESH"  --replace-file docs/source/reference/metrics.yaml -V $v
-        else
-           echo "notice: grafana/scylla-manager.template.json was updated, run ./generate-dashboards.sh $FORMAT_COMAND"
-        fi
-    fi
-fi
+IFS=','
+for v in $MANAGER_VERSION; do
+	if [ -e grafana/scylla-manager.template.json ]; then
+		VERDIR="grafana/build/manager_$v"
+		mkdir -p $VERDIR
+		set_loader "manager_$v" "" "manager_$v"
+		if [ ! -f "$VERDIR/scylla-manager.$v.json" ] || [ "$VERDIR/scylla-manager.$v.json" -ot "grafana/scylla-manager.template.json" ] || [ "$VERDIR/scylla-manager.$v.json" -ot "grafana/types.json" ] || [ ! -z "$FORCEUPDATE" ]; then
+			if [[ -z "$TEST_ONLY" ]]; then
+				echo "updating grafana/scylla-manager.$v.template.json"
+				./make_dashboards.py ${PRODUCTS[@]} -af $VERDIR -t grafana/types.json -d grafana/scylla-manager.template.json -R "__MONITOR_VERSION__=$CURRENT_VERSION" -R "__SCYLLA_VERSION_DOT__=$v" -R "__MONITOR_BRANCH_VERSION=$BRANCH_VERSION" -R "__REFRESH_INTERVAL__=$DASHBOARD_REFRESH" --replace-file docs/source/reference/metrics.yaml -V $v
+			else
+				echo "notice: grafana/scylla-manager.template.json was updated, run ./generate-dashboards.sh $FORMAT_COMAND"
+			fi
+		fi
+	fi
 done
 
 for val in "${GRAFANA_DASHBOARD_ARRAY[@]}"; do
-    VERDIR="grafana/build/default"
-    set_loader "default" "" "default"
-    mkdir -p $VERDIR
-    if [[ $val == *".template.json" ]]; then
-        val1=${val::-14}
-        val1=${val1:8}
-        if [ ! -f $VERDIR/$val1.json ] || [ $VERDIR/$val1.json -ot $val ] || [ ! -z "$FORCEUPDATE" ]; then
-            if [[ -z "$TEST_ONLY" ]]; then
-                echo "updating $val"
-               ./make_dashboards.py ${PRODUCTS[@]} -af $VERDIR -t grafana/types.json -d $val -R "__MONITOR_VERSION__=$CURRENT_VERSION" -R "__MONITOR_BRANCH_VERSION=$BRANCH_VERSION" --replace-file docs/source/reference/metrics.yaml
-            fi
-        fi
-    else
-       cp $val $VERDIR
-    fi
+	VERDIR="grafana/build/default"
+	set_loader "default" "" "default"
+	mkdir -p $VERDIR
+	if [[ $val == *".template.json" ]]; then
+		val1=${val::-14}
+		val1=${val1:8}
+		if [ ! -f $VERDIR/$val1.json ] || [ $VERDIR/$val1.json -ot $val ] || [ ! -z "$FORCEUPDATE" ]; then
+			if [[ -z "$TEST_ONLY" ]]; then
+				echo "updating $val"
+				./make_dashboards.py ${PRODUCTS[@]} -af $VERDIR -t grafana/types.json -d $val -R "__MONITOR_VERSION__=$CURRENT_VERSION" -R "__MONITOR_BRANCH_VERSION=$BRANCH_VERSION" --replace-file docs/source/reference/metrics.yaml
+			fi
+		fi
+	else
+		cp $val $VERDIR
+	fi
 done
-

--- a/grafana-datasource.sh
+++ b/grafana-datasource.sh
@@ -2,56 +2,64 @@
 usage="$(basename "$0") [-h] [-p ip:port address of prometheus ] [-m alert_manager address] [-L loki address] [--compose] -- Generate grafna's datasource file"
 
 if [ "$1" = "" ]; then
-    echo "$usage"
-    exit
+	echo "$usage"
+	exit
 fi
 BASE_DIR="grafana/provisioning/datasources"
 if [ "$1" = "--compose" ]; then
-    DB_ADDRESS="aprom:9090"
-    ALERT_MANAGER_ADDRESS="aalert:9093"
-    LOKI_ADDRESS="loki:3100"
+	DB_ADDRESS="aprom:9090"
+	ALERT_MANAGER_ADDRESS="aalert:9093"
+	LOKI_ADDRESS="loki:3100"
 else
-    while getopts ':hlEg:n:p:v:a:x:c:j:m:G:M:D:A:S:P:L:Q:s:' option; do
-      case "$option" in
-        h) echo "$usage"
-           exit
-           ;;
-        p) DB_ADDRESS=$OPTARG
-           ;;
-        m) AM_ADDRESS="-m $OPTARG"
-           ALERT_MANAGER_ADDRESS=$OPTARG
-           ;;
-        L) LOKI_ADDRESS=$OPTARG
-           ;;
-        s) BASE_DIR="grafana/stack/$OPTARG/provisioning/datasources"
-           ;;
-        S) SCRAP_INTERVAL="$OPTARG"
-           ;;
-        :) printf "missing argument for -%s\n" "$OPTARG" >&2
-           echo "$usage" >&2
-           exit 1
-           ;;
-       \?) printf "illegal option: -%s\n" "$OPTARG" >&2
-           echo "$usage" >&2
-           exit 1
-           ;;
-      esac
-    done
+	while getopts ':hlEg:n:p:v:a:x:c:j:m:G:M:D:A:S:P:L:Q:s:' option; do
+		case "$option" in
+		h)
+			echo "$usage"
+			exit
+			;;
+		p)
+			DB_ADDRESS=$OPTARG
+			;;
+		m)
+			AM_ADDRESS="-m $OPTARG"
+			ALERT_MANAGER_ADDRESS=$OPTARG
+			;;
+		L)
+			LOKI_ADDRESS=$OPTARG
+			;;
+		s)
+			BASE_DIR="grafana/stack/$OPTARG/provisioning/datasources"
+			;;
+		S)
+			SCRAP_INTERVAL="$OPTARG"
+			;;
+		:)
+			printf "missing argument for -%s\n" "$OPTARG" >&2
+			echo "$usage" >&2
+			exit 1
+			;;
+		\?)
+			printf "illegal option: -%s\n" "$OPTARG" >&2
+			echo "$usage" >&2
+			exit 1
+			;;
+		esac
+	done
 fi
 mkdir -p $BASE_DIR
 rm -f $BASE_DIR/datasource.yaml
-sed "s/DB_ADDRESS/$DB_ADDRESS/" grafana/datasource.yml | sed "s/AM_ADDRESS/$ALERT_MANAGER_ADDRESS/" > $BASE_DIR/datasource.yaml
+sed "s/DB_ADDRESS/$DB_ADDRESS/" grafana/datasource.yml | sed "s/AM_ADDRESS/$ALERT_MANAGER_ADDRESS/" >$BASE_DIR/datasource.yaml
 if [ -z "$LOKI_ADDRESS" ]; then
-    rm -f $BASE_DIR/datasource.loki.yaml
+	rm -f $BASE_DIR/datasource.loki.yaml
 else
-    sed "s/LOKI_ADDRESS/$LOKI_ADDRESS/" grafana/datasource.loki.yml> $BASE_DIR/datasource.loki.yaml
+	sed "s/LOKI_ADDRESS/$LOKI_ADDRESS/" grafana/datasource.loki.yml >$BASE_DIR/datasource.loki.yaml
 fi
 if [ -z "$SCYLLA_USER" ] || [ -z "$SCYLLA_PSSWD" ]; then
-    cp grafana/datasource.scylla.yml $BASE_DIR/datasource.scylla.yml
+	cp grafana/datasource.scylla.yml $BASE_DIR/datasource.scylla.yml
 else
-    sed "s/SCYLLA_USER/$SCYLLA_USER/" grafana/datasource.psswd.scylla.yml |sed "s/SCYLLA_PSSWD/$SCYLLA_PSSWD/">$BASE_DIR/datasource.scylla.yml
+	sed "s/SCYLLA_USER/$SCYLLA_USER/" grafana/datasource.psswd.scylla.yml | sed "s/SCYLLA_PSSWD/$SCYLLA_PSSWD/" >$BASE_DIR/datasource.scylla.yml
 fi
 
 if [[ "$SCRAP_INTERVAL" != "" ]]; then
-    sed -i "s/    timeInterval: *'[[:digit:]]*.*/    timeInterval: '${SCRAP_INTERVAL}s'/g" $BASE_DIR/datasource.yaml
+	sed -i "s/    timeInterval: *'[[:digit:]]*.*/    timeInterval: '${SCRAP_INTERVAL}s'/g" $BASE_DIR/datasource.yaml
 fi

--- a/kill-all.sh
+++ b/kill-all.sh
@@ -9,100 +9,107 @@ PROMETHEUS_KILL_WAITTIME="120"
 LOKI_PORT=""
 PROMTAIL_PORT=""
 for arg; do
-    shift
-    if [ -z "$LIMIT" ]; then
-       case $arg in
-            (--loki-port)
-                LIMIT="1"
-                PARAM="loki-port"
-                ;;
-            (--promtail-port)
-                LIMIT="1"
-                PARAM="promtail-port"
-                ;;
-            (--stack)
-                LIMIT="1"
-                PARAM="stack"
-                ;;
-            (*) set -- "$@" "$arg"
-                ;;
-        esac
-    else
-        DOCR=`echo $arg|cut -d',' -f1`
-        VALUE=`echo $arg|cut -d',' -f2-|sed 's/#/ /g'`
-        NOSPACE=`echo $arg|sed 's/ /#/g'`
-        if [ "$PARAM" = "loki-port" ]; then
-            LOKI_PORT="-p $NOSPACE"
-            unset PARAM
-        elif [ "$PARAM" = "promtail-port" ]; then
-            PROMTAIL_PORT="-p $NOSPACE"
-            unset PARAM
-        elif [ "$PARAM" = "stack" ]; then
-            STACK_ID="$NOSPACE"
-            unset PARAM
-        fi
-        unset LIMIT
-    fi
+	shift
+	if [ -z "$LIMIT" ]; then
+		case $arg in
+		--loki-port)
+			LIMIT="1"
+			PARAM="loki-port"
+			;;
+		--promtail-port)
+			LIMIT="1"
+			PARAM="promtail-port"
+			;;
+		--stack)
+			LIMIT="1"
+			PARAM="stack"
+			;;
+		*)
+			set -- "$@" "$arg"
+			;;
+		esac
+	else
+		DOCR=$(echo $arg | cut -d',' -f1)
+		VALUE=$(echo $arg | cut -d',' -f2- | sed 's/#/ /g')
+		NOSPACE=$(echo $arg | sed 's/ /#/g')
+		if [ "$PARAM" = "loki-port" ]; then
+			LOKI_PORT="-p $NOSPACE"
+			unset PARAM
+		elif [ "$PARAM" = "promtail-port" ]; then
+			PROMTAIL_PORT="-p $NOSPACE"
+			unset PARAM
+		elif [ "$PARAM" = "stack" ]; then
+			STACK_ID="$NOSPACE"
+			unset PARAM
+		fi
+		unset LIMIT
+	fi
 done
 while getopts ':hg:p:w:m:' option; do
-  case "$option" in
-    h) echo "$usage"
-       exit
-       ;;
-    g) GRAFANA_PORT="-p $OPTARG"
-       ;;
-    p) PROMETHEUS_PORT="-p $OPTARG"
-       PROMETHEUS_NAME="aprom-$OPTARG"
-       ;;
-    m) ALERTMANAGER_PORT="-p $OPTARG"
-       ;;
-    w) PROMETHEUS_KILL_WAITTIME=$OPTARG
-       ;;
-    :) printf "missing argument for -%s\n" "$OPTARG" >&2
-       echo "$usage" >&2
-       exit 1
-       ;;
-   \?) printf "illegal option: -%s\n" "$OPTARG" >&2
-       echo "$usage" >&2
-       exit 1
-       ;;
-  esac
+	case "$option" in
+	h)
+		echo "$usage"
+		exit
+		;;
+	g)
+		GRAFANA_PORT="-p $OPTARG"
+		;;
+	p)
+		PROMETHEUS_PORT="-p $OPTARG"
+		PROMETHEUS_NAME="aprom-$OPTARG"
+		;;
+	m)
+		ALERTMANAGER_PORT="-p $OPTARG"
+		;;
+	w)
+		PROMETHEUS_KILL_WAITTIME=$OPTARG
+		;;
+	:)
+		printf "missing argument for -%s\n" "$OPTARG" >&2
+		echo "$usage" >&2
+		exit 1
+		;;
+	\?)
+		printf "illegal option: -%s\n" "$OPTARG" >&2
+		echo "$usage" >&2
+		exit 1
+		;;
+	esac
 done
 
 if [ "$STACK_ID" != "" ]; then
-    PROMETHEUS_PORT="-p "${STACK_PROMETHEUS["$STACK_ID"]}
-    GRAFANA_PORT="-p "${STACK_GRAFANA["$STACK_ID"]}
-    ALERTMANAGER_PORT="-p "${STACK_ALERTMANAGER["$STACK_ID"]}
-    PROMETHEUS_NAME="aprom-"${STACK_PROMETHEUS["$STACK_ID"]}
+	PROMETHEUS_PORT="-p "${STACK_PROMETHEUS["$STACK_ID"]}
+	GRAFANA_PORT="-p "${STACK_GRAFANA["$STACK_ID"]}
+	ALERTMANAGER_PORT="-p "${STACK_ALERTMANAGER["$STACK_ID"]}
+	PROMETHEUS_NAME="aprom-"${STACK_PROMETHEUS["$STACK_ID"]}
 fi
 
 docker exec $PROMETHEUS_NAME kill 15
 TRIES=0
 OK=0
 until [ $OK -eq 1 ] || [ $TRIES -eq $PROMETHEUS_KILL_WAITTIME ]; do
-    if VAL=`docker logs aprom|&tail -1 |grep 'See you next time'`; then
-        if [ -z "$VAL" ]; then
-            printf '.'
-            ((TRIES=TRIES+1))
-            sleep 1
-        else
-           OK=1
-        fi
-    else
-        OK=1
-    fi
+	if VAL=$(docker logs aprom |& tail -1 | grep 'See you next time'); then
+		if [ -z "$VAL" ]; then
+			printf '.'
+			((TRIES = TRIES + 1))
+			sleep 1
+		else
+			OK=1
+		fi
+	else
+		OK=1
+	fi
 done
 sleep 2
 ./kill-container.sh $PROMETHEUS_PORT -b aprom
 ./kill-container.sh $GRAFANA_PORT -b agraf
 ./kill-container.sh $ALERTMANAGER_PORT -b aalert
 if [ -z $STACK_ID ]; then
-    ./kill-container.sh -b agrafrender
-    ./kill-container.sh -b vmalert
-    ./kill-container.sh $LOKI_PORT -b loki
-    ./kill-container.sh $PROMTAIL_PORT -b promtail
-    ./kill-container.sh -b sidecar1
-    ./kill-container.sh -b thanos
-    ./kill-container.sh -b datadog-agent
+	./kill-container.sh -b agrafrender
+	./kill-container.sh -b vmalert
+	./kill-container.sh $LOKI_PORT -b loki
+	./kill-container.sh $PROMTAIL_PORT -b promtail
+	./kill-container.sh -b sidecar1
+	./kill-container.sh -b thanos
+	./kill-container.sh -b datadog-agent
 fi
-

--- a/kill-container.sh
+++ b/kill-container.sh
@@ -3,38 +3,44 @@
 usage="$(basename "$0") [-h] [ -p container port ] [-n optional name] [-b base name] -- kills existing Docker instances at given ports"
 
 while getopts ':hb:p:n:' option; do
-  case "$option" in
-    h) echo "$usage"
-       exit
-       ;;
-    p) PORT=$OPTARG
-       ;;
-    n) NAME=$OPTARG
-       ;;
-    b) BASE_NAME=$OPTARG
-       ;;
-    :) printf "missing argument for -%s\n" "$OPTARG" >&2
-       echo "$usage" >&2
-       exit 1
-       ;;
-   \?) printf "illegal option: -%s\n" "$OPTARG" >&2
-       echo "$usage" >&2
-       exit 1
-       ;;
-  esac
+	case "$option" in
+	h)
+		echo "$usage"
+		exit
+		;;
+	p)
+		PORT=$OPTARG
+		;;
+	n)
+		NAME=$OPTARG
+		;;
+	b)
+		BASE_NAME=$OPTARG
+		;;
+	:)
+		printf "missing argument for -%s\n" "$OPTARG" >&2
+		echo "$usage" >&2
+		exit 1
+		;;
+	\?)
+		printf "illegal option: -%s\n" "$OPTARG" >&2
+		echo "$usage" >&2
+		exit 1
+		;;
+	esac
 done
 if [ -z $NAME ]; then
 	if [ -z $PORT ]; then
-	    NAME=$BASE_NAME
+		NAME=$BASE_NAME
 	else
-	    NAME=$BASE_NAME-$PORT
+		NAME=$BASE_NAME-$PORT
 	fi
 fi
 
 if [ "$(docker ps -q -f name=$NAME)" ]; then
-    docker kill $NAME
+	docker kill $NAME
 fi
 
-if [[ "$(docker ps -aq --filter name=$NAME 2> /dev/null)" != "" ]]; then
-    docker rm -v $NAME
+if [[ "$(docker ps -aq --filter name=$NAME 2>/dev/null)" != "" ]]; then
+	docker rm -v $NAME
 fi

--- a/load-grafana.sh
+++ b/load-grafana.sh
@@ -2,14 +2,14 @@
 
 CURRENT_VERSION="master"
 if [ -f CURRENT_VERSION.sh ]; then
-    CURRENT_VERSION=`cat CURRENT_VERSION.sh`
+	CURRENT_VERSION=$(cat CURRENT_VERSION.sh)
 fi
 
 . versions.sh
 . dashboards.sh
 
 VERSIONS=$DEFAULT_VERSION
-BRANCH_VERSION=`echo $CURRENT_VERSION|cut -d'.' -f1,2`
+BRANCH_VERSION=$(echo $CURRENT_VERSION | cut -d'.' -f1,2)
 GRAFANA_HOST="localhost"
 GRAFANA_PORT=3000
 DB_ADDRESS="127.0.0.1:9090"
@@ -17,74 +17,80 @@ DB_ADDRESS="127.0.0.1:9090"
 usage="$(basename "$0") [-h] [-v comma separated versions ] [-g grafana port ] [-H grafana hostname] [-m alert_manager ip:port] [-p ip:port address of prometheus ] [-a admin password] [-j additional dashboard to load to Grafana, multiple params are supported] [-M scylla-manager version ] -- loads the prometheus datasource and the Scylla dashboards into an existing grafana installation"
 
 while getopts ':hg:H:p:v:a:j:m:M:' option; do
-  case "$option" in
-    h) echo "$usage"
-       exit
-       ;;
-    v) VERSIONS=$OPTARG
-       ;;
-    M) MANAGER_VERSION=$OPTARG
-       ;;
-    g) GRAFANA_PORT=$OPTARG
-       ;;
-    H) GRAFANA_HOST=$OPTARG
-       ;;
-    j) GRAFANA_DASHBOARD_ARRAY+=("$OPTARG")
-       ;;
-    p) DB_ADDRESS=$OPTARG
-       ;;
-    m) AM_ADDRESS=$OPTARG
-       ;;
-    a) GRAFANA_ADMIN_PASSWORD=$OPTARG
-       ;;
-  esac
+	case "$option" in
+	h)
+		echo "$usage"
+		exit
+		;;
+	v)
+		VERSIONS=$OPTARG
+		;;
+	M)
+		MANAGER_VERSION=$OPTARG
+		;;
+	g)
+		GRAFANA_PORT=$OPTARG
+		;;
+	H)
+		GRAFANA_HOST=$OPTARG
+		;;
+	j)
+		GRAFANA_DASHBOARD_ARRAY+=("$OPTARG")
+		;;
+	p)
+		DB_ADDRESS=$OPTARG
+		;;
+	m)
+		AM_ADDRESS=$OPTARG
+		;;
+	a)
+		GRAFANA_ADMIN_PASSWORD=$OPTARG
+		;;
+	esac
 done
 
 curl -XPOST -i http://admin:$GRAFANA_ADMIN_PASSWORD@$GRAFANA_HOST:$GRAFANA_PORT/api/datasources \
-     --data-binary '{"name":"prometheus", "type":"prometheus", "url":"'"http://$DB_ADDRESS"'", "access":"proxy", "basicAuth":false}' \
-     -H "Content-Type: application/json"
+	--data-binary '{"name":"prometheus", "type":"prometheus", "url":"'"http://$DB_ADDRESS"'", "access":"proxy", "basicAuth":false}' \
+	-H "Content-Type: application/json"
 
-if [ -n $AM_ADDRESS ]
-then
-  curl -XPOST -i http://admin:$GRAFANA_ADMIN_PASSWORD@localhost:$GRAFANA_PORT/api/datasources \
-       --data-binary '{"orgId":1,"name":"alertmanager", "type":"camptocamp-prometheus-alertmanager-datasource","typeLogoUrl":"public/img/icn-datasource.svg","access":"proxy","url":"'"http://$AM_ADDRESS"'","password":"","user":"","database":"","basicAuth":false,"isDefault":false,"jsonData":{"severity_critical": "4","severity_high": "3", "severity_warning": "2","severity_info": "1"}}' \
-       -H "Content-Type: application/json"
+if [ -n $AM_ADDRESS ]; then
+	curl -XPOST -i http://admin:$GRAFANA_ADMIN_PASSWORD@localhost:$GRAFANA_PORT/api/datasources \
+		--data-binary '{"orgId":1,"name":"alertmanager", "type":"camptocamp-prometheus-alertmanager-datasource","typeLogoUrl":"public/img/icn-datasource.svg","access":"proxy","url":"'"http://$AM_ADDRESS"'","password":"","user":"","database":"","basicAuth":false,"isDefault":false,"jsonData":{"severity_critical": "4","severity_high": "3", "severity_warning": "2","severity_info": "1"}}' \
+		-H "Content-Type: application/json"
 fi
 
 mkdir -p grafana/build
-IFS=',' ;for v in $VERSIONS; do
-for f in "${DASHBOARDS[@]}"; do
-    if [ -e grafana/$f.template.json ]
-    then
-        ./make_dashboards.py -t grafana/types.json -d grafana/$f.template.json -R "__MONITOR_VERSION__=$CURRENT_VERSION" -R "__MONITOR_BRANCH_VERSION=$BRANCH_VERSION" -V $v
-        curl -XPOST -i http://admin:$GRAFANA_ADMIN_PASSWORD@$GRAFANA_HOST:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/build/$f.$v.json -H "Content-Type: application/json"
-    else
-        if [ -f grafana/$f.$v.json ]
-        then
-            curl -XPOST -i http://admin:$GRAFANA_ADMIN_PASSWORD@$GRAFANA_HOST:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/$f.$v.json -H "Content-Type: application/json"
-        else
-            printf "\nDashboard $f for version $v, not found"
-        fi
-    fi
-done
+IFS=','
+for v in $VERSIONS; do
+	for f in "${DASHBOARDS[@]}"; do
+		if [ -e grafana/$f.template.json ]; then
+			./make_dashboards.py -t grafana/types.json -d grafana/$f.template.json -R "__MONITOR_VERSION__=$CURRENT_VERSION" -R "__MONITOR_BRANCH_VERSION=$BRANCH_VERSION" -V $v
+			curl -XPOST -i http://admin:$GRAFANA_ADMIN_PASSWORD@$GRAFANA_HOST:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/build/$f.$v.json -H "Content-Type: application/json"
+		else
+			if [ -f grafana/$f.$v.json ]; then
+				curl -XPOST -i http://admin:$GRAFANA_ADMIN_PASSWORD@$GRAFANA_HOST:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/$f.$v.json -H "Content-Type: application/json"
+			else
+				printf "\nDashboard $f for version $v, not found"
+			fi
+		fi
+	done
 done
 
-if [ -e grafana/scylla-manager.$MANAGER_VERSION.template.json ]
-then
-    if [ ! -f "grafana/build/scylla-manager.$MANAGER_VERSION.json" ] || [ "grafana/build/scylla-manager.$MANAGER_VERSION.json" -ot "grafana/scylla-manager.$MANAGER_VERSION.template.json" ]; then
-        ./make_dashboards.py -t grafana/types.json -d grafana/scylla-manager.$MANAGER_VERSION.template.json
-    fi
-    curl -XPOST -i http://admin:$GRAFANA_ADMIN_PASSWORD@$GRAFANA_HOST:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/build/scylla-manager.$MANAGER_VERSION.json -H "Content-Type: application/json"
+if [ -e grafana/scylla-manager.$MANAGER_VERSION.template.json ]; then
+	if [ ! -f "grafana/build/scylla-manager.$MANAGER_VERSION.json" ] || [ "grafana/build/scylla-manager.$MANAGER_VERSION.json" -ot "grafana/scylla-manager.$MANAGER_VERSION.template.json" ]; then
+		./make_dashboards.py -t grafana/types.json -d grafana/scylla-manager.$MANAGER_VERSION.template.json
+	fi
+	curl -XPOST -i http://admin:$GRAFANA_ADMIN_PASSWORD@$GRAFANA_HOST:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/build/scylla-manager.$MANAGER_VERSION.json -H "Content-Type: application/json"
 fi
 
 for val in "${GRAFANA_DASHBOARD_ARRAY[@]}"; do
-    if [[ $val == *".template.json" ]]; then
-        val1=${val::-14}
-        val1=${val1:8}
-        if [ ! -f "$val1.json" ] || [ "$val1.json" -ot "$val" ]; then
-           ./make_dashboards.py -t grafana/types.json -d $val
-        fi
-        val="$val1.json"
-    fi
-    curl -XPOST -i http://admin:$GRAFANA_ADMIN_PASSWORD@$GRAFANA_HOST:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/build/$val -H "Content-Type: application/json"
+	if [[ $val == *".template.json" ]]; then
+		val1=${val::-14}
+		val1=${val1:8}
+		if [ ! -f "$val1.json" ] || [ "$val1.json" -ot "$val" ]; then
+			./make_dashboards.py -t grafana/types.json -d $val
+		fi
+		val="$val1.json"
+	fi
+	curl -XPOST -i http://admin:$GRAFANA_ADMIN_PASSWORD@$GRAFANA_HOST:$GRAFANA_PORT/api/dashboards/db --data-binary @./grafana/build/$val -H "Content-Type: application/json"
 done

--- a/make-compose.sh
+++ b/make-compose.sh
@@ -1,40 +1,40 @@
 #!/usr/bin/env bash
 
 . versions.sh
-if [ -f  env.sh ]; then
-    . env.sh
+if [ -f env.sh ]; then
+	. env.sh
 fi
 DATA_SOURCES=""
 CURRENT_VERSION="master"
 LOKI_WALL_DIR="./loki-wall"
 if [ -f CURRENT_VERSION.sh ]; then
-    CURRENT_VERSION=`cat CURRENT_VERSION.sh`
+	CURRENT_VERSION=$(cat CURRENT_VERSION.sh)
 fi
 
 if [ -z "$BRANCH_VERSION" ]; then
-  BRANCH_VERSION=$CURRENT_VERSION
+	BRANCH_VERSION=$CURRENT_VERSION
 fi
 if [ -z ${DEFAULT_VERSION[$CURRENT_VERSION]} ]; then
-    BRANCH_VERSION=`echo $CURRENT_VERSION|cut -d'.' -f1,2`
+	BRANCH_VERSION=$(echo $CURRENT_VERSION | cut -d'.' -f1,2)
 fi
 if [ "$1" = "-e" ]; then
-    DEFAULT_VERSION=${DEFAULT_ENTERPRISE_VERSION[$BRANCH_VERSION]}
+	DEFAULT_VERSION=${DEFAULT_ENTERPRISE_VERSION[$BRANCH_VERSION]}
 fi
 
-if [ -z "$MANAGER_VERSION" ];then
-  MANAGER_VERSION=${MANAGER_DEFAULT_VERSION[$BRANCH_VERSION]}
+if [ -z "$MANAGER_VERSION" ]; then
+	MANAGER_VERSION=${MANAGER_DEFAULT_VERSION[$BRANCH_VERSION]}
 fi
 
 if [ "$CURRENT_VERSION" = "master" ]; then
-    echo ""
-    echo "*****************************************************"
-    echo "* WARNING: You are using the unstable master branch *"
-    echo "* Check the README.md file for the stable releases  *"
-    echo "*****************************************************"
-    echo ""
-    echo "Make sure you run generate-dashboards.sh to generate your dashboards."
-    echo 'For example to use Scylla 2021.1 run `./generate-dashboards.sh -F -v 2021.1`'
-    echo ""
+	echo ""
+	echo "*****************************************************"
+	echo "* WARNING: You are using the unstable master branch *"
+	echo "* Check the README.md file for the stable releases  *"
+	echo "*****************************************************"
+	echo ""
+	echo "Make sure you run generate-dashboards.sh to generate your dashboards."
+	echo 'For example to use Scylla 2021.1 run `./generate-dashboards.sh -F -v 2021.1`'
+	echo ""
 fi
 if [ -z $LOKI_RULE_DIR ]; then
 	LOKI_RULE_DIR=./loki/rules/scylla
@@ -45,22 +45,22 @@ fi
 if [ -z $PROMTAIL_CONFIG ]; then
 	PROMTAIL_CONFIG=$PWD/loki/promtail/promtail_config.yml
 fi
-if [ "`id -u`" -eq 0 ]; then
-    echo "Running as root is not advised, please check the documentation on how to run as non-root user"
+if [ "$(id -u)" -eq 0 ]; then
+	echo "Running as root is not advised, please check the documentation on how to run as non-root user"
 else
-    GROUPID=`id -g`
-    PROMETHEUS_USER_PERMISSIONS="user: $UID:$GROUPID"
-    LOKi_USER_PERMISSIONS="user: $UID:$GROUPID"
+	GROUPID=$(id -g)
+	PROMETHEUS_USER_PERMISSIONS="user: $UID:$GROUPID"
+	LOKi_USER_PERMISSIONS="user: $UID:$GROUPID"
 fi
 
 if [[ $(uname) == "Linux" ]]; then
-  readlink_command="readlink -f"
+	readlink_command="readlink -f"
 elif [[ $(uname) == "Darwin" ]]; then
-  readlink_command="realpath "
+	readlink_command="realpath "
 fi
 
 function usage {
-  __usage="Usage: $(basename $0) [-h] [--version] [-e] [-d Prometheus data-dir] [-L resolve the servers from the manger running on the given address] [-G path to grafana data-dir] [-s scylla-target-file] [-n node-target-file] [-l] [-v comma separated versions] [-j additional dashboard to load to Grafana, multiple params are supported] [-c grafana environment variable, multiple params are supported] [-b Prometheus command line options] [-g grafana port ] [ -p prometheus port ] [-a admin password] [-m alertmanager port] [ -M scylla-manager version ] [-D encapsulate docker param] [-r alert-manager-config] [-R prometheus-alert-file] [-N manager target file] [-A bind-to-ip-address] [-C alertmanager commands] [-Q Grafana anonymous role (Admin/Editor/Viewer)] [-S start with a system specific dashboard set] [-T additional-prometheus-targets] [--no-loki] [--auto-restart] [--no-renderer] [-f alertmanager-dir]
+	__usage="Usage: $(basename $0) [-h] [--version] [-e] [-d Prometheus data-dir] [-L resolve the servers from the manger running on the given address] [-G path to grafana data-dir] [-s scylla-target-file] [-n node-target-file] [-l] [-v comma separated versions] [-j additional dashboard to load to Grafana, multiple params are supported] [-c grafana environment variable, multiple params are supported] [-b Prometheus command line options] [-g grafana port ] [ -p prometheus port ] [-a admin password] [-m alertmanager port] [ -M scylla-manager version ] [-D encapsulate docker param] [-r alert-manager-config] [-R prometheus-alert-file] [-N manager target file] [-A bind-to-ip-address] [-C alertmanager commands] [-Q Grafana anonymous role (Admin/Editor/Viewer)] [-S start with a system specific dashboard set] [-T additional-prometheus-targets] [--no-loki] [--auto-restart] [--no-renderer] [-f alertmanager-dir]
 
 Options:
   -h print this help and exit
@@ -107,28 +107,28 @@ Options:
   --archive                      - Treat data directory as an archive. This disables Prometheus time-to-live (infinite retention).
 The script starts Scylla Monitoring stack.
 "
-  echo "$__usage"
+	echo "$__usage"
 }
 
-function is_local () {
-    for var in "$@"; do
-        if grep -q '\s127.' $1; then
-            echo "Local host found in $1"
-            grep '\s127.' $1
-            return 0
-        fi
-        if grep -q 'localhost' $1; then
-            return 0
-        fi
-    done
-    return 1
+function is_local() {
+	for var in "$@"; do
+		if grep -q '\s127.' $1; then
+			echo "Local host found in $1"
+			grep '\s127.' $1
+			return 0
+		fi
+		if grep -q 'localhost' $1; then
+			return 0
+		fi
+	done
+	return 1
 }
 
 function add_param() {
 	arr=("$@")
 	for value in "${arr[@]}"; do
-        echo -n "    - $value\n"
-    done
+		echo -n "    - $value\n"
+	done
 }
 
 function set_path() {
@@ -154,380 +154,419 @@ if [ -z "$GF_SECURITY_ADMIN_PASSWORD" ]; then
 fi
 
 if [ -z "$PROMETHEUS_RULES" ]; then
-  PROMETHEUS_RULES="$PWD/prometheus/prom_rules/:/etc/prometheus/prom_rules/"
+	PROMETHEUS_RULES="$PWD/prometheus/prom_rules/:/etc/prometheus/prom_rules/"
 fi
 
 if [ -z "$VERSIONS" ]; then
-  VERSIONS=${DEFAULT_VERSION[$BRANCH_VERSION]}
+	VERSIONS=${DEFAULT_VERSION[$BRANCH_VERSION]}
 fi
 
 if [ -z "$SCYLLA_TARGET_FILES" ]; then
-  SCYLLA_TARGET_FILES=($PWD/prometheus/scylla_servers.yml $PWD/scylla_servers.yml)
+	SCYLLA_TARGET_FILES=($PWD/prometheus/scylla_servers.yml $PWD/scylla_servers.yml)
 fi
 if [ -z "$SCYLLA_MANGER_TARGET_FILES" ]; then
-  SCYLLA_MANGER_TARGET_FILES=($PWD/prometheus/scylla_manager_servers.yml $PWD/scylla_manager_servers.yml $PWD/prometheus/scylla_manager_servers.example.yml)
+	SCYLLA_MANGER_TARGET_FILES=($PWD/prometheus/scylla_manager_servers.yml $PWD/scylla_manager_servers.yml $PWD/prometheus/scylla_manager_servers.example.yml)
 fi
 if [ -z "$GRAFANA_ADMIN_PASSWORD" ]; then
-  GRAFANA_ADMIN_PASSWORD=""
+	GRAFANA_ADMIN_PASSWORD=""
 fi
 
 if [ -z "$ALERTMANAGER_PORT" ]; then
-  ALERTMANAGER_PORT=""
+	ALERTMANAGER_PORT=""
 fi
 
 if [ -z "$LOKI_PORT" ]; then
 	LOKI_PORT=3100
 fi
 if [ -z "$DOCKER_PARAM" ]; then
-  DOCKER_PARAM=""
+	DOCKER_PARAM=""
 fi
 if [ -z "$DATA_DIR" ]; then
-  DATA_DIR=""
+	DATA_DIR=""
 fi
 if [ -z "$DATA_DIR_CMD" ]; then
-  DATA_DIR_CMD=""
+	DATA_DIR_CMD=""
 fi
 if [ -z "$CONSUL_ADDRESS" ]; then
-  CONSUL_ADDRESS=""
+	CONSUL_ADDRESS=""
 fi
 if [ -z "$PROMETHEUS_TARGETS" ]; then
-  PROMETHEUS_TARGETS=""
+	PROMETHEUS_TARGETS=""
 fi
 if [ -z "$BIND_ADDRESS" ]; then
-  BIND_ADDRESS=""
+	BIND_ADDRESS=""
 fi
 if [ -z "$GRAFNA_ANONYMOUS_ROLE" ]; then
-  GRAFNA_ANONYMOUS_ROLE=""
+	GRAFNA_ANONYMOUS_ROLE=""
 fi
 if [ -z "$SPECIFIC_SOLUTION" ]; then
-  SPECIFIC_SOLUTION=""
+	SPECIFIC_SOLUTION=""
 fi
 if [ -z "$LDAP_FILE" ]; then
-  LDAP_FILE=""
+	LDAP_FILE=""
 fi
 if [ -z "$RUN_RENDERER" ]; then
-  RUN_RENDERER="-E"
+	RUN_RENDERER="-E"
 fi
 if [ -z "$RUN_LOKI" ]; then
-  RUN_LOKI=1
+	RUN_LOKI=1
 fi
 if [ -z "$RUN_THANOS_SC" ]; then
-  RUN_THANOS_SC=0
+	RUN_THANOS_SC=0
 fi
 if [ -z "$RUN_THANOS" ]; then
-  RUN_THANOS=0
+	RUN_THANOS=0
 fi
 if [ -z "$ALERT_MANAGER_DIR" ]; then
-  ALERT_MANAGER_DIR=""
+	ALERT_MANAGER_DIR=""
 fi
 if [ -z "$LOKI_DIR" ]; then
-  LOKI_DIR=""
+	LOKI_DIR=""
 fi
 for arg; do
-    shift
-    if [ -z "$LIMIT" ]; then
-       case $arg in
-            (--compose) RUN_COMPOSE=1
-                ;;
-            (--no-loki) RUN_LOKI=0
-                ;;
-            (--no-renderer) RUN_RENDERER=""
-                ;;
-            (--thanos-sc) RUN_THANOS_SC=1
-                ;;
-            (--thanos) RUN_THANOS=1
-                ;;
-            (--auto-restart) DOCKER_PARAM="$DOCKER_PARAM    restart: unless-stopped\n"
-                ;;
-            (--victoria-metrics) VICTORIA_METRICS="1"
-                ;;
-            (--auth)
-                GF_AUTH_BASIC_ENABLED="true"
-                ;;
-            (--disable-anonymous)
-                GF_AUTH_ANONYMOUS_ENABLED="false"
-                ;;
-            (--limit)
-                LIMIT="1"
-                ;;
-            (--volume)
-                LIMIT="1"
-                VOLUME="1"
-                ;;
-            (--param)
-                LIMIT="1"
-                PARAM="1"
-                ;;
-            (--evaluation-interval)
-                LIMIT="1"
-                PARAM="evaluation-interval"
-                ;;
-            (--manager-agents)
-                LIMIT="1"
-                PARAM="manager-agents"
-                ;;
-            (--datadog-api-keys)
-                LIMIT="1"
-                PARAM="datadog-api-keys"
-                ;;
-            (--datadog-hostname)
-                LIMIT="1"
-                PARAM="datadog-hostname"
-                ;;
-            (--version)
-                echo "Scylla-Monitoring Stack version: $CURRENT_VERSION"
-    			echo "Supported versions:" ${SUPPORTED_VERSIONS[$BRANCH_VERSION]}
-    			echo "Manager supported versions:" ${MANAGER_SUPPORTED_VERSIONS[$BRANCH_VERSION]}
-    			exit 0
-            (--no-cas-cdc)
-                PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-cas-cdc"
-                ;;
-            (--no-cas)
-                PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-cas"
-                ;;
-            (--no-cdc)
-                PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-cdc"
-                ;;
-            (--target-directory)
-                LIMIT="1"
-                PARAM="target-directory"
-                ;;
-            (--help) usage
-                ;;
-            (--archive)
-                PROMETHEUS_COMMAND_LINE_OPTIONS_ARRAY+=(--storage.tsdb.retention.time=100y)
-                ;;
-            (*) set -- "$@" "$arg"
-                ;;
-        esac
-    else
-        DOCR=`echo $arg|cut -d',' -f1`
-        VALUE=`echo $arg|cut -d',' -f2-|sed 's/#/ /g'`
-        NOSPACE=`echo $arg|sed 's/ /#/g'`
-        if [ "$PARAM" = "1" ]; then
-            if [ -z "${DOCKER_PARAMS[$DOCR]}" ]; then
-                DOCKER_PARAMS[$DOCR]=""
-            fi
-            DOCKER_PARAMS[$DOCR]="${DOCKER_PARAMS[$DOCR]} $VALUE"
-            PARAMS="$PARAMS --param $NOSPACE"
-            unset PARAM
-        elif [ "$PARAM" = "evaluation-interval" ]; then
-            PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS -E $NOSPACE"
-            unset PARAM
-        elif [ "$PARAM" = "manager-agents" ]; then
-            SCYLLA_MANGER_AGENT_TARGET_FILE="$NOSPACE"
-            unset PARAM
-        elif [ "$PARAM" = "target-directory" ]; then
-            TARGET_DIRECTORY="$NOSPACE"
-            unset PARAM
-        elif [ "$PARAM" = "datadog-api-keys" ]; then
-            DATDOGPARAM="$DATDOGPARAM -A $NOSPACE"
-            unset PARAM
-        elif [ "$PARAM" = "datadog-hostname" ]; then
-            DATDOGPARAM="$DATDOGPARAM -H $NOSPACE"
-            unset PARAM
-        else
-            if [ -z "${DOCKER_LIMITS[$DOCR]}" ]; then
-                DOCKER_LIMITS[$DOCR]=""
-            fi
-            if [ "$VOLUME" = "1" ]; then
-                SRC=`echo $VALUE|cut -d':' -f1`
-                DST=`echo $VALUE|cut -d':' -f2-`
-                SRC=$($readlink_command "$SRC")
-                DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} -v $SRC:$DST"
-                VOLUMES="$VOLUMES --volume $NOSPACE"
-                unset VOLUME
-            else
-                DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} $VALUE"
-                LIMITS="$LIMITS --limit $NOSPACE"
-            fi
-        fi
-        unset LIMIT
-    fi
+	shift
+	if [ -z "$LIMIT" ]; then
+		case $arg in
+		--compose)
+			RUN_COMPOSE=1
+			;;
+		--no-loki)
+			RUN_LOKI=0
+			;;
+		--no-renderer)
+			RUN_RENDERER=""
+			;;
+		--thanos-sc)
+			RUN_THANOS_SC=1
+			;;
+		--thanos)
+			RUN_THANOS=1
+			;;
+		--auto-restart)
+			DOCKER_PARAM="$DOCKER_PARAM    restart: unless-stopped\n"
+			;;
+		--victoria-metrics)
+			VICTORIA_METRICS="1"
+			;;
+		--auth)
+			GF_AUTH_BASIC_ENABLED="true"
+			;;
+		--disable-anonymous)
+			GF_AUTH_ANONYMOUS_ENABLED="false"
+			;;
+		--limit)
+			LIMIT="1"
+			;;
+		--volume)
+			LIMIT="1"
+			VOLUME="1"
+			;;
+		--param)
+			LIMIT="1"
+			PARAM="1"
+			;;
+		--evaluation-interval)
+			LIMIT="1"
+			PARAM="evaluation-interval"
+			;;
+		--manager-agents)
+			LIMIT="1"
+			PARAM="manager-agents"
+			;;
+		--datadog-api-keys)
+			LIMIT="1"
+			PARAM="datadog-api-keys"
+			;;
+		--datadog-hostname)
+			LIMIT="1"
+			PARAM="datadog-hostname"
+			;;
+		--version)
+			echo "Scylla-Monitoring Stack version: $CURRENT_VERSION"
+			echo "Supported versions:" ${SUPPORTED_VERSIONS[$BRANCH_VERSION]}
+			echo "Manager supported versions:" ${MANAGER_SUPPORTED_VERSIONS[$BRANCH_VERSION]}
+			exit 0
+			(--no-cas-cdc)
+			PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-cas-cdc"
+			;;
+		--no-cas)
+			PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-cas"
+			;;
+		--no-cdc)
+			PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-cdc"
+			;;
+		--target-directory)
+			LIMIT="1"
+			PARAM="target-directory"
+			;;
+		--help)
+			usage
+			;;
+		--archive)
+			PROMETHEUS_COMMAND_LINE_OPTIONS_ARRAY+=(--storage.tsdb.retention.time=100y)
+			;;
+		*)
+			set -- "$@" "$arg"
+			;;
+		esac
+	else
+		DOCR=$(echo $arg | cut -d',' -f1)
+		VALUE=$(echo $arg | cut -d',' -f2- | sed 's/#/ /g')
+		NOSPACE=$(echo $arg | sed 's/ /#/g')
+		if [ "$PARAM" = "1" ]; then
+			if [ -z "${DOCKER_PARAMS[$DOCR]}" ]; then
+				DOCKER_PARAMS[$DOCR]=""
+			fi
+			DOCKER_PARAMS[$DOCR]="${DOCKER_PARAMS[$DOCR]} $VALUE"
+			PARAMS="$PARAMS --param $NOSPACE"
+			unset PARAM
+		elif [ "$PARAM" = "evaluation-interval" ]; then
+			PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS -E $NOSPACE"
+			unset PARAM
+		elif [ "$PARAM" = "manager-agents" ]; then
+			SCYLLA_MANGER_AGENT_TARGET_FILE="$NOSPACE"
+			unset PARAM
+		elif [ "$PARAM" = "target-directory" ]; then
+			TARGET_DIRECTORY="$NOSPACE"
+			unset PARAM
+		elif [ "$PARAM" = "datadog-api-keys" ]; then
+			DATDOGPARAM="$DATDOGPARAM -A $NOSPACE"
+			unset PARAM
+		elif [ "$PARAM" = "datadog-hostname" ]; then
+			DATDOGPARAM="$DATDOGPARAM -H $NOSPACE"
+			unset PARAM
+		else
+			if [ -z "${DOCKER_LIMITS[$DOCR]}" ]; then
+				DOCKER_LIMITS[$DOCR]=""
+			fi
+			if [ "$VOLUME" = "1" ]; then
+				SRC=$(echo $VALUE | cut -d':' -f1)
+				DST=$(echo $VALUE | cut -d':' -f2-)
+				SRC=$($readlink_command "$SRC")
+				DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} -v $SRC:$DST"
+				VOLUMES="$VOLUMES --volume $NOSPACE"
+				unset VOLUME
+			else
+				DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} $VALUE"
+				LIMITS="$LIMITS --limit $NOSPACE"
+			fi
+		fi
+		unset LIMIT
+	fi
 done
 
 while getopts ':hleEd:g:p:v:s:n:a:c:j:b:m:r:R:M:G:D:L:N:C:Q:A:f:P:S:T:k:' option; do
-  case "$option" in
-    h) usage
-       exit
-       ;;
-    v) VERSIONS=$OPTARG
-       ;;
-    M) MANAGER_VERSION=$OPTARG
-       ;;
-    d) DATA_DIR=$OPTARG
-       ;;
-    G) EXTERNAL_VOLUME="-G $OPTARG"
-       ;;
-    A) BIND_ADDRESS="$OPTARG:"
-       ;;
-    r) ALERT_MANAGER_RULE_CONFIG=$(set_path $OPTARG)
-       ;;
-    R) if [[ -d "$OPTARG" ]]; then
-        PROMETHEUS_RULES=$($readlink_command $OPTARG)":/etc/prometheus/prom_rules/"
-       else
-        PROMETHEUS_RULES=$($readlink_command $OPTARG)":/etc/prometheus/prometheus.rules.yml"
-       fi
-       ;;
-    g) GRAFANA_PORT="$OPTARG"
-       ;;
-    m) ALERTMANAGER_PORT="$OPTARG"
-       ;;
-    T) PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS -T $OPTARG"
-       ;;
-    Q) GF_AUTH_ANONYMOUS_ORG_ROLE="$OPTARG"
-       ;;
-    p) PROMETHEUS_PORT=$OPTARG
-       ;;
-    s) SCYLLA_TARGET_FILES=("$OPTARG")
-       ;;
-    n) NODE_TARGET_FILE=$OPTARG
-       ;;
-    l) DOCKER_PARAM="$DOCKER_PARAM    network_mode: host\n"
-       ;;
-    L) CONSUL_ADDRESS="-L $OPTARG"
-       ;;
-    P) LDAP_FILE="-P $OPTARG"
-       ;;
-    a) GF_SECURITY_ADMIN_PASSWORD="$OPTARG"
-       ;;
-    j) GRAFANA_DASHBOARD_ARRAY+=("$OPTARG")
-       ;;
-    c) GRAFANA_ENV_ARRAY+=("$OPTARG")
-       ;;
-    C) ALERTMANAGER_COMMANDS+=("$OPTARG")
-       ;;
-    D) DOCKER_PARAM="$DOCKER_PARAM    $OPTARG\n"
-       ;;
-    b) PROMETHEUS_COMMAND_LINE_OPTIONS_ARRAY+=("$OPTARG")
-       ;;
-    N) SCYLLA_MANGER_TARGET_FILES=($OPTARG)
-       ;;
-    S) SPECIFIC_SOLUTION="-S $OPTARG"
-       ;;
-    E) RUN_RENDERER="-E"
-       ;;
-    f) ALERT_MANAGER_DIR=( $(set_path $OPTARG):/alertmanager/data:z)
-       ;;
-    k) LOKI_DIR=`set_path $OPTARG`
-       if [ ! -d $LOKI_DIR ]; then
-           mkdir -p $LOKI_DIR
-       fi
-       LOKI_DIR="- $LOKI_DIR:/tmp/loki:z"
-       ;;
-    :) printf "missing argument for -%s\n" "$OPTARG" >&2
-       echo "$usage" >&2
-       exit 1
-       ;;
-   \?) printf "illegal option: -%s\n" "$OPTARG" >&2
-       echo "$usage" >&2
-       exit 1
-       ;;
-  esac
+	case "$option" in
+	h)
+		usage
+		exit
+		;;
+	v)
+		VERSIONS=$OPTARG
+		;;
+	M)
+		MANAGER_VERSION=$OPTARG
+		;;
+	d)
+		DATA_DIR=$OPTARG
+		;;
+	G)
+		EXTERNAL_VOLUME="-G $OPTARG"
+		;;
+	A)
+		BIND_ADDRESS="$OPTARG:"
+		;;
+	r)
+		ALERT_MANAGER_RULE_CONFIG=$(set_path $OPTARG)
+		;;
+	R)
+		if [[ -d "$OPTARG" ]]; then
+			PROMETHEUS_RULES=$($readlink_command $OPTARG)":/etc/prometheus/prom_rules/"
+		else
+			PROMETHEUS_RULES=$($readlink_command $OPTARG)":/etc/prometheus/prometheus.rules.yml"
+		fi
+		;;
+	g)
+		GRAFANA_PORT="$OPTARG"
+		;;
+	m)
+		ALERTMANAGER_PORT="$OPTARG"
+		;;
+	T)
+		PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS -T $OPTARG"
+		;;
+	Q)
+		GF_AUTH_ANONYMOUS_ORG_ROLE="$OPTARG"
+		;;
+	p)
+		PROMETHEUS_PORT=$OPTARG
+		;;
+	s)
+		SCYLLA_TARGET_FILES=("$OPTARG")
+		;;
+	n)
+		NODE_TARGET_FILE=$OPTARG
+		;;
+	l)
+		DOCKER_PARAM="$DOCKER_PARAM    network_mode: host\n"
+		;;
+	L)
+		CONSUL_ADDRESS="-L $OPTARG"
+		;;
+	P)
+		LDAP_FILE="-P $OPTARG"
+		;;
+	a)
+		GF_SECURITY_ADMIN_PASSWORD="$OPTARG"
+		;;
+	j)
+		GRAFANA_DASHBOARD_ARRAY+=("$OPTARG")
+		;;
+	c)
+		GRAFANA_ENV_ARRAY+=("$OPTARG")
+		;;
+	C)
+		ALERTMANAGER_COMMANDS+=("$OPTARG")
+		;;
+	D)
+		DOCKER_PARAM="$DOCKER_PARAM    $OPTARG\n"
+		;;
+	b)
+		PROMETHEUS_COMMAND_LINE_OPTIONS_ARRAY+=("$OPTARG")
+		;;
+	N)
+		SCYLLA_MANGER_TARGET_FILES=($OPTARG)
+		;;
+	S)
+		SPECIFIC_SOLUTION="-S $OPTARG"
+		;;
+	E)
+		RUN_RENDERER="-E"
+		;;
+	f)
+		ALERT_MANAGER_DIR=($(set_path $OPTARG):/alertmanager/data:z)
+		;;
+	k)
+		LOKI_DIR=$(set_path $OPTARG)
+		if [ ! -d $LOKI_DIR ]; then
+			mkdir -p $LOKI_DIR
+		fi
+		LOKI_DIR="- $LOKI_DIR:/tmp/loki:z"
+		;;
+	:)
+		printf "missing argument for -%s\n" "$OPTARG" >&2
+		echo "$usage" >&2
+		exit 1
+		;;
+	\?)
+		printf "illegal option: -%s\n" "$OPTARG" >&2
+		echo "$usage" >&2
+		exit 1
+		;;
+	esac
 done
 
 if [ -z "$VERSIONS" ]; then
-  echo "Scylla-version was not not found, add the -v command-line with a specific version (i.e. -v 2021.1)"
-  exit 1
+	echo "Scylla-version was not not found, add the -v command-line with a specific version (i.e. -v 2021.1)"
+	exit 1
 fi
 
 if [[ $DOCKER_PARAM = *"network_mode: host"* ]]; then
-    if [ ! -z "$ALERTMANAGER_PORT" ] || [ ! -z "$GRAFANA_PORT" ] || [ ! -z $PROMETHEUS_PORT ]; then
-        echo "Port mapping is not supported with host network, remove the -l flag from the command line"
-        exit 1
-    fi
-    HOST_NETWORK=1
+	if [ ! -z "$ALERTMANAGER_PORT" ] || [ ! -z "$GRAFANA_PORT" ] || [ ! -z $PROMETHEUS_PORT ]; then
+		echo "Port mapping is not supported with host network, remove the -l flag from the command line"
+		exit 1
+	fi
+	HOST_NETWORK=1
 fi
 
 if [ -z "$TARGET_DIRECTORY" ] && [ -z "$CONSUL_ADDRESS" ]; then
-    for f in ${SCYLLA_TARGET_FILES[@]}; do
-        if [ -f $f ]; then
-            SCYLLA_TARGET_FILE=$f
-            break
-        fi
-    done
+	for f in ${SCYLLA_TARGET_FILES[@]}; do
+		if [ -f $f ]; then
+			SCYLLA_TARGET_FILE=$f
+			break
+		fi
+	done
 
-    if [ -z $SCYLLA_TARGET_FILE ]; then
-        echo "Scylla target file '${SCYLLA_TARGET_FILES}' does not exist, you can use prometheus/scylla_servers.example.yml as an example."
-        exit 1
-    fi
+	if [ -z $SCYLLA_TARGET_FILE ]; then
+		echo "Scylla target file '${SCYLLA_TARGET_FILES}' does not exist, you can use prometheus/scylla_servers.example.yml as an example."
+		exit 1
+	fi
 
-    if [ -z $NODE_TARGET_FILE ]; then
-       PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-node-exporter-file"
-       NODE_TARGET_FILE=$SCYLLA_TARGET_FILE
-    fi
+	if [ -z $NODE_TARGET_FILE ]; then
+		PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-node-exporter-file"
+		NODE_TARGET_FILE=$SCYLLA_TARGET_FILE
+	fi
 
-    if [ -z $SCYLLA_MANGER_AGENT_TARGET_FILE ]; then
-       PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-manager-agent-file"
-       SCYLLA_MANGER_AGENT_TARGET_FILE=$SCYLLA_TARGET_FILE
-    fi
-    if [ ! -f $NODE_TARGET_FILE ]; then
-        echo "Node target file '${NODE_TARGET_FILE}' does not exist"
-        exit 1
-    fi
+	if [ -z $SCYLLA_MANGER_AGENT_TARGET_FILE ]; then
+		PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-manager-agent-file"
+		SCYLLA_MANGER_AGENT_TARGET_FILE=$SCYLLA_TARGET_FILE
+	fi
+	if [ ! -f $NODE_TARGET_FILE ]; then
+		echo "Node target file '${NODE_TARGET_FILE}' does not exist"
+		exit 1
+	fi
 
-    for f in ${SCYLLA_MANGER_TARGET_FILES[@]}; do
-        if [ -f $f ]; then
-            SCYLLA_MANGER_TARGET_FILE=$f
-            break
-        fi
-    done
-    if [ -z $SCYLLA_MANGER_TARGET_FILE ]; then
-        echo "Scylla-Manager target file '${SCYLLA_MANGER_TARGET_FILES}' does not exist, you can use prometheus/scylla_manager_servers.example.yml as an example."
-        exit 1
-    fi
-    if [ -z "$HOST_NETWORK" ]; then
-        if  is_local $SCYLLA_TARGET_FILE $SCYLLA_MANGER_TARGET_FILE $NODE_TARGET_FILE; then
-            echo "Warning: It seems that you are trying to connect to localhost (either localhost or IP on the 127.x.x.x range)."
-            echo "  For example, maybe Scylla Manager is running on the localhost."
-            echo "If that is the case, you should set your Docker to use the host network. You can do that with the -l flag."
-            echo ""
-        fi
-    fi
-    SCYLLA_TARGET_FILE=$(set_path $SCYLLA_TARGET_FILE):/etc/scylla.d/prometheus/targets/scylla_servers.yml
-    SCYLLA_MANGER_TARGET_FILE=$(set_path $SCYLLA_MANGER_TARGET_FILE):/etc/scylla.d/prometheus/targets/scylla_manager_servers.yml
-    NODE_TARGET_FILE=$(set_path $NODE_TARGET_FILE)":/etc/scylla.d/prometheus/targets/node_exporter_servers.yml"
-    SCYLLA_MANGER_AGENT_TARGET_FILE=$(set_path $SCYLLA_MANGER_AGENT_TARGET_FILE)":/etc/scylla.d/prometheus/targets/scylla_manager_agents.yml"
+	for f in ${SCYLLA_MANGER_TARGET_FILES[@]}; do
+		if [ -f $f ]; then
+			SCYLLA_MANGER_TARGET_FILE=$f
+			break
+		fi
+	done
+	if [ -z $SCYLLA_MANGER_TARGET_FILE ]; then
+		echo "Scylla-Manager target file '${SCYLLA_MANGER_TARGET_FILES}' does not exist, you can use prometheus/scylla_manager_servers.example.yml as an example."
+		exit 1
+	fi
+	if [ -z "$HOST_NETWORK" ]; then
+		if is_local $SCYLLA_TARGET_FILE $SCYLLA_MANGER_TARGET_FILE $NODE_TARGET_FILE; then
+			echo "Warning: It seems that you are trying to connect to localhost (either localhost or IP on the 127.x.x.x range)."
+			echo "  For example, maybe Scylla Manager is running on the localhost."
+			echo "If that is the case, you should set your Docker to use the host network. You can do that with the -l flag."
+			echo ""
+		fi
+	fi
+	SCYLLA_TARGET_FILE=$(set_path $SCYLLA_TARGET_FILE):/etc/scylla.d/prometheus/targets/scylla_servers.yml
+	SCYLLA_MANGER_TARGET_FILE=$(set_path $SCYLLA_MANGER_TARGET_FILE):/etc/scylla.d/prometheus/targets/scylla_manager_servers.yml
+	NODE_TARGET_FILE=$(set_path $NODE_TARGET_FILE)":/etc/scylla.d/prometheus/targets/node_exporter_servers.yml"
+	SCYLLA_MANGER_AGENT_TARGET_FILE=$(set_path $SCYLLA_MANGER_AGENT_TARGET_FILE)":/etc/scylla.d/prometheus/targets/scylla_manager_agents.yml"
 else
-    SCYLLA_TARGET_FILE=""
-    SCYLLA_MANGER_TARGET_FILE=""
-    SCYLLA_MANGER_AGENT_TARGET_FILE=""
-    NODE_TARGET_FILE=""
+	SCYLLA_TARGET_FILE=""
+	SCYLLA_MANGER_TARGET_FILE=""
+	SCYLLA_MANGER_AGENT_TARGET_FILE=""
+	NODE_TARGET_FILE=""
 fi
 
 if [ "$TARGET_DIRECTORY" != "" ]; then
-    SCYLLA_TARGET_FILE=$(set_path $TARGET_DIRECTORY)":/etc/scylla.d/prometheus/targets/"
+	SCYLLA_TARGET_FILE=$(set_path $TARGET_DIRECTORY)":/etc/scylla.d/prometheus/targets/"
 fi
-if [ -z $DATA_DIR ]
-then
-    PROMETHEUS_USER_PERMISSIONS=""
-    echo "Warning: without an external Prometheus directory, Prometheus data will be deleted on shutdown, use the -d command line flag for data persistence."
+if [ -z $DATA_DIR ]; then
+	PROMETHEUS_USER_PERMISSIONS=""
+	echo "Warning: without an external Prometheus directory, Prometheus data will be deleted on shutdown, use the -d command line flag for data persistence."
 else
-    if [ -d $DATA_DIR ]; then
-        echo "Loading prometheus data from $DATA_DIR"
-    else
-        echo "Creating data directory $DATA_DIR"
-        mkdir -p $DATA_DIR
-    fi
-    if [[ "$VICTORIA_METRICS" = "1" ]]; then
-    	PROMETHEUS_PROMETHEUS_VOLUMES_ARRAY+=($(set_path $DATA_DIR)":/victoria-metrics-data")
-    else
-        PROMETHEUS_PROMETHEUS_VOLUMES_ARRAY+=($(set_path $DATA_DIR)":/prometheus/data:Z")
-    fi
+	if [ -d $DATA_DIR ]; then
+		echo "Loading prometheus data from $DATA_DIR"
+	else
+		echo "Creating data directory $DATA_DIR"
+		mkdir -p $DATA_DIR
+	fi
+	if [[ "$VICTORIA_METRICS" = "1" ]]; then
+		PROMETHEUS_PROMETHEUS_VOLUMES_ARRAY+=($(set_path $DATA_DIR)":/victoria-metrics-data")
+	else
+		PROMETHEUS_PROMETHEUS_VOLUMES_ARRAY+=($(set_path $DATA_DIR)":/prometheus/data:Z")
+	fi
 fi
 
-if (( ${#ALERTMANAGER_COMMANDS[@]} )); then
-    ALERTMANAGER_COMMAND="    command:\n"`add_param "${ALERTMANAGER_COMMANDS[@]}"`
+if ((${#ALERTMANAGER_COMMANDS[@]})); then
+	ALERTMANAGER_COMMAND="    command:\n"$(add_param "${ALERTMANAGER_COMMANDS[@]}")
 fi
 
 if [ -z $PROMETHEUS_PORT ]; then
-    PROMETHEUS_PORT=9090
+	PROMETHEUS_PORT=9090
 fi
 if [ -z $ALERTMANAGER_PORT ]; then
-    ALERTMANAGER_PORT=9093
+	ALERTMANAGER_PORT=9093
 fi
 if [ -z $GRAFANA_PORT ]; then
-    GRAFANA_PORT=3000
+	GRAFANA_PORT=3000
 fi
 if [ -z $ANALYTICS_REPORTING_ENABLED ]; then
 	ANALYTICS_REPORTING_ENABLED="false"
@@ -547,8 +586,8 @@ fi
 DATA_SOURCES="-p aprom:$PROMETHEUS_PORT -m $ALERTMANAGER_ADDRESS -L loki:$LOKI_PORT"
 ALERTMANAGER_ADDRESS="aalert:$ALERTMANAGER_PORT"
 if [[ "$HOST_NETWORK" = "1" ]]; then
-    ALERTMANAGER_ADDRESS="127.0.0.1:$ALERTMANAGER_PORT"
-    DATA_SOURCES="-p 127.0.0.1:$PROMETHEUS_PORT -m $ALERTMANAGER_ADDRESS -L 127.0.0.1:$LOKI_PORT"
+	ALERTMANAGER_ADDRESS="127.0.0.1:$ALERTMANAGER_PORT"
+	DATA_SOURCES="-p 127.0.0.1:$PROMETHEUS_PORT -m $ALERTMANAGER_ADDRESS -L 127.0.0.1:$LOKI_PORT"
 fi
 
 if [[ ! -d $LOKI_WALL_DIR ]]; then
@@ -558,57 +597,57 @@ fi
 if [ -z $ALERT_MANAGER_RULE_CONFIG ]; then
 	ALERT_MANAGER_RULE_CONFIG=./prometheus/rule_config.yml
 fi
-cat docker-compose.template.yml > docker-compose.yml
-echo "" > .env
-echo "PROMETHEUS_VERSION=$PROMETHEUS_VERSION" >> .env
-echo "ALERT_MANAGER_VERSION=$ALERT_MANAGER_VERSION" >> .env
-echo "GRAFANA_VERSION=$GRAFANA_VERSION" >> .env
-echo "LOKI_VERSION=$LOKI_VERSION" >> .env
-echo "GRAFANA_RENDERER_VERSION=$GRAFANA_RENDERER_VERSION" >> .env
-echo "THANOS_VERSION=$THANOS_VERSION" >> .env
-echo "VICTORIA_METRICS_VERSION=$VICTORIA_METRICS_VERSION" >> .env
-echo "GF_AUTH_BASIC_ENABLED=$GF_AUTH_BASIC_ENABLED" >> .env
-echo "GF_AUTH_ANONYMOUS_ENABLED=$GF_AUTH_ANONYMOUS_ENABLED" >> .env
-echo "GF_AUTH_ANONYMOUS_ORG_ROLE=$GF_AUTH_ANONYMOUS_ORG_ROLE" >> .env
-echo "GF_SECURITY_ADMIN_PASSWORD=$GF_SECURITY_ADMIN_PASSWORD" >> .env
-echo "GF_ANALYTICS_REPORTING_ENABLED=$ANALYTICS_REPORTING_ENABLED" >> .env
-echo "GF_ANALYTICS_CHECK_FOR_UPDATES=$ANALYTICS_CHECK_FOR_UPDATES" >> .env
-echo "GF_ANALYTICS_CHECK_FOR_PLUGIN_UPDATES=$ANALYTICS_CHECK_FOR_PLUGIN_UPDATES" >> .env
-echo "GF_SECURITY_ANGULAR_SUPPORT_ENABLED=$SECURITY_ANGULAR_SUPPORT_ENABLED" >> .env
-echo "GF_SERVER_ENABLE_GZIP=$SERVER_ENABLE_GZIP" >> .env
-echo "SCYLLA_VERSION=$VERSIONS" >> .env
-echo "ALERTMANAGER_PORT=$ALERTMANAGER_PORT" >> .env
-echo "GRAFANA_PORT=$GRAFANA_PORT" >> .env
-echo "PROMETHEUS_PORT=$PROMETHEUS_PORT" >> .env
-echo "ALERT_MANAGER_RULE_CONFIG=$ALERT_MANAGER_RULE_CONFIG" >> .env
-echo "PROMETHEUS_RULES=$PROMETHEUS_RULES">> .env
-echo "BIND_ADDRESS=$BIND_ADDRESS">> .env
-echo "SCYLLA_TARGET_FILE=$SCYLLA_TARGET_FILE">> .env
-echo "SCYLLA_MANGER_TARGET_FILE=$SCYLLA_MANGER_TARGET_FILE">> .env
-echo "SCYLLA_MANGER_AGENT_TARGET_FILE=$SCYLLA_MANGER_AGENT_TARGET_FILE">> .env
-echo "NODE_TARGET_FILE=$NODE_TARGET_FILE">> .env
-echo "LOKI_RULE_DIR=$LOKI_RULE_DIR">> .env
-echo "LOKI_CONF_DIR=$LOKI_CONF_DIR">> .env
-echo "LOKI_DIR=$LOKI_DIR">> .env
-echo "LOKI_PORT=$LOKI_PORT">> .env
-echo "LOKI_WALL_DIR=$LOKI_WALL_DIR">> .env
+cat docker-compose.template.yml >docker-compose.yml
+echo "" >.env
+echo "PROMETHEUS_VERSION=$PROMETHEUS_VERSION" >>.env
+echo "ALERT_MANAGER_VERSION=$ALERT_MANAGER_VERSION" >>.env
+echo "GRAFANA_VERSION=$GRAFANA_VERSION" >>.env
+echo "LOKI_VERSION=$LOKI_VERSION" >>.env
+echo "GRAFANA_RENDERER_VERSION=$GRAFANA_RENDERER_VERSION" >>.env
+echo "THANOS_VERSION=$THANOS_VERSION" >>.env
+echo "VICTORIA_METRICS_VERSION=$VICTORIA_METRICS_VERSION" >>.env
+echo "GF_AUTH_BASIC_ENABLED=$GF_AUTH_BASIC_ENABLED" >>.env
+echo "GF_AUTH_ANONYMOUS_ENABLED=$GF_AUTH_ANONYMOUS_ENABLED" >>.env
+echo "GF_AUTH_ANONYMOUS_ORG_ROLE=$GF_AUTH_ANONYMOUS_ORG_ROLE" >>.env
+echo "GF_SECURITY_ADMIN_PASSWORD=$GF_SECURITY_ADMIN_PASSWORD" >>.env
+echo "GF_ANALYTICS_REPORTING_ENABLED=$ANALYTICS_REPORTING_ENABLED" >>.env
+echo "GF_ANALYTICS_CHECK_FOR_UPDATES=$ANALYTICS_CHECK_FOR_UPDATES" >>.env
+echo "GF_ANALYTICS_CHECK_FOR_PLUGIN_UPDATES=$ANALYTICS_CHECK_FOR_PLUGIN_UPDATES" >>.env
+echo "GF_SECURITY_ANGULAR_SUPPORT_ENABLED=$SECURITY_ANGULAR_SUPPORT_ENABLED" >>.env
+echo "GF_SERVER_ENABLE_GZIP=$SERVER_ENABLE_GZIP" >>.env
+echo "SCYLLA_VERSION=$VERSIONS" >>.env
+echo "ALERTMANAGER_PORT=$ALERTMANAGER_PORT" >>.env
+echo "GRAFANA_PORT=$GRAFANA_PORT" >>.env
+echo "PROMETHEUS_PORT=$PROMETHEUS_PORT" >>.env
+echo "ALERT_MANAGER_RULE_CONFIG=$ALERT_MANAGER_RULE_CONFIG" >>.env
+echo "PROMETHEUS_RULES=$PROMETHEUS_RULES" >>.env
+echo "BIND_ADDRESS=$BIND_ADDRESS" >>.env
+echo "SCYLLA_TARGET_FILE=$SCYLLA_TARGET_FILE" >>.env
+echo "SCYLLA_MANGER_TARGET_FILE=$SCYLLA_MANGER_TARGET_FILE" >>.env
+echo "SCYLLA_MANGER_AGENT_TARGET_FILE=$SCYLLA_MANGER_AGENT_TARGET_FILE" >>.env
+echo "NODE_TARGET_FILE=$NODE_TARGET_FILE" >>.env
+echo "LOKI_RULE_DIR=$LOKI_RULE_DIR" >>.env
+echo "LOKI_CONF_DIR=$LOKI_CONF_DIR" >>.env
+echo "LOKI_DIR=$LOKI_DIR" >>.env
+echo "LOKI_PORT=$LOKI_PORT" >>.env
+echo "LOKI_WALL_DIR=$LOKI_WALL_DIR" >>.env
 if [ "$VICTORIA_METRICS" = "1" ]; then
 	sed -i 's&prom/prometheus:${PROMETHEUS_VERSION}&victoriametrics/victoria-metrics:${VICTORIA_METRICS_VERSION}&' docker-compose.yml
 	sed -i 's&./prometheus/build/prometheus.yml:/etc/prometheus/prometheus.yml&./prometheus/build/prometheus.yml:/etc/promscrape.config.yml:z&' docker-compose.yml
-	PROMETHEUS_COMMAND_LINE_OPTIONS_ARRAY+=( -promscrape.config=/etc/promscrape.config.yml -promscrape.config.strictParse=false -httpListenAddr=:9090)
+	PROMETHEUS_COMMAND_LINE_OPTIONS_ARRAY+=(-promscrape.config=/etc/promscrape.config.yml -promscrape.config.strictParse=false -httpListenAddr=:9090)
 else
 	PROMETHEUS_COMMAND_LINE_OPTIONS_ARRAY+=(--config.file=/etc/prometheus/prometheus.yml --web.enable-lifecycle)
 fi
 PROMETHEUS_COMMAND_LINE=""
-if (( ${#PROMETHEUS_COMMAND_LINE_OPTIONS_ARRAY[@]} )); then
-    PROMETHEUS_COMMAND_LINE="    command:\n"`add_param "${PROMETHEUS_COMMAND_LINE_OPTIONS_ARRAY[@]}"`
+if ((${#PROMETHEUS_COMMAND_LINE_OPTIONS_ARRAY[@]})); then
+	PROMETHEUS_COMMAND_LINE="    command:\n"$(add_param "${PROMETHEUS_COMMAND_LINE_OPTIONS_ARRAY[@]}")
 fi
 
 sed -i "s& *#PROMETHEUS_COMMAND_LINE&$PROMETHEUS_COMMAND_LINE&" docker-compose.yml
-val=`add_param "${PROMETHEUS_PROMETHEUS_VOLUMES_ARRAY[@]}"`
+val=$(add_param "${PROMETHEUS_PROMETHEUS_VOLUMES_ARRAY[@]}")
 sed -i "s& *#PROMETHEUS_VOLUMES&$val&" docker-compose.yml
 
-val=`add_param "${GRAFANA_ENV_ARRAY[@]}"`
+val=$(add_param "${GRAFANA_ENV_ARRAY[@]}")
 sed -i "s& *#GRAFANA_ENV&$val&" docker-compose.yml
 
 sed -i "s& *#GENERAL_DOCER_CONFIG&$DOCKER_PARAM&" docker-compose.yml
@@ -620,7 +659,7 @@ sed -i "s&#LOKi_USER_PERMISSIONS&$LOKi_USER_PERMISSIONS&" docker-compose.yml
 
 ./prometheus-config.sh -m $ALERTMANAGER_ADDRESS $CONSUL_ADDRESS $PROMETHEUS_TARGETS
 for val in "${GRAFANA_DASHBOARD_ARRAY[@]}"; do
-        GRAFANA_DASHBOARD_COMMAND="$GRAFANA_DASHBOARD_COMMAND -j $val"
+	GRAFANA_DASHBOARD_COMMAND="$GRAFANA_DASHBOARD_COMMAND -j $val"
 done
 ./generate-dashboards.sh -t $SPECIFIC_SOLUTION -v $VERSIONS -M $MANAGER_VERSION $GRAFANA_DASHBOARD_COMMAND
 

--- a/packer/files/add_centos_user.sh
+++ b/packer/files/add_centos_user.sh
@@ -1,31 +1,31 @@
 #!/usr/bin/bash
 print_usage() {
-    echo "add_centos_user.sh [--os centos/ubuntu] [--copy]"
-    exit 1
+	echo "add_centos_user.sh [--os centos/ubuntu] [--copy]"
+	exit 1
 }
 OS="centos"
 COPY=""
 while [ $# -gt 0 ]; do
-    case "$1" in
-        "--os")
-            OS="$2"
-            shift 2
-            ;;
-        "--copy")
-            COPY="1"
-            shift 1
-            ;;
-        *)
-            print_usage
-            ;;
-    esac
+	case "$1" in
+	"--os")
+		OS="$2"
+		shift 2
+		;;
+	"--copy")
+		COPY="1"
+		shift 1
+		;;
+	*)
+		print_usage
+		;;
+	esac
 done
 
 if [ "$OS" = "ubuntu" ]; then
-    sudo useradd -m -s $(which bash) -G sudo -G docker centos
-    echo "centos ALL=(ALL) NOPASSWD:ALL" |sudo tee -a  /etc/sudoers.d/100-cloud-cntos-user > /dev/null
-    if [ "$COPY" = "1" ]; then
-        sudo cp -r  /home/ubuntu/scylla-grafana-monitoring-scylla-monitoring /home/centos/
-    fi
-    sudo chown -R centos:centos /home/centos
+	sudo useradd -m -s $(which bash) -G sudo -G docker centos
+	echo "centos ALL=(ALL) NOPASSWD:ALL" | sudo tee -a /etc/sudoers.d/100-cloud-cntos-user >/dev/null
+	if [ "$COPY" = "1" ]; then
+		sudo cp -r /home/ubuntu/scylla-grafana-monitoring-scylla-monitoring /home/centos/
+	fi
+	sudo chown -R centos:centos /home/centos
 fi

--- a/packer/files/conf-from-user.py
+++ b/packer/files/conf-from-user.py
@@ -3,12 +3,10 @@
 import urllib.request
 import json
 import subprocess
-import shutil
 import shlex
 import yaml
 import argparse
 import email
-from pathlib import Path
 
 HOME_DIR='/home/centos/'
 USER='centos'
@@ -100,7 +98,7 @@ def getVersions(version):
 
 def mk_servers(obj):
     with open(HOME_DIR + 'scylla-grafana-monitoring-scylla-monitoring/prometheus/scylla_servers.yml', 'w') as f:
-        documents = yaml.dump(obj, f)
+        yaml.dump(obj, f)
 
 def getDataDir(data):
     if 'prometheus_data' in data:
@@ -116,7 +114,7 @@ def mk_env(data):
 def setupStartAll(data):
     try:
         run('sudo -u {_USER} cp {_HOME}/scylla-grafana-monitoring-scylla-monitoring/prometheus/rule_config.original.yml {_HOME}/scylla-grafana-monitoring-scylla-monitoring/prometheus/rule_config.yml')
-    except Exception as e:
+    except Exception:
         print("Error while running:")
     if 'env' in data: 
         mk_env(data['env']['obj'])
@@ -136,18 +134,19 @@ def add_dashboard(scylla_monitoring, data):
                 if 'name' in dashboard and dashboard['name'] in data:
                     f.write(data[dashboard['name']]['payload'])
 
-parser = argparse.ArgumentParser(description='Setup Scylla Monitoring from userdata', conflict_handler="resolve")
-parser.add_argument('-u', '--user', default="centos", help='The username that is being used')
-parser.add_argument('-c', '--cloud', default="aws", help='The cloud to connect to (aws/gcp)')
-parser.add_argument('-a', '--address', default="", help='If set uses the provided address to fetch the data from')
-args = parser.parse_args()
-data = getData(args)
-USER = args.user
-HOME_DIR='/home/' + USER + '/'
-if "scylla-monitoring" not in data or "version" not in data["scylla-monitoring"]['obj']:
-    exit(0)
-scylla_monitoring = data["scylla-monitoring"]['obj']
-setupStartAll(data)
-generate_dashboard(scylla_monitoring)
-add_dashboard(scylla_monitoring, data)
-run('sudo -u {_USER} ./start-all.sh')
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Setup Scylla Monitoring from userdata', conflict_handler="resolve")
+    parser.add_argument('-u', '--user', default="centos", help='The username that is being used')
+    parser.add_argument('-c', '--cloud', default="aws", help='The cloud to connect to (aws/gcp)')
+    parser.add_argument('-a', '--address', default="", help='If set uses the provided address to fetch the data from')
+    args = parser.parse_args()
+    data = getData(args)
+    USER = args.user
+    HOME_DIR='/home/' + USER + '/'
+    if "scylla-monitoring" not in data or "version" not in data["scylla-monitoring"]['obj']:
+        exit(0)
+    scylla_monitoring = data["scylla-monitoring"]['obj']
+    setupStartAll(data)
+    generate_dashboard(scylla_monitoring)
+    add_dashboard(scylla_monitoring, data)
+    run('sudo -u {_USER} ./start-all.sh')

--- a/packer/files/env.sh
+++ b/packer/files/env.sh
@@ -1,2 +1,1 @@
 RUN_THANOS_SC=1
-

--- a/packer/files/node_exporter_install
+++ b/packer/files/node_exporter_install
@@ -22,7 +22,6 @@
 
 import os
 import sys
-import tempfile
 import tarfile
 from scylla_util import *
 import argparse
@@ -45,8 +44,8 @@ if __name__ == '__main__':
             try:
                 node_exporter = systemd_unit('node-exporter.service')
                 node_exporter.stop()
-            except:
-                pass
+            except Exception as e:
+                print("could not create node-exporter.service file", e)
         else:
             print('node_exporter already installed, you can use `--force` to force reinstallation')
             sys.exit(1)

--- a/packer/files/scylla_monitoring_install_ami
+++ b/packer/files/scylla_monitoring_install_ami
@@ -21,14 +21,9 @@
 
 import os
 import sys
-import glob
-import re
-import shutil
 import shlex
-import tarfile
 import argparse
 import subprocess
-from pathlib import Path
 HOME_DIR='/home/centos/'
 USER='centos'
 COPY_OR_MOVE='mv'
@@ -43,7 +38,7 @@ def install_pip_dep():
     run('pip3 install traceback-with-variables')
 
 def get_swap_scripts():
-    with open("{_HOME}/scylla_product.py".format(_HOME=HOME_DIR, _USER=USER), "w") as f:
+    with open("{_HOME}/scylla_product.py".format(_HOME=HOME_DIR, ), "w") as f:
         f.write('PRODUCT="scylla-monitoring"')
     run('chown {_USER}:{_USER} {_HOME}/scylla_product.py')
 
@@ -101,7 +96,7 @@ def install_docker():
         run('add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable"')
         run('apt-cache policy docker-ce')
         run('apt install -y docker-ce')
-    run('usermod -aG docker {_USER}'.format(_HOME=HOME_DIR, _USER=USER))
+    run('usermod -aG docker {_USER}'.format(_USER=USER))
     run('systemctl enable docker')
     run('systemctl start docker')
 
@@ -126,9 +121,9 @@ def install_monitoring(version):
     run('sudo -u {_USER} {_COPY_OR_MOVE} {_HOME}/{NAME} {_HOME}/scylla-grafana-monitoring-scylla-monitoring'.format(NAME=name, _HOME=HOME_DIR, _USER=USER, _COPY_OR_MOVE=COPY_OR_MOVE))
 
 def run_monitoring():
-    if os.path.exists('{_HOME}/scylla-grafana-monitoring-scylla-monitoring/prometheus/scylla_servers.example.yml'.format(_HOME=HOME_DIR, _USER=USER)):
+    if os.path.exists('{_HOME}/scylla-grafana-monitoring-scylla-monitoring/prometheus/scylla_servers.example.yml'.format(_HOME=HOME_DIR, )):
         run('sudo -u {_USER} cp {_HOME}/scylla-grafana-monitoring-scylla-monitoring/prometheus/scylla_servers.example.yml {_HOME}/scylla-grafana-monitoring-scylla-monitoring/prometheus/scylla_servers.yml')
-    if os.path.exists('{_HOME}/scylla-grafana-monitoring-scylla-monitoring/prometheus/scylla_manager_servers.example.yml'.format(_HOME=HOME_DIR, _USER=USER)):
+    if os.path.exists('{_HOME}/scylla-grafana-monitoring-scylla-monitoring/prometheus/scylla_manager_servers.example.yml'.format(_HOME=HOME_DIR, )):
         run('sudo -u {_USER} cp {_HOME}/scylla-grafana-monitoring-scylla-monitoring/prometheus/scylla_manager_servers.example.yml {_HOME}/scylla-grafana-monitoring-scylla-monitoring/prometheus/scylla_manager_servers.yml')
     run('sudo -u {_USER} mkdir -p {_HOME}/scylla-grafana-monitoring-scylla-monitoring/data')
     chdir('{_HOME}/scylla-grafana-monitoring-scylla-monitoring/')
@@ -154,7 +149,7 @@ def install_dbaas(version):
     run('sudo -u {_USER} cp  {_HOME}/scylla-centralized.template.json {_HOME}/scylla-grafana-monitoring-scylla-monitoring/grafana/')
     run('sudo -u {_USER} cp {_HOME}/prometheus.dbaas.yml.template {_HOME}/scylla-grafana-monitoring-scylla-monitoring/prometheus/')
     chdir('{_HOME}/scylla-grafana-monitoring-scylla-monitoring/')
-    run('sudo -u {_USER} ./generate-dashboards.sh -F -v master'.format(VERSION="master", _USER=USER))
+    run('sudo -u {_USER} ./generate-dashboards.sh -F -v master'.format(_USER=USER))
     run_monitoring()
 
 def install_node_exporter():

--- a/packer/files/scylla_swap_setup
+++ b/packer/files/scylla_swap_setup
@@ -21,11 +21,7 @@
 
 import os
 import sys
-import glob
-import re
-import shutil
 import shlex
-import tarfile
 import argparse
 import subprocess
 

--- a/packer/files/scylla_util
+++ b/packer/files/scylla_util
@@ -3,12 +3,9 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 import configparser
-import glob
 import io
 import os
 import re
-import shlex
-import shutil
 import subprocess
 import yaml
 import sys
@@ -17,9 +14,7 @@ from subprocess import run, DEVNULL
 
 import distro
 from scylla_sysconfdir import SYSCONFDIR
-from scylla_product import PRODUCT
 
-from multiprocessing import cpu_count
 
 import traceback
 import traceback_with_variables

--- a/packer/files/scylla_util.py
+++ b/packer/files/scylla_util.py
@@ -3,15 +3,13 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 import configparser
-import glob
 import io
 import os
 import re
-import shlex
-import shutil
 import subprocess
 import yaml
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -20,9 +18,7 @@ from subprocess import run, DEVNULL
 
 import distro
 from scylla_sysconfdir import SYSCONFDIR
-from scylla_product import PRODUCT
 
-from multiprocessing import cpu_count
 
 import traceback
 import traceback_with_variables

--- a/prometheus-config.sh
+++ b/prometheus-config.sh
@@ -3,122 +3,132 @@ usage="$(basename "$0") [-h] [-m alert_manager address]  [-L] [-T additional-pro
 CONSUL_ADDRESS=""
 COMPOSE=0
 BASE_DIR="$PWD/prometheus/build"
-if [ -f  env.sh ]; then
-    . env.sh
+if [ -f env.sh ]; then
+	. env.sh
 fi
 
 if [ "$1" = "" ]; then
-    echo "$usage"
-    exit
+	echo "$usage"
+	exit
 fi
 for arg; do
-    shift
-    if [ -z "$PARAM" ]; then
-        case $arg in
-            (--compose) COMPOSE=1
-                AM_ADDRESS="aalert:9093"
-                ;;
-            (--no-cas-cdc)
-                NO_CAS="1"
-                NO_CDC="1"
-                ;;
-            (--no-cas)
-                NO_CAS="1"
-                ;;
-            (--no-cdc)
-                NO_CDC="1"
-                ;;
-            (--scrap)
-                PARAM="scrap"
-                ;;
-            (--no-node-exporter-file)
-                NO_NODE_EXPORTER_FILE="1"
-                ;;
-            (--no-manager-agent-file)
-                NO_MANAGER_AGENT_FILE="1"
-                ;;
-            (*) set -- "$@" "$arg"
-                ;;
-        esac
-    else
-        DOCR=`echo $arg|cut -d',' -f1`
-        VALUE=`echo $arg|cut -d',' -f2-|sed 's/#/ /g'`
-        NOSPACE=`echo $arg|sed 's/ /#/g'`
-        if [[ $NOSPACE == --* ]]; then
-            echo "Error: No value given to --$PARAM"
-            echo
-            usage
-            exit 1
-        fi
-        if [ "$PARAM" = "scrap" ]; then
-            SCRAP_INTERVAL="$NOSPACE"
-        fi
-        unset PARAM
-    fi
+	shift
+	if [ -z "$PARAM" ]; then
+		case $arg in
+		--compose)
+			COMPOSE=1
+			AM_ADDRESS="aalert:9093"
+			;;
+		--no-cas-cdc)
+			NO_CAS="1"
+			NO_CDC="1"
+			;;
+		--no-cas)
+			NO_CAS="1"
+			;;
+		--no-cdc)
+			NO_CDC="1"
+			;;
+		--scrap)
+			PARAM="scrap"
+			;;
+		--no-node-exporter-file)
+			NO_NODE_EXPORTER_FILE="1"
+			;;
+		--no-manager-agent-file)
+			NO_MANAGER_AGENT_FILE="1"
+			;;
+		*)
+			set -- "$@" "$arg"
+			;;
+		esac
+	else
+		DOCR=$(echo $arg | cut -d',' -f1)
+		VALUE=$(echo $arg | cut -d',' -f2- | sed 's/#/ /g')
+		NOSPACE=$(echo $arg | sed 's/ /#/g')
+		if [[ $NOSPACE == --* ]]; then
+			echo "Error: No value given to --$PARAM"
+			echo
+			usage
+			exit 1
+		fi
+		if [ "$PARAM" = "scrap" ]; then
+			SCRAP_INTERVAL="$NOSPACE"
+		fi
+		unset PARAM
+	fi
 done
 
 while getopts ':hL:m:T:E:s:' option; do
-  case "$option" in
-    h) echo "$usage"
-       exit
-       ;;
-    L) CONSUL_ADDRESS="$OPTARG"
-       ;;
-    T) PROMETHEUS_TARGETS+=("$OPTARG")
-       ;;
-    m) AM_ADDRESS="$OPTARG"
-       ;;
-    s) BASE_DIR="$PWD/prometheus/build/stack/$OPTARG"
-       ;;
-    E) EVALUATION_INTERVAL="$OPTARG"
-       ;;
-    :) printf "missing argument for -%s\n" "$OPTARG" >&2
-       echo "$usage" >&2
-       exit 1
-       ;;
-   \?) printf "illegal option: -%s\n" "$OPTARG" >&2
-       echo "$usage" >&2
-       exit 1
-       ;;
-  esac
+	case "$option" in
+	h)
+		echo "$usage"
+		exit
+		;;
+	L)
+		CONSUL_ADDRESS="$OPTARG"
+		;;
+	T)
+		PROMETHEUS_TARGETS+=("$OPTARG")
+		;;
+	m)
+		AM_ADDRESS="$OPTARG"
+		;;
+	s)
+		BASE_DIR="$PWD/prometheus/build/stack/$OPTARG"
+		;;
+	E)
+		EVALUATION_INTERVAL="$OPTARG"
+		;;
+	:)
+		printf "missing argument for -%s\n" "$OPTARG" >&2
+		echo "$usage" >&2
+		exit 1
+		;;
+	\?)
+		printf "illegal option: -%s\n" "$OPTARG" >&2
+		echo "$usage" >&2
+		exit 1
+		;;
+	esac
 done
 
 mkdir -p $BASE_DIR/
 if [ -z $CONSUL_ADDRESS ]; then
-    sed "s/AM_ADDRESS/$AM_ADDRESS/" $PWD/prometheus/prometheus.yml.template > $BASE_DIR/prometheus.yml
+	sed "s/AM_ADDRESS/$AM_ADDRESS/" $PWD/prometheus/prometheus.yml.template >$BASE_DIR/prometheus.yml
 else
-    if [[ ! $CONSUL_ADDRESS = *":"* ]]; then
-        CONSUL_ADDRESS="$CONSUL_ADDRESS:5090"
-    fi
-    sed "s/AM_ADDRESS/$AM_ADDRESS/" $PWD/prometheus/prometheus.consul.yml.template| sed "s/MANAGER_ADDRESS/$CONSUL_ADDRESS/" > $BASE_DIR/prometheus.yml
+	if [[ ! $CONSUL_ADDRESS = *":"* ]]; then
+		CONSUL_ADDRESS="$CONSUL_ADDRESS:5090"
+	fi
+	sed "s/AM_ADDRESS/$AM_ADDRESS/" $PWD/prometheus/prometheus.consul.yml.template | sed "s/MANAGER_ADDRESS/$CONSUL_ADDRESS/" >$BASE_DIR/prometheus.yml
 fi
 
 if [[ "$EVALUATION_INTERVAL" != "" ]]; then
-    sed -i "s/  evaluation_interval: [[:digit:]]*.*/  evaluation_interval: ${EVALUATION_INTERVAL}/g" $BASE_DIR/prometheus.yml
+	sed -i "s/  evaluation_interval: [[:digit:]]*.*/  evaluation_interval: ${EVALUATION_INTERVAL}/g" $BASE_DIR/prometheus.yml
 fi
 if [[ "$SCRAP_INTERVAL" != "" ]]; then
-    sed -i "s/  scrape_interval: [[:digit:]]*.*# *Default.*/  scrape_interval: ${SCRAP_INTERVAL}s/g" $BASE_DIR/prometheus.yml
-    TIMEOUT=$(($SCRAP_INTERVAL - 5))
-    sed -i "s/  scrape_timeout: [[:digit:]]*.*# *Default.*/  scrape_timeout: ${TIMEOUT}s/g" $BASE_DIR/prometheus.yml
+	sed -i "s/  scrape_interval: [[:digit:]]*.*# *Default.*/  scrape_interval: ${SCRAP_INTERVAL}s/g" $BASE_DIR/prometheus.yml
+	TIMEOUT=$(($SCRAP_INTERVAL - 5))
+	sed -i "s/  scrape_timeout: [[:digit:]]*.*# *Default.*/  scrape_timeout: ${TIMEOUT}s/g" $BASE_DIR/prometheus.yml
 fi
 if [ "$NO_CAS" = "1" ] && [ "$NO_CDC" = "1" ]; then
-    sed -i "s/ *# FILTER_METRICS.*/    - source_labels: [__name__]\\n      regex: '(.*_cdc_.*|.*_cas.*)'\\n      action: drop/g" $BASE_DIR/prometheus.yml
+	sed -i "s/ *# FILTER_METRICS.*/    - source_labels: [__name__]\\n      regex: '(.*_cdc_.*|.*_cas.*)'\\n      action: drop/g" $BASE_DIR/prometheus.yml
 elif [ "$NO_CAS" = "1" ]; then
-    sed -i "s/ *# FILTER_METRICS.*/    - source_labels: [__name__]\\n      regex: '(.*_cas.*)'\\n      action: drop/g" $BASE_DIR/prometheus.yml
+	sed -i "s/ *# FILTER_METRICS.*/    - source_labels: [__name__]\\n      regex: '(.*_cas.*)'\\n      action: drop/g" $BASE_DIR/prometheus.yml
 elif [ "$NO_CDC" = "1" ]; then
-    sed -i "s/ *# FILTER_METRICS.*/    - source_labels: [__name__]\\n      regex: '(.*_cdc_.*)'\\n      action: drop/g" $BASE_DIR/prometheus.yml
+	sed -i "s/ *# FILTER_METRICS.*/    - source_labels: [__name__]\\n      regex: '(.*_cdc_.*)'\\n      action: drop/g" $BASE_DIR/prometheus.yml
 fi
 if [ "$NO_NODE_EXPORTER_FILE" = "1" ]; then
-    sed -i "s/ *# NODE_EXPORTER_PORT_MAPPING.*/    - source_labels: [__address__]\\n      regex:  '(.*):\\\\d+'\\n      target_label: __address__\\n      replacement: '\$\{1\}'\\n/g" $BASE_DIR/prometheus.yml
+	sed -i "s/ *# NODE_EXPORTER_PORT_MAPPING.*/    - source_labels: [__address__]\\n      regex:  '(.*):\\\\d+'\\n      target_label: __address__\\n      replacement: '\$\{1\}'\\n/g" $BASE_DIR/prometheus.yml
 fi
 if [ "$NO_MANAGER_AGENT_FILE" = "1" ]; then
-    sed -i "s/ *# MANAGER_AGENT_PORT_MAPPING.*/    - source_labels: [__address__]\\n      regex:  '(.*):\\\\d+'\\n      target_label: __address__\\n      replacement: \'\$\{1\}\'\\n/g" $BASE_DIR/prometheus.yml
+	sed -i "s/ *# MANAGER_AGENT_PORT_MAPPING.*/    - source_labels: [__address__]\\n      regex:  '(.*):\\\\d+'\\n      target_label: __address__\\n      replacement: \'\$\{1\}\'\\n/g" $BASE_DIR/prometheus.yml
 fi
 
 for val in "${PROMETHEUS_TARGETS[@]}"; do
-    if [[ ! -f $val ]]; then
-        echo "Target file $val does not exists"
-        exit 1
-    fi
-    cat $val >> $BASE_DIR/prometheus.yml
+	if [[ ! -f $val ]]; then
+		echo "Target file $val does not exists"
+		exit 1
+	fi
+	cat $val >>$BASE_DIR/prometheus.yml
 done

--- a/promutil.py
+++ b/promutil.py
@@ -119,7 +119,7 @@ def get_delta(s):
 
 def get_time(s):
     t = get_delta(s)
-    if t != None:
+    if t is not None:
         return datetime.now() - t
     return str2time(s)
 
@@ -163,7 +163,7 @@ def do_range_query_by_host(host, args):
         # range_to_openmatrics(range_query(host, params), name=args.query_name)
     if args.rules:
         rules = get_rules(args.rules)
-        i = 0
+        # i = 0
         for r in rules:
             if 'record' in r and args.skip_rules or 'record' not in r and args.skip_alerts:
                 continue 
@@ -183,10 +183,10 @@ def do_range_query(args):
     if args.host_file:
         print("using host file", args.host_file)
         with open(args.host_file) as file:
-            for l in file:
-                print(l.strip())
-                if l.strip() != "":
-                    do_range_query_by_host(add_port_if_needed(l.strip()), args)
+            for line in file:
+                print(line.strip())
+                if line.strip() != "":
+                    do_range_query_by_host(add_port_if_needed(line.strip()), args)
     else:
         do_range_query_by_host(add_port_if_needed(args.host), args)
     terminate_output(args.out_file, args.format, args.new_file, args.skip_eof)

--- a/start-alertmanager.sh
+++ b/start-alertmanager.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 . versions.sh
-if [ -f  env.sh ]; then
-    . env.sh
+if [ -f env.sh ]; then
+	. env.sh
 fi
 
 is_podman="$(docker --help | grep -o podman)"
@@ -13,152 +13,161 @@ ALERTMANAGER_COMMANDS=""
 ALERT_MANAGER_DIR=""
 USER_PERMISSIONS=""
 usage="$(basename "$0") [-h] [-p alertmanager port ] [-l] [-D encapsulate docker param] [-C alertmanager commands] [-r rule-file] [-f alertmanager-dir]"
-if [ "`id -u`" -ne 0 ]; then
-    GROUPID=`id -g`
-    USER_PERMISSIONS="-u $UID:$GROUPID"
+if [ "$(id -u)" -ne 0 ]; then
+	GROUPID=$(id -g)
+	USER_PERMISSIONS="-u $UID:$GROUPID"
 fi
 LIMITS=""
 VOLUMES=""
 PARAMS=""
 for arg; do
-    shift
-    if [ -z "$LIMIT" ]; then
-        case $arg in
-            (--limit)
-                LIMIT="1"
-                ;;
-            (--volume)
-                LIMIT="1"
-                VOLUME="1"
-                ;;
-            (--param)
-                LIMIT="1"
-                PARAM="1"
-                ;;
-            (*) set -- "$@" "$arg"
-                ;;
-        esac
-    else
-        DOCR=`echo $arg|cut -d',' -f1`
-        VALUE=`echo $arg|cut -d',' -f2-|sed 's/#/ /g'`
-        NOSPACE=`echo $arg|sed 's/ /#/g'`
-        if [ "$PARAM" = "1" ]; then
-            if [ -z "${DOCKER_PARAMS[$DOCR]}" ]; then
-                DOCKER_PARAMS[$DOCR]=""
-            fi
-            DOCKER_PARAMS[$DOCR]="${DOCKER_PARAMS[$DOCR]} $VALUE"
-            PARAMS="$PARAMS --param $NOSPACE"
-            unset PARAM
-        else
-            if [ -z "${DOCKER_LIMITS[$DOCR]}" ]; then
-                DOCKER_LIMITS[$DOCR]=""
-            fi
-            if [ "$VOLUME" = "1" ]; then
-                SRC=`echo $VALUE|cut -d':' -f1`
-                DST=`echo $VALUE|cut -d':' -f2-`
-                SRC=$(readlink -m $SRC)
-                DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} -v $SRC:$DST"
-                VOLUMES="$VOLUMES --volume $NOSPACE"
-                unset VOLUME
-            else
-                DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} $VALUE"
-                LIMITS="$LIMITS --limit $NOSPACE"
-            fi
-        fi
-        unset LIMIT
-    fi
+	shift
+	if [ -z "$LIMIT" ]; then
+		case $arg in
+		--limit)
+			LIMIT="1"
+			;;
+		--volume)
+			LIMIT="1"
+			VOLUME="1"
+			;;
+		--param)
+			LIMIT="1"
+			PARAM="1"
+			;;
+		*)
+			set -- "$@" "$arg"
+			;;
+		esac
+	else
+		DOCR=$(echo $arg | cut -d',' -f1)
+		VALUE=$(echo $arg | cut -d',' -f2- | sed 's/#/ /g')
+		NOSPACE=$(echo $arg | sed 's/ /#/g')
+		if [ "$PARAM" = "1" ]; then
+			if [ -z "${DOCKER_PARAMS[$DOCR]}" ]; then
+				DOCKER_PARAMS[$DOCR]=""
+			fi
+			DOCKER_PARAMS[$DOCR]="${DOCKER_PARAMS[$DOCR]} $VALUE"
+			PARAMS="$PARAMS --param $NOSPACE"
+			unset PARAM
+		else
+			if [ -z "${DOCKER_LIMITS[$DOCR]}" ]; then
+				DOCKER_LIMITS[$DOCR]=""
+			fi
+			if [ "$VOLUME" = "1" ]; then
+				SRC=$(echo $VALUE | cut -d':' -f1)
+				DST=$(echo $VALUE | cut -d':' -f2-)
+				SRC=$(readlink -m $SRC)
+				DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} -v $SRC:$DST"
+				VOLUMES="$VOLUMES --volume $NOSPACE"
+				unset VOLUME
+			else
+				DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} $VALUE"
+				LIMITS="$LIMITS --limit $NOSPACE"
+			fi
+		fi
+		unset LIMIT
+	fi
 done
 if [ "$DOCKER_PARAM" != "" ]; then
-    DOCKER_PARAM_FROM_FILE="1"
+	DOCKER_PARAM_FROM_FILE="1"
 fi
 
 while getopts ':hlp:r:D:C:f:A:' option; do
-  case "$option" in
-    h) echo "$usage"
-       exit
-       ;;
-    p) ALERTMANAGER_PORT=$OPTARG
-       ;;
-    r) RULE_FILE=`readlink -m $OPTARG`
-       ;;
-    f) ALERT_MANAGER_DIR="$USER_PERMISSIONS -v $(readlink -m $OPTARG):/alertmanager/data:z"
-       ;;
-    l) if [[ "$DOCKER_PARAM" != *"--net=host"* ]]; then
-        DOCKER_PARAM="$DOCKER_PARAM --net=host"
-       fi
-       ;;
-    D) if [ "$DOCKER_PARAM_FROM_FILE" = "1" ]; then
-          DOCKER_PARAM=""
-          DOCKER_PARAM_FROM_FILE=""
-       fi
-       DOCKER_PARAM="$DOCKER_PARAM $OPTARG"
-       ;;
-    C) ALERTMANAGER_COMMANDS="$ALERTMANAGER_COMMANDS $OPTARG"
-       ;;
-    A) BIND_ADDRESS="$OPTARG:"
-       ;;
-    :) printf "missing argument for -%s\n" "$OPTARG" >&2
-       echo "$usage" >&2
-       exit 1
-       ;;
-   \?) printf "illegal option: -%s\n" "$OPTARG" >&2
-       echo "$usage" >&2
-       exit 1
-       ;;
-  esac
+	case "$option" in
+	h)
+		echo "$usage"
+		exit
+		;;
+	p)
+		ALERTMANAGER_PORT=$OPTARG
+		;;
+	r)
+		RULE_FILE=$(readlink -m $OPTARG)
+		;;
+	f)
+		ALERT_MANAGER_DIR="$USER_PERMISSIONS -v $(readlink -m $OPTARG):/alertmanager/data:z"
+		;;
+	l)
+		if [[ "$DOCKER_PARAM" != *"--net=host"* ]]; then
+			DOCKER_PARAM="$DOCKER_PARAM --net=host"
+		fi
+		;;
+	D)
+		if [ "$DOCKER_PARAM_FROM_FILE" = "1" ]; then
+			DOCKER_PARAM=""
+			DOCKER_PARAM_FROM_FILE=""
+		fi
+		DOCKER_PARAM="$DOCKER_PARAM $OPTARG"
+		;;
+	C)
+		ALERTMANAGER_COMMANDS="$ALERTMANAGER_COMMANDS $OPTARG"
+		;;
+	A)
+		BIND_ADDRESS="$OPTARG:"
+		;;
+	:)
+		printf "missing argument for -%s\n" "$OPTARG" >&2
+		echo "$usage" >&2
+		exit 1
+		;;
+	\?)
+		printf "illegal option: -%s\n" "$OPTARG" >&2
+		echo "$usage" >&2
+		exit 1
+		;;
+	esac
 done
 if [ -z $ALERTMANAGER_PORT ]; then
-    ALERTMANAGER_PORT=9093
-    ALERTMANAGER_NAME=aalert
+	ALERTMANAGER_PORT=9093
+	ALERTMANAGER_NAME=aalert
 else
-    ALERTMANAGER_NAME=aalert-$ALERTMANAGER_PORT
+	ALERTMANAGER_NAME=aalert-$ALERTMANAGER_PORT
 fi
 
-docker container inspect $ALERTMANAGER_NAME > /dev/null 2>&1
+docker container inspect $ALERTMANAGER_NAME >/dev/null 2>&1
 if [ $? -eq 0 ]; then
-    printf "\nSome of the monitoring docker instances ($ALERTMANAGER_NAME) exist. Make sure all containers are killed and removed. You can use kill-all.sh for that\n"
-    exit 1
+	printf "\nSome of the monitoring docker instances ($ALERTMANAGER_NAME) exist. Make sure all containers are killed and removed. You can use kill-all.sh for that\n"
+	exit 1
 fi
 
 if [[ ! $DOCKER_PARAM = *"--net=host"* ]]; then
-    PORT_MAPPING="-p $BIND_ADDRESS$ALERTMANAGER_PORT:9093"
+	PORT_MAPPING="-p $BIND_ADDRESS$ALERTMANAGER_PORT:9093"
 fi
 
 docker run ${DOCKER_LIMITS["alertmanager"]} -d $DOCKER_PARAM -i $PORT_MAPPING \
-	 -v $RULE_FILE:/etc/alertmanager/config.yml:z \
-	 $ALERT_MANAGER_DIR \
-     --name $ALERTMANAGER_NAME docker.io/prom/alertmanager:$ALERT_MANAGER_VERSION \
-     $ALERTMANAGER_COMMANDS --log.level=debug --config.file=/etc/alertmanager/config.yml ${DOCKER_PARAMS["alertmanager"]}  >& /dev/null
-
+	-v $RULE_FILE:/etc/alertmanager/config.yml:z \
+	$ALERT_MANAGER_DIR \
+	--name $ALERTMANAGER_NAME docker.io/prom/alertmanager:$ALERT_MANAGER_VERSION \
+	$ALERTMANAGER_COMMANDS --log.level=debug --config.file=/etc/alertmanager/config.yml ${DOCKER_PARAMS["alertmanager"]} >&/dev/null
 
 if [ $? -ne 0 ]; then
-    echo "Error: Alertmanager container failed to start"
-    echo "For more information use: docker logs $ALERTMANAGER_NAME"
-    exit 1
+	echo "Error: Alertmanager container failed to start"
+	echo "For more information use: docker logs $ALERTMANAGER_NAME"
+	exit 1
 fi
 
 # Wait till Alertmanager is available
 RETRIES=5
 TRIES=0
 until $(curl --output /dev/null -f --silent http://localhost:$ALERTMANAGER_PORT) || [ $TRIES -eq $RETRIES ]; do
-    ((TRIES=TRIES+1))
-    sleep 5
+	((TRIES = TRIES + 1))
+	sleep 5
 done
 
-if [ ! "$(docker ps -q -f name=$ALERTMANAGER_NAME)" ]
-then
-    echo "Error: Alertmanager container failed to start"
-    exit 1
+if [ ! "$(docker ps -q -f name=$ALERTMANAGER_NAME)" ]; then
+	echo "Error: Alertmanager container failed to start"
+	exit 1
 fi
 
 AM_ADDRESS="$(docker inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $ALERTMANAGER_NAME):9093"
 if [ "$AM_ADDRESS" = ":9093" ]; then
-    if [[ $(uname) == "Linux" ]]; then
-        HOST_IP=$(hostname -I | awk '{print $1}')
-    elif [[ $(uname) == "Darwin" ]]; then
-        HOST_IP=$(ifconfig en0 | awk '/inet / {print $2}')
-    fi
-    AM_ADDRESS="$HOST_IP:9093"
+	if [[ $(uname) == "Linux" ]]; then
+		HOST_IP=$(hostname -I | awk '{print $1}')
+	elif [[ $(uname) == "Darwin" ]]; then
+		HOST_IP=$(ifconfig en0 | awk '/inet / {print $2}')
+	fi
+	AM_ADDRESS="$HOST_IP:9093"
 fi
 
 echo $AM_ADDRESS

--- a/start-all.sh
+++ b/start-all.sh
@@ -1,58 +1,58 @@
 #!/usr/bin/env bash
 
 . versions.sh
-if [ -f  env.sh ]; then
-    . env.sh
+if [ -f env.sh ]; then
+	. env.sh
 fi
 
 CURRENT_VERSION="master"
 if [ -f CURRENT_VERSION.sh ]; then
-    CURRENT_VERSION=`cat CURRENT_VERSION.sh`
+	CURRENT_VERSION=$(cat CURRENT_VERSION.sh)
 fi
 
 if [ -z "$BRANCH_VERSION" ]; then
-  BRANCH_VERSION=$CURRENT_VERSION
+	BRANCH_VERSION=$CURRENT_VERSION
 fi
 if [ -z ${DEFAULT_VERSION[$CURRENT_VERSION]} ]; then
-    BRANCH_VERSION=`echo $CURRENT_VERSION|cut -d'.' -f1,2`
+	BRANCH_VERSION=$(echo $CURRENT_VERSION | cut -d'.' -f1,2)
 fi
 if [ "$1" = "-e" ]; then
-    DEFAULT_VERSION=${DEFAULT_ENTERPRISE_VERSION[$BRANCH_VERSION]}
+	DEFAULT_VERSION=${DEFAULT_ENTERPRISE_VERSION[$BRANCH_VERSION]}
 fi
 
-if [ -z "$MANAGER_VERSION" ];then
-  MANAGER_VERSION=${MANAGER_DEFAULT_VERSION[$BRANCH_VERSION]}
+if [ -z "$MANAGER_VERSION" ]; then
+	MANAGER_VERSION=${MANAGER_DEFAULT_VERSION[$BRANCH_VERSION]}
 fi
 
 if [ "$1" = "--version" ]; then
-    echo "Scylla-Monitoring Stack version: $CURRENT_VERSION"
-    echo "Supported versions:" ${SUPPORTED_VERSIONS[$BRANCH_VERSION]}
-    echo "Manager supported versions:" ${MANAGER_SUPPORTED_VERSIONS[$BRANCH_VERSION]}
-    exit
+	echo "Scylla-Monitoring Stack version: $CURRENT_VERSION"
+	echo "Supported versions:" ${SUPPORTED_VERSIONS[$BRANCH_VERSION]}
+	echo "Manager supported versions:" ${MANAGER_SUPPORTED_VERSIONS[$BRANCH_VERSION]}
+	exit
 fi
 
-if [ "`id -u`" -eq 0 ]; then
-    echo "Running as root is not advised, please check the documentation on how to run as non-root user"
-    USER_PERMISSIONS="-u 0:0"
+if [ "$(id -u)" -eq 0 ]; then
+	echo "Running as root is not advised, please check the documentation on how to run as non-root user"
+	USER_PERMISSIONS="-u 0:0"
 else
-    GROUPID=`id -g`
-    USER_PERMISSIONS="-u $UID:$GROUPID"
+	GROUPID=$(id -g)
+	USER_PERMISSIONS="-u $UID:$GROUPID"
 fi
 
 group_args=()
 is_podman="$(docker --help | grep -o podman)"
 if [ ! -z "$is_podman" ]; then
-    group_args+=(--userns=keep-id)
+	group_args+=(--userns=keep-id)
 fi
 
 if [[ $(uname) == "Linux" ]]; then
-  readlink_command="readlink -f"
+	readlink_command="readlink -f"
 elif [[ $(uname) == "Darwin" ]]; then
-  readlink_command="realpath "
+	readlink_command="realpath "
 fi
 
 function usage {
-  __usage="Usage: $(basename $0) [-h] [--version] [-e] [-d Prometheus data-dir] [-L resolve the servers from the manager running on the given address] [-G path to grafana data-dir] [-s scylla-target-file] [-n node-target-file] [-l] [-v comma separated versions] [-j additional dashboard to load to Grafana, multiple params are supported] [-c grafana environment variable, multiple params are supported] [-b Prometheus command line options] [-g grafana port ] [ -p prometheus port ] [-a admin password] [-m alertmanager port] [ -M scylla-manager version ] [-D encapsulate docker param] [-r alert-manager-config] [-R prometheus-alert-file] [-N manager target file] [-A bind-to-ip-address] [-C alertmanager commands] [-Q Grafana anonymous role (Admin/Editor/Viewer)] [-S start with a system specific dashboard set] [-T additional-prometheus-targets] [--no-loki] [--no-alertmanager] [--loki-port port] [--promtail-port port] [--auto-restart] [--no-renderer] [-f alertmanager-dir]
+	__usage="Usage: $(basename $0) [-h] [--version] [-e] [-d Prometheus data-dir] [-L resolve the servers from the manager running on the given address] [-G path to grafana data-dir] [-s scylla-target-file] [-n node-target-file] [-l] [-v comma separated versions] [-j additional dashboard to load to Grafana, multiple params are supported] [-c grafana environment variable, multiple params are supported] [-b Prometheus command line options] [-g grafana port ] [ -p prometheus port ] [-a admin password] [-m alertmanager port] [ -M scylla-manager version ] [-D encapsulate docker param] [-r alert-manager-config] [-R prometheus-alert-file] [-N manager target file] [-A bind-to-ip-address] [-C alertmanager commands] [-Q Grafana anonymous role (Admin/Editor/Viewer)] [-S start with a system specific dashboard set] [-T additional-prometheus-targets] [--no-loki] [--no-alertmanager] [--loki-port port] [--promtail-port port] [--auto-restart] [--no-renderer] [-f alertmanager-dir]
 
 Options:
   -h print this help and exit
@@ -106,95 +106,95 @@ Options:
   --archive  data-directory      - Treat data directory as an archive. This disables Prometheus time-to-live (infinite retention), and would run a minimal mode
 The script starts Scylla Monitoring stack.
 "
-  echo "$__usage"
+	echo "$__usage"
 }
 
-is_local () {
-    for var in "$@"; do
-        if grep -q '\s127.' $1; then
-            echo "Local host found in $1"
-            grep '\s127.' $1
-            return 0
-        fi
-        if grep -q 'localhost' $1; then
-            return 0
-        fi
-    done
-    return 1
+is_local() {
+	for var in "$@"; do
+		if grep -q '\s127.' $1; then
+			echo "Local host found in $1"
+			grep '\s127.' $1
+			return 0
+		fi
+		if grep -q 'localhost' $1; then
+			return 0
+		fi
+	done
+	return 1
 }
 
 if [ -z "$PROMETHEUS_RULES" ]; then
-  PROMETHEUS_RULES="$PWD/prometheus/prom_rules/:/etc/prometheus/prom_rules/"
+	PROMETHEUS_RULES="$PWD/prometheus/prom_rules/:/etc/prometheus/prom_rules/"
 fi
 
 if [ -z "$VERSIONS" ]; then
-  VERSIONS=${DEFAULT_VERSION[$BRANCH_VERSION]}
+	VERSIONS=${DEFAULT_VERSION[$BRANCH_VERSION]}
 fi
 
 if [ -z "$SCYLLA_TARGET_FILES" ]; then
-  SCYLLA_TARGET_FILES=($PWD/prometheus/scylla_servers.yml $PWD/scylla_servers.yml)
+	SCYLLA_TARGET_FILES=($PWD/prometheus/scylla_servers.yml $PWD/scylla_servers.yml)
 fi
 if [ -z "$SCYLLA_MANGER_TARGET_FILES" ]; then
-  SCYLLA_MANGER_TARGET_FILES=($PWD/prometheus/scylla_manager_servers.yml $PWD/scylla_manager_servers.yml $PWD/prometheus/scylla_manager_servers.example.yml)
+	SCYLLA_MANGER_TARGET_FILES=($PWD/prometheus/scylla_manager_servers.yml $PWD/scylla_manager_servers.yml $PWD/prometheus/scylla_manager_servers.example.yml)
 fi
 if [ -z "$GRAFANA_ADMIN_PASSWORD" ]; then
-  GRAFANA_ADMIN_PASSWORD=""
+	GRAFANA_ADMIN_PASSWORD=""
 fi
 
 if [ -z "$ALERTMANAGER_PORT" ]; then
-  ALERTMANAGER_PORT=""
+	ALERTMANAGER_PORT=""
 fi
 
 if [ -z "$DOCKER_PARAM" ]; then
-  DOCKER_PARAM=""
+	DOCKER_PARAM=""
 fi
 if [ -z "$DATA_DIR" ]; then
-  DATA_DIR=""
+	DATA_DIR=""
 fi
 if [ -z "$DATA_DIR_CMD" ]; then
-  DATA_DIR_CMD=""
+	DATA_DIR_CMD=""
 fi
 if [ -z "$CONSUL_ADDRESS" ]; then
-  CONSUL_ADDRESS=""
+	CONSUL_ADDRESS=""
 fi
 if [ -z "$PROMETHEUS_TARGETS" ]; then
-  PROMETHEUS_TARGETS=""
+	PROMETHEUS_TARGETS=""
 fi
 if [ -z "$BIND_ADDRESS" ]; then
-  BIND_ADDRESS=""
+	BIND_ADDRESS=""
 fi
 if [ -z "$BIND_ADDRESS_CONFIG" ]; then
-  BIND_ADDRESS_CONFIG=""
+	BIND_ADDRESS_CONFIG=""
 fi
 if [ -z "$GRAFNA_ANONYMOUS_ROLE" ]; then
-  GRAFNA_ANONYMOUS_ROLE=""
+	GRAFNA_ANONYMOUS_ROLE=""
 fi
 if [ -z "$SPECIFIC_SOLUTION" ]; then
-  SPECIFIC_SOLUTION=""
+	SPECIFIC_SOLUTION=""
 fi
 if [ -z "$LDAP_FILE" ]; then
-  LDAP_FILE=""
+	LDAP_FILE=""
 fi
 if [ -z "$RUN_RENDERER" ]; then
-  RUN_RENDERER="-E"
+	RUN_RENDERER="-E"
 fi
 if [ -z "$RUN_LOKI" ]; then
-  RUN_LOKI=1
+	RUN_LOKI=1
 fi
 if [ -z "$RUN_THANOS_SC" ]; then
-  RUN_THANOS_SC=0
+	RUN_THANOS_SC=0
 fi
 if [ -z "$RUN_THANOS" ]; then
-  RUN_THANOS=0
+	RUN_THANOS=0
 fi
 if [ -z "$ALERT_MANAGER_DIR" ]; then
-  ALERT_MANAGER_DIR=""
+	ALERT_MANAGER_DIR=""
 fi
 if [ -z "$LOKI_DIR" ]; then
-  LOKI_DIR=""
+	LOKI_DIR=""
 fi
 if [ -z "$LOKI_PORT" ]; then
-  LOKI_PORT=""
+	LOKI_PORT=""
 fi
 LIMITS=""
 VOLUMES=""
@@ -207,537 +207,574 @@ for arg; do
 done
 
 for arg; do
-    shift
-    if [ -z "$LIMIT" ]; then
-       case $arg in
-            (--no-loki) RUN_LOKI=0
-                ;;
-            (--no-alertmanager) SKIP_ALERTMANAGER=1
-                ;;
-            (--loki-port)
-                LIMIT="1"
-                PARAM="loki-port"
-                ;;
-            (--promtail-port)
-                LIMIT="1"
-                PARAM="promtail-port"
-                ;;
-            (--promtail-binary-port)
-                LIMIT="1"
-                PARAM="promtail-binary-port"
-                ;;
-            (--no-renderer) RUN_RENDERER=""
-                ;;
-            (--thanos-sc) RUN_THANOS_SC=1
-                ;;
-            (--thanos) RUN_THANOS=1
-                ;;
-            (--auto-restart) DOCKER_PARAM="--restart=unless-stopped"
-                ;;
-            (--victoria-metrics) VICTORIA_METRICS="1"
-                ;;
-            (--auth)
-                GRAFANA_ENV_COMMAND="$GRAFANA_ENV_COMMAND --auth"
-                ;;
-            (--disable-anonymous)
-                GRAFANA_ENV_COMMAND="$GRAFANA_ENV_COMMAND --disable-anonymous"
-                ;;
-            (--enable-protobuf)
-                PROMETHEUS_COMMAND_LINE_OPTIONS_ARRAY+=(--enable-feature=native-histograms)
-                ;;
-            (--alternator)
-                RUN_ALTERNATOR="1"
-                ;;
-            (--limit)
-                LIMIT="1"
-                ;;
-            (--volume)
-                LIMIT="1"
-                VOLUME="1"
-                ;;
-            (--param)
-                LIMIT="1"
-                PARAM="param"
-                ;;
-            (--evaluation-interval)
-                LIMIT="1"
-                PARAM="evaluation-interval"
-                ;;
-            (--manager-agents)
-                LIMIT="1"
-                PARAM="manager-agents"
-                ;;
-            (--datadog-api-keys)
-                LIMIT="1"
-                PARAM="datadog-api-keys"
-                ;;
-            (--datadog-hostname)
-                LIMIT="1"
-                PARAM="datadog-hostname"
-                ;;
-            (--stack)
-                LIMIT="1"
-                PARAM="stack"
-                ;;
-            (--scrap)
-                LIMIT="1"
-                PARAM="scrap"
-                ;;
-            (--no-cas-cdc)
-                PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-cas-cdc"
-                ;;
-            (--no-cas)
-                PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-cas"
-                ;;
-            (--no-cdc)
-                PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-cdc"
-                ;;
-            (--target-directory)
-                LIMIT="1"
-                PARAM="target-directory"
-                ;;
-            (--help) usage
-                ;;
-            (--archive)
-                ARCHIVE="1"
-                LIMIT="1"
-                PARAM="archive"
-                ;;
-            (*) set -- "$@" "$arg"
-                ;;
-        esac
-    else
-        DOCR=`echo $arg|cut -d',' -f1`
-        VALUE=`echo $arg|cut -d',' -f2-|sed 's/#/ /g'`
-        NOSPACE=`echo $arg|sed 's/ /#/g'`
-        if [[ $NOSPACE == --* ]]; then
-            echo "Error: No value given to --$PARAM"
-            echo
-            usage
-            exit 1
-        fi
-        if [ "$PARAM" = "param" ]; then
-            if [ -z "${DOCKER_PARAMS[$DOCR]}" ]; then
-                DOCKER_PARAMS[$DOCR]=""
-            fi
-            DOCKER_PARAMS[$DOCR]="${DOCKER_PARAMS[$DOCR]} $VALUE"
-            PARAMS="$PARAMS --param $NOSPACE"
-            unset PARAM
-        elif [ "$PARAM" = "evaluation-interval" ]; then
-            PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS -E $NOSPACE"
-            unset PARAM
-        elif [ "$PARAM" = "manager-agents" ]; then
-            SCYLLA_MANGER_AGENT_TARGET_FILE="$NOSPACE"
-            unset PARAM
-        elif [ "$PARAM" = "target-directory" ]; then
-            TARGET_DIRECTORY="$NOSPACE"
-            unset PARAM
-        elif [ "$PARAM" = "datadog-api-keys" ]; then
-            DATDOGPARAM="$DATDOGPARAM -A $NOSPACE"
-            unset PARAM
-        elif [ "$PARAM" = "datadog-hostname" ]; then
-            DATDOGPARAM="$DATDOGPARAM -H $NOSPACE"
-            unset PARAM
-        elif [ "$PARAM" = "loki-port" ]; then
-            LOKI_PORT="$LOKI_PORT -p $NOSPACE"
-            unset PARAM
-        elif [ "$PARAM" = "promtail-port" ]; then
-            LOKI_PORT="$LOKI_PORT -t $NOSPACE"
-            unset PARAM
-        elif [ "$PARAM" = "promtail-binary-port" ]; then
-            LOKI_PORT="$LOKI_PORT -T $NOSPACE"
-            unset PARAM
-        elif [ "$PARAM" = "stack" ]; then
-            STACK_ID="$NOSPACE"
-            STACK_CMD="-s $NOSPACE"
-            STACK="/stack/$NOSPACE"
-            unset PARAM
-        elif [ "$PARAM" = "scrap" ]; then
-            SCRAP_CMD="--scrap $NOSPACE"
-            unset PARAM
-        elif [ "$PARAM" = "archive" ]; then
-            DATA_DIR="$NOSPACE"
-            unset PARAM
-        else
-            if [ -z "${DOCKER_LIMITS[$DOCR]}" ]; then
-                DOCKER_LIMITS[$DOCR]=""
-            fi
-            if [ "$VOLUME" = "1" ]; then
-                SRC=`echo $VALUE|cut -d':' -f1`
-                DST=`echo $VALUE|cut -d':' -f2-`
-                SRC=$($readlink_command "$SRC")
-                DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} -v $SRC:$DST"
-                VOLUMES="$VOLUMES --volume $NOSPACE"
-                unset VOLUME
-            else
-                DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} $VALUE"
-                LIMITS="$LIMITS --limit $NOSPACE"
-            fi
-        fi
-        unset LIMIT
-    fi
+	shift
+	if [ -z "$LIMIT" ]; then
+		case $arg in
+		--no-loki)
+			RUN_LOKI=0
+			;;
+		--no-alertmanager)
+			SKIP_ALERTMANAGER=1
+			;;
+		--loki-port)
+			LIMIT="1"
+			PARAM="loki-port"
+			;;
+		--promtail-port)
+			LIMIT="1"
+			PARAM="promtail-port"
+			;;
+		--promtail-binary-port)
+			LIMIT="1"
+			PARAM="promtail-binary-port"
+			;;
+		--no-renderer)
+			RUN_RENDERER=""
+			;;
+		--thanos-sc)
+			RUN_THANOS_SC=1
+			;;
+		--thanos)
+			RUN_THANOS=1
+			;;
+		--auto-restart)
+			DOCKER_PARAM="--restart=unless-stopped"
+			;;
+		--victoria-metrics)
+			VICTORIA_METRICS="1"
+			;;
+		--auth)
+			GRAFANA_ENV_COMMAND="$GRAFANA_ENV_COMMAND --auth"
+			;;
+		--disable-anonymous)
+			GRAFANA_ENV_COMMAND="$GRAFANA_ENV_COMMAND --disable-anonymous"
+			;;
+		--enable-protobuf)
+			PROMETHEUS_COMMAND_LINE_OPTIONS_ARRAY+=(--enable-feature=native-histograms)
+			;;
+		--alternator)
+			RUN_ALTERNATOR="1"
+			;;
+		--limit)
+			LIMIT="1"
+			;;
+		--volume)
+			LIMIT="1"
+			VOLUME="1"
+			;;
+		--param)
+			LIMIT="1"
+			PARAM="param"
+			;;
+		--evaluation-interval)
+			LIMIT="1"
+			PARAM="evaluation-interval"
+			;;
+		--manager-agents)
+			LIMIT="1"
+			PARAM="manager-agents"
+			;;
+		--datadog-api-keys)
+			LIMIT="1"
+			PARAM="datadog-api-keys"
+			;;
+		--datadog-hostname)
+			LIMIT="1"
+			PARAM="datadog-hostname"
+			;;
+		--stack)
+			LIMIT="1"
+			PARAM="stack"
+			;;
+		--scrap)
+			LIMIT="1"
+			PARAM="scrap"
+			;;
+		--no-cas-cdc)
+			PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-cas-cdc"
+			;;
+		--no-cas)
+			PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-cas"
+			;;
+		--no-cdc)
+			PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-cdc"
+			;;
+		--target-directory)
+			LIMIT="1"
+			PARAM="target-directory"
+			;;
+		--help)
+			usage
+			;;
+		--archive)
+			ARCHIVE="1"
+			LIMIT="1"
+			PARAM="archive"
+			;;
+		*)
+			set -- "$@" "$arg"
+			;;
+		esac
+	else
+		DOCR=$(echo $arg | cut -d',' -f1)
+		VALUE=$(echo $arg | cut -d',' -f2- | sed 's/#/ /g')
+		NOSPACE=$(echo $arg | sed 's/ /#/g')
+		if [[ $NOSPACE == --* ]]; then
+			echo "Error: No value given to --$PARAM"
+			echo
+			usage
+			exit 1
+		fi
+		if [ "$PARAM" = "param" ]; then
+			if [ -z "${DOCKER_PARAMS[$DOCR]}" ]; then
+				DOCKER_PARAMS[$DOCR]=""
+			fi
+			DOCKER_PARAMS[$DOCR]="${DOCKER_PARAMS[$DOCR]} $VALUE"
+			PARAMS="$PARAMS --param $NOSPACE"
+			unset PARAM
+		elif [ "$PARAM" = "evaluation-interval" ]; then
+			PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS -E $NOSPACE"
+			unset PARAM
+		elif [ "$PARAM" = "manager-agents" ]; then
+			SCYLLA_MANGER_AGENT_TARGET_FILE="$NOSPACE"
+			unset PARAM
+		elif [ "$PARAM" = "target-directory" ]; then
+			TARGET_DIRECTORY="$NOSPACE"
+			unset PARAM
+		elif [ "$PARAM" = "datadog-api-keys" ]; then
+			DATDOGPARAM="$DATDOGPARAM -A $NOSPACE"
+			unset PARAM
+		elif [ "$PARAM" = "datadog-hostname" ]; then
+			DATDOGPARAM="$DATDOGPARAM -H $NOSPACE"
+			unset PARAM
+		elif [ "$PARAM" = "loki-port" ]; then
+			LOKI_PORT="$LOKI_PORT -p $NOSPACE"
+			unset PARAM
+		elif [ "$PARAM" = "promtail-port" ]; then
+			LOKI_PORT="$LOKI_PORT -t $NOSPACE"
+			unset PARAM
+		elif [ "$PARAM" = "promtail-binary-port" ]; then
+			LOKI_PORT="$LOKI_PORT -T $NOSPACE"
+			unset PARAM
+		elif [ "$PARAM" = "stack" ]; then
+			STACK_ID="$NOSPACE"
+			STACK_CMD="-s $NOSPACE"
+			STACK="/stack/$NOSPACE"
+			unset PARAM
+		elif [ "$PARAM" = "scrap" ]; then
+			SCRAP_CMD="--scrap $NOSPACE"
+			unset PARAM
+		elif [ "$PARAM" = "archive" ]; then
+			DATA_DIR="$NOSPACE"
+			unset PARAM
+		else
+			if [ -z "${DOCKER_LIMITS[$DOCR]}" ]; then
+				DOCKER_LIMITS[$DOCR]=""
+			fi
+			if [ "$VOLUME" = "1" ]; then
+				SRC=$(echo $VALUE | cut -d':' -f1)
+				DST=$(echo $VALUE | cut -d':' -f2-)
+				SRC=$($readlink_command "$SRC")
+				DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} -v $SRC:$DST"
+				VOLUMES="$VOLUMES --volume $NOSPACE"
+				unset VOLUME
+			else
+				DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} $VALUE"
+				LIMITS="$LIMITS --limit $NOSPACE"
+			fi
+		fi
+		unset LIMIT
+	fi
 done
 
 if [ ! -z $LIMIT ]; then
-    echo "Error: No value given to --$PARAM"
-    echo
-    usage
-    exit -1
+	echo "Error: No value given to --$PARAM"
+	echo
+	usage
+	exit -1
 fi
 if [ "$DOCKER_PARAM" != "" ]; then
-    DOCKER_PARAM_FROM_FILE="1"
+	DOCKER_PARAM_FROM_FILE="1"
 fi
 while getopts ':hleEd:g:p:v:s:n:a:c:j:b:m:r:R:M:G:D:L:N:C:Q:A:f:P:S:T:k:' option; do
-  case "$option" in
-    h) usage
-       exit
-       ;;
-    v) VERSIONS=$OPTARG
-       ;;
-    M) MANAGER_VERSION=$OPTARG
-       ;;
-    d) DATA_DIR=$OPTARG
-       ;;
-    G) EXTERNAL_VOLUME="-G $OPTARG"
-       ;;
-    A) BIND_ADDRESS="$OPTARG:"
-       BIND_ADDRESS_CONFIG="-A $OPTARG"
-       ;;
-    r) ALERT_MANAGER_RULE_CONFIG="-r $OPTARG"
-       ;;
-    R) if [[ -d "$OPTARG" ]]; then
-        PROMETHEUS_RULES=$($readlink_command $OPTARG)":/etc/prometheus/prom_rules/"
-       else
-        PROMETHEUS_RULES=$($readlink_command $OPTARG)":/etc/prometheus/prometheus.rules.yml"
-       fi
-       ;;
-    g) GRAFANA_PORT="-g $OPTARG"
-       ;;
-    m) ALERTMANAGER_PORT="-p $OPTARG"
-       ;;
-    T) PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS -T $OPTARG"
-       ;;
-    Q) GRAFNA_ANONYMOUS_ROLE="-Q $OPTARG"
-       ;;
-    p) PROMETHEUS_PORT=$OPTARG
-       ;;
-    s) SCYLLA_TARGET_FILES=("$OPTARG")
-       ;;
-    n) NODE_TARGET_FILE=$OPTARG
-       ;;
-    l) if [[ "$DOCKER_PARAM" != *"--net=host"* ]]; then
-        DOCKER_PARAM="$DOCKER_PARAM --net=host"
-       fi
-       ;;
-    L) CONSUL_ADDRESS="-L $OPTARG"
-       ;;
-    P) LDAP_FILE="-P $OPTARG"
-       ;;
-    a) GRAFANA_ADMIN_PASSWORD="-a $OPTARG"
-       ;;
-    j) GRAFANA_DASHBOARD_ARRAY+=("$OPTARG")
-       ;;
-    c) GRAFANA_ENV_ARRAY+=("$OPTARG")
-       ;;
-    C) ALERTMANAGER_COMMANDS+=("$OPTARG")
-       ;;
-    D) if [ "$DOCKER_PARAM_FROM_FILE" = "1" ]; then
-          DOCKER_PARAM=""
-          DOCKER_PARAM_FROM_FILE=""
-       fi
-       DOCKER_PARAM="$DOCKER_PARAM $OPTARG"
-       ;;
-    b) PROMETHEUS_COMMAND_LINE_OPTIONS_ARRAY+=("$OPTARG")
-       ;;
-    N) SCYLLA_MANGER_TARGET_FILES=($OPTARG)
-       ;;
-    S) SPECIFIC_SOLUTION="-S $OPTARG"
-       ;;
-    E) RUN_RENDERER="-E"
-       ;;
-    f) ALERT_MANAGER_DIR="-f $OPTARG"
-       ;;
-    k) LOKI_DIR="-k $OPTARG"
-       ;;
-    :) printf "missing argument for -%s\n" "$OPTARG" >&2
-       echo "$usage" >&2
-       exit 1
-       ;;
-   \?) printf "illegal option: -%s\n" "$OPTARG" >&2
-       echo "$usage" >&2
-       exit 1
-       ;;
-  esac
+	case "$option" in
+	h)
+		usage
+		exit
+		;;
+	v)
+		VERSIONS=$OPTARG
+		;;
+	M)
+		MANAGER_VERSION=$OPTARG
+		;;
+	d)
+		DATA_DIR=$OPTARG
+		;;
+	G)
+		EXTERNAL_VOLUME="-G $OPTARG"
+		;;
+	A)
+		BIND_ADDRESS="$OPTARG:"
+		BIND_ADDRESS_CONFIG="-A $OPTARG"
+		;;
+	r)
+		ALERT_MANAGER_RULE_CONFIG="-r $OPTARG"
+		;;
+	R)
+		if [[ -d "$OPTARG" ]]; then
+			PROMETHEUS_RULES=$($readlink_command $OPTARG)":/etc/prometheus/prom_rules/"
+		else
+			PROMETHEUS_RULES=$($readlink_command $OPTARG)":/etc/prometheus/prometheus.rules.yml"
+		fi
+		;;
+	g)
+		GRAFANA_PORT="-g $OPTARG"
+		;;
+	m)
+		ALERTMANAGER_PORT="-p $OPTARG"
+		;;
+	T)
+		PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS -T $OPTARG"
+		;;
+	Q)
+		GRAFNA_ANONYMOUS_ROLE="-Q $OPTARG"
+		;;
+	p)
+		PROMETHEUS_PORT=$OPTARG
+		;;
+	s)
+		SCYLLA_TARGET_FILES=("$OPTARG")
+		;;
+	n)
+		NODE_TARGET_FILE=$OPTARG
+		;;
+	l)
+		if [[ "$DOCKER_PARAM" != *"--net=host"* ]]; then
+			DOCKER_PARAM="$DOCKER_PARAM --net=host"
+		fi
+		;;
+	L)
+		CONSUL_ADDRESS="-L $OPTARG"
+		;;
+	P)
+		LDAP_FILE="-P $OPTARG"
+		;;
+	a)
+		GRAFANA_ADMIN_PASSWORD="-a $OPTARG"
+		;;
+	j)
+		GRAFANA_DASHBOARD_ARRAY+=("$OPTARG")
+		;;
+	c)
+		GRAFANA_ENV_ARRAY+=("$OPTARG")
+		;;
+	C)
+		ALERTMANAGER_COMMANDS+=("$OPTARG")
+		;;
+	D)
+		if [ "$DOCKER_PARAM_FROM_FILE" = "1" ]; then
+			DOCKER_PARAM=""
+			DOCKER_PARAM_FROM_FILE=""
+		fi
+		DOCKER_PARAM="$DOCKER_PARAM $OPTARG"
+		;;
+	b)
+		PROMETHEUS_COMMAND_LINE_OPTIONS_ARRAY+=("$OPTARG")
+		;;
+	N)
+		SCYLLA_MANGER_TARGET_FILES=($OPTARG)
+		;;
+	S)
+		SPECIFIC_SOLUTION="-S $OPTARG"
+		;;
+	E)
+		RUN_RENDERER="-E"
+		;;
+	f)
+		ALERT_MANAGER_DIR="-f $OPTARG"
+		;;
+	k)
+		LOKI_DIR="-k $OPTARG"
+		;;
+	:)
+		printf "missing argument for -%s\n" "$OPTARG" >&2
+		echo "$usage" >&2
+		exit 1
+		;;
+	\?)
+		printf "illegal option: -%s\n" "$OPTARG" >&2
+		echo "$usage" >&2
+		exit 1
+		;;
+	esac
 done
 if [ "$ARCHIVE" == "1" ]; then
-    PROMETHEUS_COMMAND_LINE_OPTIONS_ARRAY+=(--storage.tsdb.retention.time=100y)
-    RUN_LOKI=0
-    SKIP_ALERTMANAGER="1"
-    RUN_RENDERER=""
-    CONSUL_ADDRESS="-L 127.0.0.1:0"
-    if [ ! -d $DATA_DIR/ ]; then
-        echo "The giving data directory $DATA_DIR does not exist"
-        exit 1
-    fi
-    if [ -f $DATA_DIR/scylla.txt ]; then
-        . $DATA_DIR/scylla.txt
-        echo "Taking version from $DATA_DIR/scylla.txt"
-        echo "Version set to $VERSIONS"
-    else
-        echo "scylla.txt not found in $DATA_DIR/. You can use it to start the monitoring stack with a given version"
-        echo "For example, to start the monitoring stack with version 2014.1 and manager 3.3"
-        echo 'echo VERSIONS="2024.1">'$DATA_DIR/scylla.txt
-        echo 'echo MANAGER_VERSION="3.3">>'$DATA_DIR/scylla.txt
-    fi
+	PROMETHEUS_COMMAND_LINE_OPTIONS_ARRAY+=(--storage.tsdb.retention.time=100y)
+	RUN_LOKI=0
+	SKIP_ALERTMANAGER="1"
+	RUN_RENDERER=""
+	CONSUL_ADDRESS="-L 127.0.0.1:0"
+	if [ ! -d $DATA_DIR/ ]; then
+		echo "The giving data directory $DATA_DIR does not exist"
+		exit 1
+	fi
+	if [ -f $DATA_DIR/scylla.txt ]; then
+		. $DATA_DIR/scylla.txt
+		echo "Taking version from $DATA_DIR/scylla.txt"
+		echo "Version set to $VERSIONS"
+	else
+		echo "scylla.txt not found in $DATA_DIR/. You can use it to start the monitoring stack with a given version"
+		echo "For example, to start the monitoring stack with version 2014.1 and manager 3.3"
+		echo 'echo VERSIONS="2024.1">'$DATA_DIR/scylla.txt
+		echo 'echo MANAGER_VERSION="3.3">>'$DATA_DIR/scylla.txt
+	fi
 fi
 
 if [ -z "$VERSIONS" ]; then
-  echo "Scylla-version was not not found, add the -v command-line with a specific version (i.e. -v 2021.1)"
-  exit 1
+	echo "Scylla-version was not not found, add the -v command-line with a specific version (i.e. -v 2021.1)"
+	exit 1
 fi
 
 if [ "$CURRENT_VERSION" = "master" ]; then
-    if [ "$ARCHIVE" = "" ]; then
-        echo ""
-        echo "*****************************************************"
-        echo "* WARNING: You are using the unstable master branch *"
-        echo "* Check the README.md file for the stable releases  *"
-        echo "*****************************************************"
-        ./generate-dashboards.sh -v $VERSIONS -m $MANAGER_VERSION $STACK_CMD
-    else
-        echo ./generate-dashboards.sh -v $VERSIONS -F -R 0 -m $MANAGER_VERSION $STACK_CMD
-        ./generate-dashboards.sh -v $VERSIONS -F -R 0 -m $MANAGER_VERSION $STACK_CMD
-    fi
-    echo "Generating the dashboards"
+	if [ "$ARCHIVE" = "" ]; then
+		echo ""
+		echo "*****************************************************"
+		echo "* WARNING: You are using the unstable master branch *"
+		echo "* Check the README.md file for the stable releases  *"
+		echo "*****************************************************"
+		./generate-dashboards.sh -v $VERSIONS -m $MANAGER_VERSION $STACK_CMD
+	else
+		echo ./generate-dashboards.sh -v $VERSIONS -F -R 0 -m $MANAGER_VERSION $STACK_CMD
+		./generate-dashboards.sh -v $VERSIONS -F -R 0 -m $MANAGER_VERSION $STACK_CMD
+	fi
+	echo "Generating the dashboards"
 
 fi
 
 if [[ $DOCKER_PARAM = *"--net=host"* ]]; then
-    if [ ! -z "$ALERTMANAGER_PORT" ] || [ ! -z "$GRAFANA_PORT" ] || [ ! -z $PROMETHEUS_PORT ]; then
-        echo "Port mapping is not supported with host network, remove the -l flag from the command line"
-        exit 1
-    fi
-    HOST_NETWORK=1
+	if [ ! -z "$ALERTMANAGER_PORT" ] || [ ! -z "$GRAFANA_PORT" ] || [ ! -z $PROMETHEUS_PORT ]; then
+		echo "Port mapping is not supported with host network, remove the -l flag from the command line"
+		exit 1
+	fi
+	HOST_NETWORK=1
 fi
 
 if [ -z "$TARGET_DIRECTORY" ] && [ -z "$CONSUL_ADDRESS" ]; then
-    for f in ${SCYLLA_TARGET_FILES[@]}; do
-        if [ -f $f ]; then
-            SCYLLA_TARGET_FILE=$f
-            break
-        fi
-    done
+	for f in ${SCYLLA_TARGET_FILES[@]}; do
+		if [ -f $f ]; then
+			SCYLLA_TARGET_FILE=$f
+			break
+		fi
+	done
 
-    if [ -z $SCYLLA_TARGET_FILE ]; then
-        echo "Scylla target file '${SCYLLA_TARGET_FILES}' does not exist, you can use prometheus/scylla_servers.example.yml as an example."
-        exit 1
-    fi
+	if [ -z $SCYLLA_TARGET_FILE ]; then
+		echo "Scylla target file '${SCYLLA_TARGET_FILES}' does not exist, you can use prometheus/scylla_servers.example.yml as an example."
+		exit 1
+	fi
 
-    if [ -z $NODE_TARGET_FILE ]; then
-       PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-node-exporter-file"
-       NODE_TARGET_FILE=$SCYLLA_TARGET_FILE
-    fi
+	if [ -z $NODE_TARGET_FILE ]; then
+		PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-node-exporter-file"
+		NODE_TARGET_FILE=$SCYLLA_TARGET_FILE
+	fi
 
-    if [ -z $SCYLLA_MANGER_AGENT_TARGET_FILE ]; then
-       PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-manager-agent-file"
-       SCYLLA_MANGER_AGENT_TARGET_FILE=$SCYLLA_TARGET_FILE
-    fi
-    if [ ! -f $NODE_TARGET_FILE ]; then
-        echo "Node target file '${NODE_TARGET_FILE}' does not exist"
-        exit 1
-    fi
+	if [ -z $SCYLLA_MANGER_AGENT_TARGET_FILE ]; then
+		PROMETHEUS_TARGETS="$PROMETHEUS_TARGETS --no-manager-agent-file"
+		SCYLLA_MANGER_AGENT_TARGET_FILE=$SCYLLA_TARGET_FILE
+	fi
+	if [ ! -f $NODE_TARGET_FILE ]; then
+		echo "Node target file '${NODE_TARGET_FILE}' does not exist"
+		exit 1
+	fi
 
-    for f in ${SCYLLA_MANGER_TARGET_FILES[@]}; do
-        if [ -f $f ]; then
-            SCYLLA_MANGER_TARGET_FILE=$f
-            break
-        fi
-    done
-    if [ -z $SCYLLA_MANGER_TARGET_FILE ]; then
-        echo "Scylla-Manager target file '${SCYLLA_MANGER_TARGET_FILES}' does not exist, you can use prometheus/scylla_manager_servers.example.yml as an example."
-        exit 1
-    fi
-    if [ -z "$HOST_NETWORK" ]; then
-        if  is_local $SCYLLA_TARGET_FILE $SCYLLA_MANGER_TARGET_FILE $NODE_TARGET_FILE; then
-            echo "Warning: It seems that you are trying to connect to localhost (either localhost or IP on the 127.x.x.x range)."
-            echo "  For example, maybe Scylla Manager is running on the localhost."
-            echo "If that is the case, you should set your Docker to use the host network. You can do that with the -l flag."
-            echo ""
-        fi
-    fi
+	for f in ${SCYLLA_MANGER_TARGET_FILES[@]}; do
+		if [ -f $f ]; then
+			SCYLLA_MANGER_TARGET_FILE=$f
+			break
+		fi
+	done
+	if [ -z $SCYLLA_MANGER_TARGET_FILE ]; then
+		echo "Scylla-Manager target file '${SCYLLA_MANGER_TARGET_FILES}' does not exist, you can use prometheus/scylla_manager_servers.example.yml as an example."
+		exit 1
+	fi
+	if [ -z "$HOST_NETWORK" ]; then
+		if is_local $SCYLLA_TARGET_FILE $SCYLLA_MANGER_TARGET_FILE $NODE_TARGET_FILE; then
+			echo "Warning: It seems that you are trying to connect to localhost (either localhost or IP on the 127.x.x.x range)."
+			echo "  For example, maybe Scylla Manager is running on the localhost."
+			echo "If that is the case, you should set your Docker to use the host network. You can do that with the -l flag."
+			echo ""
+		fi
+	fi
 
-    SCYLLA_TARGET_FILE="-v "$($readlink_command $SCYLLA_TARGET_FILE)":/etc/scylla.d/prometheus/targets/scylla_servers.yml"
-    SCYLLA_MANGER_TARGET_FILE="-v "$($readlink_command $SCYLLA_MANGER_TARGET_FILE)":/etc/scylla.d/prometheus/targets/scylla_manager_servers.yml"
-    NODE_TARGET_FILE="-v "$($readlink_command $NODE_TARGET_FILE)":/etc/scylla.d/prometheus/targets/node_exporter_servers.yml"
-    SCYLLA_MANGER_AGENT_TARGET_FILE="-v "$($readlink_command $SCYLLA_MANGER_AGENT_TARGET_FILE)":/etc/scylla.d/prometheus/targets/scylla_manager_agents.yml"
+	SCYLLA_TARGET_FILE="-v "$($readlink_command $SCYLLA_TARGET_FILE)":/etc/scylla.d/prometheus/targets/scylla_servers.yml"
+	SCYLLA_MANGER_TARGET_FILE="-v "$($readlink_command $SCYLLA_MANGER_TARGET_FILE)":/etc/scylla.d/prometheus/targets/scylla_manager_servers.yml"
+	NODE_TARGET_FILE="-v "$($readlink_command $NODE_TARGET_FILE)":/etc/scylla.d/prometheus/targets/node_exporter_servers.yml"
+	SCYLLA_MANGER_AGENT_TARGET_FILE="-v "$($readlink_command $SCYLLA_MANGER_AGENT_TARGET_FILE)":/etc/scylla.d/prometheus/targets/scylla_manager_agents.yml"
 else
-    SCYLLA_TARGET_FILE=""
-    SCYLLA_MANGER_TARGET_FILE=""
-    SCYLLA_MANGER_AGENT_TARGET_FILE=""
-    NODE_TARGET_FILE=""
+	SCYLLA_TARGET_FILE=""
+	SCYLLA_MANGER_TARGET_FILE=""
+	SCYLLA_MANGER_AGENT_TARGET_FILE=""
+	NODE_TARGET_FILE=""
 fi
 
 if [ "$TARGET_DIRECTORY" != "" ]; then
-    SCYLLA_TARGET_FILE="-v "$($readlink_command $TARGET_DIRECTORY)":/etc/scylla.d/prometheus/targets/:z"
-    if [ ! -f $TARGET_DIRECTORY/scylla_servers.yml ]; then
-        echo "Warning, using $TARGET_DIRECTORY for Prometheus traget directory, scylla_servers.yml is missing, make sure to create it, or ScyllaDB targets will be missing"
-    fi
-    if [ ! -f $TARGET_DIRECTORY/node_exporter_servers.yml ]; then
-        echo "Warning, using $TARGET_DIRECTORY for Prometheus traget directory, node_exporter_servers.yml is missing, make sure to create it, or node-exporter targets will be missing"
-    fi
-    if [ ! -f $TARGET_DIRECTORY/scylla_manager_agents.yml ]; then
-        echo "Warning, using $TARGET_DIRECTORY for Prometheus traget directory, scylla_manager_agents.yml is missing, make sure to create it, or ScyllaDB manager-agent targets will be missing"
-    fi
-    if [ ! -f $TARGET_DIRECTORY/scylla_manager_servers.yml ]; then
-        echo "Warning, using $TARGET_DIRECTORY for Prometheus traget directory, scylla_manager_servers.yml is missing, make sure to create it, or ScyllaDB manager target will be missing"
-    fi
+	SCYLLA_TARGET_FILE="-v "$($readlink_command $TARGET_DIRECTORY)":/etc/scylla.d/prometheus/targets/:z"
+	if [ ! -f $TARGET_DIRECTORY/scylla_servers.yml ]; then
+		echo "Warning, using $TARGET_DIRECTORY for Prometheus traget directory, scylla_servers.yml is missing, make sure to create it, or ScyllaDB targets will be missing"
+	fi
+	if [ ! -f $TARGET_DIRECTORY/node_exporter_servers.yml ]; then
+		echo "Warning, using $TARGET_DIRECTORY for Prometheus traget directory, node_exporter_servers.yml is missing, make sure to create it, or node-exporter targets will be missing"
+	fi
+	if [ ! -f $TARGET_DIRECTORY/scylla_manager_agents.yml ]; then
+		echo "Warning, using $TARGET_DIRECTORY for Prometheus traget directory, scylla_manager_agents.yml is missing, make sure to create it, or ScyllaDB manager-agent targets will be missing"
+	fi
+	if [ ! -f $TARGET_DIRECTORY/scylla_manager_servers.yml ]; then
+		echo "Warning, using $TARGET_DIRECTORY for Prometheus traget directory, scylla_manager_servers.yml is missing, make sure to create it, or ScyllaDB manager target will be missing"
+	fi
 fi
-if [ -z $DATA_DIR ]
-then
-    USER_PERMISSIONS=""
-    echo "Warning: without an external Prometheus directory, Prometheus data will be deleted on shutdown, use the -d command line flag for data persistence."
+if [ -z $DATA_DIR ]; then
+	USER_PERMISSIONS=""
+	echo "Warning: without an external Prometheus directory, Prometheus data will be deleted on shutdown, use the -d command line flag for data persistence."
 else
-    if [ -d $DATA_DIR ]; then
-        echo "Loading prometheus data from $DATA_DIR"
-    else
-        echo "Creating data directory $DATA_DIR"
-        mkdir -p $DATA_DIR
-    fi
-    if [[ "$VICTORIA_METRICS" = "1" ]]; then
-        DATA_DIR_CMD="-v "$($readlink_command $DATA_DIR)":/victoria-metrics-data"
-    else
-        DATA_DIR_CMD="-v "$($readlink_command $DATA_DIR)":/prometheus/data:Z"
-    fi
+	if [ -d $DATA_DIR ]; then
+		echo "Loading prometheus data from $DATA_DIR"
+	else
+		echo "Creating data directory $DATA_DIR"
+		mkdir -p $DATA_DIR
+	fi
+	if [[ "$VICTORIA_METRICS" = "1" ]]; then
+		DATA_DIR_CMD="-v "$($readlink_command $DATA_DIR)":/victoria-metrics-data"
+	else
+		DATA_DIR_CMD="-v "$($readlink_command $DATA_DIR)":/prometheus/data:Z"
+	fi
 fi
 
 if [ "$VERSIONS" = "latest" ]; then
-    if [ -z "$BRANCH_VERSION" ] || [ "$BRANCH_VERSION" = "master" ]; then
-        echo "Default versions (-v latest) is not supported on the master branch, use specific version instead"
-        exit 1
-    fi
-    VERSIONS=${DEFAULT_VERSION[$BRANCH_VERSION]}
-    echo "The use of -v latest is deprecated. Use a specific version instead."
+	if [ -z "$BRANCH_VERSION" ] || [ "$BRANCH_VERSION" = "master" ]; then
+		echo "Default versions (-v latest) is not supported on the master branch, use specific version instead"
+		exit 1
+	fi
+	VERSIONS=${DEFAULT_VERSION[$BRANCH_VERSION]}
+	echo "The use of -v latest is deprecated. Use a specific version instead."
 else
-    if [ "$VERSIONS" = "all" ]; then
-        VERSIONS=$ALL
-    fi
+	if [ "$VERSIONS" = "all" ]; then
+		VERSIONS=$ALL
+	fi
 fi
 if [ "$STACK_ID" != "" ]; then
-    echo "Running a seconddary stack $STACK_ID"
-    echo "Note that the following containers will not run: loki, promtail, grafana renderer"
-    echo "to stop it use ./kill-all.sh --stack $STACK_ID"
-    RUN_LOKI=0
-    RUN_RENDERER=""
-    PROMETHEUS_PORT=${STACK_PROMETHEUS["$STACK_ID"]}
-    GRAFANA_PORT="-g"${STACK_GRAFANA["$STACK_ID"]}
-    ALERTMANAGER_PORT="-p "${STACK_ALERTMANAGER["$STACK_ID"]}
+	echo "Running a seconddary stack $STACK_ID"
+	echo "Note that the following containers will not run: loki, promtail, grafana renderer"
+	echo "to stop it use ./kill-all.sh --stack $STACK_ID"
+	RUN_LOKI=0
+	RUN_RENDERER=""
+	PROMETHEUS_PORT=${STACK_PROMETHEUS["$STACK_ID"]}
+	GRAFANA_PORT="-g"${STACK_GRAFANA["$STACK_ID"]}
+	ALERTMANAGER_PORT="-p "${STACK_ALERTMANAGER["$STACK_ID"]}
 fi
 
 ALERTMANAGER_COMMAND=""
 for val in "${ALERTMANAGER_COMMANDS[@]}"; do
-    ALERTMANAGER_COMMAND="$ALERTMANAGER_COMMAND -C $val"
+	ALERTMANAGER_COMMAND="$ALERTMANAGER_COMMAND -C $val"
 done
 
 if [ "$SKIP_ALERTMANAGER" = "1" ]; then
-    AM_ADDRESS="127.0.0.1:9093"
+	AM_ADDRESS="127.0.0.1:9093"
 else
-    echo "Wait for alert manager container to start"
-    AM_ADDRESS=`./start-alertmanager.sh $ALERTMANAGER_PORT $ALERT_MANAGER_DIR -D "$DOCKER_PARAM" $LIMITS $VOLUMES $PARAMS $ALERTMANAGER_COMMAND $BIND_ADDRESS_CONFIG $ALERT_MANAGER_RULE_CONFIG`
-    if [ $? -ne 0 ]; then
-        echo "$AM_ADDRESS"
-        exit 1
-    fi
+	echo "Wait for alert manager container to start"
+	AM_ADDRESS=$(./start-alertmanager.sh $ALERTMANAGER_PORT $ALERT_MANAGER_DIR -D "$DOCKER_PARAM" $LIMITS $VOLUMES $PARAMS $ALERTMANAGER_COMMAND $BIND_ADDRESS_CONFIG $ALERT_MANAGER_RULE_CONFIG)
+	if [ $? -ne 0 ]; then
+		echo "$AM_ADDRESS"
+		exit 1
+	fi
 fi
 LOKI_ADDRESS=""
 if [ $RUN_LOKI -eq 1 ]; then
-    echo "Wait for Loki container to start."
-	LOKI_ADDRESS=`./start-loki.sh $BIND_ADDRESS_CONFIG $LOKI_DIR $LOKI_PORT -D "$DOCKER_PARAM" $LIMITS $VOLUMES $PARAMS -m $AM_ADDRESS`
+	echo "Wait for Loki container to start."
+	LOKI_ADDRESS=$(./start-loki.sh $BIND_ADDRESS_CONFIG $LOKI_DIR $LOKI_PORT -D "$DOCKER_PARAM" $LIMITS $VOLUMES $PARAMS -m $AM_ADDRESS)
 	if [ $? -ne 0 ]; then
-	    echo "$LOKI_ADDRESS"
-	    exit 1
+		echo "$LOKI_ADDRESS"
+		exit 1
 	fi
-    LOKI_ADDRESS="-L $LOKI_ADDRESS"
+	LOKI_ADDRESS="-L $LOKI_ADDRESS"
 fi
 
 if [ -z $PROMETHEUS_PORT ]; then
-    PROMETHEUS_PORT=9090
-    PROMETHEUS_NAME=aprom
+	PROMETHEUS_PORT=9090
+	PROMETHEUS_NAME=aprom
 else
-    PROMETHEUS_NAME=aprom-$PROMETHEUS_PORT
+	PROMETHEUS_NAME=aprom-$PROMETHEUS_PORT
 fi
 
-docker container inspect $PROMETHEUS_NAME > /dev/null 2>&1
+docker container inspect $PROMETHEUS_NAME >/dev/null 2>&1
 if [ $? -eq 0 ]; then
-    printf "\nSome of the monitoring docker instances ($PROMETHEUS_NAME) exist. Make sure all containers are killed and removed. You can use kill-all.sh for that\n"
-    exit 1
+	printf "\nSome of the monitoring docker instances ($PROMETHEUS_NAME) exist. Make sure all containers are killed and removed. You can use kill-all.sh for that\n"
+	exit 1
 fi
-
 
 # Exit if Docker engine is not running
-if [ ! "$(docker ps)" ]
-then
-        echo "Error: Docker engine is not running"
-        exit 1
+if [ ! "$(docker ps)" ]; then
+	echo "Error: Docker engine is not running"
+	exit 1
 fi
 
 for val in "${PROMETHEUS_COMMAND_LINE_OPTIONS_ARRAY[@]}"; do
-    if [[ $val = "--"* ]]; then
-        PROMETHEUS_COMMAND_LINE_OPTIONS+=" $val"
-    else
-        echo "Using single hyphen is deprecated and will be removed in future version use -$val instead"
-        PROMETHEUS_COMMAND_LINE_OPTIONS+=" -$val"
-    fi
+	if [[ $val = "--"* ]]; then
+		PROMETHEUS_COMMAND_LINE_OPTIONS+=" $val"
+	else
+		echo "Using single hyphen is deprecated and will be removed in future version use -$val instead"
+		PROMETHEUS_COMMAND_LINE_OPTIONS+=" -$val"
+	fi
 done
 
 ./prometheus-config.sh -m $AM_ADDRESS $STACK_CMD $SCRAP_CMD $CONSUL_ADDRESS $PROMETHEUS_TARGETS
 if [ "$DATA_DIR" != "" ] && [ "$ARCHIVE" != "1" ]; then
-    DATE=$(date +"%Y-%m-%d_%H_%M_%S")
-    if [ -f $DATA_DIR/scylla.txt ]; then
-        mv $DATA_DIR/scylla.txt $DATA_DIR/scylla.$DATE.txt
-    fi
-    echo LAST_COMMAND_LINE='"'"$@"'"' > $DATA_DIR/scylla.txt
-    echo VERSIONS='"'"$VERSIONS"'"' >> $DATA_DIR/scylla.txt
-    echo MANAGER_VERSION='"'"$MANAGER_VERSION"'"' >> $DATA_DIR/scylla.txt
-    echo MONITORING_VERSION='"'"$CURRENT_VERSION"'"' >> $DATA_DIR/scylla.txt
-    echo PROMETHEUS_VERSION='"'"$PROMETHEUS_VERSION"'"' >> $DATA_DIR/scylla.txt
-    echo LAST_RUN='"'"$DATE"'"' >> $DATA_DIR/scylla.txt
-    if [ "$RUN_ALTERNATOR" = "1" ]; then
-        echo RUN_ALTERNATOR=1 >> $DATA_DIR/scylla.txt
-    fi
+	DATE=$(date +"%Y-%m-%d_%H_%M_%S")
+	if [ -f $DATA_DIR/scylla.txt ]; then
+		mv $DATA_DIR/scylla.txt $DATA_DIR/scylla.$DATE.txt
+	fi
+	echo LAST_COMMAND_LINE='"'"$@"'"' >$DATA_DIR/scylla.txt
+	echo VERSIONS='"'"$VERSIONS"'"' >>$DATA_DIR/scylla.txt
+	echo MANAGER_VERSION='"'"$MANAGER_VERSION"'"' >>$DATA_DIR/scylla.txt
+	echo MONITORING_VERSION='"'"$CURRENT_VERSION"'"' >>$DATA_DIR/scylla.txt
+	echo PROMETHEUS_VERSION='"'"$PROMETHEUS_VERSION"'"' >>$DATA_DIR/scylla.txt
+	echo LAST_RUN='"'"$DATE"'"' >>$DATA_DIR/scylla.txt
+	if [ "$RUN_ALTERNATOR" = "1" ]; then
+		echo RUN_ALTERNATOR=1 >>$DATA_DIR/scylla.txt
+	fi
 fi
 if [ -z $HOST_NETWORK ]; then
-    PORT_MAPPING="-p $BIND_ADDRESS$PROMETHEUS_PORT:9090"
+	PORT_MAPPING="-p $BIND_ADDRESS$PROMETHEUS_PORT:9090"
 fi
 if [[ "$VICTORIA_METRICS" = "1" ]]; then
-    echo "Using victoria metrics"
+	echo "Using victoria metrics"
 
-    docker run -d --rm $DATA_DIR_CMD $PORT_MAPPING --name $PROMETHEUS_NAME \
-    -v $PWD/prometheus/build/prometheus.yml:/etc/promscrape.config.yml:z \
-    $SCYLLA_TARGET_FILE \
-     $SCYLLA_MANGER_TARGET_FILE \
-     $NODE_TARGET_FILE \
-     $SCYLLA_MANGER_AGENT_TARGET_FILE \
-    victoriametrics/victoria-metrics:$VICTORIA_METRICS_VERSION $PROMETHEUS_COMMAND_LINE_OPTIONS \
-     ${DOCKER_PARAMS["prometheus"]} -promscrape.config=/etc/promscrape.config.yml -promscrape.config.strictParse=false -httpListenAddr=:9090
+	docker run -d --rm $DATA_DIR_CMD $PORT_MAPPING --name $PROMETHEUS_NAME \
+		-v $PWD/prometheus/build/prometheus.yml:/etc/promscrape.config.yml:z \
+		$SCYLLA_TARGET_FILE \
+		$SCYLLA_MANGER_TARGET_FILE \
+		$NODE_TARGET_FILE \
+		$SCYLLA_MANGER_AGENT_TARGET_FILE \
+		victoriametrics/victoria-metrics:$VICTORIA_METRICS_VERSION $PROMETHEUS_COMMAND_LINE_OPTIONS \
+		${DOCKER_PARAMS["prometheus"]} -promscrape.config=/etc/promscrape.config.yml -promscrape.config.strictParse=false -httpListenAddr=:9090
 else
-docker run -d $DOCKER_PARAM ${DOCKER_LIMITS["prometheus"]} $USER_PERMISSIONS \
-     $DATA_DIR_CMD \
-     "${group_args[@]}" \
-     -v $PWD/prometheus/build$STACK/prometheus.yml:/etc/prometheus/prometheus.yml:z \
-     -v $PROMETHEUS_RULES:z \
-     $SCYLLA_TARGET_FILE \
-     $SCYLLA_MANGER_TARGET_FILE \
-     $NODE_TARGET_FILE \
-     $SCYLLA_MANGER_AGENT_TARGET_FILE \
-     $PORT_MAPPING --name $PROMETHEUS_NAME docker.io/prom/prometheus:$PROMETHEUS_VERSION \
-     --web.enable-lifecycle --config.file=/etc/prometheus/prometheus.yml $PROMETHEUS_COMMAND_LINE_OPTIONS \
-     ${DOCKER_PARAMS["prometheus"]}
+	docker run -d $DOCKER_PARAM ${DOCKER_LIMITS["prometheus"]} $USER_PERMISSIONS \
+		$DATA_DIR_CMD \
+		"${group_args[@]}" \
+		-v $PWD/prometheus/build$STACK/prometheus.yml:/etc/prometheus/prometheus.yml:z \
+		-v $PROMETHEUS_RULES:z \
+		$SCYLLA_TARGET_FILE \
+		$SCYLLA_MANGER_TARGET_FILE \
+		$NODE_TARGET_FILE \
+		$SCYLLA_MANGER_AGENT_TARGET_FILE \
+		$PORT_MAPPING --name $PROMETHEUS_NAME docker.io/prom/prometheus:$PROMETHEUS_VERSION \
+		--web.enable-lifecycle --config.file=/etc/prometheus/prometheus.yml $PROMETHEUS_COMMAND_LINE_OPTIONS \
+		${DOCKER_PARAMS["prometheus"]}
 fi
 
 if [ $? -ne 0 ]; then
-    echo "Error: Prometheus container failed to start"
-    echo "For more information use: docker logs $PROMETHEUS_NAME"
-    exit 1
+	echo "Error: Prometheus container failed to start"
+	echo "For more information use: docker logs $PROMETHEUS_NAME"
+	exit 1
 fi
 
 # Number of retries waiting for a Docker container to start
@@ -747,17 +784,16 @@ RETRIES=7
 printf "Wait for Prometheus container to start."
 TRIES=0
 until $(curl --output /dev/null -f --silent http://localhost:$PROMETHEUS_PORT) || [ $TRIES -eq $RETRIES ]; do
-    printf '.'
-    ((TRIES=TRIES+1))
-    sleep 5
+	printf '.'
+	((TRIES = TRIES + 1))
+	sleep 5
 done
 echo
 
-if [ ! "$(docker ps -q -f name=$PROMETHEUS_NAME)" ]
-then
-        echo "Error: Prometheus container failed to start"
-        echo "For more information use: docker logs $PROMETHEUS_NAME"
-        exit 1
+if [ ! "$(docker ps -q -f name=$PROMETHEUS_NAME)" ]; then
+	echo "Error: Prometheus container failed to start"
+	echo "For more information use: docker logs $PROMETHEUS_NAME"
+	exit 1
 fi
 
 # Can't use localhost here, because the monitoring may be running remotely.
@@ -765,50 +801,50 @@ fi
 DB_ADDRESS="$(docker inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $PROMETHEUS_NAME):9090"
 
 if [ "$DB_ADDRESS" = ":9090" ]; then
-    if [[ $(uname) == "Linux" ]]; then
-        HOST_IP=$(hostname -I | awk '{print $1}')
-    elif [[ $(uname) == "Darwin" ]]; then
-        HOST_IP=$(ifconfig en0 | awk '/inet / {print $2}')
-    fi
-    DB_ADDRESS="$HOST_IP:$PROMETHEUS_PORT"
+	if [[ $(uname) == "Linux" ]]; then
+		HOST_IP=$(hostname -I | awk '{print $1}')
+	elif [[ $(uname) == "Darwin" ]]; then
+		HOST_IP=$(ifconfig en0 | awk '/inet / {print $2}')
+	fi
+	DB_ADDRESS="$HOST_IP:$PROMETHEUS_PORT"
 fi
 
 if [[ "$VICTORIA_METRICS" = "1" ]]; then
-     echo "running vmalert"
+	echo "running vmalert"
 
-     docker run -d \
-     --name vmalert \
-     -v $PROMETHEUS_RULES:z \
-     victoriametrics/vmalert:$VICTORIA_METRICS_VERSION -rule=/etc/prometheus/prom_rules/*yml \
-    -datasource.url=http://$DB_ADDRESS \
-    -notifier.url=http://$AM_ADDRESS \
-    -notifier.url=http://$AM_ADDRESS \
-    -remoteWrite.url=http://$DB_ADDRESS \
-    -remoteRead.url=http://$DB_ADDRESS
+	docker run -d \
+		--name vmalert \
+		-v $PROMETHEUS_RULES:z \
+		victoriametrics/vmalert:$VICTORIA_METRICS_VERSION -rule=/etc/prometheus/prom_rules/*yml \
+		-datasource.url=http://$DB_ADDRESS \
+		-notifier.url=http://$AM_ADDRESS \
+		-notifier.url=http://$AM_ADDRESS \
+		-remoteWrite.url=http://$DB_ADDRESS \
+		-remoteRead.url=http://$DB_ADDRESS
 fi
 if [ $RUN_THANOS_SC -eq 1 ]; then
-    if [ -z $DATA_DIR ]; then
-        echo "You must use external prometheus directory to use the thanos side cart"
-    else
-        ./start-thanos-sc.sh -d $DATA_DIR -D "$DOCKER_PARAM" -a $DB_ADDRESS $LIMITS $VOLUMES $PARAMS $BIND_ADDRESS_CONFIG
-    fi
+	if [ -z $DATA_DIR ]; then
+		echo "You must use external prometheus directory to use the thanos side cart"
+	else
+		./start-thanos-sc.sh -d $DATA_DIR -D "$DOCKER_PARAM" -a $DB_ADDRESS $LIMITS $VOLUMES $PARAMS $BIND_ADDRESS_CONFIG
+	fi
 fi
 
 if [ $RUN_THANOS -eq 1 ]; then
-    ./start-thanos.sh -D "$DOCKER_PARAM" $BIND_ADDRESS_CONFIG
+	./start-thanos.sh -D "$DOCKER_PARAM" $BIND_ADDRESS_CONFIG
 fi
 
 for val in "${GRAFANA_ENV_ARRAY[@]}"; do
-        GRAFANA_ENV_COMMAND="$GRAFANA_ENV_COMMAND -c $val"
+	GRAFANA_ENV_COMMAND="$GRAFANA_ENV_COMMAND -c $val"
 done
 
 for val in "${GRAFANA_DASHBOARD_ARRAY[@]}"; do
-        GRAFANA_DASHBOARD_COMMAND="$GRAFANA_DASHBOARD_COMMAND -j $val"
+	GRAFANA_DASHBOARD_COMMAND="$GRAFANA_DASHBOARD_COMMAND -j $val"
 done
 if [ ! -z "$DATDOGPARAM" ]; then
-   ./start-datadog.sh $DATDOGPARAM -p $DB_ADDRESS
+	./start-datadog.sh $DATDOGPARAM -p $DB_ADDRESS
 fi
 if [ "$RUN_ALTERNATOR" = 1 ]; then
-    GRAFANA_ENV_COMMAND="$GRAFANA_ENV_COMMAND --alternator"
+	GRAFANA_ENV_COMMAND="$GRAFANA_ENV_COMMAND --alternator"
 fi
 ./start-grafana.sh $SCRAP_CMD $LDAP_FILE $LOKI_ADDRESS $LIMITS $VOLUMES $PARAMS $BIND_ADDRESS_CONFIG $RUN_RENDERER $SPECIFIC_SOLUTION -p $DB_ADDRESS $GRAFNA_ANONYMOUS_ROLE -D "$DOCKER_PARAM" $GRAFANA_PORT $EXTERNAL_VOLUME -m $AM_ADDRESS -M $MANAGER_VERSION -v $VERSIONS $GRAFANA_ENV_COMMAND $GRAFANA_DASHBOARD_COMMAND $GRAFANA_ADMIN_PASSWORD $STACK_CMD

--- a/start-datadog.sh
+++ b/start-datadog.sh
@@ -1,96 +1,106 @@
 #!/usr/bin/env bash
-if [ -f  env.sh ]; then
-    . env.sh
+if [ -f env.sh ]; then
+	. env.sh
 fi
 usage="$(basename "$0") [-h] [-A DD_API_KEY ][-p ip:port address of prometheus ] [-d configuration directory] [-e environment variable, multiple params are supported] [-D encapsulate docker param] -- Start a datadog agent inside a container"
 
 while getopts ':hA:p:e:H:D:' option; do
-  case "$option" in
-    h) echo "$usage"
-       exit
-       ;;
-    A) DD_API_KEY=$OPTARG
-       ;;
-    D) DOCKER_PARAM="$DOCKER_PARAM $OPTARG"
-       ;;
-    H) hostname="$OPTARG"
-       ;;
-    e) ENV_ARRAY+=("$OPTARG")
-       ;;
-    d) CONF_DIR="$OPTARG"
-       ;;
-    p) PROMIP="$OPTARG"
-       ;;
-    l) DOCKER_PARAM="$DOCKER_PARAM --net=host"
-       ;;
-    :) printf "missing argument for -%s\n" "$OPTARG" >&2
-       echo "$usage" >&2
-       exit 1
-       ;;
-   \?) printf "illegal option: -%s\n" "$OPTARG" >&2
-       echo "$usage" >&2
-       exit 1
-       ;;
-  esac
+	case "$option" in
+	h)
+		echo "$usage"
+		exit
+		;;
+	A)
+		DD_API_KEY=$OPTARG
+		;;
+	D)
+		DOCKER_PARAM="$DOCKER_PARAM $OPTARG"
+		;;
+	H)
+		hostname="$OPTARG"
+		;;
+	e)
+		ENV_ARRAY+=("$OPTARG")
+		;;
+	d)
+		CONF_DIR="$OPTARG"
+		;;
+	p)
+		PROMIP="$OPTARG"
+		;;
+	l)
+		DOCKER_PARAM="$DOCKER_PARAM --net=host"
+		;;
+	:)
+		printf "missing argument for -%s\n" "$OPTARG" >&2
+		echo "$usage" >&2
+		exit 1
+		;;
+	\?)
+		printf "illegal option: -%s\n" "$OPTARG" >&2
+		echo "$usage" >&2
+		exit 1
+		;;
+	esac
 done
 
 if [ -z "$DD_API_KEY" ]; then
 	printf "\nDatagot API keys are not present, exiting.\n"
-    exit 1
+	exit 1
 fi
 if [ -z "$DATADOG_NAME" ]; then
-    DATADOG_NAME="datadog-agent"
+	DATADOG_NAME="datadog-agent"
 fi
 
-docker container inspect $DATADOG_NAME > /dev/null 2>&1
+docker container inspect $DATADOG_NAME >/dev/null 2>&1
 if [ $? -eq 0 ]; then
-    printf "\nSome of the monitoring docker instances ($DATADOG_NAME) exist. Make sure all containers are killed and removed. You can use kill-all.sh for that\n"
-    exit 1
+	printf "\nSome of the monitoring docker instances ($DATADOG_NAME) exist. Make sure all containers are killed and removed. You can use kill-all.sh for that\n"
+	exit 1
 fi
 
 group_args=()
 is_podman="$(docker --help | grep -o podman)"
 if [ ! -z "$is_podman" ]; then
-    group_args+=(--userns=keep-id)
+	group_args+=(--userns=keep-id)
 fi
 
 if [ -z "$CONF_DIR" ]; then
-    CONF_DIR="datadog_conf"
+	CONF_DIR="datadog_conf"
 fi
 
 for val in "${ENV_ARRAY[@]}"; do
-        ENV_COMMAND="$ENV_COMMAND -e $val"
+	ENV_COMMAND="$ENV_COMMAND -e $val"
 done
 
 if [[ -z "${DOCKER_HOST}" ]]; then
-    if [ ! -z "$is_podman" ]; then
-        if [[ $(uname) == "Linux" ]]; then
-            DOCKER_HOST=$(hostname -I | awk '{print $1}')
-        elif [[ $(uname) == "Darwin" ]]; then
-            DOCKER_HOST=$(ifconfig bridge0 | awk '/inet / {print $2}')
-        fi
-    else
-        if [[ $(uname) == "Linux" ]]; then
-            DOCKER_HOST=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+')
-        elif [[ $(uname) == "Darwin" ]]; then
-            DOCKER_HOST=$(ifconfig bridge0 | awk '/inet / {print $2}')
-        fi
-    fi
+	if [ ! -z "$is_podman" ]; then
+		if [[ $(uname) == "Linux" ]]; then
+			DOCKER_HOST=$(hostname -I | awk '{print $1}')
+		elif [[ $(uname) == "Darwin" ]]; then
+			DOCKER_HOST=$(ifconfig bridge0 | awk '/inet / {print $2}')
+		fi
+	else
+		if [[ $(uname) == "Linux" ]]; then
+			DOCKER_HOST=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+')
+		elif [[ $(uname) == "Darwin" ]]; then
+			DOCKER_HOST=$(ifconfig bridge0 | awk '/inet / {print $2}')
+		fi
+	fi
 fi
 
 if [[ $(uname) == "Linux" ]]; then
-  readlink_command="readlink -f"
+	readlink_command="readlink -f"
 elif [[ $(uname) == "Darwin" ]]; then
-  readlink_command="realpath "
+	readlink_command="realpath "
 fi
 
 if [ -z "$hostname" ]; then
-    hostname=$HOSTNAME
+	hostname=$HOSTNAME
 fi
-    
+
 mkdir -p $CONF_DIR/conf.d/prometheus.d
 if [ ! -f $CONF_DIR/datadog.yaml ]; then
-    cat >$CONF_DIR/datadog.yaml <<EOL
+	cat >$CONF_DIR/datadog.yaml <<EOL
 # datadog.yaml
 process_config:
   enabled: true
@@ -101,13 +111,13 @@ log_level: INFO
 hostname: ${hostname}
 EOL
 fi
-cat docs/source/procedures/datadog/conf.yaml|sed "s/IP:9090/$PROMIP/g" > $CONF_DIR/conf.d/prometheus.d/conf.yaml
+cat docs/source/procedures/datadog/conf.yaml | sed "s/IP:9090/$PROMIP/g" >$CONF_DIR/conf.d/prometheus.d/conf.yaml
 
 CONF_DIR=$($readlink_command "$CONF_DIR")
 
 docker run -d $DOCKER_PARAM ${DOCKER_LIMITS["datadog"]} -i \
---name $DATADOG_NAME \
---pid host -v $CONF_DIR/datadog.yaml:/etc/datadog-agent/datadog.yaml \
--v $CONF_DIR/conf.d/:/conf.d \
-$ENV_COMMAND \
--e DD_API_KEY="$DD_API_KEY" -e DD_CONTAINER_INCLUDE="" gcr.io/datadoghq/agent:latest
+	--name $DATADOG_NAME \
+	--pid host -v $CONF_DIR/datadog.yaml:/etc/datadog-agent/datadog.yaml \
+	-v $CONF_DIR/conf.d/:/conf.d \
+	$ENV_COMMAND \
+	-e DD_API_KEY="$DD_API_KEY" -e DD_CONTAINER_INCLUDE="" gcr.io/datadoghq/agent:latest

--- a/start-grafana-renderer.sh
+++ b/start-grafana-renderer.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 . versions.sh
-if [ -f  env.sh ]; then
-    . env.sh
+if [ -f env.sh ]; then
+	. env.sh
 fi
 
 VERSION="$GRAFANA_RENDERER_VERSION"
@@ -16,82 +16,88 @@ LIMITS=""
 VOLUMES=""
 PARAMS=""
 for arg; do
-    shift
-    if [ -z "$LIMIT" ]; then
-        case $arg in
-            (--limit)
-                LIMIT="1"
-                ;;
-            (--volume)
-                LIMIT="1"
-                VOLUME="1"
-                ;;
-            (--param)
-                LIMIT="1"
-                PARAM="1"
-                ;;
-            (*) set -- "$@" "$arg"
-                ;;
-        esac
-    else
-        DOCR=`echo $arg|cut -d',' -f1`
-        VALUE=`echo $arg|cut -d',' -f2-|sed 's/#/ /g'`
-        NOSPACE=`echo $arg|sed 's/ /#/g'`
-        if [ "$PARAM" = "1" ]; then
-            if [ -z "${DOCKER_PARAMS[$DOCR]}" ]; then
-                DOCKER_PARAMS[$DOCR]=""
-            fi
-            DOCKER_PARAMS[$DOCR]="${DOCKER_PARAMS[$DOCR]} $VALUE"
-            PARAMS="$PARAMS --param $NOSPACE"
-            unset PARAM
-        else
-            if [ -z "${DOCKER_LIMITS[$DOCR]}" ]; then
-                DOCKER_LIMITS[$DOCR]=""
-            fi
-            if [ "$VOLUME" = "1" ]; then
-                SRC=`echo $VALUE|cut -d':' -f1`
-                DST=`echo $VALUE|cut -d':' -f2-`
-                SRC=$(readlink -m $SRC)
-                DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} -v $SRC:$DST"
-                VOLUMES="$VOLUMES --volume $NOSPACE"
-                unset VOLUME
-            else
-                DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} $VALUE"
-                LIMITS="$LIMITS --limit $NOSPACE"
-            fi
-        fi
-        unset LIMIT
-    fi
+	shift
+	if [ -z "$LIMIT" ]; then
+		case $arg in
+		--limit)
+			LIMIT="1"
+			;;
+		--volume)
+			LIMIT="1"
+			VOLUME="1"
+			;;
+		--param)
+			LIMIT="1"
+			PARAM="1"
+			;;
+		*)
+			set -- "$@" "$arg"
+			;;
+		esac
+	else
+		DOCR=$(echo $arg | cut -d',' -f1)
+		VALUE=$(echo $arg | cut -d',' -f2- | sed 's/#/ /g')
+		NOSPACE=$(echo $arg | sed 's/ /#/g')
+		if [ "$PARAM" = "1" ]; then
+			if [ -z "${DOCKER_PARAMS[$DOCR]}" ]; then
+				DOCKER_PARAMS[$DOCR]=""
+			fi
+			DOCKER_PARAMS[$DOCR]="${DOCKER_PARAMS[$DOCR]} $VALUE"
+			PARAMS="$PARAMS --param $NOSPACE"
+			unset PARAM
+		else
+			if [ -z "${DOCKER_LIMITS[$DOCR]}" ]; then
+				DOCKER_LIMITS[$DOCR]=""
+			fi
+			if [ "$VOLUME" = "1" ]; then
+				SRC=$(echo $VALUE | cut -d':' -f1)
+				DST=$(echo $VALUE | cut -d':' -f2-)
+				SRC=$(readlink -m $SRC)
+				DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} -v $SRC:$DST"
+				VOLUMES="$VOLUMES --volume $NOSPACE"
+				unset VOLUME
+			else
+				DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} $VALUE"
+				LIMITS="$LIMITS --limit $NOSPACE"
+			fi
+		fi
+		unset LIMIT
+	fi
 done
 while getopts ':hlg:D:' option; do
-  case "$option" in
-    h) echo "$usage"
-       exit
-       ;;
-    l) DOCKER_PARAM="$DOCKER_PARAM --net=host"
-       ;;
-    D) DOCKER_PARAM="$DOCKER_PARAM $OPTARG"
-       ;;
-    :) printf "missing argument for -%s\n" "$OPTARG" >&2
-       echo "$usage" >&2
-       exit 1
-       ;;
-   \?) printf "illegal option: -%s\n" "$OPTARG" >&2
-       echo "$usage" >&2
-       exit 1
-       ;;
-  esac
+	case "$option" in
+	h)
+		echo "$usage"
+		exit
+		;;
+	l)
+		DOCKER_PARAM="$DOCKER_PARAM --net=host"
+		;;
+	D)
+		DOCKER_PARAM="$DOCKER_PARAM $OPTARG"
+		;;
+	:)
+		printf "missing argument for -%s\n" "$OPTARG" >&2
+		echo "$usage" >&2
+		exit 1
+		;;
+	\?)
+		printf "illegal option: -%s\n" "$OPTARG" >&2
+		echo "$usage" >&2
+		exit 1
+		;;
+	esac
 done
 
-if [ "`id -u`" -ne 0 ]; then
-    GROUPID=`id -g`
-    USER_PERMISSIONS="-u $UID:$GROUPID"
+if [ "$(id -u)" -ne 0 ]; then
+	GROUPID=$(id -g)
+	USER_PERMISSIONS="-u $UID:$GROUPID"
 fi
 
 if [[ ! $DOCKER_PARAM = *"--net=host"* ]]; then
-    PORT_MAPPING="-p $GRAFANA_RENDPORT:8081"
+	PORT_MAPPING="-p $GRAFANA_RENDPORT:8081"
 fi
 
 docker run ${DOCKER_LIMITS["grafanarender"]} -d $DOCKER_PARAM -i $USER_PERMISSIONS $PORT_MAPPING \
-     --name $GRAFANA_NAME docker.io/grafana/grafana-image-renderer:$VERSION \
-     ${DOCKER_PARAMS["grafanarender"]}
+	--name $GRAFANA_NAME docker.io/grafana/grafana-image-renderer:$VERSION \
+	${DOCKER_PARAMS["grafanarender"]}

--- a/start-grafana.sh
+++ b/start-grafana.sh
@@ -1,22 +1,22 @@
 #!/usr/bin/env bash
 CURRENT_VERSION="master"
 if [ -f CURRENT_VERSION.sh ]; then
-    CURRENT_VERSION=`cat CURRENT_VERSION.sh`
+	CURRENT_VERSION=$(cat CURRENT_VERSION.sh)
 fi
 LOCAL=""
 if [ -z "$GRAFANA_ADMIN_PASSWORD" ]; then
-    GRAFANA_ADMIN_PASSWORD="admin"
+	GRAFANA_ADMIN_PASSWORD="admin"
 fi
 if [ -z "$GRAFANA_AUTH" ]; then
-    GRAFANA_AUTH=false
+	GRAFANA_AUTH=false
 fi
 if [ -z "$GRAFANA_AUTH_ANONYMOUS" ]; then
-    GRAFANA_AUTH_ANONYMOUS=true
+	GRAFANA_AUTH_ANONYMOUS=true
 fi
 EXTERNAL_VOLUME=""
 BIND_ADDRESS=""
 if [ -z "$ANONYMOUS_ROLE" ]; then
-    ANONYMOUS_ROLE="Admin"
+	ANONYMOUS_ROLE="Admin"
 fi
 SPECIFIC_SOLUTION=""
 LDAP_FILE=""
@@ -28,164 +28,188 @@ PARAMS=""
 DEFAULT_THEME="light"
 . versions.sh
 . UA.sh
-if [ -f  env.sh ]; then
-    . env.sh
+if [ -f env.sh ]; then
+	. env.sh
 fi
 DOCKER_PARAM=""
 
 BRANCH_VERSION=$CURRENT_VERSION
 if [ -z ${DEFAULT_VERSION[$CURRENT_VERSION]} ]; then
-    BRANCH_VERSION=`echo $CURRENT_VERSION|cut -d'.' -f1,2`
+	BRANCH_VERSION=$(echo $CURRENT_VERSION | cut -d'.' -f1,2)
 fi
 
 if [ "$1" = "-e" ]; then
-    DEFAULT_VERSION=${DEFAULT_ENTERPRISE_VERSION[$BRANCH_VERSION]}
+	DEFAULT_VERSION=${DEFAULT_ENTERPRISE_VERSION[$BRANCH_VERSION]}
 fi
 MANAGER_VERSION=${MANAGER_DEFAULT_VERSION[$BRANCH_VERSION]}
 for arg; do
-    shift
-    if [ -z "$LIMIT" ]; then
-        case $arg in
-            (--limit)
-                LIMIT="1"
-                ;;
-            (--alternator)
-                RUN_ALTERNATOR="1"
-                ;;
-            (--volume)
-                LIMIT="1"
-                VOLUME="1"
-                ;;
-            (--param)
-                LIMIT="1"
-                PARAM="1"
-                ;;
-            (--scrap)
-                PARAM="scrap"
-                LIMIT="1"
-                ;;
-            (--auth)
-                GRAFANA_AUTH=true
-                ;;
-            (--disable-anonymous)
-                GRAFANA_AUTH_ANONYMOUS=false
-                ;;
-            (*) set -- "$@" "$arg"
-                ;;
-        esac
-    else
-        DOCR=`echo $arg|cut -d',' -f1`
-        VALUE=`echo $arg|cut -d',' -f2-|sed 's/#/ /g'`
-        NOSPACE=`echo $arg|sed 's/ /#/g'`
-        if [ "$PARAM" = "1" ]; then
-            if [ -z "${DOCKER_PARAMS[$DOCR]}" ]; then
-                DOCKER_PARAMS[$DOCR]=""
-            fi
-            DOCKER_PARAMS[$DOCR]="${DOCKER_PARAMS[$DOCR]} $VALUE"
-            PARAMS="$PARAMS --param $NOSPACE"
-            unset PARAM
-        elif [ "$PARAM" = "scrap" ]; then
-            SCRAP_INTERVAL="-S $NOSPACE"
-            unset PARAM
-        else
-            if [ -z "${DOCKER_LIMITS[$DOCR]}" ]; then
-                DOCKER_LIMITS[$DOCR]=""
-            fi
-            if [ "$VOLUME" = "1" ]; then
-                SRC=`echo $VALUE|cut -d':' -f1`
-                DST=`echo $VALUE|cut -d':' -f2-`
-                SRC=$(readlink -m $SRC)
-                DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} -v $SRC:$DST"
-                VOLUMES="$VOLUMES --volume $NOSPACE"
-                unset VOLUME
-            else
-                DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} $VALUE"
-                LIMITS="$LIMITS --limit $NOSPACE"
-            fi
-        fi
-        unset LIMIT
-    fi
+	shift
+	if [ -z "$LIMIT" ]; then
+		case $arg in
+		--limit)
+			LIMIT="1"
+			;;
+		--alternator)
+			RUN_ALTERNATOR="1"
+			;;
+		--volume)
+			LIMIT="1"
+			VOLUME="1"
+			;;
+		--param)
+			LIMIT="1"
+			PARAM="1"
+			;;
+		--scrap)
+			PARAM="scrap"
+			LIMIT="1"
+			;;
+		--auth)
+			GRAFANA_AUTH=true
+			;;
+		--disable-anonymous)
+			GRAFANA_AUTH_ANONYMOUS=false
+			;;
+		*)
+			set -- "$@" "$arg"
+			;;
+		esac
+	else
+		DOCR=$(echo $arg | cut -d',' -f1)
+		VALUE=$(echo $arg | cut -d',' -f2- | sed 's/#/ /g')
+		NOSPACE=$(echo $arg | sed 's/ /#/g')
+		if [ "$PARAM" = "1" ]; then
+			if [ -z "${DOCKER_PARAMS[$DOCR]}" ]; then
+				DOCKER_PARAMS[$DOCR]=""
+			fi
+			DOCKER_PARAMS[$DOCR]="${DOCKER_PARAMS[$DOCR]} $VALUE"
+			PARAMS="$PARAMS --param $NOSPACE"
+			unset PARAM
+		elif [ "$PARAM" = "scrap" ]; then
+			SCRAP_INTERVAL="-S $NOSPACE"
+			unset PARAM
+		else
+			if [ -z "${DOCKER_LIMITS[$DOCR]}" ]; then
+				DOCKER_LIMITS[$DOCR]=""
+			fi
+			if [ "$VOLUME" = "1" ]; then
+				SRC=$(echo $VALUE | cut -d':' -f1)
+				DST=$(echo $VALUE | cut -d':' -f2-)
+				SRC=$(readlink -m $SRC)
+				DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} -v $SRC:$DST"
+				VOLUMES="$VOLUMES --volume $NOSPACE"
+				unset VOLUME
+			else
+				DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} $VALUE"
+				LIMITS="$LIMITS --limit $NOSPACE"
+			fi
+		fi
+		unset LIMIT
+	fi
 done
 usage="$(basename "$0") [-h] [-v comma separated versions ] [-g grafana port ] [-G path to external dir] [-n grafana container name ] [-p ip:port address of prometheus ] [-j additional dashboard to load to Grafana, multiple params are supported] [-c grafana environment variable, multiple params are supported] [-x http_proxy_host:port] [-m alert_manager address] [-a admin password] [ -M scylla-manager version ] [-D encapsulate docker param] [-Q Grafana anonymous role (Admin/Editor/Viewer)] [-S start with a system specific dashboard set] [-P ldap_config_file] -- loads the prometheus datasource and the Scylla dashboards into an existing grafana installation"
 if [ "$DOCKER_PARAM" != "" ]; then
-    DOCKER_PARAM_FROM_FILE="1"
+	DOCKER_PARAM_FROM_FILE="1"
 fi
 while getopts ':hlEg:n:p:v:a:x:c:j:m:G:M:D:A:S:P:L:Q:s:' option; do
-  case "$option" in
-    h) echo "$usage"
-       exit
-       ;;
-    v) VERSIONS=$OPTARG
-       ;;
-    M) MANAGER_VERSION=$OPTARG
-       ;;
-    g) GRAFANA_PORT=$OPTARG
-       ;;
-    G) EXTERNAL_VOLUME="-v "`readlink -m $OPTARG`":/var/lib/grafana"
-       if [ ! -d $OPTARG ]; then
-         echo "Creating grafana external directory $OPTARG"
-         mkdir -p $OPTARG
-       fi
-       ;;
-    n) GRAFANA_NAME=$OPTARG
-       ;;
-    p) DATA_SOURCES="$DATA_SOURCES -p $OPTARG"
-       ;;
-    m) DATA_SOURCES="$DATA_SOURCES -m $OPTARG"
-       ;;
-    L) DATA_SOURCES="$DATA_SOURCES -L $OPTARG"
-       ;;
-    l) if [[ "$DOCKER_PARAM" != *"--net=host"* ]]; then
-        DOCKER_PARAM="$DOCKER_PARAM --net=host"
-       fi
-       ;;
-    P) LDAP_FILE="$OPTARG"
-       GRAFANA_ENV_ARRAY+=("GF_AUTH_LDAP_ENABLED=true" "GF_AUTH_LDAP_CONFIG_FILE=/etc/grafana/ldap.toml" "GF_AUTH_LDAP_ALLOW_SIGN_UP=true")
-       LDAP_FILE="-v "`readlink -m $OPTARG`":/etc/grafana/ldap.toml"
-       GRAFANA_AUTH=true
-       GRAFANA_AUTH_ANONYMOUS=false
-       ;;
-    D) if [ "$DOCKER_PARAM_FROM_FILE" = "1" ]; then
-          DOCKER_PARAM=""
-          DOCKER_PARAM_FROM_FILE=""
-       fi
-       DOCKER_PARAM="$DOCKER_PARAM $OPTARG"
-       ;;
-    Q) ANONYMOUS_ROLE=$OPTARG
-       ;;
-    a) GRAFANA_ADMIN_PASSWORD=$OPTARG
-       ;;
-    x) HTTP_PROXY="$OPTARG"
-       ;;
-    c) GRAFANA_ENV_ARRAY+=("$OPTARG")
-       ;;
-    j) GRAFANA_DASHBOARD_ARRAY+=("$OPTARG")
-       ;;
-    A) BIND_ADDRESS="$OPTARG:"
-       ;;
-    S) SPECIFIC_SOLUTION="-S $OPTARG"
-       ;;
-    s) STACK="/stack/$OPTARG"
-       STACK_CMD="-s $OPTARG"
-       ;;
-    E) RUN_RENDERER="-E"
-       ;;
-    :) printf "missing argument for -%s\n" "$OPTARG" >&2
-       echo "$usage" >&2
-       exit 1
-       ;;
-   \?) printf "illegal option: -%s\n" "$OPTARG" >&2
-       echo "$usage" >&2
-       exit 1
-       ;;
-  esac
+	case "$option" in
+	h)
+		echo "$usage"
+		exit
+		;;
+	v)
+		VERSIONS=$OPTARG
+		;;
+	M)
+		MANAGER_VERSION=$OPTARG
+		;;
+	g)
+		GRAFANA_PORT=$OPTARG
+		;;
+	G)
+		EXTERNAL_VOLUME="-v "$(readlink -m $OPTARG)":/var/lib/grafana"
+		if [ ! -d $OPTARG ]; then
+			echo "Creating grafana external directory $OPTARG"
+			mkdir -p $OPTARG
+		fi
+		;;
+	n)
+		GRAFANA_NAME=$OPTARG
+		;;
+	p)
+		DATA_SOURCES="$DATA_SOURCES -p $OPTARG"
+		;;
+	m)
+		DATA_SOURCES="$DATA_SOURCES -m $OPTARG"
+		;;
+	L)
+		DATA_SOURCES="$DATA_SOURCES -L $OPTARG"
+		;;
+	l)
+		if [[ "$DOCKER_PARAM" != *"--net=host"* ]]; then
+			DOCKER_PARAM="$DOCKER_PARAM --net=host"
+		fi
+		;;
+	P)
+		LDAP_FILE="$OPTARG"
+		GRAFANA_ENV_ARRAY+=("GF_AUTH_LDAP_ENABLED=true" "GF_AUTH_LDAP_CONFIG_FILE=/etc/grafana/ldap.toml" "GF_AUTH_LDAP_ALLOW_SIGN_UP=true")
+		LDAP_FILE="-v "$(readlink -m $OPTARG)":/etc/grafana/ldap.toml"
+		GRAFANA_AUTH=true
+		GRAFANA_AUTH_ANONYMOUS=false
+		;;
+	D)
+		if [ "$DOCKER_PARAM_FROM_FILE" = "1" ]; then
+			DOCKER_PARAM=""
+			DOCKER_PARAM_FROM_FILE=""
+		fi
+		DOCKER_PARAM="$DOCKER_PARAM $OPTARG"
+		;;
+	Q)
+		ANONYMOUS_ROLE=$OPTARG
+		;;
+	a)
+		GRAFANA_ADMIN_PASSWORD=$OPTARG
+		;;
+	x)
+		HTTP_PROXY="$OPTARG"
+		;;
+	c)
+		GRAFANA_ENV_ARRAY+=("$OPTARG")
+		;;
+	j)
+		GRAFANA_DASHBOARD_ARRAY+=("$OPTARG")
+		;;
+	A)
+		BIND_ADDRESS="$OPTARG:"
+		;;
+	S)
+		SPECIFIC_SOLUTION="-S $OPTARG"
+		;;
+	s)
+		STACK="/stack/$OPTARG"
+		STACK_CMD="-s $OPTARG"
+		;;
+	E)
+		RUN_RENDERER="-E"
+		;;
+	:)
+		printf "missing argument for -%s\n" "$OPTARG" >&2
+		echo "$usage" >&2
+		exit 1
+		;;
+	\?)
+		printf "illegal option: -%s\n" "$OPTARG" >&2
+		echo "$usage" >&2
+		exit 1
+		;;
+	esac
 done
 
 if [ -z $GRAFANA_PORT ]; then
-    GRAFANA_PORT=3000
-    if [ -z $GRAFANA_NAME ]; then
-        GRAFANA_NAME=agraf
-    fi
+	GRAFANA_PORT=3000
+	if [ -z $GRAFANA_NAME ]; then
+		GRAFANA_NAME=agraf
+	fi
 fi
 if [ -z $ANALYTICS_REPORTING_ENABLED ]; then
 	ANALYTICS_REPORTING_ENABLED="false"
@@ -203,131 +227,131 @@ if [ -z $SERVER_ENABLE_GZIP ]; then
 	SERVER_ENABLE_GZIP="true"
 fi
 
-VERSION=`echo $VERSIONS|cut -d',' -f1`
+VERSION=$(echo $VERSIONS | cut -d',' -f1)
 if [ "$VERSION" = "" ]; then
-    echo "Scylla-version was not not found, add the -v command-line with a specific version (i.e. -v 2021.1)"
-    exit 1
+	echo "Scylla-version was not not found, add the -v command-line with a specific version (i.e. -v 2021.1)"
+	exit 1
 fi
 
 if [ "$VERSION" = "latest" ]; then
-    if [ -z "$BRANCH_VERSION" ] || [ "$BRANCH_VERSION" = "master" ]; then
-        echo "Default versions (-v latest) is not supported on the master branch, use specific version instead"
-        exit 1
-    fi
-    VERSION=${DEFAULT_VERSION[$BRANCH_VERSION]}
-    echo "The use of -v latest is deprecated. Use a specific version instead."
+	if [ -z "$BRANCH_VERSION" ] || [ "$BRANCH_VERSION" = "master" ]; then
+		echo "Default versions (-v latest) is not supported on the master branch, use specific version instead"
+		exit 1
+	fi
+	VERSION=${DEFAULT_VERSION[$BRANCH_VERSION]}
+	echo "The use of -v latest is deprecated. Use a specific version instead."
 fi
 if [ -z $GRAFANA_NAME ]; then
-    GRAFANA_NAME=agraf-$GRAFANA_PORT
+	GRAFANA_NAME=agraf-$GRAFANA_PORT
 fi
 
-docker container inspect $GRAFANA_NAME > /dev/null 2>&1
+docker container inspect $GRAFANA_NAME >/dev/null 2>&1
 if [ $? -eq 0 ]; then
-    printf "\nSome of the monitoring docker instances ($GRAFANA_NAME) exist. Make sure all containers are killed and removed. You can use kill-all.sh for that\n"
-    exit 1
+	printf "\nSome of the monitoring docker instances ($GRAFANA_NAME) exist. Make sure all containers are killed and removed. You can use kill-all.sh for that\n"
+	exit 1
 fi
 
 group_args=()
 is_podman="$(docker --help | grep -o podman)"
 if [ ! -z "$is_podman" ]; then
-    group_args+=(--userns=keep-id)
+	group_args+=(--userns=keep-id)
 fi
-if [ "`id -u`" -ne 0 ]; then
-    GROUPID=`id -g`
-    USER_PERMISSIONS="-u $UID:$GROUPID"
+if [ "$(id -u)" -ne 0 ]; then
+	GROUPID=$(id -g)
+	USER_PERMISSIONS="-u $UID:$GROUPID"
 fi
 
 proxy_args=()
 if [[ -n "$HTTP_PROXY" ]]; then
-    proxy_args=(-e http_proxy="$HTTP_PROXY")
+	proxy_args=(-e http_proxy="$HTTP_PROXY")
 fi
 
 for val in "${GRAFANA_ENV_ARRAY[@]}"; do
-        GRAFANA_ENV_COMMAND="$GRAFANA_ENV_COMMAND -e $val"
-        if [[ $val == GF_USERS_DEFAULT_THEME=* ]]; then
-            DEFAULT_THEME=""
-        fi
+	GRAFANA_ENV_COMMAND="$GRAFANA_ENV_COMMAND -e $val"
+	if [[ $val == GF_USERS_DEFAULT_THEME=* ]]; then
+		DEFAULT_THEME=""
+	fi
 done
 if [[ $DEFAULT_THEME != "" ]]; then
-    GRAFANA_ENV_COMMAND="$GRAFANA_ENV_COMMAND -e GF_USERS_DEFAULT_THEME=$DEFAULT_THEME"
+	GRAFANA_ENV_COMMAND="$GRAFANA_ENV_COMMAND -e GF_USERS_DEFAULT_THEME=$DEFAULT_THEME"
 fi
 
 for val in "${GRAFANA_DASHBOARD_ARRAY[@]}"; do
-        GRAFANA_DASHBOARD_COMMAND="$GRAFANA_DASHBOARD_COMMAND -j $val"
+	GRAFANA_DASHBOARD_COMMAND="$GRAFANA_DASHBOARD_COMMAND -j $val"
 done
 ./generate-dashboards.sh -t $SPECIFIC_SOLUTION -v $VERSIONS -M $MANAGER_VERSION $STACK_CMD $GRAFANA_DASHBOARD_COMMAND
 ./grafana-datasource.sh $DATA_SOURCES $STACK_CMD $SCRAP_INTERVAL
 
 if [[ ! $DOCKER_PARAM = *"--net=host"* ]]; then
-    PORT_MAPPING="-p $BIND_ADDRESS$GRAFANA_PORT:3000"
+	PORT_MAPPING="-p $BIND_ADDRESS$GRAFANA_PORT:3000"
 fi
 
 if [[ "$HOME_DASHBOARD" = "" ]]; then
-    if [ "$RUN_ALTERNATOR" = "1" ]; then
-        HOME_DASHBOARD="/var/lib/grafana/dashboards/ver_$VERSION/alternator.$VERSION.json"
-    else
-        HOME_DASHBOARD="/var/lib/grafana/dashboards/ver_$VERSION/scylla-overview.$VERSION.json"
-    fi
+	if [ "$RUN_ALTERNATOR" = "1" ]; then
+		HOME_DASHBOARD="/var/lib/grafana/dashboards/ver_$VERSION/alternator.$VERSION.json"
+	else
+		HOME_DASHBOARD="/var/lib/grafana/dashboards/ver_$VERSION/scylla-overview.$VERSION.json"
+	fi
 fi
 
 if [[ -z "${DOCKER_HOST}" ]]; then
-    if [ ! -z "$is_podman" ]; then
-        if [[ $(uname) == "Linux" ]]; then
-            DOCKER_HOST=$(hostname -I | awk '{print $1}')
-        elif [[ $(uname) == "Darwin" ]]; then
-            DOCKER_HOST=$(ifconfig bridge0 | awk '/inet / {print $2}')
-        fi
-    else
-        if [[ $(uname) == "Linux" ]]; then
-            DOCKER_HOST=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+')
-        elif [[ $(uname) == "Darwin" ]]; then
-            DOCKER_HOST=$(ifconfig bridge0 | awk '/inet / {print $2}')
-        fi
-    fi
+	if [ ! -z "$is_podman" ]; then
+		if [[ $(uname) == "Linux" ]]; then
+			DOCKER_HOST=$(hostname -I | awk '{print $1}')
+		elif [[ $(uname) == "Darwin" ]]; then
+			DOCKER_HOST=$(ifconfig bridge0 | awk '/inet / {print $2}')
+		fi
+	else
+		if [[ $(uname) == "Linux" ]]; then
+			DOCKER_HOST=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+')
+		elif [[ $(uname) == "Darwin" ]]; then
+			DOCKER_HOST=$(ifconfig bridge0 | awk '/inet / {print $2}')
+		fi
+	fi
 fi
 
 if [ ! -z $RUN_RENDERER ]; then
 	if [ ! -z "$is_podman" ]; then
-		HOST_ADDRESS=`hostname -I | awk '{print $1}'`
+		HOST_ADDRESS=$(hostname -I | awk '{print $1}')
 	else
 		HOST_ADDRESS=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+')
 	fi
-    RENDERING_SERVER_URL=`./start-grafana-renderer.sh $LIMITS $VOLUMES $PARAMS  -D "$DOCKER_PARAM"`
-    GRAFANA_ENV_COMMAND="$GRAFANA_ENV_COMMAND -e GF_RENDERING_SERVER_URL=http://$HOST_ADDRESS:8081/render -e GF_RENDERING_CALLBACK_URL=http://$HOST_ADDRESS:$GRAFANA_PORT/"
+	RENDERING_SERVER_URL=$(./start-grafana-renderer.sh $LIMITS $VOLUMES $PARAMS -D "$DOCKER_PARAM")
+	GRAFANA_ENV_COMMAND="$GRAFANA_ENV_COMMAND -e GF_RENDERING_SERVER_URL=http://$HOST_ADDRESS:8081/render -e GF_RENDERING_CALLBACK_URL=http://$HOST_ADDRESS:$GRAFANA_PORT/"
 fi
 
 if [ -z $STACK ]; then
-    STACK=""
+	STACK=""
 fi
 
 docker run -d $DOCKER_PARAM ${DOCKER_LIMITS["grafana"]} -i $USER_PERMISSIONS $PORT_MAPPING \
-     -e "GF_AUTH_BASIC_ENABLED=$GRAFANA_AUTH" \
-     -e "GF_AUTH_ANONYMOUS_ENABLED=$GRAFANA_AUTH_ANONYMOUS" \
-     -e "GF_AUTH_ANONYMOUS_ORG_ROLE=$ANONYMOUS_ROLE" \
-     -e "GF_PANELS_DISABLE_SANITIZE_HTML=true" \
-     $LDAP_FILE \
-     "${group_args[@]}" \
-     -v $PWD/grafana/build:/var/lib/grafana/dashboards:z \
-     -v $PWD/grafana/plugins:/var/lib/grafana/plugins:z \
-     -v $PWD/grafana$STACK/provisioning:/var/lib/grafana/provisioning:z $EXTERNAL_VOLUME \
-     -e "GF_PATHS_PROVISIONING=/var/lib/grafana/provisioning" \
-     -e "GF_SECURITY_ADMIN_PASSWORD=$GRAFANA_ADMIN_PASSWORD" \
-     -e "GF_ANALYTICS_GOOGLE_ANALYTICS_UA_ID=$UA_ANALTYICS" \
-     -e "GF_ANALYTICS_REPORTING_ENABLED=$ANALYTICS_REPORTING_ENABLED" \
-     -e "GF_ANALYTICS_CHECK_FOR_UPDATES=$ANALYTICS_CHECK_FOR_UPDATES" \
-     -e "GF_ANALYTICS_CHECK_FOR_PLUGIN_UPDATES=$ANALYTICS_CHECK_FOR_PLUGIN_UPDATES" \
-     -e "GF_SECURITY_ANGULAR_SUPPORT_ENABLED=$SECURITY_ANGULAR_SUPPORT_ENABLED" \
-     -e "GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=scylladb-scylla-datasource" \
-     -e "GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=$HOME_DASHBOARD" \
-     -e "GF_SERVER_ENABLE_GZIP=$SERVER_ENABLE_GZIP" \
-     $GRAFANA_ENV_COMMAND \
-     "${proxy_args[@]}" \
-     --name $GRAFANA_NAME docker.io/grafana/grafana:$GRAFANA_VERSION ${DOCKER_PARAMS["grafana"]} >& /dev/null
+	-e "GF_AUTH_BASIC_ENABLED=$GRAFANA_AUTH" \
+	-e "GF_AUTH_ANONYMOUS_ENABLED=$GRAFANA_AUTH_ANONYMOUS" \
+	-e "GF_AUTH_ANONYMOUS_ORG_ROLE=$ANONYMOUS_ROLE" \
+	-e "GF_PANELS_DISABLE_SANITIZE_HTML=true" \
+	$LDAP_FILE \
+	"${group_args[@]}" \
+	-v $PWD/grafana/build:/var/lib/grafana/dashboards:z \
+	-v $PWD/grafana/plugins:/var/lib/grafana/plugins:z \
+	-v $PWD/grafana$STACK/provisioning:/var/lib/grafana/provisioning:z $EXTERNAL_VOLUME \
+	-e "GF_PATHS_PROVISIONING=/var/lib/grafana/provisioning" \
+	-e "GF_SECURITY_ADMIN_PASSWORD=$GRAFANA_ADMIN_PASSWORD" \
+	-e "GF_ANALYTICS_GOOGLE_ANALYTICS_UA_ID=$UA_ANALTYICS" \
+	-e "GF_ANALYTICS_REPORTING_ENABLED=$ANALYTICS_REPORTING_ENABLED" \
+	-e "GF_ANALYTICS_CHECK_FOR_UPDATES=$ANALYTICS_CHECK_FOR_UPDATES" \
+	-e "GF_ANALYTICS_CHECK_FOR_PLUGIN_UPDATES=$ANALYTICS_CHECK_FOR_PLUGIN_UPDATES" \
+	-e "GF_SECURITY_ANGULAR_SUPPORT_ENABLED=$SECURITY_ANGULAR_SUPPORT_ENABLED" \
+	-e "GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=scylladb-scylla-datasource" \
+	-e "GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=$HOME_DASHBOARD" \
+	-e "GF_SERVER_ENABLE_GZIP=$SERVER_ENABLE_GZIP" \
+	$GRAFANA_ENV_COMMAND \
+	"${proxy_args[@]}" \
+	--name $GRAFANA_NAME docker.io/grafana/grafana:$GRAFANA_VERSION ${DOCKER_PARAMS["grafana"]} >&/dev/null
 
 if [ $? -ne 0 ]; then
-    echo "Error: Grafana container failed to start"
-    echo "For more information use: docker logs $GRAFANA_NAME"
-    exit 1
+	echo "Error: Grafana container failed to start"
+	echo "For more information use: docker logs $GRAFANA_NAME"
+	exit 1
 fi
 
 # Wait till Grafana API is available
@@ -335,18 +359,17 @@ printf "Wait for Grafana container to start."
 RETRIES=7
 TRIES=0
 until $(curl --output /dev/null -f --silent http://localhost:$GRAFANA_PORT/api/org) || [ $TRIES -eq $RETRIES ]; do
-    printf '.'
-    ((TRIES=TRIES+1))
-    sleep 5
+	printf '.'
+	((TRIES = TRIES + 1))
+	sleep 5
 done
 echo
-if [ ! "$(docker ps -q -f name=$GRAFANA_NAME)" ]
-then
-        echo "Error: Grafana container failed to start"
-        echo "For more information use: docker logs $GRAFANA_NAME"
-        exit 1
+if [ ! "$(docker ps -q -f name=$GRAFANA_NAME)" ]; then
+	echo "Error: Grafana container failed to start"
+	echo "For more information use: docker logs $GRAFANA_NAME"
+	exit 1
 fi
 if [ -z "$BIND_ADDRESS" ]; then
-    BIND_ADDRESS="localhost:"
+	BIND_ADDRESS="localhost:"
 fi
 printf "Start completed successfully, check http://$BIND_ADDRESS$GRAFANA_PORT\n"

--- a/start-loki.sh
+++ b/start-loki.sh
@@ -2,8 +2,8 @@
 
 is_podman="$(docker --help | grep -o podman)"
 . versions.sh
-if [ -f  env.sh ]; then
-    . env.sh
+if [ -f env.sh ]; then
+	. env.sh
 fi
 
 VERSIONS=$DEFAULT_VERSION
@@ -15,219 +15,230 @@ BIND_ADDRESS=""
 LOKI_COMMANDS="--ingester.wal-enabled=false"
 LOKI_DIR=""
 usage="$(basename "$0") [-h] [-l] [-D encapsulate docker param] [-m alert_manager address]"
-if [ "`id -u`" -ne 0 ]; then
-    GROUPID=`id -g`
-    USER_PERMISSIONS="-u $UID:$GROUPID"
+if [ "$(id -u)" -ne 0 ]; then
+	GROUPID=$(id -g)
+	USER_PERMISSIONS="-u $UID:$GROUPID"
 fi
 LIMITS=""
 VOLUMES=""
 PARAMS=""
 for arg; do
-    shift
-    if [ -z "$LIMIT" ]; then
-        case $arg in
-            (--limit)
-                LIMIT="1"
-                ;;
-            (--volume)
-                LIMIT="1"
-                VOLUME="1"
-                ;;
-            (--param)
-                LIMIT="1"
-                PARAM="1"
-                ;;
-            (*) set -- "$@" "$arg"
-                ;;
-        esac
-    else
-        DOCR=`echo $arg|cut -d',' -f1`
-        VALUE=`echo $arg|cut -d',' -f2-|sed 's/#/ /g'`
-        NOSPACE=`echo $arg|sed 's/ /#/g'`
-        if [ "$PARAM" = "1" ]; then
-            if [ -z "${DOCKER_PARAMS[$DOCR]}" ]; then
-                DOCKER_PARAMS[$DOCR]=""
-            fi
-            DOCKER_PARAMS[$DOCR]="${DOCKER_PARAMS[$DOCR]} $VALUE"
-            PARAMS="$PARAMS --param $NOSPACE"
-            unset PARAM
-        else
-            if [ -z "${DOCKER_LIMITS[$DOCR]}" ]; then
-                DOCKER_LIMITS[$DOCR]=""
-            fi
-            if [ "$VOLUME" = "1" ]; then
-                SRC=`echo $VALUE|cut -d':' -f1`
-                DST=`echo $VALUE|cut -d':' -f2-`
-                SRC=$(readlink -m $SRC)
-                DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} -v $SRC:$DST"
-                VOLUMES="$VOLUMES --volume $NOSPACE"
-                unset VOLUME
-            else
-                DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} $VALUE"
-                LIMITS="$LIMITS --limit $NOSPACE"
-            fi
-        fi
-        unset LIMIT
-    fi
+	shift
+	if [ -z "$LIMIT" ]; then
+		case $arg in
+		--limit)
+			LIMIT="1"
+			;;
+		--volume)
+			LIMIT="1"
+			VOLUME="1"
+			;;
+		--param)
+			LIMIT="1"
+			PARAM="1"
+			;;
+		*)
+			set -- "$@" "$arg"
+			;;
+		esac
+	else
+		DOCR=$(echo $arg | cut -d',' -f1)
+		VALUE=$(echo $arg | cut -d',' -f2- | sed 's/#/ /g')
+		NOSPACE=$(echo $arg | sed 's/ /#/g')
+		if [ "$PARAM" = "1" ]; then
+			if [ -z "${DOCKER_PARAMS[$DOCR]}" ]; then
+				DOCKER_PARAMS[$DOCR]=""
+			fi
+			DOCKER_PARAMS[$DOCR]="${DOCKER_PARAMS[$DOCR]} $VALUE"
+			PARAMS="$PARAMS --param $NOSPACE"
+			unset PARAM
+		else
+			if [ -z "${DOCKER_LIMITS[$DOCR]}" ]; then
+				DOCKER_LIMITS[$DOCR]=""
+			fi
+			if [ "$VOLUME" = "1" ]; then
+				SRC=$(echo $VALUE | cut -d':' -f1)
+				DST=$(echo $VALUE | cut -d':' -f2-)
+				SRC=$(readlink -m $SRC)
+				DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} -v $SRC:$DST"
+				VOLUMES="$VOLUMES --volume $NOSPACE"
+				unset VOLUME
+			else
+				DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} $VALUE"
+				LIMITS="$LIMITS --limit $NOSPACE"
+			fi
+		fi
+		unset LIMIT
+	fi
 done
 if [ "$DOCKER_PARAM" != "" ]; then
-    DOCKER_PARAM_FROM_FILE="1"
+	DOCKER_PARAM_FROM_FILE="1"
 fi
 
 while getopts ':hlp:D:m:A:k:t:T:' option; do
-  case "$option" in
-    h) echo "$usage"
-       exit
-       ;;
-    p) LOKI_PORT=$OPTARG
-       ;;
-    t) PROMTAIL_PORT=$OPTARG
-       ;;
-    T) PROMTAIL_BIN_PORT=$OPTARG
-       ;;
-    r) LOKI_RULE_DIR=`readlink -m $OPTARG`
-       ;;
-    l) if [[ "$DOCKER_PARAM" != *"--net=host"* ]]; then
-        DOCKER_PARAM="$DOCKER_PARAM --net=host"
-       fi
-       ;;
-    D) if [ "$DOCKER_PARAM_FROM_FILE" = "1" ]; then
-          DOCKER_PARAM=""
-          DOCKER_PARAM_FROM_FILE=""
-       fi
-       DOCKER_PARAM="$DOCKER_PARAM $OPTARG"
-       ;;
-    C) LOKI_COMMANDS="$LOKI_COMMANDS $OPTARG"
-       ;;
-    A) BIND_ADDRESS="$OPTARG:"
-       ;;
-    k) LOKI_DIR=`readlink -m $OPTARG`
-       if [ ! -d $LOKI_DIR ]; then
-           mkdir -p $LOKI_DIR
-       fi
-       LOKI_DIR="-v $LOKI_DIR:/tmp/loki:z"
-       ;;
-    m) ALERT_MANAGER_ADDRESS=$OPTARG
-       ;;
-    :) printf "missing argument for -%s\n" "$OPTARG" >&2
-       echo "$usage" >&2
-       exit 1
-       ;;
-   \?) printf "illegal option: -%s\n" "$OPTARG" >&2
-       echo "$usage" >&2
-       exit 1
-       ;;
-  esac
+	case "$option" in
+	h)
+		echo "$usage"
+		exit
+		;;
+	p)
+		LOKI_PORT=$OPTARG
+		;;
+	t)
+		PROMTAIL_PORT=$OPTARG
+		;;
+	T)
+		PROMTAIL_BIN_PORT=$OPTARG
+		;;
+	r)
+		LOKI_RULE_DIR=$(readlink -m $OPTARG)
+		;;
+	l)
+		if [[ "$DOCKER_PARAM" != *"--net=host"* ]]; then
+			DOCKER_PARAM="$DOCKER_PARAM --net=host"
+		fi
+		;;
+	D)
+		if [ "$DOCKER_PARAM_FROM_FILE" = "1" ]; then
+			DOCKER_PARAM=""
+			DOCKER_PARAM_FROM_FILE=""
+		fi
+		DOCKER_PARAM="$DOCKER_PARAM $OPTARG"
+		;;
+	C)
+		LOKI_COMMANDS="$LOKI_COMMANDS $OPTARG"
+		;;
+	A)
+		BIND_ADDRESS="$OPTARG:"
+		;;
+	k)
+		LOKI_DIR=$(readlink -m $OPTARG)
+		if [ ! -d $LOKI_DIR ]; then
+			mkdir -p $LOKI_DIR
+		fi
+		LOKI_DIR="-v $LOKI_DIR:/tmp/loki:z"
+		;;
+	m)
+		ALERT_MANAGER_ADDRESS=$OPTARG
+		;;
+	:)
+		printf "missing argument for -%s\n" "$OPTARG" >&2
+		echo "$usage" >&2
+		exit 1
+		;;
+	\?)
+		printf "illegal option: -%s\n" "$OPTARG" >&2
+		echo "$usage" >&2
+		exit 1
+		;;
+	esac
 done
 if [ -z $LOKI_PORT ]; then
-    LOKI_PORT=3100
-    LOKI_NAME=loki
+	LOKI_PORT=3100
+	LOKI_NAME=loki
 else
-    LOKI_NAME=loki-$LOKI_PORT
+	LOKI_NAME=loki-$LOKI_PORT
 fi
 
 if [[ $LOKI_DIR = "" ]]; then
-  USER_PERMISSIONS=""
+	USER_PERMISSIONS=""
 fi
 
-docker container inspect $LOKI_NAME > /dev/null 2>&1
+docker container inspect $LOKI_NAME >/dev/null 2>&1
 if [ $? -eq 0 ]; then
-    printf "\nSome of the monitoring docker instances ($LOKI_NAME) exist. Make sure all containers are killed and removed. You can use kill-all.sh for that\n"
-    exit 1
+	printf "\nSome of the monitoring docker instances ($LOKI_NAME) exist. Make sure all containers are killed and removed. You can use kill-all.sh for that\n"
+	exit 1
 fi
 
 if [[ ! $DOCKER_PARAM = *"--net=host"* ]]; then
-    PORT_MAPPING="-p $BIND_ADDRESS$LOKI_PORT:3100"
+	PORT_MAPPING="-p $BIND_ADDRESS$LOKI_PORT:3100"
 fi
 
 if [ -z $ALERT_MANAGER_ADDRESS ]; then
 	ALERT_MANAGER_ADDRESS="$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' aalert):9093"
 fi
 
-sed "s/ALERTMANAGER/$ALERT_MANAGER_ADDRESS/" loki/conf/loki-config.template.yaml > loki/conf/loki-config.yaml
+sed "s/ALERTMANAGER/$ALERT_MANAGER_ADDRESS/" loki/conf/loki-config.template.yaml >loki/conf/loki-config.yaml
 
 docker run ${DOCKER_LIMITS["loki"]} -d $DOCKER_PARAM -i $PORT_MAPPING \
-     $USER_PERMISSIONS \
-	 -v $LOKI_RULE_DIR:/etc/loki/rules/fake:z \
-	 -v $LOKI_CONF_DIR:/mnt/config:z \
-	 $LOKI_DIR \
-     --name $LOKI_NAME docker.io/grafana/loki:$LOKI_VERSION $LOKI_COMMANDS --config.file=/mnt/config/loki-config.yaml ${DOCKER_PARAMS["loki"]} >& /dev/null
+	$USER_PERMISSIONS \
+	-v $LOKI_RULE_DIR:/etc/loki/rules/fake:z \
+	-v $LOKI_CONF_DIR:/mnt/config:z \
+	$LOKI_DIR \
+	--name $LOKI_NAME docker.io/grafana/loki:$LOKI_VERSION $LOKI_COMMANDS --config.file=/mnt/config/loki-config.yaml ${DOCKER_PARAMS["loki"]} >&/dev/null
 
 if [ $? -ne 0 ]; then
-    echo "Error: Loki container failed to start"
-    echo "For more information use: docker logs $LOKI_NAME"
-    exit 1
+	echo "Error: Loki container failed to start"
+	echo "For more information use: docker logs $LOKI_NAME"
+	exit 1
 fi
 
 # Wait till Loki is available
 RETRIES=5
 TRIES=0
 until $(curl --output /dev/null -f --silent http://localhost:$LOKI_PORT) || [ $TRIES -eq $RETRIES ]; do
-    ((TRIES=TRIES+1))
-    sleep 5
+	((TRIES = TRIES + 1))
+	sleep 5
 done
 
-if [ ! "$(docker ps -q -f name=$LOKI_NAME)" ]
-then
-    echo "Error: Loki container failed to start"
-    exit 1
+if [ ! "$(docker ps -q -f name=$LOKI_NAME)" ]; then
+	echo "Error: Loki container failed to start"
+	exit 1
 fi
 
 LOKI_ADDRESS="$(docker inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $LOKI_NAME):3100"
 if [ "$LOKI_ADDRESS" = ":3100" ]; then
-    if [[ $(uname) == "Linux" ]]; then
-        HOST_IP=$(hostname -I | awk '{print $1}')
-    elif [[ $(uname) == "Darwin" ]]; then
-        HOST_IP=$(ifconfig en0 | awk '/inet / {print $2}')
-    fi
-    LOKI_ADDRESS="$HOST_IP:3100"
+	if [[ $(uname) == "Linux" ]]; then
+		HOST_IP=$(hostname -I | awk '{print $1}')
+	elif [[ $(uname) == "Darwin" ]]; then
+		HOST_IP=$(ifconfig en0 | awk '/inet / {print $2}')
+	fi
+	LOKI_ADDRESS="$HOST_IP:3100"
 fi
-
 
 if [ -z $PROMTAIL_PORT ]; then
-    PROMTAIL_PORT=9080
-    PROMTAIL_NAME=promtail
+	PROMTAIL_PORT=9080
+	PROMTAIL_NAME=promtail
 else
-    PROMTAIL_NAME=promtail-$PROMTAIL_PORT
+	PROMTAIL_NAME=promtail-$PROMTAIL_PORT
 fi
 if [ -z $PROMTAIL_BIN_PORT ]; then
-    PROMTAIL_BIN_PORT=1514
+	PROMTAIL_BIN_PORT=1514
 fi
 
-docker container inspect $PROMTAIL_NAME > /dev/null 2>&1
+docker container inspect $PROMTAIL_NAME >/dev/null 2>&1
 if [ $? -eq 0 ]; then
-    printf "\nSome of the monitoring docker instances ($PROMTAIL_NAME) exist. Make sure all containers are killed and removed. You can use kill-all.sh for that\n"
-    exit 1
+	printf "\nSome of the monitoring docker instances ($PROMTAIL_NAME) exist. Make sure all containers are killed and removed. You can use kill-all.sh for that\n"
+	exit 1
 fi
 
 if [[ ! $DOCKER_PARAM = *"--net=host"* ]]; then
-    PROMTAIL_PORT_MAPPING="-p $BIND_ADDRESS$PROMTAIL_PORT:9080 -p ${BIND_ADDRESS}$PROMTAIL_BIN_PORT:1514"
+	PROMTAIL_PORT_MAPPING="-p $BIND_ADDRESS$PROMTAIL_PORT:9080 -p ${BIND_ADDRESS}$PROMTAIL_BIN_PORT:1514"
 fi
 
-sed "s/LOKI_IP/$LOKI_ADDRESS/" loki/promtail/promtail_config.template.yml > loki/promtail/promtail_config.yml
+sed "s/LOKI_IP/$LOKI_ADDRESS/" loki/promtail/promtail_config.template.yml >loki/promtail/promtail_config.yml
 
-docker run ${DOCKER_LIMITS["promtail"]}  -d $DOCKER_PARAM -i $PROMTAIL_PORT_MAPPING \
-	 -v $PROMTAIL_CONFIG:/etc/promtail/config.yml:z \
-     --name $PROMTAIL_NAME docker.io/grafana/promtail:$LOKI_VERSION --config.file=/etc/promtail/config.yml ${DOCKER_PARAMS["promtail"]} >& /dev/null
+docker run ${DOCKER_LIMITS["promtail"]} -d $DOCKER_PARAM -i $PROMTAIL_PORT_MAPPING \
+	-v $PROMTAIL_CONFIG:/etc/promtail/config.yml:z \
+	--name $PROMTAIL_NAME docker.io/grafana/promtail:$LOKI_VERSION --config.file=/etc/promtail/config.yml ${DOCKER_PARAMS["promtail"]} >&/dev/null
 
 if [ $? -ne 0 ]; then
-    echo "Error: Promtail container failed to start"
-    echo "For more information use: docker logs $PROMTAIL_NAME"
-    exit 1
+	echo "Error: Promtail container failed to start"
+	echo "For more information use: docker logs $PROMTAIL_NAME"
+	exit 1
 fi
 
 # Wait till Loki is available
 RETRIES=5
 TRIES=0
 until $(curl --output /dev/null -f --silent http://localhost:$PROMTAIL_PORT) || [ $TRIES -eq $RETRIES ]; do
-    ((TRIES=TRIES+1))
-    sleep 5
+	((TRIES = TRIES + 1))
+	sleep 5
 done
 
-if [ ! "$(docker ps -q -f name=$PROMTAIL_NAME)" ]
-then
-    echo "Error: Promtail container failed to start"
-    exit 1
+if [ ! "$(docker ps -q -f name=$PROMTAIL_NAME)" ]; then
+	echo "Error: Promtail container failed to start"
+	exit 1
 fi
 
 echo "$LOKI_ADDRESS"

--- a/start-thanos-sc.sh
+++ b/start-thanos-sc.sh
@@ -1,21 +1,21 @@
 #!/usr/bin/env bash
 . versions.sh
-if [ -f  env.sh ]; then
-    . env.sh
+if [ -f env.sh ]; then
+	. env.sh
 fi
 
-PROM_ADRESS=`docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' aprom`:9090
+PROM_ADRESS=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' aprom):9090
 DATADIR="/prometheus-data/"
 DOCKER_PARAM=""
 NAME="1"
-if [ "`id -u`" -eq 0 ]; then
-    echo "Running as root is not advised, please check the documentation on how to run as non-root user"
+if [ "$(id -u)" -eq 0 ]; then
+	echo "Running as root is not advised, please check the documentation on how to run as non-root user"
 else
-    GROUPID=`id -g`
-    USER_PERMISSIONS="-u $UID:$GROUPID"
+	GROUPID=$(id -g)
+	USER_PERMISSIONS="-u $UID:$GROUPID"
 fi
 function usage {
-  __usage="Usage: $(basename $0) [-h] [-d /path/to/dir] [-a ip:port] [-A ip]
+	__usage="Usage: $(basename $0) [-h] [-d /path/to/dir] [-a ip:port] [-A ip]
 
 Options:
   -h print this help and exit
@@ -25,139 +25,149 @@ Options:
 
 The script starts Thanos sidecart, it will read from Prometheus directory, so that directory must be external
 "
-  echo "$__usage"
+	echo "$__usage"
 }
 group_args=()
 is_podman="$(docker --help | grep -o podman)"
 if [ ! -z "$is_podman" ]; then
-    group_args+=(--userns=keep-id)
+	group_args+=(--userns=keep-id)
 fi
 LIMITS=""
 VOLUMES=""
 PARAMS=""
 for arg; do
-    shift
-    if [ -z "$LIMIT" ]; then
-        case $arg in
-            (--limit)
-                LIMIT="1"
-                ;;
-            (--volume)
-                LIMIT="1"
-                VOLUME="1"
-                ;;
-            (--param)
-                LIMIT="1"
-                PARAM="1"
-                ;;
-            (*) set -- "$@" "$arg"
-                ;;
-        esac
-    else
-        DOCR=`echo $arg|cut -d',' -f1`
-        VALUE=`echo $arg|cut -d',' -f2-|sed 's/#/ /g'`
-        NOSPACE=`echo $arg|sed 's/ /#/g'`
-        if [ "$PARAM" = "1" ]; then
-            if [ -z "${DOCKER_PARAMS[$DOCR]}" ]; then
-                DOCKER_PARAMS[$DOCR]=""
-            fi
-            DOCKER_PARAMS[$DOCR]="${DOCKER_PARAMS[$DOCR]} $VALUE"
-            PARAMS="$PARAMS --param $NOSPACE"
-            unset PARAM
-        else
-            if [ -z "${DOCKER_LIMITS[$DOCR]}" ]; then
-                DOCKER_LIMITS[$DOCR]=""
-            fi
-            if [ "$VOLUME" = "1" ]; then
-                SRC=`echo $VALUE|cut -d':' -f1`
-                DST=`echo $VALUE|cut -d':' -f2-`
-                SRC=$(readlink -m $SRC)
-                DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} -v $SRC:$DST"
-                VOLUMES="$VOLUMES --volume $NOSPACE"
-                unset VOLUME
-            else
-                DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} $VALUE"
-                LIMITS="$LIMITS --limit $NOSPACE"
-            fi
-        fi
-        unset LIMIT
-    fi
+	shift
+	if [ -z "$LIMIT" ]; then
+		case $arg in
+		--limit)
+			LIMIT="1"
+			;;
+		--volume)
+			LIMIT="1"
+			VOLUME="1"
+			;;
+		--param)
+			LIMIT="1"
+			PARAM="1"
+			;;
+		*)
+			set -- "$@" "$arg"
+			;;
+		esac
+	else
+		DOCR=$(echo $arg | cut -d',' -f1)
+		VALUE=$(echo $arg | cut -d',' -f2- | sed 's/#/ /g')
+		NOSPACE=$(echo $arg | sed 's/ /#/g')
+		if [ "$PARAM" = "1" ]; then
+			if [ -z "${DOCKER_PARAMS[$DOCR]}" ]; then
+				DOCKER_PARAMS[$DOCR]=""
+			fi
+			DOCKER_PARAMS[$DOCR]="${DOCKER_PARAMS[$DOCR]} $VALUE"
+			PARAMS="$PARAMS --param $NOSPACE"
+			unset PARAM
+		else
+			if [ -z "${DOCKER_LIMITS[$DOCR]}" ]; then
+				DOCKER_LIMITS[$DOCR]=""
+			fi
+			if [ "$VOLUME" = "1" ]; then
+				SRC=$(echo $VALUE | cut -d':' -f1)
+				DST=$(echo $VALUE | cut -d':' -f2-)
+				SRC=$(readlink -m $SRC)
+				DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} -v $SRC:$DST"
+				VOLUMES="$VOLUMES --volume $NOSPACE"
+				unset VOLUME
+			else
+				DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} $VALUE"
+				LIMITS="$LIMITS --limit $NOSPACE"
+			fi
+		fi
+		unset LIMIT
+	fi
 done
 if [ "$DOCKER_PARAM" != "" ]; then
-    DOCKER_PARAM_FROM_FILE="1"
+	DOCKER_PARAM_FROM_FILE="1"
 fi
 
 while getopts ':hl:p:a:D:d:A:n:' option; do
-  case "$option" in
-    l) if [[ "$DOCKER_PARAM" != *"--net=host"* ]]; then
-        DOCKER_PARAM="$DOCKER_PARAM --net=host"
-       fi
-       ;;
-    d) DATA_DIR="$OPTARG"
-       ;;
-    h) usage
-       exit
-       ;;
-    n) NAME="$OPTARG"
-       ;;
-    a) PROM_ADRESS=$OPTARG
-	   ;;
-	p) THANOS_SC_PORT=$OPTARG
-       ;;
-    A) BIND_ADDRESS="$OPTARG:"
-       ;;
-    D) if [ "$DOCKER_PARAM_FROM_FILE" = "1" ]; then
-          DOCKER_PARAM=""
-          DOCKER_PARAM_FROM_FILE=""
-       fi
-       DOCKER_PARAM="$DOCKER_PARAM $OPTARG"
-       ;;
-    :) printf "missing argument for -%s\n" "$OPTARG" >&2
-       echo "$usage" >&2
-       exit 1
-       ;;
-   \?) printf "illegal option: -%s\n" "$OPTARG" >&2
-       echo "$usage" >&2
-       exit 1
-       ;;
-  esac
+	case "$option" in
+	l)
+		if [[ "$DOCKER_PARAM" != *"--net=host"* ]]; then
+			DOCKER_PARAM="$DOCKER_PARAM --net=host"
+		fi
+		;;
+	d)
+		DATA_DIR="$OPTARG"
+		;;
+	h)
+		usage
+		exit
+		;;
+	n)
+		NAME="$OPTARG"
+		;;
+	a)
+		PROM_ADRESS=$OPTARG
+		;;
+	p)
+		THANOS_SC_PORT=$OPTARG
+		;;
+	A)
+		BIND_ADDRESS="$OPTARG:"
+		;;
+	D)
+		if [ "$DOCKER_PARAM_FROM_FILE" = "1" ]; then
+			DOCKER_PARAM=""
+			DOCKER_PARAM_FROM_FILE=""
+		fi
+		DOCKER_PARAM="$DOCKER_PARAM $OPTARG"
+		;;
+	:)
+		printf "missing argument for -%s\n" "$OPTARG" >&2
+		echo "$usage" >&2
+		exit 1
+		;;
+	\?)
+		printf "illegal option: -%s\n" "$OPTARG" >&2
+		echo "$usage" >&2
+		exit 1
+		;;
+	esac
 done
 
-if [ -z $DATA_DIR ]
-then
-    exit 0
+if [ -z $DATA_DIR ]; then
+	exit 0
 else
-    DATA_DIR="-v "$(readlink -m $DATA_DIR)":/data/prom$NAME:z"
+	DATA_DIR="-v "$(readlink -m $DATA_DIR)":/data/prom$NAME:z"
 fi
 if [[ $DOCKER_PARAM = *"--net=host"* ]]; then
-    if [ ! -z "$ALERTMANAGER_PORT" ] || [ ! -z "$GRAFANA_PORT" ] || [ ! -z $PROMETHEUS_PORT ]; then
-        echo "Port mapping is not supported with host network, remove the -l flag from the command line"
-        exit 1
-    fi
-    HOST_NETWORK=1
+	if [ ! -z "$ALERTMANAGER_PORT" ] || [ ! -z "$GRAFANA_PORT" ] || [ ! -z $PROMETHEUS_PORT ]; then
+		echo "Port mapping is not supported with host network, remove the -l flag from the command line"
+		exit 1
+	fi
+	HOST_NETWORK=1
 fi
 if [ -z "$BIND_ADDRESS" ]; then
-  BIND_ADDRESS=""
+	BIND_ADDRESS=""
 fi
 if [ -z "$THANOS_SC_PORT"]; then
-    THANOS_SC_PORT="10911"
+	THANOS_SC_PORT="10911"
 fi
 
 if [ -z $HOST_NETWORK ]; then
-    PORT_MAPPING="-p $BIND_ADDRESS$THANOS_SC_PORT:10911"
+	PORT_MAPPING="-p $BIND_ADDRESS$THANOS_SC_PORT:10911"
 fi
 
 echo "Starting Thanos sidecar"
 docker run ${DOCKER_LIMITS["sidecar"]} -d $DOCKER_PARAM $USER_PERMISSIONS \
-     $DATA_DIR \
-     $DOCKER_PARAM \
-     -i $PORT_MAPPING --name sidecar$NAME docker.io/thanosio/thanos:$THANOS_VERSION \
-        "sidecar" \
-       "--debug.name=$NAME" \
-       ${DOCKER_PARAMS["sidecar"]} \
-       "--grpc-address=0.0.0.0:10911" \
-       "--grpc-grace-period=1s" \
-       "--http-address=0.0.0.0:10912" \
-       "--http-grace-period=1s" \
-       "--prometheus.url=http://$PROM_ADRESS" \
-       "--tsdb.path=/data/prom$NAME"
+	$DATA_DIR \
+	$DOCKER_PARAM \
+	-i $PORT_MAPPING --name sidecar$NAME docker.io/thanosio/thanos:$THANOS_VERSION \
+	"sidecar" \
+	"--debug.name=$NAME" \
+	${DOCKER_PARAMS["sidecar"]} \
+	"--grpc-address=0.0.0.0:10911" \
+	"--grpc-grace-period=1s" \
+	"--http-address=0.0.0.0:10912" \
+	"--http-grace-period=1s" \
+	"--prometheus.url=http://$PROM_ADRESS" \
+	"--tsdb.path=/data/prom$NAME"

--- a/start-thanos.sh
+++ b/start-thanos.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 . versions.sh
-if [ -f  env.sh ]; then
-    . env.sh
+if [ -f env.sh ]; then
+	. env.sh
 fi
 
 function usage {
-  __usage="Usage: $(basename $0) [-h] [-S ip:port]
+	__usage="Usage: $(basename $0) [-h] [-S ip:port]
 
 Options:
   -h print this help and exit
@@ -14,16 +14,16 @@ Options:
 
 The script starts Thanos query, it connect to external Thanos side carts and act as a grafana data source
 "
-  echo "$__usage"
+	echo "$__usage"
 }
 
 function update_data_source {
-  THANOS_ADDRESS="$(docker inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' thanos)"
-  if [[ $THANOS_ADDRESS = "" ]]; then
-      THANOS_ADDRESS=`hostname -I | awk '{print $1}'`
-  fi
-  THANOS_ADDRESS="$THANOS_ADDRESS:10904"
-  __datasource="# config file version
+	THANOS_ADDRESS="$(docker inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' thanos)"
+	if [[ $THANOS_ADDRESS = "" ]]; then
+		THANOS_ADDRESS=$(hostname -I | awk '{print $1}')
+	fi
+	THANOS_ADDRESS="$THANOS_ADDRESS:10904"
+	__datasource="# config file version
 apiVersion: 1
 datasources:
 - name: thanos
@@ -32,106 +32,114 @@ datasources:
   access: proxy
   basicAuth: false
 "
-  echo "$__datasource" > grafana/provisioning/datasources/thanos.yaml
+	echo "$__datasource" >grafana/provisioning/datasources/thanos.yaml
 }
 LIMITS=""
 VOLUMES=""
 PARAMS=""
 for arg; do
-    shift
-    if [ -z "$LIMIT" ]; then
-        case $arg in
-            (--limit)
-                LIMIT="1"
-                ;;
-            (--volume)
-                LIMIT="1"
-                VOLUME="1"
-                ;;
-            (--param)
-                LIMIT="1"
-                PARAM="1"
-                ;;
-            (*) set -- "$@" "$arg"
-                ;;
-        esac
-    else
-        DOCR=`echo $arg|cut -d',' -f1`
-        VALUE=`echo $arg|cut -d',' -f2-|sed 's/#/ /g'`
-        NOSPACE=`echo $arg|sed 's/ /#/g'`
-        if [ "$PARAM" = "1" ]; then
-            if [ -z "${DOCKER_PARAMS[$DOCR]}" ]; then
-                DOCKER_PARAMS[$DOCR]=""
-            fi
-            DOCKER_PARAMS[$DOCR]="${DOCKER_PARAMS[$DOCR]} $VALUE"
-            PARAMS="$PARAMS --param $NOSPACE"
-            unset PARAM
-        else
-            if [ -z "${DOCKER_LIMITS[$DOCR]}" ]; then
-                DOCKER_LIMITS[$DOCR]=""
-            fi
-            if [ "$VOLUME" = "1" ]; then
-                SRC=`echo $VALUE|cut -d':' -f1`
-                DST=`echo $VALUE|cut -d':' -f2-`
-                SRC=$(readlink -m $SRC)
-                DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} -v $SRC:$DST"
-                VOLUMES="$VOLUMES --volume $NOSPACE"
-                unset VOLUME
-            else
-                DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} $VALUE"
-                LIMITS="$LIMITS --limit $NOSPACE"
-            fi
-        fi
-        unset LIMIT
-    fi
+	shift
+	if [ -z "$LIMIT" ]; then
+		case $arg in
+		--limit)
+			LIMIT="1"
+			;;
+		--volume)
+			LIMIT="1"
+			VOLUME="1"
+			;;
+		--param)
+			LIMIT="1"
+			PARAM="1"
+			;;
+		*)
+			set -- "$@" "$arg"
+			;;
+		esac
+	else
+		DOCR=$(echo $arg | cut -d',' -f1)
+		VALUE=$(echo $arg | cut -d',' -f2- | sed 's/#/ /g')
+		NOSPACE=$(echo $arg | sed 's/ /#/g')
+		if [ "$PARAM" = "1" ]; then
+			if [ -z "${DOCKER_PARAMS[$DOCR]}" ]; then
+				DOCKER_PARAMS[$DOCR]=""
+			fi
+			DOCKER_PARAMS[$DOCR]="${DOCKER_PARAMS[$DOCR]} $VALUE"
+			PARAMS="$PARAMS --param $NOSPACE"
+			unset PARAM
+		else
+			if [ -z "${DOCKER_LIMITS[$DOCR]}" ]; then
+				DOCKER_LIMITS[$DOCR]=""
+			fi
+			if [ "$VOLUME" = "1" ]; then
+				SRC=$(echo $VALUE | cut -d':' -f1)
+				DST=$(echo $VALUE | cut -d':' -f2-)
+				SRC=$(readlink -m $SRC)
+				DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} -v $SRC:$DST"
+				VOLUMES="$VOLUMES --volume $NOSPACE"
+				unset VOLUME
+			else
+				DOCKER_LIMITS[$DOCR]="${DOCKER_LIMITS[$DOCR]} $VALUE"
+				LIMITS="$LIMITS --limit $NOSPACE"
+			fi
+		fi
+		unset LIMIT
+	fi
 done
 SIDECAR=()
 
 if [ "$DOCKER_PARAM" != "" ]; then
-    DOCKER_PARAM_FROM_FILE="1"
+	DOCKER_PARAM_FROM_FILE="1"
 else
-    DOCKER_PARAM=""
+	DOCKER_PARAM=""
 fi
 
 while getopts ':hlp:S:D:' option; do
-  case "$option" in
-    l) if [[ "$DOCKER_PARAM" != *"--net=host"* ]]; then
-        DOCKER_PARAM="$DOCKER_PARAM --net=host"
-       fi
-       ;;
-    h) usage
-       exit
-       ;;
-    S) IFS=',' ;for s in $OPTARG; do
-         SIDECAR+=(--store=$s)
-	   done
-	   ;;
-    D) if [ "$DOCKER_PARAM_FROM_FILE" = "1" ]; then
-          DOCKER_PARAM=""
-          DOCKER_PARAM_FROM_FILE=""
-       fi
-       DOCKER_PARAM="$DOCKER_PARAM $OPTARG"
-       ;;
-    :) printf "missing argument for -%s\n" "$OPTARG" >&2
-       echo "$usage" >&2
-       exit 1
-       ;;
-   \?) printf "illegal option: -%s\n" "$OPTARG" >&2
-       echo "$usage" >&2
-       exit 1
-       ;;
-  esac
+	case "$option" in
+	l)
+		if [[ "$DOCKER_PARAM" != *"--net=host"* ]]; then
+			DOCKER_PARAM="$DOCKER_PARAM --net=host"
+		fi
+		;;
+	h)
+		usage
+		exit
+		;;
+	S)
+		IFS=','
+		for s in $OPTARG; do
+			SIDECAR+=(--store=$s)
+		done
+		;;
+	D)
+		if [ "$DOCKER_PARAM_FROM_FILE" = "1" ]; then
+			DOCKER_PARAM=""
+			DOCKER_PARAM_FROM_FILE=""
+		fi
+		DOCKER_PARAM="$DOCKER_PARAM $OPTARG"
+		;;
+	:)
+		printf "missing argument for -%s\n" "$OPTARG" >&2
+		echo "$usage" >&2
+		exit 1
+		;;
+	\?)
+		printf "illegal option: -%s\n" "$OPTARG" >&2
+		echo "$usage" >&2
+		exit 1
+		;;
+	esac
 done
 
 docker run ${DOCKER_LIMITS["thanos"]} -d $DOCKER_PARAM -i --name thanos -- docker.io/thanosio/thanos:$THANOS_VERSION \
-       query \
-      "--debug.name=query0" \
-      "--grpc-address=0.0.0.0:10903" \
-      "--grpc-grace-period=1s" \
-      "--http-address=0.0.0.0:10904" \
-      "--http-grace-period=1s" \
-      "--query.replica-label=prometheus" \
-      ${DOCKER_PARAMS["thanos"]} \
-      ${SIDECAR[@]}
+	query \
+	"--debug.name=query0" \
+	"--grpc-address=0.0.0.0:10903" \
+	"--grpc-grace-period=1s" \
+	"--http-address=0.0.0.0:10904" \
+	"--http-grace-period=1s" \
+	"--query.replica-label=prometheus" \
+	${DOCKER_PARAMS["thanos"]} \
+	${SIDECAR[@]}
 
 update_data_source

--- a/upload_report.sh
+++ b/upload_report.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
 function usage {
-  __usage="Usage: $(basename $0) [OPTIONS]
+	__usage="Usage: $(basename $0) [OPTIONS]
 
 Options:
   -h print this help and exit
@@ -16,69 +16,80 @@ The script will copy Prometheus local metrics and will upload them.
 Metrics does not contain internal data.
 By default the script will use /tmp partition and will delete the directory when completed
 "
-  echo "$__usage"
+	echo "$__usage"
 }
 
 VERBOSE=""
 DOCKER="aprom"
 
 while getopts ':hvku:d:D:t:' option; do
-  case "$option" in
-    h) usage
-       exit
-       ;;
-    D) DOCKER=$OPTARG
-       ;;
-    d) DIR=$OPTARG
-       ;;
-    u) UPLOADID=$OPTARG
-       ;;
-    t) TMPDIR=$OPTARG
-       ;;
-    k) KEEP=1
-       ;;
-    v) VERBOSE="-v"
-       ;;
-    
-    \?) printf "illegal option: -%s\n" "$OPTARG" >&2
-       usage >&2
-       exit 1
-       ;;
-  esac
+	case "$option" in
+	h)
+		usage
+		exit
+		;;
+	D)
+		DOCKER=$OPTARG
+		;;
+	d)
+		DIR=$OPTARG
+		;;
+	u)
+		UPLOADID=$OPTARG
+		;;
+	t)
+		TMPDIR=$OPTARG
+		;;
+	k)
+		KEEP=1
+		;;
+	v)
+		VERBOSE="-v"
+		;;
+
+	\?)
+		printf "illegal option: -%s\n" "$OPTARG" >&2
+		usage >&2
+		exit 1
+		;;
+	esac
 done
 
 if [ -z "$UPLOADID" ]; then
-    UPLOADID=$(uuidgen)
+	UPLOADID=$(uuidgen)
 fi
 if [ -z "$TMPDIR" ]; then
-    TMPDIR=$(mktemp -d -t prom-data-XXXXXXXXXX)
+	TMPDIR=$(mktemp -d -t prom-data-XXXXXXXXXX)
 else
-    mkdir -p $TMPDIR
-    TMPDIR="$TMPDIR/$UPLOADID"
-    mkdir $DEST_DIR || { echo 'make sure the directory does not exists' $DEST_DIR  ; exit 1; }
+	mkdir -p $TMPDIR
+	TMPDIR="$TMPDIR/$UPLOADID"
+	mkdir $DEST_DIR || {
+		echo 'make sure the directory does not exists' $DEST_DIR
+		exit 1
+	}
 fi
 
-NEED_SIZE=`docker exec aprom du -s /prometheus|awk '{print $1}'`
-SIZE=`df -P -k $TMPDIR |grep -v Filesystem |awk '{print $4}'`
+NEED_SIZE=$(docker exec aprom du -s /prometheus | awk '{print $1}')
+SIZE=$(df -P -k $TMPDIR | grep -v Filesystem | awk '{print $4}')
 
 # Add 10M for the needed size
-NEED_SIZE=$(( NEED_SIZE + 10000))
+NEED_SIZE=$((NEED_SIZE + 10000))
 if [ $NEED_SIZE -gt $SIZE ]; then
-    echo "Not enough diskspace, " $NEED_SIZE " is needed" $SIZE "is available"
-    exit 1
+	echo "Not enough diskspace, " $NEED_SIZE " is needed" $SIZE "is available"
+	exit 1
 fi
 if [ -z "$DIR" ]; then
-    docker cp -a $DOCKER:/prometheus  - |gzip -9 > $TMPDIR/prometheus_data.tar.gz
+	docker cp -a $DOCKER:/prometheus - | gzip -9 >$TMPDIR/prometheus_data.tar.gz
 #    tar $VERBOSE -zcf $TMPDIR/prometheus_data.tar.gz -C $DEST_DIR --remove-files .
 else
-    tar $VERBOSE -zcf $TMPDIR/prometheus_data.tar.gz $DIR
+	tar $VERBOSE -zcf $TMPDIR/prometheus_data.tar.gz $DIR
 fi
 curl -X PUT http://upload.scylladb.com/$UPLOADID/prometheus_data.tar.gz -T $TMPDIR/prometheus_data.tar.gz
 
 echo "Files were uploaded with UUID " $UPLOADID "include it in your ticket/issue"
 
-if [ -z "$KEEP" ];  then
-    rm -rf $TMPDIR
+if [ -z "$KEEP" ]; then
+	rm -rf $TMPDIR
 else
-    echo "uploaded data can be found at $TMPDIR"
+	echo "uploaded data can be found at $TMPDIR"
 fi


### PR DESCRIPTION
```shell
$ # Installation
$ brew install ruff
$ brew install shfmt

$ # Run formatters
$ ruff check --fix .
$ shfmt -w .
```

Besides that, in some python files I fixed it myself with the standard `__name__ == "__main__"`. Also, `Ruff` does not interfere with python files that do not end with `.py`. In the process, I specified the files one by one and ran them. Maybe we can add the `.py` extension for these files.
- `packer/files/scylla_swap_setup`
- `packer/files/scylla_swap_setup-install`
- `packer/files/scylla_util`
- `packer/files/scylla_monitoring_install_ami`
- `packer/files/node_exporter_install`

Fixes https://github.com/scylladb/scylla-monitoring/issues/2430
