### PR TITLE
alternator: move the delete by TTL to be part of the cluster-wide section

### DIFF
--- a/grafana/alternator.template.json
+++ b/grafana/alternator.template.json
@@ -499,6 +499,21 @@
                         ],
                         "description": "The avarage batch size of BatchGetItem",
                         "title": "Average Batch size of BatchGetItem by [[by]]"
+                    },
+                    {
+                        "class": "ops_panel",
+                        "description": "The number of items deleted by their TTL",
+                        "span": 4,
+                        "targets": [
+                            {
+                                "expr": "$func(rate(scylla_expiration_items_deleted{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[$__rate_interval])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Expired Item Deleted by [[by]]"
                     }
                     ]
             },
@@ -856,21 +871,6 @@
                             }
                         ],
                         "title": "DescribeEndpoints by [[by]]"
-                    },
-                    {
-                        "class": "ops_panel",
-                        "description": "The number of items deleted by their TTL",
-                        "span": 4,
-                        "targets": [
-                            {
-                                "expr": "$func(rate(scylla_expiration_items_deleted{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[$__rate_interval])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A",
-                                "step": 1
-                            }
-                        ],
-                        "title": "Expired Item Deleted by [[by]]"
                     }
                     ]
             },


### PR DESCRIPTION
This patch moves the delete by TTL panel to the cluster-wide operation section.
Fixes #2545