### PR TITLE
scylla-detailed: include only user scheduling group

### DIFF
--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -2603,16 +2603,14 @@
                       "selected": true,
                       "tags": [],
                       "text": [
-                        "sl:default",
-                        "statement"
+                        "sl:default"
                       ],
                       "value": [
-                        "sl:default",
-                        "statement"
+                        "sl:default"
                       ]
                     },
                     "name": "sg",
-                    "query": "label_values(scylla_scheduler_runtime_ms{cluster=\"$cluster\"}, group)",
+                    "query": "label_values(scylla_scheduler_runtime_ms{cluster=\"$cluster\", group=~\"sl:..*\"}, group)",
                     "sort": 3
                 },
                 {


### PR DESCRIPTION
In the group selector, only include user faceing scheduling group, i.e groups that starts with sl:
<img width="397" height="367" alt="image" src="https://github.com/user-attachments/assets/0167b8d6-c4d7-4c79-94c7-da601bf39bf2" />

Fixes: #2511