### PR TITLE
types.json: node_table show disk usage

### DIFF
--- a/grafana/types.json
+++ b/grafana/types.json
@@ -3868,7 +3868,7 @@
             "format":"table"
          },
          {
-            "expr":"sum(scylla_gossip_live{cluster=\"$cluster\"})by (instance)",
+            "expr":"100-100*node_filesystem_avail_bytes{mountpoint=\"$mount_point\",  dc=~\"$dc\", instance=~\"$node\"}/node_filesystem_size_bytes{mountpoint=\"$mount_point\", dc=~\"$dc\", instance=~\"$node\"}",
             "legendFormat":"",
             "interval":"",
             "refId":"F",
@@ -4307,6 +4307,26 @@
                   {
                     "id": "unit",
                     "value": "percent"
+                  }
+               ]
+            },
+            {
+               "matcher": {
+                  "id": "byName",
+                  "options": "Value #F"
+               },
+               "properties": [
+                  {
+                     "id": "custom.width",
+                     "value": 120
+                  },
+                  {
+                     "id": "displayName",
+                     "value": "Disk Usage"
+                  },
+                  {
+                     "id": "unit",
+                     "value": "percent"
                   }
                ]
             }


### PR DESCRIPTION
This patch completes a change that adds the disk usage percentage to the node table.
![image](https://github.com/user-attachments/assets/a4e51b30-ce85-419a-919e-5c67ab9896d2)

Fixes #2551