### PR TITLE
scylla-manager: add one2one metrics

### DIFF
--- a/grafana/scylla-manager.template.json
+++ b/grafana/scylla-manager.template.json
@@ -479,11 +479,9 @@
             },
             {
                 "class": "row",
-                "dashversion":">3.1",
                 "panels": [
 			           {
 	                        "class": "percent_panel",
-	                        "dashversion":">3.2",
 	                        "targets": [
 	                            {
 	                                "expr": "scylla_manager_restore_progress{cluster=~\"[[cluster]]\"} < 100",
@@ -492,7 +490,7 @@
 	                                "step": 4
 	                            }
 	                        ],
-	                        "span":4,
+	                        "span":3,
 	                        "description": "Shows current restore progress",
 	                        "title": "Restore Progress"
 	                    },
@@ -513,9 +511,44 @@
                                 "step": 4
                             }
                         ],
-                        "span":4,
+                        "span":3,
                         "description": "Shows restore progress, the remaining bytes to complete",
                         "title": "Restore Remaining Bytes"
+                    },
+                    {
+	                        "class": "percent_panel",
+	                        "targets": [
+	                            {
+	                                "expr": "scylla_manager_one2onerestore_progress{cluster=~\"[[cluster]]\"} < 100",
+	                                "intervalFactor": 1,
+	                                "refId": "A",
+	                                "step": 4
+	                            }
+	                        ],
+	                        "span":3,
+	                        "description": "Shows current one to one restore progress",
+	                        "title": "one to one Restore Progress"
+	                    },
+	                    {
+                        "class": "bytes_panel",
+                        "fieldConfig": {
+                            "defaults": {
+                              "links": [],
+                              "unit": "decbytes"
+                            },
+                            "overrides": []
+                          },
+                        "targets": [
+                            {
+                                "expr": "sum(scylla_manager_one2onerestore_download_remaining_bytes{cluster=~\"[[cluster]]\", node=~\"$instance\"}) by ([[by]])",
+                                "intervalFactor": 1,
+                                "refId": "A",
+                                "step": 4
+                            }
+                        ],
+                        "span":3,
+                        "description": "Shows one to one restore progress, the remaining bytes to complete",
+                        "title": "one to one Remaining Bytes"
                     }
                 ],
                 "title": "Backup Restore Bytes"


### PR DESCRIPTION
This patch adds the one2one metrics to the manager dashboard

![image](https://github.com/user-attachments/assets/17fa6a23-a6cc-4035-9c42-edd8182c543a)


Fixes #2557 