### PR TITLE
Vector target

### DIFF
--- a/prometheus-config.sh
+++ b/prometheus-config.sh
@@ -32,6 +32,9 @@ for arg; do
 		--scrap)
 			PARAM="scrap"
 			;;
+		--vector-store)
+			VECTOR_STORE="1"
+			;;
 		--no-node-exporter-file)
 			NO_NODE_EXPORTER_FILE="1"
 			;;
@@ -132,3 +135,17 @@ for val in "${PROMETHEUS_TARGETS[@]}"; do
 	fi
 	cat $val >>$BASE_DIR/prometheus.yml
 done
+
+if [ ! -z "$VECTOR_STORE" ]; then
+	__target="- job_name: vector_store
+  honor_labels: false
+  file_sd_configs:
+    - files:
+      - /etc/scylla.d/prometheus/targets/vector_store_servers.yml
+  relabel_configs:
+    - source_labels: [__address__, __port__]
+      regex:  '(.+);$'
+      target_label: __address__
+      replacement: '\${1}:6080'"
+	echo "$__target" >>$BASE_DIR/prometheus.yml
+fi


### PR DESCRIPTION
This series adds an option to scrap a vector-store service.

The start-all.sh has a new command line flag ```--vector-store``` that points to a vector-store target file.
When used, the Prometheus configuration will include a vector-store section.

Currently, metrics will be recorded but not display

Fixes #2580
