### PR TITLE
scylla-detailed: Add a load balancer load panel to tablets

### DIFF
--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -204,7 +204,7 @@
                      {
                      "title": "Tablets per [[by]]",
                      "class": "barchart_panel",
-                     "span": 12,
+                     "span": 9,
                      "targets": [
                        {
                          "refId": "A",
@@ -216,6 +216,22 @@
                        }
 
                      ]
+                    },
+                     {
+                     "title": "Tablets load balancer [[by]]",
+                     "class": "graph_panel",
+                     "span": 3,
+                     "targets": [
+                         {
+                             "refId": "A",
+                             "expr": "$topbottom([[filter_limit]], sum(scylla_load_balancer_load{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by(target_node, [[by]]))",
+                             "range": false,
+                             "format": "time_series",
+                               "instant": false,
+                             "legendFormat": "{{dc}} {{target_node}} {{instance}} {{shard}}"
+                           }
+                     ],
+                     "description": "node load during last load balancing\n\nscylla_load_balancer_load"
                     }
                 ]
             },


### PR DESCRIPTION
This patch adds a panel for the tablet's load balancer load
![Screenshot_20250514_172151](https://github.com/user-attachments/assets/d07c4f1a-5f26-4021-a133-269d5424557d)

Fixes #2514