### PR TITLE
packer: install node_exporter without registering the deb in dpkg

### DIFF
--- a/packer/files/node-exporter.service
+++ b/packer/files/node-exporter.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Node Exporter
+After=network.target
+
+[Service]
+User=nodeexporter
+Group=nodeexporter
+ExecStart=/opt/node_exporter/node_exporter --no-collector.interrupts --no-collector.hwmon --no-collector.bcache --no-collector.btrfs --no-collector.fibrechannel --no-collector.infiniband --no-collector.ipvs --no-collector.nfs --no-collector.nfsd --no-collector.powersupplyclass --no-collector.rapl --no-collector.tapestats --no-collector.thermal_zone --no-collector.udp_queues --no-collector.zfs
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/packer/files/node_exporter_install
+++ b/packer/files/node_exporter_install
@@ -31,21 +31,25 @@ from scylla_util import *
 import argparse
 
 VERSION='1.11.1-2'
-# The scylla-node-exporter deb installs the binary under /opt/scylladb and
-# ships its own systemd unit, which runs as the 'scylla' user.
-NODE_EXPORTER_BIN = Path('/opt/scylladb/node_exporter/node_exporter')
-NODE_EXPORTER_SERVICE = 'scylla-node-exporter.service'
-NODE_EXPORTER_USER = 'scylla'
+# The node_exporter binary is taken from the scylla-node-exporter deb, but the
+# deb is extracted rather than installed with dpkg: registering the package
+# (version 1:1.11.1-2, with an epoch) in dpkg would block installing Scylla on
+# the same machine, because scylla depends on scylla-node-exporter with an
+# exact epoch-0 version pin and apt refuses to downgrade across the epoch.
+# SCT installs Scylla + Scylla Manager on top of the monitoring image, so the
+# scylla-node-exporter package name must stay unclaimed, and our binary and
+# unit must live in paths a real scylla-node-exporter install does not own.
+NODE_EXPORTER_DIR = Path('/opt/node_exporter')
+NODE_EXPORTER_BIN = NODE_EXPORTER_DIR / 'node_exporter'
+NODE_EXPORTER_BIN_IN_DEB = 'opt/scylladb/node_exporter/node_exporter'
+NODE_EXPORTER_SERVICE = 'node-exporter.service'
+NODE_EXPORTER_USER = 'nodeexporter'
 
 def run(cmd):
     subprocess.check_call(shlex.split(cmd))
 
 def ensure_user(user):
-    """Create the system user/group the node-exporter unit runs as.
-
-    The monitoring image has no scylla installation, so the user the deb's
-    unit expects (User=scylla) does not exist and the service would fail to
-    start."""
+    """Create the dedicated system user/group node-exporter.service runs as."""
     try:
         grp.getgrnam(user)
     except KeyError:
@@ -87,9 +91,18 @@ if __name__ == '__main__':
             version=VERSION, arch=arch), byte=True)
         with open(deb_file, 'wb') as f:
             f.write(data)
-        ensure_user(NODE_EXPORTER_USER)
-        run('dpkg -i {deb}'.format(deb=deb_file))
+        extract_dir = '/var/tmp/scylla-node-exporter-extract'
+        run('rm -rf {dir}'.format(dir=extract_dir))
+        run('dpkg-deb -x {deb} {dir}'.format(deb=deb_file, dir=extract_dir))
+        run('install -d {dir}'.format(dir=NODE_EXPORTER_DIR))
+        run('install -m 755 {src} {dst}'.format(
+            src=os.path.join(extract_dir, NODE_EXPORTER_BIN_IN_DEB), dst=NODE_EXPORTER_BIN))
+        run('rm -rf {dir}'.format(dir=extract_dir))
         os.remove(deb_file)
+        ensure_user(NODE_EXPORTER_USER)
+        unit_src = Path(__file__).resolve().parent / NODE_EXPORTER_SERVICE
+        run('install -m 644 {src} /etc/systemd/system/{service}'.format(
+            src=unit_src, service=NODE_EXPORTER_SERVICE))
         run('systemctl daemon-reload')
         node_exporter = systemd_unit(NODE_EXPORTER_SERVICE)
         node_exporter.enable()

--- a/packer/files/scylla_monitoring_install_ami
+++ b/packer/files/scylla_monitoring_install_ami
@@ -199,9 +199,8 @@ def install_dbaas(version):
 def install_node_exporter(arch='amd64'):
     if not is_centos():
         run('apt-get install -y policycoreutils')
-    # The scylla-node-exporter deb ships its own systemd unit; a failure here
-    # must fail the image build instead of silently producing an image
-    # without node_exporter.
+    # A failure here must fail the image build instead of silently producing
+    # an image without node_exporter.
     run('{_HOME}/node_exporter_install --arch {arch}'.format(arch=arch, _HOME=HOME_DIR))
 
 if __name__ == '__main__':


### PR DESCRIPTION
The monitoring image installed the scylla-node-exporter deb with 'dpkg -i', registering the package at version 1:1.11.1-2 (the 2026.3-era build, which carries an epoch).  SCT installs Scylla + Scylla Manager on top of the monitoring image, and scylla depends on scylla-node-exporter with an exact epoch-0 version pin (e.g. = 2025.4.10-...); apt refuses to downgrade across the epoch, so 'apt-get install scylla' fails with unmet dependencies on any image that has the deb installed:

 scylla : Depends: scylla-node-exporter (= 2025.4.10-0.20260609...-1)
          but 1:1.11.1-2 is to be installed

This was latent since the switch to the deb (196fbb63): until d95f6560 the install silently failed, so published images never actually contained the package.  d95f6560 made the install work and fail loudly, and the first image that really shipped the deb (2026-08-30) broke the SCT provision test (scylladb/scylla-cluster-tests#14932).

Keep the deb as the artifact source, but extract it with 'dpkg-deb -x' instead of installing it: copy the binary to /opt/node_exporter (a path no scylla-node-exporter package owns) and run it via a monitoring-owned node-exporter.service under a dedicated 'nodeexporter' system user. dpkg never learns the scylla-node-exporter name, so both use cases work: the image serves node metrics on :9100 as before, and any Scylla version can still be installed on the node.  The fail-loudly behavior from d95f6560 (unit must be active or the image build fails) is kept.

Verified in an ubuntu:24.04 container against the scylladb-2025.4 repo: with the deb dpkg-installed, 'apt-get install -s scylla' reproduces the SCT failure verbatim; with the extract-only install it resolves cleanly, pulling scylla-node-exporter 2025.4.10 as a dependency.