### PR TITLE
scylla-manager.template.json: CQL failed only if node is in normal state

### DIFF
--- a/grafana/scylla-manager.template.json
+++ b/grafana/scylla-manager.template.json
@@ -92,7 +92,7 @@
                         "class": "small_stat",
                         "targets": [
                             {
-                                "expr": "count(scylla_manager_healthcheck_cql_status{cluster=\"$cluster\"}==-1) OR vector(0)",
+                                "expr": "count((scylla_manager_healthcheck_cql_status{cluster=\"$cluster\"}==-1) and on(instance) (scylla_node_operation_mode{cluster=\"$cluster\"} == 3) ) OR vector(0)",
                                 "intervalFactor": 1,
                                 "legendFormat": "Nodes without CQL connection",
                                 "refId": "A",


### PR DESCRIPTION
Fixes #2427