### PR TITLE
ci(packer): add us-east-2 to AMI copy regions

### DIFF
--- a/packer/scylla-monitor-template.json
+++ b/packer/scylla-monitor-template.json
@@ -12,7 +12,7 @@
         "most_recent": true
       },
       "instance_type": "{{user `aws_instance_type`}}",
-      "ami_regions": "us-west-2,eu-west-2,eu-west-1,eu-central-1,eu-north-1,eu-west-3,ca-central-1",
+      "ami_regions": "us-west-2,us-east-2,eu-west-2,eu-west-1,eu-central-1,eu-north-1,eu-west-3,ca-central-1",
       "user_data_file": "files/user_data.txt",
       "subnet_filter": {
         "filters": {


### PR DESCRIPTION
## Summary
- Add `us-east-2` to `ami_regions` in packer template
- Supports perf tests using i8g.4xlarge instances in us-east-2

[QAINFRA-103]

[QAINFRA-103]: https://scylladb.atlassian.net/browse/QAINFRA-103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