### PR TITLE
start-loki.sh: poll /ready instead of / when waiting for startup

### DIFF
--- a/start-loki.sh
+++ b/start-loki.sh
@@ -184,7 +184,7 @@ fi
 TRIES=0
 RETRIES=25
 if [ ! "$QUICK_STARTUP" = "1" ]; then
-    until $(curl --output /dev/null -f --silent http://localhost:$LOKI_PORT) || [ $TRIES -eq $RETRIES ]; do
+    until $(curl --output /dev/null -f --silent http://localhost:$LOKI_PORT/ready) || [ $TRIES -eq $RETRIES ]; do
     	((TRIES = TRIES + 1))
     	sleep 1
     done
@@ -244,7 +244,7 @@ fi
 RETRIES=25
 TRIES=0
 if [ ! "$QUICK_STARTUP" = "1" ]; then
-    until $(curl --output /dev/null -f --silent http://localhost:$PROMTAIL_PORT) || [ $TRIES -eq $RETRIES ]; do
+    until $(curl --output /dev/null -f --silent http://localhost:$PROMTAIL_PORT/ready) || [ $TRIES -eq $RETRIES ]; do
     	((TRIES = TRIES + 1))
     	sleep 1
     done


### PR DESCRIPTION
The startup wait loops probed the service root, but Loki 3.x has no route registered on "/" and answers 404 there, so "curl -f" never succeeded and the loop only ever exited by exhausting all 25 retries. Every start-loki.sh run therefore paid a fixed 25s stall before continuing.

Poll /ready instead, which both Loki and promtail expose: it returns 503 while starting up and 200 once the service is ready, so the loop now exits as soon as the container is actually usable.