### PR TITLE
scylla-overview: Add the cluster name if it's available

### DIFF
--- a/grafana/scylla-overview.template.json
+++ b/grafana/scylla-overview.template.json
@@ -16,7 +16,7 @@
                         "w": 24
                       },
                       "panels": [],
-                      "title": "Cluster overview $cluster",
+                      "title": "Cluster overview $cluster $cluster_name",
                       "type": "row"
                     }
                 ]
@@ -535,6 +535,17 @@
                     "query": "node_filesystem_avail_bytes",
                     "regex": "/mountpoint=\"([^\"]*)\".*/",
                     "sort": 0
+                },
+                {
+                    "class": "template_variable_single",
+                    "definition": "label_values(scylla_scylladb_current_version,cluster_name)",
+                    "query": {
+                      "qryType": 1,
+                      "query": "label_values(scylla_scylladb_current_version,cluster_name)"
+                    },
+                    "hide": 2,
+                    "label": "cluster_name",
+                    "name": "cluster_name"
                 },
                 {
                     "class": "template_variable_all",


### PR DESCRIPTION
This patch takes the cluster name from the version metrics if it's available and use that in the overview dashboard next to the cluster id.

<img width="500" height="176" alt="image" src="https://github.com/user-attachments/assets/0922fa60-25d3-432e-9ff4-1fddc6e3783d" />

Fixes #2589
