### PR TITLE
Cql histograms

### DIFF
--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -1580,6 +1580,24 @@
                                 "spec/description": "",
                                 "spec/data/spec/queries/0/spec/query/spec/expr": "$topbottom([[filter_limit]], $func(scylla_storage_proxy_coordinator_foreground_writes{instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}) by (scheduling_group_name, [[by]]))",
                                 "spec/data/spec/queries/0/spec/query/spec/legendFormat": "{{scheduling_group_name}} {{dc}} {{instance}} {{shard}}"
+                            },
+                            {
+                                "span": 3,
+                                "class": "us_panel",
+                                "dashversion": [">2026.3"],
+                                "spec/title": "CQL request latency by [[by]]",
+                                "spec/description": "CQL request latencies, measuring from the start of the request processing until the response is written to the socket.",
+                                "spec/data/spec/queries/0/spec/query/spec/expr": "$topbottom([[filter_limit]], scylla_transport_cql_request_latency_summary{quantile=~\"0.9.*\", instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", scheduling_group_name=\"$sg\", by=\"[[by]]\"})",
+                                "spec/data/spec/queries/0/spec/query/spec/legendFormat": "P{{quantile}} - {{scheduling_group_name}} {{dc}} {{instance}}"
+                            },
+                            {
+                                "span": 3,
+                                "class": "us_panel",
+                                "dashversion": [">2026.3"],
+                                "spec/title": "CQL client timestamp drift by [[by]]",
+                                "spec/description": "CQL client timestamp drifts, the drift time between the client-provided CQL timestamp and the server time at request arrival. Useful for detecting transport delays before requests reach the CQL server.",
+                                "spec/data/spec/queries/0/spec/query/spec/expr": "$topbottom([[filter_limit]], scylla_transport_cql_client_timestamp_drift_summary{quantile=~\"0.9.*\", instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", scheduling_group_name=\"$sg\", by=\"[[by]]\"})",
+                                "spec/data/spec/queries/0/spec/query/spec/legendFormat": "P{{quantile}} - {{scheduling_group_name}} {{dc}} {{instance}}"
                             }
                         ],
                         "title": "$sg"

--- a/prometheus/prom_rules/prometheus.latency.rules.yml
+++ b/prometheus/prom_rules/prometheus.latency.rules.yml
@@ -478,6 +478,222 @@ groups:
       by: "cluster"
       quantile: "0.5"
       dd: "1"
