### PR TITLE
Add more AWS regions to packer configuration

### DIFF
--- a/packer/scylla-monitor-template.json
+++ b/packer/scylla-monitor-template.json
@@ -6,7 +6,7 @@
       "ami_name": "{{ user `monitor_image_name` }}",
       "source_ami": "{{user `aws_source_ami`}}",
       "instance_type": "{{user `aws_instance_type`}}",
-      "ami_regions": "us-west-2,eu-west-2,eu-west-1,eu-central-1,eu-north-1",
+      "ami_regions": "us-west-2,eu-west-2,eu-west-1,eu-central-1,eu-north-1,eu-west-3,ca-central-1",
       "user_data_file": "files/user_data.txt",
       "subnet_filter": {
         "filters": {


### PR DESCRIPTION
this commit add `eu-west-3` and `ca-central-1`
those are new two regions that SCT supports and we need the image available there on every build
so SCT can run two regions out of the box