### PR TITLE
grafana/types.json: cluster is missing in operation exprssion

### DIFF
--- a/grafana/types.json
+++ b/grafana/types.json
@@ -2940,7 +2940,7 @@
       },
       "targets":[
          {
-            "expr":"0*scylla_scylladb_current_version{cluster=\"$cluster\", dc=~\"$dc\"} + on (instance) group_left() (scylla_node_operation_mode{cluster=\"$cluster\", dc=~\"$dc\"}!= 3 or on (instance) ((scylla_gossip_live{cluster=\"$cluster\", dc=~\"$dc\"}+1<  bool scalar(count(scylla_node_operation_mode==3)))*6 + 3))",
+            "expr":"0*scylla_scylladb_current_version{cluster=\"$cluster\", dc=~\"$dc\"} + on (instance) group_left() (scylla_node_operation_mode{cluster=\"$cluster\", dc=~\"$dc\"}!= 3 or on (instance) ((scylla_gossip_live{cluster=\"$cluster\", dc=~\"$dc\"}+1<  bool scalar(count(scylla_node_operation_mode{cluster=\"$cluster\"}==3)))*6 + 3))",
             "legendFormat":"",
             "interval":"",
             "format":"table",
@@ -3728,7 +3728,7 @@
       "span":8,
       "targets":[
          {
-            "expr":"0*scylla_scylladb_current_version{cluster=\"$cluster\", dc=~\"$dc\"} + on (instance) group_left() (scylla_node_operation_mode{cluster=\"$cluster\", dc=~\"$dc\"}!= 3 or on (instance) ((scylla_gossip_live{cluster=\"$cluster\", dc=~\"$dc\"}+1<  bool scalar(count(scylla_node_operation_mode==3)))*6 + 3))",
+            "expr":"0*scylla_scylladb_current_version{cluster=\"$cluster\", dc=~\"$dc\"} + on (instance) group_left() (scylla_node_operation_mode{cluster=\"$cluster\", dc=~\"$dc\"}!= 3 or on (instance) ((scylla_gossip_live{cluster=\"$cluster\", dc=~\"$dc\"}+1<  bool scalar(count(scylla_node_operation_mode{cluster=\"$cluster\"}==3)))*6 + 3))",
             "legendFormat":"",
             "interval":"",
             "format":"table",


### PR DESCRIPTION
This patch fixes an issue with split-brain warning in the nodes table when using multiple clusters.
It adds the cluster filter.

Fixes #2502