### PR TITLE
packer: make the deb-based node_exporter install work and fail loudly

### DIFF
--- a/packer/files/node-exporter.service
+++ b/packer/files/node-exporter.service
@@ -1,8 +1,0 @@
-[Unit]
-Description=Node Exporter
-
-[Service]
-ExecStart=/usr/bin/node_exporter --no-collector.interrupts --no-collector.hwmon --no-collector.bcache --no-collector.btrfs --no-collector.fibrechannel --no-collector.infiniband --no-collector.ipvs --no-collector.nfs --no-collector.nfsd --no-collector.powersupplyclass --no-collector.rapl --no-collector.tapestats --no-collector.thermal_zone --no-collector.udp_queues --no-collector.zfs
-
-[Install]
-WantedBy=multi-user.target

--- a/packer/files/node_exporter_install
+++ b/packer/files/node_exporter_install
@@ -22,15 +22,38 @@
 
 import os
 import sys
+import grp
+import pwd
 import shlex
 import subprocess
+from pathlib import Path
 from scylla_util import *
 import argparse
 
 VERSION='1.11.1-2'
+# The scylla-node-exporter deb installs the binary under /opt/scylladb and
+# ships its own systemd unit, which runs as the 'scylla' user.
+NODE_EXPORTER_BIN = Path('/opt/scylladb/node_exporter/node_exporter')
+NODE_EXPORTER_SERVICE = 'scylla-node-exporter.service'
+NODE_EXPORTER_USER = 'scylla'
 
 def run(cmd):
     subprocess.check_call(shlex.split(cmd))
+
+def ensure_user(user):
+    """Create the system user/group the node-exporter unit runs as.
+
+    The monitoring image has no scylla installation, so the user the deb's
+    unit expects (User=scylla) does not exist and the service would fail to
+    start."""
+    try:
+        grp.getgrnam(user)
+    except KeyError:
+        run('groupadd --system {user}'.format(user=user))
+    try:
+        pwd.getpwnam(user)
+    except KeyError:
+        run('useradd --system --gid {user} --no-create-home --shell /usr/sbin/nologin {user}'.format(user=user))
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Download and install prometheus node_exporter')
@@ -42,15 +65,14 @@ if __name__ == '__main__':
     if not is_nonroot() and os.getuid() > 0:
         print('Requires root permission.')
         sys.exit(1)
-    node_exporter_p = bindir_p() / 'node_exporter'
-    if node_exporter_p.exists() or (bindir_p() / 'prometheus-node_exporter').exists():
+    if NODE_EXPORTER_BIN.exists() or (bindir_p() / 'node_exporter').exists() or (bindir_p() / 'prometheus-node_exporter').exists():
         if force:
             print('node_exporter already installed, reinstalling')
             try:
-                node_exporter = systemd_unit('node-exporter.service')
+                node_exporter = systemd_unit(NODE_EXPORTER_SERVICE)
                 node_exporter.stop()
             except Exception as e:
-                print("could not create node-exporter.service file", e)
+                print("could not stop {}".format(NODE_EXPORTER_SERVICE), e)
         else:
             print('node_exporter already installed, you can use `--force` to force reinstallation')
             sys.exit(1)
@@ -65,7 +87,15 @@ if __name__ == '__main__':
             version=VERSION, arch=arch), byte=True)
         with open(deb_file, 'wb') as f:
             f.write(data)
+        ensure_user(NODE_EXPORTER_USER)
         run('dpkg -i {deb}'.format(deb=deb_file))
         os.remove(deb_file)
+        run('systemctl daemon-reload')
+        node_exporter = systemd_unit(NODE_EXPORTER_SERVICE)
+        node_exporter.enable()
+        node_exporter.restart()
+        if node_exporter.is_active().strip() != 'active':
+            print('{} failed to start'.format(NODE_EXPORTER_SERVICE))
+            sys.exit(1)
 
     print('node_exporter successfully installed')

--- a/packer/files/scylla_monitoring_install_ami
+++ b/packer/files/scylla_monitoring_install_ami
@@ -194,18 +194,10 @@ def install_dbaas(version):
 def install_node_exporter(arch='amd64'):
     if not is_centos():
         run('apt-get install -y policycoreutils')
-    run('cp {_HOME}/node-exporter.service /etc/systemd/system/')
-    try:
-        run('cp {_HOME}/node-exporter.service /usr/lib/systemd/system/')
-    except Exception as e:
-        print("could not place node-exporter file in user/lib/systemd" + str(e))
-        print(e.output)
-    run('systemctl daemon-reload')
-    try:
-        run('{_HOME}/node_exporter_install --arch {arch}'.format(arch=arch, _HOME=HOME_DIR))
-    except Exception as e:
-        print("node_exporter_install failed" + str(e))
-        print(e.output)
+    # The scylla-node-exporter deb ships its own systemd unit; a failure here
+    # must fail the image build instead of silently producing an image
+    # without node_exporter.
+    run('{_HOME}/node_exporter_install --arch {arch}'.format(arch=arch, _HOME=HOME_DIR))
 
 if __name__ == '__main__':
     if os.getuid() > 0:


### PR DESCRIPTION
The switch to the scylla-node-exporter deb (1.11.1-2) left two problems on the monitoring image:

* The deb ships its own scylla-node-exporter.service running as User=scylla, a user that does not exist on the monitoring image, so the unit never started (dpkg's postinst hides the failure with '|| true').  The old node-exporter.service we kept copying still pointed at /usr/bin/node_exporter, which the deb does not install, and was never enabled.

* scylla_monitoring_install_ami swallowed any node_exporter_install failure, so an image without node_exporter was built and published as a success (see the 4.16.0 build, where node_exporter_install rejected --arch on every builder and the run still passed).

node_exporter_install now creates the scylla system user/group before 'dpkg -i', enables and restarts scylla-node-exporter.service and exits non-zero unless the unit is active.  The already-installed check looks at the deb's /opt/scylladb path.  scylla_monitoring_install_ami no longer installs the stale node-exporter.service (removed) and lets a node_exporter_install failure fail the packer build.