### PR TITLE
packer: add manual workflow and script to delete cloud images

### DIFF
--- a/.github/workflows/delete-cloud-images.yaml
+++ b/.github/workflows/delete-cloud-images.yaml
@@ -62,6 +62,10 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
 
       - name: ${{ inputs.action == 'delete' && 'Delete images' || 'List images (dry run)' }}
+        env:
+          IMAGE_NAME: ${{ inputs.image_name }}
+          CLOUD: ${{ inputs.cloud }}
+          ACTION: ${{ inputs.action }}
         run: |
-          ./delete_cloud_images.sh --name "${{ inputs.image_name }}" --cloud "${{ inputs.cloud }}" --${{ inputs.action }}
+          ./delete_cloud_images.sh --name "$IMAGE_NAME" --cloud "$CLOUD" "--$ACTION"
         working-directory: packer

--- a/.github/workflows/delete-cloud-images.yaml
+++ b/.github/workflows/delete-cloud-images.yaml
@@ -1,0 +1,67 @@
+name: Delete Cloud Images
+
+# Manual only. Removes Scylla Monitor images (AWS AMIs + snapshots in all
+# release regions, GCP images) by name, using the same cloud credentials as
+# the Build Cloud Images workflow. Runs as a dry run unless "delete" is
+# explicitly selected.
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_name:
+        description: 'Image name to delete, e.g. scylladb-monitor-4-16-0-rc0-2026-06-28t11-42-58z (a trailing * matches several builds)'
+        required: true
+        type: string
+      cloud:
+        description: 'Which cloud to clean'
+        required: true
+        type: choice
+        default: all
+        options:
+          - all
+          - aws
+          - gcp
+      action:
+        description: 'dry-run only lists the matching images; delete removes them'
+        required: true
+        type: choice
+        default: dry-run
+        options:
+          - dry-run
+          - delete
+
+jobs:
+  delete-cloud-images:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup AWS credentials
+        if: inputs.cloud != 'gcp'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.MONITOR_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.MONITOR_AWS_SECRET_ACCESS_KEY }}
+          aws-region: 'us-east-1'
+
+      - name: Setup GCP credentials
+        if: inputs.cloud != 'aws'
+        uses: google-github-actions/auth@v2.1.2
+        with:
+          workload_identity_provider: ${{ secrets.MONITOR_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.MONITOR_GCP_SERVICE_ACCOUNT }}
+
+      - name: Setup gcloud
+        if: inputs.cloud != 'aws'
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: ${{ inputs.action == 'delete' && 'Delete images' || 'List images (dry run)' }}
+        run: |
+          ./delete_cloud_images.sh --name "${{ inputs.image_name }}" --cloud "${{ inputs.cloud }}" --${{ inputs.action }}
+        working-directory: packer

--- a/packer/README.md
+++ b/packer/README.md
@@ -76,3 +76,25 @@ Set your GCP service account key as an environment variable:
 ```shell
 export GOOGLE_APPLICATION_CREDENTIALS="/path/to/your/service-account-file.json"
 ```
+
+## Deleting images
+
+`delete_cloud_images.sh` removes images by their packer name (`monitor_image_name`) from
+AWS (the AMI and its snapshot, in `aws_region` and every region in `aws_ami_regions`)
+and from GCP (`gcp_project_id`). It is a dry run unless `--delete` is given:
+
+```shell
+# show what would be removed
+./delete_cloud_images.sh --name scylladb-monitor-4-16-0-rc0-2026-06-28t11-42-58z
+
+# a trailing * matches several builds; restrict to one cloud with --cloud aws|gcp
+./delete_cloud_images.sh --name 'scylladb-monitor-4-16-0-rc*' --cloud aws
+
+# actually delete
+./delete_cloud_images.sh --name scylladb-monitor-4-16-0-rc0-2026-06-28t11-42-58z --delete
+```
+
+Only AMIs owned by the current AWS account are considered, so run it with the
+credentials of the account that built the images. The same script is exposed as the
+manual **Delete Cloud Images** GitHub Actions workflow, which uses the CI account
+credentials; pick `action: dry-run` first to review the list, then re-run with `delete`.

