### PR TITLE
scylla-detailed: add an all line to the compression graphs

### DIFF
--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -850,6 +850,12 @@
                                 "step": 1
                             }
                         ],
+                        "transformations": [
+                            {
+                              "id": "calculateField",
+                              "options": {}
+                            }
+                          ],
                         "description": "Bytes sent using compressed algorithm\n\nscylla_rpc_compression_compressed_bytes_sent",
                         "title": "Compressed Bytes Sent by Algorithm"
                     },


### PR DESCRIPTION
This patch adds a `total` line to the rcp compression graphs
![download](https://github.com/user-attachments/assets/d23ce054-545d-4516-9f76-e897632d1186)

Fixes #2500