### PR TITLE
node_exporter_install: switch to scylladb-node-exporter v1.11.1-1

### DIFF
--- a/packer/files/node_exporter_install
+++ b/packer/files/node_exporter_install
@@ -26,7 +26,7 @@ import tarfile
 from scylla_util import *
 import argparse
 
-VERSION='1.8.2'
+VERSION='1.11.1-1'
 INSTALL_DIR=scylladir()+'/Prometheus/node_exporter'
 
 if __name__ == '__main__':
@@ -55,7 +55,7 @@ if __name__ == '__main__':
         print('app-metrics/node_exporter does not install systemd service files, please fill a bug if you need them.')
         sys.exit(1)
     else:
-        data = curl('https://github.com/prometheus/node_exporter/releases/download/v{version}/node_exporter-{version}.linux-amd64.tar.gz'.format(version=VERSION), byte=True)
+        data = curl('https://github.com/scylladb/scylladb-node-exporter/releases/download/v{version}/node_exporter-{version}.linux-amd64.tar.gz'.format(version=VERSION), byte=True)
         with open('/var/tmp/node_exporter-{version}.linux-amd64.tar.gz'.format(version=VERSION), 'wb') as f:
             f.write(data)
         with tarfile.open('/var/tmp/node_exporter-{version}.linux-amd64.tar.gz'.format(version=VERSION)) as tf:


### PR DESCRIPTION
Switch the node_exporter download source from prometheus/node_exporter to scylladb/scylladb-node-exporter and bump version from 1.8.2 to 1.11.1-1.

Fixes: https://scylladb.atlassian.net/browse/RELENG-521
Refs: https://scylladb.atlassian.net/browse/RELENG-495