### PR TITLE
scylla-os: limit the disk names to scylla nodes

### DIFF
--- a/grafana/scylla-os.template.json
+++ b/grafana/scylla-os.template.json
@@ -659,7 +659,7 @@
                     "class": "template_variable_all",
                     "label": null,
                     "name": "monitor_disk",
-                    "query": "node_disk_read_bytes_total",
+                    "query": "node_disk_read_bytes_total{job=~\"node_exporter.*\"}",
                     "regex": "/.*device=\"([^\\\"]*)\".*/"
                 },
                 {


### PR DESCRIPTION
This patch limit the disk names in the dropdown menue to scylla nodes only.
This removes other monitoring entities like the manager from it.

Fixes #2628