### PR TITLE
prometheus.yml.template add network error metrics to datadog

### DIFF
--- a/prometheus/prometheus.yml.template
+++ b/prometheus/prometheus.yml.template
@@ -163,7 +163,7 @@ scrape_configs:
       replacement: '${1}'
   metric_relabel_configs:
     - source_labels: [__name__]
-      regex: '(node_filesystem_size_bytes|node_filesystem_avail_bytes|node_network_receive_packets_total|node_network_transmit_packets_total|node_network_receive_bytes_total|node_network_transmit_bytes_total|node_ethtool_.*)'
+      regex: '(node_filesystem_size_bytes|node_filesystem_avail_bytes|node_network_receive_packets_total|node_network_transmit_packets_total|node_network_receive_bytes_total|node_netstat_Tcp_RetransSegs|node_network_receive_drop_total|node_network_transmit_drop_total|node_network_transmit_bytes_total|node_ethtool_.*)'
       target_label: dd
       replacement: '1'
 


### PR DESCRIPTION
This patch adds the following metrics to the datadog integration: node_netstat_Tcp_RetransSegs
node_network_receive_drop_total
node_network_transmit_drop_total

Relates to #2472 