+  - record: scylla_transport_cql_request_summary_bytes
+    expr: histogram_quantile(0.5, sum(rate(scylla_transport_cql_request_histogram_bytes[60s])) by (cluster, dc, instance, scheduling_group_name))
+    labels:
+      by: "instance"
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_transport_cql_request_summary_bytes
+    expr: histogram_quantile(0.5, sum(rate(scylla_transport_cql_request_histogram_bytes[60s])) by (cluster, dc, scheduling_group_name))
+    labels:
+      by: "dc"
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_transport_cql_request_summary_bytes
+    expr: histogram_quantile(0.5, sum(rate(scylla_transport_cql_request_histogram_bytes[60s])) by (cluster, scheduling_group_name))
+    labels:
+      by: "cluster"
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_transport_cql_request_summary_bytes
+    expr: histogram_quantile(0.95, sum(rate(scylla_transport_cql_request_histogram_bytes[60s])) by (cluster, dc, instance, scheduling_group_name))
+    labels:
+      by: "instance"
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_transport_cql_request_summary_bytes
+    expr: histogram_quantile(0.95, sum(rate(scylla_transport_cql_request_histogram_bytes[60s])) by (cluster, dc, scheduling_group_name))
+    labels:
+      by: "dc"
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_transport_cql_request_summary_bytes
+    expr: histogram_quantile(0.95, sum(rate(scylla_transport_cql_request_histogram_bytes[60s])) by (cluster, scheduling_group_name))
+    labels:
+      by: "cluster"
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_transport_cql_request_summary_bytes
+    expr: histogram_quantile(0.99, sum(rate(scylla_transport_cql_request_histogram_bytes[60s])) by (cluster, dc, instance, scheduling_group_name))
+    labels:
+      by: "instance"
+      quantile: "0.99"
+      dd: "1"
+  - record: scylla_transport_cql_request_summary_bytes
+    expr: histogram_quantile(0.99, sum(rate(scylla_transport_cql_request_histogram_bytes[60s])) by (cluster, dc, scheduling_group_name))
+    labels:
+      by: "dc"
+      quantile: "0.99"
+      dd: "1"
+  - record: scylla_transport_cql_request_summary_bytes
+    expr: histogram_quantile(0.99, sum(rate(scylla_transport_cql_request_histogram_bytes[60s])) by (cluster, scheduling_group_name))
+    labels:
+      by: "cluster"
+      quantile: "0.99"
+      dd: "1"
+  - record: scylla_transport_cql_response_summary_bytes
+    expr: histogram_quantile(0.5, sum(rate(scylla_transport_cql_response_histogram_bytes_bucket[60s])) by (cluster, dc, instance, le, scheduling_group_name))
+    labels:
+      by: "instance"
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_transport_cql_response_summary_bytes
+    expr: histogram_quantile(0.5, sum(rate(scylla_transport_cql_response_histogram_bytes_bucket[60s])) by (cluster, dc, le, scheduling_group_name))
+    labels:
+      by: "dc"
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_transport_cql_response_summary_bytes
+    expr: histogram_quantile(0.5, sum(rate(scylla_transport_cql_response_histogram_bytes_bucket[60s])) by (cluster, le, scheduling_group_name))
+    labels:
+      by: "cluster"
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_transport_cql_response_summary_bytes
+    expr: histogram_quantile(0.95, sum(rate(scylla_transport_cql_response_histogram_bytes_bucket[60s])) by (cluster, dc, instance, le, scheduling_group_name))
+    labels:
+      by: "instance"
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_transport_cql_response_summary_bytes
+    expr: histogram_quantile(0.95, sum(rate(scylla_transport_cql_response_histogram_bytes_bucket[60s])) by (cluster, dc, le, scheduling_group_name))
+    labels:
+      by: "dc"
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_transport_cql_response_summary_bytes
+    expr: histogram_quantile(0.95, sum(rate(scylla_transport_cql_response_histogram_bytes_bucket[60s])) by (cluster, le, scheduling_group_name))
+    labels:
+      by: "cluster"
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_transport_cql_response_summary_bytes
+    expr: histogram_quantile(0.99, sum(rate(scylla_transport_cql_response_histogram_bytes_bucket[60s])) by (cluster, dc, instance, le, scheduling_group_name))
+    labels:
+      by: "instance"
+      quantile: "0.99"
+      dd: "1"
+  - record: scylla_transport_cql_response_summary_bytes
+    expr: histogram_quantile(0.99, sum(rate(scylla_transport_cql_response_histogram_bytes_bucket[60s])) by (cluster, dc, le, scheduling_group_name))
+    labels:
+      by: "dc"
+      quantile: "0.99"
+      dd: "1"
+  - record: scylla_transport_cql_response_summary_bytes
+    expr: histogram_quantile(0.99, sum(rate(scylla_transport_cql_response_histogram_bytes_bucket[60s])) by (cluster, le, scheduling_group_name))
+    labels:
+      by: "cluster"
+      quantile: "0.99"
+      dd: "1"
+  - record: scylla_transport_cql_request_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_transport_cql_request_latency_histogram_bucket[60s])) by (cluster, dc, instance, le, scheduling_group_name))
+    labels:
+      by: "instance"
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_transport_cql_request_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_transport_cql_request_latency_histogram_bucket[60s])) by (cluster, dc, le, scheduling_group_name))
+    labels:
+      by: "dc"
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_transport_cql_request_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_transport_cql_request_latency_histogram_bucket[60s])) by (cluster, le, scheduling_group_name))
+    labels:
+      by: "cluster"
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_transport_cql_request_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_transport_cql_request_latency_histogram_bucket[60s])) by (cluster, dc, instance, le, scheduling_group_name))
+    labels:
+      by: "instance"
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_transport_cql_request_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_transport_cql_request_latency_histogram_bucket[60s])) by (cluster, dc, le, scheduling_group_name))
+    labels:
+      by: "dc"
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_transport_cql_request_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_transport_cql_request_latency_histogram_bucket[60s])) by (cluster, le, scheduling_group_name))
+    labels:
+      by: "cluster"
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_transport_cql_request_latency_summary
+    expr: histogram_quantile(0.99, sum(rate(scylla_transport_cql_request_latency_histogram_bucket[60s])) by (cluster, dc, instance, le, scheduling_group_name))
+    labels:
+      by: "instance"
+      quantile: "0.99"
+      dd: "1"
+  - record: scylla_transport_cql_request_latency_summary
+    expr: histogram_quantile(0.99, sum(rate(scylla_transport_cql_request_latency_histogram_bucket[60s])) by (cluster, dc, le, scheduling_group_name))
+    labels:
+      by: "dc"
+      quantile: "0.99"
+      dd: "1"
+  - record: scylla_transport_cql_request_latency_summary
+    expr: histogram_quantile(0.99, sum(rate(scylla_transport_cql_request_latency_histogram_bucket[60s])) by (cluster, le, scheduling_group_name))
+    labels:
+      by: "cluster"
+      quantile: "0.99"
+      dd: "1"
+  - record: scylla_transport_cql_client_timestamp_drift_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_transport_cql_client_timestamp_drift_histogram_bucket[60s])) by (cluster, dc, instance, le, scheduling_group_name))
+    labels:
+      by: "instance"
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_transport_cql_client_timestamp_drift_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_transport_cql_client_timestamp_drift_histogram_bucket[60s])) by (cluster, dc, le, scheduling_group_name))
+    labels:
+      by: "dc"
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_transport_cql_client_timestamp_drift_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_transport_cql_client_timestamp_drift_histogram_bucket[60s])) by (cluster, le, scheduling_group_name))
+    labels:
+      by: "cluster"
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_transport_cql_client_timestamp_drift_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_transport_cql_client_timestamp_drift_histogram_bucket[60s])) by (cluster, dc, instance, le, scheduling_group_name))
+    labels:
+      by: "instance"
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_transport_cql_client_timestamp_drift_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_transport_cql_client_timestamp_drift_histogram_bucket[60s])) by (cluster, dc, le, scheduling_group_name))
+    labels:
+      by: "dc"
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_transport_cql_client_timestamp_drift_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_transport_cql_client_timestamp_drift_histogram_bucket[60s])) by (cluster, le, scheduling_group_name))
+    labels:
+      by: "cluster"
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_transport_cql_client_timestamp_drift_summary
+    expr: histogram_quantile(0.99, sum(rate(scylla_transport_cql_client_timestamp_drift_histogram_bucket[60s])) by (cluster, dc, instance, le, scheduling_group_name))
+    labels:
+      by: "instance"
+      quantile: "0.99"
+      dd: "1"
+  - record: scylla_transport_cql_client_timestamp_drift_summary
+    expr: histogram_quantile(0.99, sum(rate(scylla_transport_cql_client_timestamp_drift_histogram_bucket[60s])) by (cluster, dc, le, scheduling_group_name))
+    labels:
+      by: "dc"
+      quantile: "0.99"
+      dd: "1"
+  - record: scylla_transport_cql_client_timestamp_drift_summary
+    expr: histogram_quantile(0.99, sum(rate(scylla_transport_cql_client_timestamp_drift_histogram_bucket[60s])) by (cluster, le, scheduling_group_name))
+    labels:
+      by: "cluster"
+      quantile: "0.99"
+      dd: "1"
   - record: scylla_alternator_op_latency_summary
     expr: histogram_quantile(0.5, sum(rate(scylla_alternator_op_latency[60s])>0) by (cluster, dc, instance, op))
     labels:


### PR DESCRIPTION
This series adds CQL request latency and timestamp drift panels to the detailed dashboard.
It also adds recording rules for efficient latency calculation

<img width="1305" height="211" alt="image" src="https://github.com/user-attachments/assets/c2296f86-3a1c-432d-a4de-82ea1af65131" />

Fixes https://scylladb.atlassian.net/browse/MONITOR-70
