### PR TITLE
Keyspace dashboard, hide missing indexes

### DIFF
--- a/grafana/scylla-ks.template.json
+++ b/grafana/scylla-ks.template.json
@@ -141,30 +141,6 @@
                 "collapse": false
             },
             {
-                "class": "row",
-                "panels": [
-                    {
-                        "gridPos": {
-                            "h": 13,
-                            "w": 24
-                        },
-                        "class": "heatmap_panel",
-                        "spec/title": "Tablets over time per [[by]]",
-                        "spec/data/spec/queries/0/spec/query/spec/expr": "sum(scylla_column_family_tablet_count{ks=\"$ks\", cf=~\"$table\", instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\"}) by([[by]])",
-                        "spec/data/spec/queries/0/spec/query/spec/legendFormat": "{{dc}} {{instance}}"
-                    },
-                    {
-                        "span": 12,
-                        "class": "barchart_panel",
-                        "spec/title": "Tablets $func by [[by]]",
-                        "spec/data/spec/queries/0/spec/query/spec/expr": "sum(scylla_column_family_tablet_count{ks=\"$ks\", cf=~\"$table\",instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\"}) by([[by]])",
-                        "spec/data/spec/queries/0/spec/query/spec/legendFormat": "__auto",
-                        "spec/data/spec/queries/0/spec/query/spec/instant": true,
-                        "spec/data/spec/queries/0/spec/query/spec/range": false
-                    }
-                ]
-            },
-            {
                 "class": "user_panel_row_header",
                 "title": ""
             },

--- a/grafana/scylla-ks.template.json
+++ b/grafana/scylla-ks.template.json
@@ -103,11 +103,16 @@
                         "spec/data/spec/queries/0/spec/query/spec/expr": "$func(scylla_column_family_tablet_count{ks=\"$ks\", cf=\"$table\", instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\"}) by([[by]])"
                     }
                 ],
-                "title": "$ks:$table",
+                "title": "Table: $ks:$table",
                 "collapse": false
             },
             {
                 "class": "row",
+                "repeat": "index",
+                "conditionalRendering": {
+                    "class": "conditionalRendering_var",
+                    "spec/items/0/spec/variable": "index"
+                },
                 "dashversion": [
                     ">2025.4"
                 ],
@@ -137,7 +142,7 @@
                         "spec/data/spec/queries/0/spec/query/spec/expr": "histogram_quantile(0.99,sum(rate(scylla_index_query_latencies_bucket{ks=\"$ks\", idx=\"$index\", instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\"}[$__rate_interval])) by ([[by]], le))"
                     }
                 ],
-                "title": "$ks:$index",
+                "title": "Index: $ks:$index",
                 "collapse": false
             },
             {

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -6975,5 +6975,21 @@
          "allowCustomValue": false,
          "valuesFormat": "csv"
       }
+   },
+   "conditionalRendering_var": {
+      "kind": "ConditionalRenderingGroup",
+      "spec": {
+         "visibility": "hide",
+         "condition": "and",
+         "items": [
+               {
+                  "kind": "ConditionalRenderingVariable",
+                  "spec": {
+                    "operator": "matches",
+                     "value": "^$"
+                  }
+               }
+         ]
+      }
    }
 }


### PR DESCRIPTION
This series address two issues with the keyspace dashboard.
1. The global view of tablets is confusing; it will be removed.
2. When there are no indexes in a keyspace, the empty line is confusing.

This is also the first use of conditional rendering in Grafana.

Fixes https://scylladb.atlassian.net/browse/MONITOR-72