### PR TITLE
scylla-detailed: prevent showing heat-map errors when there are no tablets

### DIFF
--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -193,7 +193,7 @@
                      "targets": [
                        {
                          "refId": "A",
-                         "expr": "$topbottom([[filter_limit]], sum(scylla_tablets_count{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by([[by]]))",
+                         "expr": "$topbottom([[filter_limit]], sum(scylla_tablets_count{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by([[by]])) or on() vector(0)",
                          "range": false,
                          "format": "time_series",
                            "instant": false,


### PR DESCRIPTION
Fixes #2490