### PR TITLE
alternator: Use scylla_httpd_connections_total for the number of open http connections

### DIFF
--- a/grafana/alternator.template.json
+++ b/grafana/alternator.template.json
@@ -1188,7 +1188,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$func(scylla_httpd_connections_total{service=~\"http.?-alternator\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]], service)",
+                                "expr": "$func(scylla_httpd_connections_current{service=~\"http.?-alternator\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]], service)",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",


### PR DESCRIPTION

Fixes #2813