### PR TITLE
scylla-detailed: simplify tablets load panel

### DIFF
--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -218,7 +218,7 @@
                      ]
                     },
                      {
-                     "title": "Tablets load balancer [[by]]",
+                     "title": "Tablets load by [[by]]",
                      "class": "graph_panel",
                      "span": 3,
                      "targets": [
@@ -231,7 +231,7 @@
                              "legendFormat": "{{dc}} {{target_node}} {{instance}} {{shard}}"
                            }
                      ],
-                     "description": "node load during last load balancing\n\nscylla_load_balancer_load"
+                     "description": "Represents the ‘load’ value the balancer equalizes across instances.\n\nIt is based on the number of tablets assigned to each instance, adjusted so larger disks are expected to hold proportionally more tablets.\n\nscylla_load_balancer_load"
                     }
                 ]
             },


### PR DESCRIPTION
Rename the tablets load panel and make the description clearer
<img width="523" height="266" alt="image" src="https://github.com/user-attachments/assets/29ef6101-b60b-45ac-9339-caa20d8f9502" />

Fixes #2640