### PR TITLE
packer: set connectionScope 'any' for the scylla datasource on images

### DIFF
--- a/packer/files/scylla_monitoring_install_ami
+++ b/packer/files/scylla_monitoring_install_ami
@@ -120,6 +120,40 @@ def install_monitoring(version):
         name = 'scylla-monitoring-{VERSION}'.format(VERSION=version)
     run('sudo -u {_USER} tar -xvf {_HOME}/scylla-monitoring.tar.gz -C {_HOME}/')
     run('sudo -u {_USER} {_COPY_OR_MOVE} {_HOME}/{NAME} {_HOME}/scylla-grafana-monitoring-scylla-monitoring'.format(NAME=name, _HOME=HOME_DIR, _USER=USER, _COPY_OR_MOVE=COPY_OR_MOVE))
+    set_scylla_datasource_connection_scope()
+
+def set_scylla_datasource_connection_scope(scope='any'):
+    # Grafana provisions the scylla-datasource from these files; on an image the
+    # Scylla nodes are not known ahead of time, so allow the plugin to connect to
+    # any host (connectionScope) instead of a fixed one.
+    for name in ['datasource.scylla.yml', 'datasource.psswd.scylla.yml']:
+        path = '{_HOME}/scylla-grafana-monitoring-scylla-monitoring/grafana/{NAME}'.format(_HOME=HOME_DIR, NAME=name)
+        if dry_run:
+            print("set connectionScope: '{SCOPE}' in {PATH}".format(SCOPE=scope, PATH=path))
+            continue
+        if not os.path.exists(path):
+            print("{PATH} not found, skipping connectionScope update".format(PATH=path))
+            continue
+        with open(path) as f:
+            lines = f.readlines()
+        if any(l.strip().startswith('connectionScope:') for l in lines):
+            continue
+        out = []
+        in_json_data = False
+        for l in lines:
+            if in_json_data and (not l.startswith(' ' * indent) or l.strip() == ''):
+                out.append(' ' * indent + "connectionScope: '{SCOPE}'\n".format(SCOPE=scope))
+                in_json_data = False
+            out.append(l)
+            if l.strip() == 'jsonData:':
+                indent = len(l) - len(l.lstrip()) + 2
+                in_json_data = True
+        if in_json_data:
+            out.append(' ' * indent + "connectionScope: '{SCOPE}'\n".format(SCOPE=scope))
+        if verbose:
+            print("set connectionScope: '{SCOPE}' in {PATH}".format(SCOPE=scope, PATH=path))
+        with open(path, 'w') as f:
+            f.writelines(out)
 
 def run_monitoring():
     if os.path.exists('{_HOME}/scylla-grafana-monitoring-scylla-monitoring/prometheus/scylla_servers.example.yml'.format(_HOME=HOME_DIR, )):


### PR DESCRIPTION
The monitoring image is built from the upstream tarball, where the scylla-datasource provisioning files do not set connectionScope. On an image the Scylla nodes are not known ahead of time, so patch grafana/datasource.scylla.yml (and the credentials variant) right after extraction to add connectionScope: 'any' under jsonData.

The step is idempotent and honors --dry-run/--verbose.