### PR TITLE
scylla-os: Add retransmit metrics

### DIFF
--- a/grafana/scylla-os.template.json
+++ b/grafana/scylla-os.template.json
@@ -565,6 +565,22 @@
                             "overrides": []
                           },
                         "title": "CPU Frequency"
+                    },
+                    {
+                        "class": "graph_panel",
+                        "span": 3,
+                        "description": "reports the number of TCP segments that have been retransmitted, indicating potential network issues or packet loss.",
+                        "targets": [
+                            {
+                                "expr": "sum(rate(node_netstat_Tcp_RetransSegs{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", mode=\"idle\", job=~\"node_exporter.*\"}[3m])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "TCP Retransmit"
                     }
                 ],
                 "title": "New row"


### PR DESCRIPTION
This patch adds the TCP segments that have been retransmitted
![Screenshot_20250514_112729](https://github.com/user-attachments/assets/3fe40acc-068f-4b4c-af02-cf3dce3d0ac0)


Fixes #2472