### PR TITLE
advanced: add "Host CPU" panels

### DIFF
--- a/grafana/scylla-advanced.template.json
+++ b/grafana/scylla-advanced.template.json
@@ -454,6 +454,94 @@
                 ]
             },
             {
+                "title": "Host CPU",
+                "collapse": true,
+                "rows": [
+                    {
+                        "class": "row",
+                        "panels": [
+                            {
+                                "class": "percentunit_panel",
+                                "span": 3,
+                                "spec/title": "$func host CPU user by [[by]]",
+                                "spec/description": "Host CPU time in user space. On a pinned reactor this is dominated by scylla itself.\n\nnode_cpu_seconds_total joined to scylla_reactor_location on (instance, cpu). Only CPUs that run a scylla reactor are included.",
+                                "spec/data/spec/queries/0/spec/query/spec/interval": "30s",
+                                "spec/data/spec/queries/0/spec/query/spec/expr": "$topbottom([[filter_limit]], $func(rate(node_cpu_seconds_total{mode=\"user\", instance=~\"[[node]]\", cluster=\"$cluster\", dc=~\"$dc\"}[$__rate_interval]) * on (instance, cpu) group_left(shard) scylla_reactor_location{instance=~\"[[node]]\", cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]]))",
+                                "spec/data/spec/queries/0/spec/query/spec/legendFormat": "{{cluster}} {{dc}} {{instance}} shard {{shard}} cpu {{cpu}}"
+                            },
+                            {
+                                "class": "percentunit_panel",
+                                "span": 3,
+                                "spec/title": "$func host CPU system by [[by]]",
+                                "spec/description": "Host CPU time in the kernel: syscalls the reactor made, plus kernel work charged to that CPU.\n\nnode_cpu_seconds_total joined to scylla_reactor_location on (instance, cpu). Only CPUs that run a scylla reactor are included.",
+                                "spec/data/spec/queries/0/spec/query/spec/interval": "30s",
+                                "spec/data/spec/queries/0/spec/query/spec/expr": "$topbottom([[filter_limit]], $func(rate(node_cpu_seconds_total{mode=\"system\", instance=~\"[[node]]\", cluster=\"$cluster\", dc=~\"$dc\"}[$__rate_interval]) * on (instance, cpu) group_left(shard) scylla_reactor_location{instance=~\"[[node]]\", cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]]))",
+                                "spec/data/spec/queries/0/spec/query/spec/legendFormat": "{{cluster}} {{dc}} {{instance}} shard {{shard}} cpu {{cpu}}"
+                            },
+                            {
+                                "class": "percentunit_panel",
+                                "span": 3,
+                                "spec/title": "$func host CPU iowait by [[by]]",
+                                "spec/description": "Host CPU time idle with outstanding I/O.\n\nnode_cpu_seconds_total joined to scylla_reactor_location on (instance, cpu). Only CPUs that run a scylla reactor are included.",
+                                "spec/data/spec/queries/0/spec/query/spec/interval": "30s",
+                                "spec/data/spec/queries/0/spec/query/spec/expr": "$topbottom([[filter_limit]], $func(rate(node_cpu_seconds_total{mode=\"iowait\", instance=~\"[[node]]\", cluster=\"$cluster\", dc=~\"$dc\"}[$__rate_interval]) * on (instance, cpu) group_left(shard) scylla_reactor_location{instance=~\"[[node]]\", cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]]))",
+                                "spec/data/spec/queries/0/spec/query/spec/legendFormat": "{{cluster}} {{dc}} {{instance}} shard {{shard}} cpu {{cpu}}"
+                            },
+                            {
+                                "class": "percentunit_panel",
+                                "span": 3,
+                                "spec/title": "$func host CPU irq by [[by]]",
+                                "spec/description": "Hard IRQ time. Interrupts landing on a reactor CPU take it away from the reactor.\n\nnode_cpu_seconds_total joined to scylla_reactor_location on (instance, cpu). Only CPUs that run a scylla reactor are included.",
+                                "spec/data/spec/queries/0/spec/query/spec/interval": "30s",
+                                "spec/data/spec/queries/0/spec/query/spec/expr": "$topbottom([[filter_limit]], $func(rate(node_cpu_seconds_total{mode=\"irq\", instance=~\"[[node]]\", cluster=\"$cluster\", dc=~\"$dc\"}[$__rate_interval]) * on (instance, cpu) group_left(shard) scylla_reactor_location{instance=~\"[[node]]\", cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]]))",
+                                "spec/data/spec/queries/0/spec/query/spec/legendFormat": "{{cluster}} {{dc}} {{instance}} shard {{shard}} cpu {{cpu}}"
+                            }
+                        ]
+                    },
+                    {
+                        "class": "row",
+                        "panels": [
+                            {
+                                "class": "percentunit_panel",
+                                "span": 3,
+                                "spec/title": "$func host CPU softirq by [[by]]",
+                                "spec/description": "Soft IRQ time, mostly network RX/TX. A common source of reactor stalls.\n\nnode_cpu_seconds_total joined to scylla_reactor_location on (instance, cpu). Only CPUs that run a scylla reactor are included.",
+                                "spec/data/spec/queries/0/spec/query/spec/interval": "30s",
+                                "spec/data/spec/queries/0/spec/query/spec/expr": "$topbottom([[filter_limit]], $func(rate(node_cpu_seconds_total{mode=\"softirq\", instance=~\"[[node]]\", cluster=\"$cluster\", dc=~\"$dc\"}[$__rate_interval]) * on (instance, cpu) group_left(shard) scylla_reactor_location{instance=~\"[[node]]\", cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]]))",
+                                "spec/data/spec/queries/0/spec/query/spec/legendFormat": "{{cluster}} {{dc}} {{instance}} shard {{shard}} cpu {{cpu}}"
+                            },
+                            {
+                                "class": "percentunit_panel",
+                                "span": 3,
+                                "spec/title": "$func host CPU steal by [[by]]",
+                                "spec/description": "Time the hypervisor ran something else on the CPU. Non-zero steal on a reactor CPU means the reactor was descheduled.\n\nnode_cpu_seconds_total joined to scylla_reactor_location on (instance, cpu). Only CPUs that run a scylla reactor are included.",
+                                "spec/data/spec/queries/0/spec/query/spec/interval": "30s",
+                                "spec/data/spec/queries/0/spec/query/spec/expr": "$topbottom([[filter_limit]], $func(rate(node_cpu_seconds_total{mode=\"steal\", instance=~\"[[node]]\", cluster=\"$cluster\", dc=~\"$dc\"}[$__rate_interval]) * on (instance, cpu) group_left(shard) scylla_reactor_location{instance=~\"[[node]]\", cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]]))",
+                                "spec/data/spec/queries/0/spec/query/spec/legendFormat": "{{cluster}} {{dc}} {{instance}} shard {{shard}} cpu {{cpu}}"
+                            },
+                            {
+                                "class": "percentunit_panel",
+                                "span": 3,
+                                "spec/title": "$func host CPU nice by [[by]]",
+                                "spec/description": "Host CPU time spent on niced user processes.\n\nnode_cpu_seconds_total joined to scylla_reactor_location on (instance, cpu). Only CPUs that run a scylla reactor are included.",
+                                "spec/data/spec/queries/0/spec/query/spec/interval": "30s",
+                                "spec/data/spec/queries/0/spec/query/spec/expr": "$topbottom([[filter_limit]], $func(rate(node_cpu_seconds_total{mode=\"nice\", instance=~\"[[node]]\", cluster=\"$cluster\", dc=~\"$dc\"}[$__rate_interval]) * on (instance, cpu) group_left(shard) scylla_reactor_location{instance=~\"[[node]]\", cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]]))",
+                                "spec/data/spec/queries/0/spec/query/spec/legendFormat": "{{cluster}} {{dc}} {{instance}} shard {{shard}} cpu {{cpu}}"
+                            },
+                            {
+                                "class": "percentunit_panel",
+                                "span": 3,
+                                "spec/title": "$func host CPU idle by [[by]]",
+                                "spec/description": "Host CPU idle time. Low idle together with low reactor utilization means something other than scylla is on that CPU.\n\nnode_cpu_seconds_total joined to scylla_reactor_location on (instance, cpu). Only CPUs that run a scylla reactor are included.",
+                                "spec/data/spec/queries/0/spec/query/spec/interval": "30s",
+                                "spec/data/spec/queries/0/spec/query/spec/expr": "$topbottom([[filter_limit]], $func(rate(node_cpu_seconds_total{mode=\"idle\", instance=~\"[[node]]\", cluster=\"$cluster\", dc=~\"$dc\"}[$__rate_interval]) * on (instance, cpu) group_left(shard) scylla_reactor_location{instance=~\"[[node]]\", cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]]))",
+                                "spec/data/spec/queries/0/spec/query/spec/legendFormat": "{{cluster}} {{dc}} {{instance}} shard {{shard}} cpu {{cpu}}"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
                 "class": "monitoring_version_row"
             }
         ],
@@ -474,7 +562,7 @@
                 "kind": "CustomVariable",
                 "spec": {
                     "name": "by",
-                    "query": "Cluster : cluster,DC : dc, Instance : instance, Shard : instance\\,shard",
+                    "query": "Cluster : cluster,DC : dc, Instance : instance, Shard : instance\\,shard\\,cpu",
                     "current": {
                         "tags": [],
                         "text": "DC",


### PR DESCRIPTION
They display `node_cpu_seconds_total` metrics annotated with the "shard" label. So standard aggregation and filtering still works. This allows us to inspect CPU metrics for a given shard.

### How it works ###

`node_cpu_seconds_total` is per (instance, cpu) and carries no shard label, so host CPU time could not be filtered or grouped the way the rest of the dashboard is, and lining a stalling shard up with the steal or softirq time on its own core meant reading two graphs side by side while knowing the shard-to-cpu mapping by heart. The mapping is not guessable: on a 16 core box scylla --smp=4 puts shards 0-3 on CPUs 0, 2, 4 and 6, one per physical core.

`scylla_location_shard` supplies that mapping. Joining on (instance, cpu) with group_left(shard) copies the shard label onto the host counter, so the result filters and aggregates like any other metric here - the [[shard]] filter is applied to the location metric, which is the only side that has a shard label to filter on.

### What is added ###

One row, one panel per mode: user, system, iowait, irq, softirq, steal, nice and idle. The panels aggregate by the dashboard's own [[by]] variable, so cluster, dc and instance all roll up as they do everywhere else, and the panel titles and descriptions stay neutral about granularity because the grouping already states it.

### Grouping ###

The Shard option of [[by]] now groups by instance, shard and cpu rather than instance and shard. Without cpu in the grouping the aggregation drops it and the reactor's CPU never reaches the legend, which is half the point of these panels. Every other metric on this dashboard is scylla_* and has no cpu label, so for them cpu is empty and the grouping is unchanged - verified by comparing scylla_reactor_utilization grouped both ways.

### Interval ###
 
The panels set a 30s min step on the query. scylla-monitoring scrapes node_exporter every 1m but scylla every 20s, and $__rate_interval is max($__interval + min step, 4 * min step); with no min step Grafana substitutes the data source scrape interval and the window resolves to 1m, where rate() of a 1m-scraped "node" counter sees a single sample and returns nothing. A 30s min step makes it 2m. The setting has to sit on the query, not in the panel's query options - the latter only feeds $__interval.

<img width="3666" height="1110" alt="Screenshot From 2026-09-01 00-34-00" src="https://github.com/user-attachments/assets/dd6d8aa0-7fd8-479b-b355-7bfdd86b02f4" />
