### PR TITLE
generate-dashboards.sh: Set the default refresh reate to 5m

### DIFF
--- a/generate-dashboards.sh
+++ b/generate-dashboards.sh
@@ -95,7 +95,7 @@ if [[ -z "$TEST_ONLY" ]]; then
 fi
 
 if [[ -z "$DASHBOARD_REFRESH" ]]; then
-	DASHBOARD_REFRESH="30s"
+	DASHBOARD_REFRESH="5m"
 fi
 
 if [ "$DASHBOARD_REFRESH" = "0" ]; then


### PR DESCRIPTION
It's already possible to override the dashboard refresh interval.
This patch changes the default to 5m 
Fixes #2501