### PR TITLE
start-loki.sh: pin promtail to its own version

### DIFF
--- a/start-loki.sh
+++ b/start-loki.sh
@@ -232,7 +232,7 @@ sed "s/LOKI_IP/$LOKI_ADDRESS/" loki/promtail/promtail_config.template.yml >loki/
 
 docker run ${DOCKER_LIMITS["promtail"]} -d $DOCKER_PARAM -i $PROMTAIL_PORT_MAPPING \
 	-v $PROMTAIL_CONFIG:/etc/promtail/config.yml:z \
-	--name $PROMTAIL_NAME docker.io/grafana/promtail:$LOKI_VERSION --config.file=/etc/promtail/config.yml ${DOCKER_PARAMS["promtail"]}
+	--name $PROMTAIL_NAME docker.io/grafana/promtail:$PROMTAIL_VERSION --config.file=/etc/promtail/config.yml ${DOCKER_PARAMS["promtail"]}
 
 if [ $? -ne 0 ]; then
 	echo "Error: Promtail container failed to start"

--- a/versions.sh
+++ b/versions.sh
@@ -148,6 +148,9 @@ PROMETHEUS_VERSION=v3.12.0
 ALERT_MANAGER_VERSION=v0.33.0
 GRAFANA_VERSION=13.0.3
 LOKI_VERSION=3.7.3
+# Promtail is deprecated upstream and frozen on the 3.6.x line; it has no
+# 3.7.x releases, so it needs its own version and cannot follow LOKI_VERSION.
+PROMTAIL_VERSION=3.6.11
 GRAFANA_RENDERER_VERSION=v5.9.0
 THANOS_VERSION=v0.41.0
 VICTORIA_METRICS_VERSION="v1.96.0"


### PR DESCRIPTION
Promtail and Loki shared LOKI_VERSION, but Grafana stopped publishing promtail images after the 3.6.x line (promtail is deprecated in favour of Alloy). With LOKI_VERSION=3.7.3 the promtail pull fails:

  reading manifest 3.7.3 in docker.io/grafana/promtail: manifest unknown

which aborts start-loki.sh after Loki itself has already come up.

Add a separate PROMTAIL_VERSION, pinned to the last released promtail tag (3.6.11), and use it for the promtail container.