### PR TITLE
doc: docker-compose create file with scripts

### DIFF
--- a/docs/source/install/docker-compose.rst
+++ b/docs/source/install/docker-compose.rst
@@ -3,20 +3,34 @@ Using Docker Compose
 
 Scylla-Monitoring Stack is container-based.
 You can start and stop the Scylla Monitoring Stack with the `start-all.sh` and `kill-all.sh` scripts.
- 
+
 Docker Compose is an alternative method to start and stop the stack. It requires more manual steps, but once
 configured, it simplifies starting and stopping the stack.
 
-.. warning:: 
+.. warning::
 
-    *docker-compose* **and** *start_all.sh* are two **alternative** ways to launch Scylla Monitoring Stack.
+    *docker-compose up* **and** *start-all.sh* are two **alternative** ways to launch Scylla Monitoring Stack.
     You should use **one** method, **not both**. In particular,  creating and updating *docker-compose.yml* is ignored
     when using *start_all.sh*
 
-Prerequisite 
+.. note::
+
+   There is an experimental method that uses scripts to create the Docker Compose file. See the details below.
+
+Prerequisite
 ------------
 
 Make sure you have `docker` and `docker-compose` installed.
+
+Experimental - Configure docker-compose file using scripts
+----------------------------------------------------------
+The ``make-compose.sh`` script accepts the same command-line arguments as ``start-all.sh``. It generates a ``docker-compose.yaml`` file and a ``.env`` file.
+
+Once the script is run, you can use ``docker-compose up`` to start the monitoring stack.
+You can manually modify the generated Compose file, but be aware that running ``make-compose.sh`` script again, will overwrite it.
+
+There is also an experimental ``--compose`` command-line option for ``start-all.sh``. It will first, generates the Compose file
+and then uses docker-compose to run the monitoring stack.
 
 Setting Prometheus
 ------------------
@@ -24,14 +38,14 @@ Setting Prometheus
 The Prometheus configuration file contains among others the IP address of the *alertmanager* and either the location
 of the *scylla_server.yml* file or a Consul IP address of Scylla Manager, if Scylla Manager is used for server provisioning.
 
-You can use `./prometheus-config.sh` to generate the file, for example: 
+You can use `./prometheus-config.sh` to generate the file, for example:
 
 .. code-block:: shell
 
    ./prometheus-config.sh --compose
-   
+
 For production systems, It is advised to use an external directory for the Prometheus database. Make sure to create one and
-update the docker-compose file accordingly (see the docker-compose example below).  
+update the docker-compose file accordingly (see the docker-compose example below).
 
 Setting Grafana Provisioning
 ----------------------------
@@ -48,7 +62,7 @@ Run the following command to update the datasource:
 
    ./grafana-datasource.sh --compose
 
-You can see the generated file under: `grafana/provisioning/datasources/datasource.yaml` 
+You can see the generated file under: `grafana/provisioning/datasources/datasource.yaml`
 
 Grafana Dashboard Load file
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This commit adds an explenation how to create the docker compose file with the experimental scripts.

It also remove some trailing whitespaces.