### PR TITLE
packer: drop branch from image name to fit GCP's 63-char limit

### DIFF
--- a/packer/scylla-monitor-template.json
+++ b/packer/scylla-monitor-template.json
@@ -146,7 +146,7 @@
   "variables": {
     "monitor_version": "",
     "monitor_branch": "",
-    "monitor_image_name": "scylladb-monitor-{{ user `monitor_version` | replace_all \".\" \"-\" }}-{{ user `arch` }}-branch-{{ user `monitor_branch` | replace_all \".\" \"-\" }}-{{ isotime \"2006-01-02t03-04-05z\" }}",
+    "monitor_image_name": "scylladb-monitor-{{ user `monitor_version` | replace_all \".\" \"-\" }}-{{ user `arch` }}-{{ isotime \"2006-01-02t03-04-05z\" }}",
 
     "arch": "amd64",
     "aws_region": "us-east-1",


### PR DESCRIPTION
The image name added in ff9b6932 (version + arch + branch + timestamp) reaches 66 characters for rc versions, exceeding the GCE resource name limit and failing the googlecompute builder. The branch is already recorded as an AWS tag and a GCP label, so remove it from the name.