### PR TITLE
Add Quick startup

### DIFF
--- a/docs/source/install/start-all.rst
+++ b/docs/source/install/start-all.rst
@@ -27,6 +27,8 @@ You cannot use port mapping when using the ``-l`` flag
 
 **--scrap scrap-interval** Allows changing Prometheus scrap interval.
 
+**--quick-startup** When set, the script will not validate that each of the processes start correctly. The benefit is a quicker startup time. The lack of validation makes handling errors harder, use at your own risk.
+
 Grafana Related Commands
 ------------------------
 

--- a/start-alertmanager.sh
+++ b/start-alertmanager.sh
@@ -31,6 +31,9 @@ for arg; do
 			LIMIT="1"
 			VOLUME="1"
 			;;
+        --quick-startup)
+            QUICK_STARTUP=1
+            ;;
 		--param)
 			LIMIT="1"
 			PARAM="1"
@@ -148,13 +151,14 @@ if [ $? -ne 0 ]; then
 fi
 
 # Wait till Alertmanager is available
-RETRIES=5
+RETRIES=25
 TRIES=0
-until $(curl --output /dev/null -f --silent http://localhost:$ALERTMANAGER_PORT) || [ $TRIES -eq $RETRIES ]; do
-	((TRIES = TRIES + 1))
-	sleep 5
-done
-
+if [ ! "$QUICK_STARTUP" = "1" ]; then
+    until $(curl --output /dev/null -f --silent http://localhost:$ALERTMANAGER_PORT) || [ $TRIES -eq $RETRIES ]; do
+    	((TRIES = TRIES + 1))
+    	sleep 1 
+    done
+fi
 if [ ! "$(docker ps -q -f name=$ALERTMANAGER_NAME)" ]; then
 	echo "Error: Alertmanager container failed to start"
 	exit 1

--- a/start-grafana.sh
+++ b/start-grafana.sh
@@ -49,6 +49,9 @@ for arg; do
 		--limit)
 			LIMIT="1"
 			;;
+        --quick-startup)
+            QUICK_STARTUP=1
+            ;;
 		--alternator)
 			RUN_ALTERNATOR="1"
 			;;
@@ -356,13 +359,15 @@ fi
 
 # Wait till Grafana API is available
 printf "Wait for Grafana container to start."
-RETRIES=7
+RETRIES=35
 TRIES=0
-until $(curl --output /dev/null -f --silent http://localhost:$GRAFANA_PORT/api/org) || [ $TRIES -eq $RETRIES ]; do
-	printf '.'
-	((TRIES = TRIES + 1))
-	sleep 5
-done
+if [ ! "$QUICK_STARTUP" = "1" ]; then
+    until $(curl --output /dev/null -f --silent http://localhost:$GRAFANA_PORT/api/org) || [ $TRIES -eq $RETRIES ]; do
+    	printf '.'
+    	((TRIES = TRIES + 1))
+    	sleep 1 
+    done
+fi
 echo
 if [ ! "$(docker ps -q -f name=$GRAFANA_NAME)" ]; then
 	echo "Error: Grafana container failed to start"


### PR DESCRIPTION
This series adds an option to a quicker startup process; it does not wait for each container process to start.

This method of starting the containers will not stop if a container fails to start correctly.

When experimenting on my laptop without Prometheus data,
startup time reduced from 45s to 1.5s.

To use the quick-startup, use the ```--quick-startup``` command line flag with start-all.sh or set ``QUICK_STARTUP=1``` in the env file.