### PR TITLE
node_exporter: upgrade to latest version, remove unneeded collectors

### DIFF
--- a/packer/files/node-exporter.service
+++ b/packer/files/node-exporter.service
@@ -2,7 +2,7 @@
 Description=Node Exporter
 
 [Service]
-ExecStart=/usr/bin/node_exporter
+ExecStart=/usr/bin/node_exporter --no-collector.interrupts --no-collector.hwmon --no-collector.bcache --no-collector.btrfs --no-collector.fibrechannel --no-collector.infiniband --no-collector.ipvs --no-collector.nfs --no-collector.nfsd --no-collector.powersupplyclass --no-collector.rapl --no-collector.tapestats --no-collector.thermal_zone --no-collector.udp_queues --no-collector.zfs
 
 [Install]
 WantedBy=multi-user.target

--- a/packer/files/node_exporter_install
+++ b/packer/files/node_exporter_install
@@ -26,7 +26,7 @@ import tarfile
 from scylla_util import *
 import argparse
 
-VERSION='1.6.1'
+VERSION='1.8.2'
 INSTALL_DIR=scylladir()+'/Prometheus/node_exporter'
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR update node_exporter to v1.8.2 (just like Scylla) and removes the unneeded collectors that are enabled by default (just like Scylla). The only exception is interrupts - which are still enabled by default by Scylla and are not needed here.