--- a/packer/delete_cloud_images.sh
+++ b/packer/delete_cloud_images.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# Delete Scylla Monitor cloud images (AWS AMIs + their snapshots, GCP images)
+# by image name. Dry run by default; pass --delete to actually remove them.
+#
+# Usage:
+#   ./delete_cloud_images.sh --name <image-name> [--cloud aws|gcp|all] [--delete]
+#
+# The name is the packer `monitor_image_name`, e.g.
+#   scylladb-monitor-4-16-0-rc0-2026-06-28t11-42-58z
+# A trailing '*' is allowed to match several builds, e.g.
+#   scylladb-monitor-4-16-0-rc*
+#
+# AWS regions and the GCP project are read from scylla-monitor-template.json,
+# so the script always covers the same regions the build copies AMIs to.
+# Only AMIs owned by the current AWS account are considered.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+TEMPLATE=scylla-monitor-template.json
+
+NAME=""
+CLOUD="all"
+MODE="dry-run"
+
+usage() { sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit "${1:-0}"; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --name)   NAME="$2"; shift 2 ;;
+    --cloud)  CLOUD="$2"; shift 2 ;;
+    --delete) MODE="delete"; shift ;;
+    --dry-run) MODE="dry-run"; shift ;;
+    -h|--help) usage ;;
+    *) echo "unknown argument: $1" >&2; usage 1 ;;
+  esac
+done
+
+[ -n "$NAME" ] || { echo "--name is required" >&2; usage 1; }
+case "$CLOUD" in aws|gcp|all) ;; *) echo "--cloud must be aws, gcp or all" >&2; exit 1 ;; esac
+case "$NAME" in
+  scylladb-monitor-*) ;;
+  *) echo "refusing: name must start with 'scylladb-monitor-' (got '$NAME')" >&2; exit 1 ;;
+esac
+
+echo "mode:  $MODE"
+echo "name:  $NAME"
+echo "cloud: $CLOUD"
+echo
+
+MATCHES="$(mktemp)"
+trap 'rm -f "$MATCHES"' EXIT
+
+delete_aws() {
+  local regions
+  regions="$(jq -r '.variables.aws_region, .variables.aws_ami_regions' "$TEMPLATE" | tr ',' '\n' | sort -u)"
+  echo "### AWS (account $(aws sts get-caller-identity --query Account --output text))"
+  for r in $regions; do
+    aws ec2 describe-images --region "$r" --owners self \
+      --filters "Name=name,Values=$NAME" \
+      --query 'Images[].[ImageId,Name,BlockDeviceMappings[].Ebs.SnapshotId|join(`,`,@)]' \
+      --output text |
+    while read -r ami name snaps; do
+      [ -n "$ami" ] || continue
+      echo "$r  $ami  $name  snapshots=$snaps" | tee -a "$MATCHES"
+      if [ "$MODE" = "delete" ]; then
+        aws ec2 deregister-image --region "$r" --image-id "$ami"
+        for s in ${snaps//,/ }; do
+          aws ec2 delete-snapshot --region "$r" --snapshot-id "$s"
+        done
+        echo "$r  $ami  deleted"
+      fi
+    done
+  done
+  echo
+}
+
+delete_gcp() {
+  local project regex
+  project="$(jq -r '.variables.gcp_project_id' "$TEMPLATE")"
+  regex="^$(printf '%s' "$NAME" | sed 's/[.]/\\./g; s/\*/.*/g')$"
+  echo "### GCP (project $project)"
+  gcloud compute images list --project "$project" --no-standard-images \
+    --filter="name~$regex" --format="value(name)" |
+  while read -r img; do
+    [ -n "$img" ] || continue
+    echo "$project  $img" | tee -a "$MATCHES"
+    if [ "$MODE" = "delete" ]; then
+      gcloud compute images delete --project "$project" --quiet "$img"
+      echo "$project  $img  deleted"
+    fi
+  done
+  echo
+}
+
+[ "$CLOUD" = "gcp" ] || delete_aws
+[ "$CLOUD" = "aws" ] || delete_gcp
+
+COUNT=$(wc -l < "$MATCHES")
+if [ "$COUNT" -eq 0 ]; then
+  echo "No images matched '$NAME'."
+elif [ "$MODE" = "dry-run" ]; then
+  echo "Dry run only - $COUNT image(s) matched, nothing was deleted. Re-run with --delete to remove them."
+else
+  echo "Deleted $COUNT image(s)."
+fi

--- a/packer/delete_cloud_images.sh
+++ b/packer/delete_cloud_images.sh
@@ -39,10 +39,13 @@ done
 
 [ -n "$NAME" ] || { echo "--name is required" >&2; usage 1; }
 case "$CLOUD" in aws|gcp|all) ;; *) echo "--cloud must be aws, gcp or all" >&2; exit 1 ;; esac
-case "$NAME" in
-  scylladb-monitor-*) ;;
-  *) echo "refusing: name must start with 'scylladb-monitor-' (got '$NAME')" >&2; exit 1 ;;
-esac
+# Validate the whole pattern: the scylladb-monitor- prefix, then ordinary
+# image-name characters, with at most one wildcard and only at the end. This
+# keeps shell/regex metacharacters out of the cloud filters below.
+if ! printf '%s\n' "$NAME" | grep -Eq '^scylladb-monitor-[A-Za-z0-9._-]+\*?$'; then
+  echo "refusing: name must match ^scylladb-monitor-[A-Za-z0-9._-]+\*?$ (got '$NAME')" >&2
+  exit 1
+fi
 
 echo "mode:  $MODE"
 echo "name:  $NAME"


### PR DESCRIPTION
Add delete_cloud_images.sh, which removes Scylla Monitor images by their packer image name: on AWS it deregisters the AMI and deletes its backing snapshot in the source region and every region in aws_ami_regions; on GCP it deletes the image from gcp_project_id. Regions and project are read from scylla-monitor-template.json so they stay in sync with the build. The script is a dry run unless --delete is passed and refuses names that do not start with scylladb-monitor-.

Expose it as the manual-only "Delete Cloud Images" GitHub Actions workflow, using the same CI account credentials as Build Cloud Images, with inputs for the image name, the cloud (all/aws/gcp) and dry-run/delete.