### PR TITLE
Show overview stats over time

### DIFF
--- a/grafana/types.json
+++ b/grafana/types.json
@@ -586,14 +586,11 @@
          },
 
          {
-            "class":"small_stat",
+            "class":"small_stat_area",
             "targets":[
                {
                   "expr":"sum(rate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) + (sum(rate(scylla_thrift_served{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) or on() vector(0))",
-                  "intervalFactor":1,
-                  "refId":"A",
-                  "instant":true,
-                  "step":40
+                  "refId":"A"
                }
             ],
             "gridPos":{
@@ -622,7 +619,7 @@
             "title":"Requests/s"
          },
          {
-            "class":"small_stat",
+            "class":"small_stat_area",
             "description":"Average Write Latency",
             "fieldConfig":{
                "defaults":{
@@ -650,18 +647,14 @@
             "targets":[
                {
                   "expr":"avg(wlatencya{by=\"cluster\", cluster=~\"$cluster|^$\",scheduling_group_name=~\"$sg\"}>0)",
-                  "intervalFactor":1,
-                  "legendFormat":"",
-                  "refId":"A",
-                  "instant":true,
-                  "step":4
+                  "refId":"A"
                }
             ],
             "title":"Avg Write"
          },
          {
-            "class":"small_stat",
-            "description":"99% write Latency",
+            "class":"small_stat_area",
+            "description":"P99 write Latency",
             "fieldConfig":{
                "defaults":{
                   "custom":{
@@ -688,17 +681,14 @@
             "targets":[
                {
                   "expr":"wlatencyp99{by=\"cluster\", cluster=~\"$cluster|^$\",scheduling_group_name=~\"$sg\"}>0",
-                  "intervalFactor":1,
                   "legendFormat":"{{scheduling_group_name}}",
-                  "refId":"A",
-                  "instant":true,
-                  "step":4
+                  "refId":"A"
                }
             ],
             "title":"P99 Write"
          },
          {
-            "class":"small_stat",
+            "class":"small_stat_area",
             "description":"Average Read Latency",
             "fieldConfig":{
                "defaults":{
@@ -726,18 +716,15 @@
             "targets":[
                {
                   "expr":"avg(rlatencya{by=\"cluster\", cluster=~\"$cluster|^$\",scheduling_group_name=~\"$sg\"}>0)",
-                  "intervalFactor":1,
                   "legendFormat":"",
-                  "instant":true,
-                  "refId":"A",
-                  "step":4
+                  "refId":"A"
                }
             ],
             "title":"Avg Read"
          },
          {
-            "class":"small_stat",
-            "description":"99% read Latency",
+            "class":"small_stat_area",
+            "description":"P99 read Latency",
             "fieldConfig":{
                "defaults":{
                   "custom":{
@@ -764,17 +751,14 @@
             "targets":[
                {
                   "expr":"rlatencyp99{by=\"cluster\", cluster=~\"$cluster|^$\",scheduling_group_name=~\"$sg\"}>0",
-                  "intervalFactor":1,
                   "legendFormat":"{{scheduling_group_name}}",
-                  "refId":"A",
-                  "instant":true,
-                  "step":4
+                  "refId":"A"
                }
             ],
             "title":"P99"
          },
          {
-            "class":"small_stat",
+            "class":"small_stat_area",
             "description":"The percentage of the time during which Scylla utilized the CPU. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high.",
             "fieldConfig":{
                "defaults":{
@@ -802,17 +786,14 @@
             "targets":[
                {
                   "expr":"sum(avg(rate(scylla_scheduler_runtime_ms{group=~\"sl:.*|commitlog\", instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by (group)/10)",
-                  "intervalFactor":1,
                   "legendFormat":"",
-                  "refId":"A",
-                  "instant":true,
-                  "step":4
+                  "refId":"A"
                }
             ],
             "title":"Load"
          },
          {
-            "class":"small_stat",
+            "class":"small_stat_area",
             "fieldConfig":{
                "defaults":{
                   "custom":{
@@ -837,10 +818,7 @@
             "targets":[
                {
                   "expr":"(sum(rate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[$__rate_interval])) or on() vector(0)) + (sum(rate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[$__rate_interval])) or on() vector(0))",
-                  "intervalFactor":1,
-                  "refId":"A",
-                  "instant":true,
-                  "step":40
+                  "refId":"A"
                }
             ],
             "description":"The rate of timeouts (read and write).\n\nTimeouts are an indication of an overloaded system",

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -45,10 +45,15 @@
          },
          "textMode":"auto"
       },
-      "pluginVersion":"7.1.3",
       "timeFrom":null,
       "timeShift":null,
       "type":"stat"
+   },
+   "small_stat_area": {
+       "class":"small_stat",
+       "options": {
+           "class":"stats_area_options"
+       }
    },
    "small_gauge_std":{
       "class":"small_stat",
@@ -155,6 +160,23 @@
             }
          }
       ]
+   },
+    "stats_area_options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "showPercentChange": false,
+        "percentChangeColorMode": "standard"
    },
    "manager_stat_panel": {
             "class":"small_stat",


### PR DESCRIPTION
The stats at the top over the overview dashboard are better understood with an over-time look.
They are now using a graph with the values
<img width="1400" height="246" alt="image" src="https://github.com/user-attachments/assets/376ae0f1-e651-4483-8062-23309616bdac" />
