### PR TITLE
types.json: Add number of tables stats.

### DIFF
--- a/grafana/types.json
+++ b/grafana/types.json
@@ -309,6 +309,33 @@
          },
          {
             "class":"small_stat",
+            "description":"The number of tables",
+            "title":"# Tables",
+            "fieldConfig": {
+            "defaults": {
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "expr": "count(count(scylla_column_family_cache_hit_rate{cluster=\"$cluster\", ks!~\"system.*\"}) by(cf, ks))",
+              "intervalFactor": 1,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+         },
+         {
+            "class":"small_stat",
             "options": {
                     "reduceOptions": {
                       "values": false,


### PR DESCRIPTION
This patch add a stats panel with the number of user tables served by the cluster.

Fixes #2611