### PR TITLE
grafana/types.json: combine the scheduling groups to a single number

### DIFF
--- a/grafana/types.json
+++ b/grafana/types.json
@@ -648,9 +648,9 @@
             },
             "targets":[
                {
-                  "expr":"avg(rate(scylla_scheduler_runtime_ms{group=~\"sl:.*\", instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by (group)/10 >0.01",
+                  "expr":"sum(avg(rate(scylla_scheduler_runtime_ms{group=~\"sl:.*|commitlog\", instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by (group)/10)",
                   "intervalFactor":1,
-                  "legendFormat":"{{group}}",
+                  "legendFormat":"",
                   "refId":"A",
                   "instant":true,
                   "step":4


### PR DESCRIPTION
Combine the load in the overview dashboard to be a single number that counts only the user priority groups
![image](https://github.com/user-attachments/assets/65310bd0-308f-470a-b09c-7c6b80f7a224)

Fixes #2003