### PR TITLE
scylla-detailed: scylla_hints_for_views_manager_sent_total rename

### DIFF
--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -1543,6 +1543,15 @@
                                 "expr": "$topbottom([[filter_limit]], $func(rate(scylla_hints_for_views_manager_sent{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[$__rate_interval]))  by ([[by]]))",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
+                                "dashversion":["<2025.1"],
+                                "refId": "A",
+                                "step": 10
+                            },
+                            {
+                                "expr": "$topbottom([[filter_limit]], $func(rate(scylla_hints_for_views_manager_sent_total{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[$__rate_interval]))  by ([[by]]))",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "dashversion":[">2025.1"],
                                 "refId": "A",
                                 "step": 10
                             }


### PR DESCRIPTION
This patch address the rename of
scylla_hints_for_views_manager_sent to
scylla_hints_for_views_manager_sent_total in version 2025.1

Fixes #2678