### PR TITLE
scylla-advanced: rpc metrics are only available from ScyllaDB release 2024.2

### DIFF
--- a/grafana/scylla-advanced.template.json
+++ b/grafana/scylla-advanced.template.json
@@ -725,7 +725,7 @@
             },
             {
                 "class": "row",
-                "dashversion":[">6.0", ">2024.1"],
+                "dashversion":[">6.0", ">2024.2"],
                 "panels": [
                     {
                         "class": "collapsible_row_panel",
@@ -737,7 +737,7 @@
             },
             {
                 "class": "row",
-                "dashversion":[">6.0", ">2024.1"],
+                "dashversion":[">6.0", ">2024.2"],
                 "panels": [
                     {
                         "class": "graph_panel",


### PR DESCRIPTION
Fixes #2546